### PR TITLE
Permission table has incorrect type label #24

### DIFF
--- a/apps/jetstream/src/app/components/manage-permissions/utils/permission-manager-table-utils.tsx
+++ b/apps/jetstream/src/app/components/manage-permissions/utils/permission-manager-table-utils.tsx
@@ -247,7 +247,7 @@ export function getObjectColumns(
           permissionType: 'object',
           id: permissionSetId,
           type: 'Permission Set',
-          label: permissionSet.Name,
+          label: permissionSet?.Name || '',
           actionType: startCase(permissionType) as 'Create' | 'Read' | 'Edit' | 'Delete' | 'ViewAll' | 'ModifyAll',
           actionKey: permissionType,
         })
@@ -411,8 +411,8 @@ export function getFieldColumns(
           isFirstItem: i === 0,
           permissionType: 'field',
           id: permissionSetId,
-          type: 'Profile',
-          label: permissionSet.Name,
+          type: 'Permission Set',
+          label: permissionSet?.Name || '',
           actionType: startCase(permissionType) as 'Read' | 'Edit',
           actionKey: permissionType,
         })

--- a/libs/ui/src/lib/popover/ContextMenu.tsx
+++ b/libs/ui/src/lib/popover/ContextMenu.tsx
@@ -125,7 +125,6 @@ export function ContextMenu({ containerId, menu, onItemSelected, children }: Con
           display: contents;
         `}
         onContextMenu={(event) => {
-          console.log('containerId', containerId);
           if (containerId) {
             try {
               const itemId =


### PR DESCRIPTION
Fixed type passed in to `getColumnForProfileOrPermSet` for fields

removed console.log in table contextMenu

For safety, added `?.` since there were some rollbar issues reported

resolves #24