### PR TITLE
Filtered records not shown in download #47 #53

### DIFF
--- a/apps/jetstream/src/app/components/load-records/components/LoadRecordsDataPreview.tsx
+++ b/apps/jetstream/src/app/components/load-records/components/LoadRecordsDataPreview.tsx
@@ -157,7 +157,7 @@ export const LoadRecordsDataPreview: FunctionComponent<LoadRecordsDataPreviewPro
             >
               <div className="slds-text-heading_small">File Preview</div>
               <AutoFullHeightContainer fillHeight setHeightAttr bottomBuffer={25}>
-                <DataTable allowReorder columns={columns} data={rows} getRowKey={getRowId} />
+                <DataTable columns={columns} data={rows} getRowKey={getRowId} />
               </AutoFullHeightContainer>
             </div>
           )}

--- a/apps/jetstream/src/app/components/load-records/components/load-results/LoadRecordsResultsModal.tsx
+++ b/apps/jetstream/src/app/components/load-records/components/load-results/LoadRecordsResultsModal.tsx
@@ -98,7 +98,6 @@ export const LoadRecordsResultsModal: FunctionComponent<LoadRecordsResultsModalP
             {loading && <Spinner />}
             {rows && columns && (
               <DataTable
-                allowReorder
                 columns={columns}
                 data={rows}
                 getRowKey={getRowKey}

--- a/apps/jetstream/src/app/components/platform-event-monitor/PlatformEventMonitorEvents.tsx
+++ b/apps/jetstream/src/app/components/platform-event-monitor/PlatformEventMonitorEvents.tsx
@@ -117,25 +117,6 @@ export const PlatformEventMonitorEvents: FunctionComponent<PlatformEventMonitorE
         expandedGroupIds={expandedGroupIds}
         onExpandedGroupIdsChange={(items) => setExpandedGroupIds(items)}
         rowHeight={getRowHeight}
-        // defaultMenuTabs={['filterMenuTab', 'generalMenuTab']}
-        // agGridProps={{
-        //   getRowId,
-        //   enableCellTextSelection: true,
-        //   enableRangeSelection: false,
-        //   autoGroupColumnDef: {
-        //     name: 'Event',
-        //     key: 'agGroupCellRenderer',
-        //     filterParams: {
-        //       filters: [{ filter: 'agTextColumnFilter' }, { filter: 'agSetColumnFilter', filterParams: { showTooltips: true } }],
-        //     },
-        //     menuTabs: ['filterMenuTab'],
-        //     sortable: true,
-        //     resizable: true,
-        //     sort: 'asc',
-        //   },
-        //   showOpenedGroup: true,
-        //   groupDefaultExpanded: 1,
-        // }}
       />
     </AutoFullHeightContainer>
   );

--- a/libs/ui/src/lib/data-table/DataTable.tsx
+++ b/libs/ui/src/lib/data-table/DataTable.tsx
@@ -1,11 +1,12 @@
 import { IconName } from '@jetstream/icon-factory';
 import { logger } from '@jetstream/shared/client-logger';
+import { useNonInitialEffect } from '@jetstream/shared/ui-utils';
 import { orderObjectsBy, orderStringsBy } from '@jetstream/shared/utils';
 import { SalesforceOrgUi } from '@jetstream/types';
 import { uniqueId } from 'lodash';
 import escapeRegExp from 'lodash/escapeRegExp';
 import isNil from 'lodash/isNil';
-import { useCallback, useContext, useEffect, useMemo, useReducer, useState } from 'react';
+import { forwardRef, useCallback, useContext, useEffect, useImperativeHandle, useMemo, useReducer, useState } from 'react';
 import DataGrid, {
   DataGridProps,
   HeaderRendererProps,
@@ -21,7 +22,7 @@ import Icon from '../widgets/Icon';
 import { DataTableFilterContext, DataTableGenericContext } from './data-table-context';
 import './data-table-styles.scss';
 import { ColumnWithFilter, DataTableFilter, FILTER_SET_TYPES, RowWithKey } from './data-table-types';
-import { EMPTY_FIELD, filterRecord, getSearchTextByRow, isFilterActive, resetFilter } from './data-table-utils';
+import { EMPTY_FIELD, filterRecord, getSearchTextByRow, isFilterActive, NON_DATA_COLUMN_KEYS, resetFilter } from './data-table-utils';
 import { configIdLinkRenderer, DraggableHeaderRenderer } from './DataTableRenderers';
 
 function sortStatus({ sortDirection, priority }: SortStatusProps) {
@@ -138,6 +139,16 @@ function reducer<T>(state: State<T>, action: Action): State<T> {
   }
 }
 
+export interface DataTableRef<T> {
+  hasSortApplied: () => boolean;
+  getFilteredAndSortedRows: () => readonly T[];
+  hasReorderedColumns: () => boolean;
+  /** Takes into account re-ordered columns */
+  getCurrentColumns: () => ColumnWithFilter<T>[];
+  /** Takes into account re-ordered columns */
+  getCurrentColumnNames: () => string[];
+}
+
 export type ContextMenuActionData<T> = {
   row: T;
   rows: T[];
@@ -146,7 +157,7 @@ export type ContextMenuActionData<T> = {
   columns: ColumnWithFilter<T, unknown>[];
 };
 
-export interface DataTableNewProps<T = RowWithKey, TContext = Record<string, any>>
+export interface DataTableProps<T = RowWithKey, TContext = Record<string, any>>
   extends Omit<DataGridProps<T>, 'columns' | 'rows' | 'rowKeyGetter'> {
   data: T[];
   columns: ColumnWithFilter<T>[];
@@ -163,187 +174,231 @@ export interface DataTableNewProps<T = RowWithKey, TContext = Record<string, any
   getRowKey: (row: T) => string;
   rowAlwaysVisible?: (row: T) => boolean;
   ignoreRowInSetFilter?: (row: T) => boolean;
+  onReorderColumns?: (columns: string[]) => void;
+  onSortedAndFilteredRowsChange?: (rows: readonly T[]) => void;
 }
 
-export const DataTable = <T extends object>({
-  data,
-  columns: _columns,
-  serverUrl,
-  org,
-  quickFilterText,
-  includeQuickFilter,
-  context,
-  allowReorder,
-  contextMenuItems,
-  contextMenuAction,
-  getRowKey,
-  ignoreRowInSetFilter,
-  rowAlwaysVisible,
-  ...rest
-}: DataTableNewProps<T>) => {
-  const [gridId] = useState(() => uniqueId('grid-'));
-  const [columns, setColumns] = useState(_columns || []);
-  const [sortColumns, setSortColumns] = useState<readonly SortColumn[]>([]);
-  const [rowFilterText, setRowFilterText] = useState<Record<string, string>>({});
-  const [renderers, setRenderers] = useState<Renderers<T, unknown>>({});
-
-  useEffect(() => {
-    if (contextMenuItems && contextMenuAction) {
-      setRenderers({
-        sortStatus,
-        rowRenderer: (key: React.Key, props: RowRendererProps<any>) => {
-          return (
-            <ContextMenuRenderer
-              key={key}
-              containerId={gridId}
-              props={props}
-              contextMenuItems={contextMenuItems}
-              contextMenuAction={contextMenuAction}
-            />
-          );
-        },
-      });
-    } else {
-      setRenderers({ sortStatus });
-    }
-  }, [contextMenuAction, contextMenuItems, gridId]);
-
-  const [{ columnMap, filters, filterSetValues }, dispatch] = useReducer(reducer, {
-    columnMap: new Map(),
-    filters: {},
-    filterSetValues: {},
-  });
-
-  useEffect(() => {
-    dispatch({ type: 'INIT', payload: { columns: _columns, data, ignoreRowInSetFilter } });
-  }, [_columns, data, ignoreRowInSetFilter]);
-
-  useEffect(() => {
-    setColumns(_columns);
-  }, [_columns]);
-
-  useEffect(() => {
-    if (Array.isArray(columns) && columns.length && Array.isArray(data) && data.length) {
-      setRowFilterText(getSearchTextByRow(data, columns, getRowKey));
-    } else {
-      setRowFilterText({});
-    }
-  }, [columns, data, getRowKey]);
-
-  const updateFilter = useCallback((column: string, filter: DataTableFilter) => {
-    dispatch({ type: 'UPDATE_FILTER', payload: { column, filter } });
-  }, []);
-
-  const sortedRows = useMemo((): readonly T[] => {
-    if (sortColumns.length === 0) {
-      return data;
-    }
-
-    return orderObjectsBy(
+export const DataTable = forwardRef<any, DataTableProps<any>>(
+  <T extends object>(
+    {
       data,
-      sortColumns.map(({ columnKey }) => columnKey) as any,
-      sortColumns.map(({ direction }) => (direction === 'ASC' ? 'asc' : 'desc'))
-    );
-  }, [data, sortColumns]);
+      columns: _columns,
+      serverUrl,
+      org,
+      quickFilterText,
+      includeQuickFilter,
+      context,
+      allowReorder,
+      contextMenuItems,
+      contextMenuAction,
+      getRowKey,
+      ignoreRowInSetFilter,
+      rowAlwaysVisible,
+      onReorderColumns,
+      onSortedAndFilteredRowsChange,
+      ...rest
+    }: DataTableProps<T>,
+    ref
+  ) => {
+    const [gridId] = useState(() => uniqueId('grid-'));
+    const [columns, setColumns] = useState(_columns || []);
+    const [sortColumns, setSortColumns] = useState<readonly SortColumn[]>([]);
+    const [rowFilterText, setRowFilterText] = useState<Record<string, string>>({});
+    const [renderers, setRenderers] = useState<Renderers<T, unknown>>({});
 
-  const filteredRows = useMemo((): readonly T[] => {
-    let quickFilterRegex: RegExp;
-    if (includeQuickFilter && quickFilterText) {
-      try {
-        quickFilterRegex = new RegExp(escapeRegExp(quickFilterText), 'i');
-      } catch (ex) {
-        logger.warn('Invalid quick filter text', ex);
-      }
-    }
-    return sortedRows.filter((row) => {
-      if (rowAlwaysVisible && rowAlwaysVisible(row)) {
-        return true;
-      }
-      const isVisible = Object.keys(filters)
-        .filter(
-          (columnKey) =>
-            Array.isArray(filters[columnKey]) &&
-            filters[columnKey].length &&
-            filters[columnKey].some((filter) => isFilterActive(filter, sortedRows.length))
-        )
-        .every((columnKey) => {
-          let rowValue = row[columnKey];
-          const column = columnMap.get(columnKey);
-          if (column?.getValue) {
-            rowValue = column.getValue({ row, column: columnMap.get(columnKey) });
-          }
-          return filters[columnKey]
-            .filter((filter) => isFilterActive(filter, sortedRows.length))
-            .every((filter) => {
-              const filterResult = filterRecord(filter, rowValue);
-              return filterResult;
-            });
+    useEffect(() => {
+      if (contextMenuItems && contextMenuAction) {
+        setRenderers({
+          sortStatus,
+          rowRenderer: (key: React.Key, props: RowRendererProps<any>) => {
+            return (
+              <ContextMenuRenderer
+                key={key}
+                containerId={gridId}
+                props={props}
+                contextMenuItems={contextMenuItems}
+                contextMenuAction={contextMenuAction}
+              />
+            );
+          },
         });
-      // Apply global filter
-      const key = getRowKey(row);
-      if (quickFilterRegex && key && rowFilterText[key]) {
-        return isVisible && quickFilterRegex.test(rowFilterText[key]);
+      } else {
+        setRenderers({ sortStatus });
       }
-      return isVisible;
+    }, [contextMenuAction, contextMenuItems, gridId]);
+
+    const [{ columnMap, filters, filterSetValues }, dispatch] = useReducer(reducer, {
+      columnMap: new Map(),
+      filters: {},
+      filterSetValues: {},
     });
-  }, [columnMap, filters, getRowKey, includeQuickFilter, quickFilterText, rowAlwaysVisible, rowFilterText, sortedRows]);
 
-  // This will be standard columns unless allowReorder is set to true
-  const draggableColumns = useMemo(() => {
-    if (!allowReorder) {
-      return columns;
-    }
-    function headerRenderer(props: HeaderRendererProps<T>) {
-      return <DraggableHeaderRenderer {...props} onColumnsReorder={handleColumnsReorder} />;
-    }
+    useEffect(() => {
+      dispatch({ type: 'INIT', payload: { columns: _columns, data, ignoreRowInSetFilter } });
+    }, [_columns, data, ignoreRowInSetFilter]);
 
-    function handleColumnsReorder(sourceKey: string, targetKey: string) {
-      const sourceColumnIndex = columns.findIndex((c) => c.key === sourceKey);
-      const targetColumnIndex = columns.findIndex((c) => c.key === targetKey);
-      const reorderedColumns = [...columns];
+    useNonInitialEffect(() => {
+      setColumns(_columns);
+    }, [_columns]);
 
-      reorderedColumns.splice(targetColumnIndex, 0, reorderedColumns.splice(sourceColumnIndex, 1)[0]);
+    useNonInitialEffect(() => {
+      onReorderColumns && onReorderColumns(columns.filter((column) => !NON_DATA_COLUMN_KEYS.has(column.key)).map(({ key }) => key));
+    }, [columns, onReorderColumns]);
 
-      setColumns(reorderedColumns);
-    }
-
-    return columns.map((column) => {
-      if (column.preventReorder || column.frozen) {
-        return column;
+    useEffect(() => {
+      if (Array.isArray(columns) && columns.length && Array.isArray(data) && data.length) {
+        setRowFilterText(getSearchTextByRow(data, columns, getRowKey));
+      } else {
+        setRowFilterText({});
       }
-      return { ...column, headerRenderer, _priorHeaderRenderer: column.headerRenderer };
-    });
-  }, [columns, allowReorder]);
+    }, [columns, data, getRowKey]);
 
-  if (serverUrl && org) {
-    configIdLinkRenderer(serverUrl, org);
+    const updateFilter = useCallback((column: string, filter: DataTableFilter) => {
+      dispatch({ type: 'UPDATE_FILTER', payload: { column, filter } });
+    }, []);
+
+    const sortedRows = useMemo((): readonly T[] => {
+      if (sortColumns.length === 0) {
+        return data;
+      }
+
+      return orderObjectsBy(
+        data,
+        sortColumns.map(({ columnKey }) => columnKey) as any,
+        sortColumns.map(({ direction }) => (direction === 'ASC' ? 'asc' : 'desc'))
+      );
+    }, [data, sortColumns]);
+
+    const filteredRows = useMemo((): readonly T[] => {
+      let quickFilterRegex: RegExp;
+      if (includeQuickFilter && quickFilterText) {
+        try {
+          quickFilterRegex = new RegExp(escapeRegExp(quickFilterText), 'i');
+        } catch (ex) {
+          logger.warn('Invalid quick filter text', ex);
+        }
+      }
+      return sortedRows.filter((row) => {
+        if (rowAlwaysVisible && rowAlwaysVisible(row)) {
+          return true;
+        }
+        const isVisible = Object.keys(filters)
+          .filter(
+            (columnKey) =>
+              Array.isArray(filters[columnKey]) &&
+              filters[columnKey].length &&
+              filters[columnKey].some((filter) => isFilterActive(filter, sortedRows.length))
+          )
+          .every((columnKey) => {
+            let rowValue = row[columnKey];
+            const column = columnMap.get(columnKey);
+            if (column?.getValue) {
+              rowValue = column.getValue({ row, column: columnMap.get(columnKey) });
+            }
+            return filters[columnKey]
+              .filter((filter) => isFilterActive(filter, sortedRows.length))
+              .every((filter) => {
+                const filterResult = filterRecord(filter, rowValue);
+                return filterResult;
+              });
+          });
+        // Apply global filter
+        const key = getRowKey(row);
+        if (quickFilterRegex && key && rowFilterText[key]) {
+          return isVisible && quickFilterRegex.test(rowFilterText[key]);
+        }
+        return isVisible;
+      });
+    }, [columnMap, filters, getRowKey, includeQuickFilter, quickFilterText, rowAlwaysVisible, rowFilterText, sortedRows]);
+
+    useEffect(() => {
+      onSortedAndFilteredRowsChange && onSortedAndFilteredRowsChange(filteredRows);
+    }, [filteredRows, onSortedAndFilteredRowsChange]);
+
+    // This will be standard columns unless allowReorder is set to true
+    const draggableColumns = useMemo(() => {
+      if (!allowReorder) {
+        return columns;
+      }
+      function headerRenderer(props: HeaderRendererProps<T>) {
+        return <DraggableHeaderRenderer {...props} onColumnsReorder={handleColumnsReorder} />;
+      }
+
+      function handleColumnsReorder(sourceKey: string, targetKey: string) {
+        const sourceColumnIndex = columns.findIndex((c) => c.key === sourceKey);
+        const targetColumnIndex = columns.findIndex((c) => c.key === targetKey);
+        const reorderedColumns = [...columns];
+
+        reorderedColumns.splice(targetColumnIndex, 0, reorderedColumns.splice(sourceColumnIndex, 1)[0]);
+
+        setColumns(reorderedColumns);
+      }
+
+      return columns.map((column) => {
+        if (column.preventReorder || column.frozen) {
+          return column;
+        }
+        return { ...column, headerRenderer, _priorHeaderRenderer: column.headerRenderer };
+      });
+    }, [columns, allowReorder]);
+
+    // NOTE: this is not used anywhere, so we may consider removing it.
+    useImperativeHandle<unknown, DataTableRef<T>>(
+      ref,
+      () => {
+        return {
+          hasSortApplied: () => sortColumns?.length > 0,
+          getFilteredAndSortedRows: () => filteredRows,
+          hasReorderedColumns: () => {
+            if (!allowReorder) {
+              return false;
+            }
+            const columnKeys = draggableColumns.filter((column) => !NON_DATA_COLUMN_KEYS.has(column.key)).map(({ key }) => key);
+            return (
+              allowReorder &&
+              draggableColumns
+                .filter((column) => !NON_DATA_COLUMN_KEYS.has(column.key))
+                .map(({ key }) => key)
+                .every((key, i) => columnKeys[i] === key)
+            );
+          },
+          getCurrentColumns: () => draggableColumns.filter((column) => !NON_DATA_COLUMN_KEYS.has(column.key)),
+          getCurrentColumnNames: () => draggableColumns.filter((column) => !NON_DATA_COLUMN_KEYS.has(column.key)).map(({ key }) => key),
+        };
+      },
+      [allowReorder, draggableColumns, filteredRows, sortColumns]
+    );
+
+    if (serverUrl && org) {
+      configIdLinkRenderer(serverUrl, org);
+    }
+
+    return (
+      <ContextMenuContext.Provider value={new Map()}>
+        <DataTableGenericContext.Provider value={{ ...context, rows: filteredRows, columns }}>
+          <DataTableFilterContext.Provider
+            value={{
+              filterSetValues,
+              filters,
+              portalRefForFilters: context?.portalRefForFilters,
+              updateFilter,
+            }}
+          >
+            <DataGrid
+              data-id={gridId}
+              className="rdg-light fill-grid"
+              columns={draggableColumns}
+              rows={filteredRows}
+              renderers={renderers}
+              sortColumns={sortColumns}
+              onSortColumnsChange={setSortColumns}
+              rowKeyGetter={getRowKey}
+              defaultColumnOptions={{ resizable: true, sortable: true, ...rest.defaultColumnOptions }}
+              {...rest}
+            />
+          </DataTableFilterContext.Provider>
+        </DataTableGenericContext.Provider>
+      </ContextMenuContext.Provider>
+    );
   }
-
-  return (
-    <ContextMenuContext.Provider value={new Map()}>
-      <DataTableGenericContext.Provider value={{ ...context, rows: filteredRows, columns }}>
-        <DataTableFilterContext.Provider
-          value={{
-            filterSetValues,
-            filters,
-            portalRefForFilters: context?.portalRefForFilters,
-            updateFilter,
-          }}
-        >
-          <DataGrid
-            data-id={gridId}
-            className="rdg-light fill-grid"
-            columns={draggableColumns}
-            rows={filteredRows}
-            renderers={renderers}
-            sortColumns={sortColumns}
-            onSortColumnsChange={setSortColumns}
-            rowKeyGetter={getRowKey}
-            defaultColumnOptions={{ resizable: true, sortable: true, ...rest.defaultColumnOptions }}
-            {...rest}
-          />
-        </DataTableFilterContext.Provider>
-      </DataTableGenericContext.Provider>
-    </ContextMenuContext.Provider>
-  );
-};
+);

--- a/libs/ui/src/lib/data-table/SalesforceRecordDataTable.tsx
+++ b/libs/ui/src/lib/data-table/SalesforceRecordDataTable.tsx
@@ -81,9 +81,7 @@ export const SalesforceRecordDataTable: FunctionComponent<SalesforceRecordDataTa
   }) => {
     const isMounted = useRef(null);
     const rollbar = useRollbar();
-    // const [gridApi, setGridApi] = useState<GridApi>(null);
     const [columns, setColumns] = useState<Column<RowWithKey>[]>();
-    // const [_columnDefinitions, setColumnDefinitions] = useState<Column<any>[]>();
     const [subqueryColumnsMap, setSubqueryColumnsMap] = useState<MapOf<ColumnWithFilter<RowWithKey, unknown>[]>>();
     const [records, setRecords] = useState<RowWithKey[]>();
     // Same as records but with additional data added
@@ -275,6 +273,11 @@ export const SalesforceRecordDataTable: FunctionComponent<SalesforceRecordDataTa
       }
     }
 
+    const handleColumnReorder = useCallback((newFields: string[]) => {
+      onFields({ allFields: newFields, visibleFields: newFields });
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+
     return records ? (
       <Fragment>
         <Grid className="slds-p-around_xx-small" align="spread">
@@ -325,7 +328,9 @@ export const SalesforceRecordDataTable: FunctionComponent<SalesforceRecordDataTa
               onCopy={handleCopy}
               rowHeight={28.5}
               selectedRows={selectedRows}
+              onReorderColumns={handleColumnReorder}
               onSelectedRowsChange={(rows) => setSelectedRows(rows as Set<string>)}
+              onSortedAndFilteredRowsChange={(rows) => onFilteredRowsChanged(rows as RowWithKey[])}
               contextMenuItems={contextMenuItems}
               contextMenuAction={handleContextMenuAction}
             />


### PR DESCRIPTION
Datatable was not emitting filtered records

Query result download now honors column re-order

Remove ability to reorder columns on load records preview

resolves #47
resolves #53