### PR TITLE
Feat/load from clipboard

### DIFF
--- a/apps/jetstream/src/app/components/load-records/LoadRecords.tsx
+++ b/apps/jetstream/src/app/components/load-records/LoadRecords.tsx
@@ -348,7 +348,7 @@ export const LoadRecords: FunctionComponent<LoadRecordsProps> = ({ featureFlags 
             <button
               data-testid="start-over-button"
               className="slds-button slds-button_neutral"
-              disabled={currentStep.idx === 0 || loading}
+              disabled={(currentStep.idx === 0 && !inputFileData && !selectedSObject) || loading}
               onClick={() => handleStartOver()}
             >
               <Icon type="utility" icon="refresh" className="slds-button__icon slds-button__icon_left" />

--- a/apps/jetstream/src/app/components/load-records/components/LoadRecordsDataPreview.tsx
+++ b/apps/jetstream/src/app/components/load-records/components/LoadRecordsDataPreview.tsx
@@ -61,7 +61,7 @@ function getLoadDescription(loadType: InsertUpdateUpsertDelete, totalRecordCount
 function getColumnDefinitions(headers: string[]): Column<RowWithKey>[] {
   return getColumnsForGenericTable([
     { key: NUM_COLUMN, label: '#', columnProps: { width: 75, filters: [] } },
-    ...headers.map((header) => ({ key: header, label: header, columnProps: { width: 100 } })),
+    ...headers.map((header) => ({ key: header, label: header })),
   ]);
 }
 
@@ -153,6 +153,7 @@ export const LoadRecordsDataPreview: FunctionComponent<LoadRecordsDataPreviewPro
               css={css`
                 position: absolute;
                 max-width: 100%;
+                min-width: 100%;
               `}
             >
               <div className="slds-text-heading_small">File Preview</div>

--- a/libs/icon-factory/src/lib/icon-factory.tsx
+++ b/libs/icon-factory/src/lib/icon-factory.tsx
@@ -94,6 +94,7 @@ import UtilityIcon_NewWindow from './icons/utility/NewWindow';
 import UtilityIcon_Notification from './icons/utility/Notification';
 import UtilityIcon_OpenFolder from './icons/utility/OpenFolder';
 import UtilityIcon_Page from './icons/utility/Page';
+import UtilityIcon_Paste from './icons/utility/Paste';
 import UtilityIcon_Play from './icons/utility/Play';
 import UtilityIcon_Preview from './icons/utility/Preview';
 import UtilityIcon_PromptEdit from './icons/utility/PromptEdit';
@@ -212,6 +213,7 @@ const utilityIcons: UtilityIconObj = {
   notification: UtilityIcon_Notification,
   open_folder: UtilityIcon_OpenFolder,
   page: UtilityIcon_Page,
+  paste: UtilityIcon_Paste,
   play: UtilityIcon_Play,
   preview: UtilityIcon_Preview,
   prompt_edit: UtilityIcon_PromptEdit,

--- a/libs/icon-factory/src/lib/icon-types.tsx
+++ b/libs/icon-factory/src/lib/icon-types.tsx
@@ -105,6 +105,7 @@ export interface UtilityIconObj {
   notification: IconEl;
   open_folder: IconEl;
   page: IconEl;
+  paste: IconEl;
   play: IconEl;
   preview: IconEl;
   prompt_edit: IconEl;

--- a/libs/shared/ui-utils/src/lib/hooks/useGoogleApi.ts
+++ b/libs/shared/ui-utils/src/lib/hooks/useGoogleApi.ts
@@ -30,7 +30,6 @@ export interface GoogleApiClientConfig {
  * @returns
  */
 export function useGoogleApi({ clientId, scopes = [SCOPES['drive.file']] }: GoogleApiClientConfig) {
-  const isMounted = useRef(null);
   const rollbar = useRollbar();
   const tokenClient = useRef<google.accounts.oauth2.TokenClient>(_tokenClient);
   const tokenResponse = useRef<google.accounts.oauth2.TokenResponse>(_tokenResponse);
@@ -43,17 +42,10 @@ export function useGoogleApi({ clientId, scopes = [SCOPES['drive.file']] }: Goog
   const [gisScriptLoaded, gisScriptLoadError] = useInjectScriptGis();
   const [loading, setLoading] = useState(!_apiLoaded);
   const [error, setError] = useState<string>();
-  const [hasApisLoaded, setHasApisLoaded] = useState(_apiLoaded);
+  const [hasApisLoaded, setHasApisLoaded] = useState(() => _apiLoaded && !!gapi && !!google?.accounts?.oauth2);
 
   const scriptLoaded = gapiScriptLoaded && gisScriptLoaded;
   const scriptLoadedError = gapiScriptLoadError || gisScriptLoadError;
-
-  useEffect(() => {
-    isMounted.current = true;
-    return () => {
-      isMounted.current = false;
-    };
-  }, []);
 
   // get the apis from googleapis
   useEffect(() => {
@@ -95,7 +87,7 @@ export function useGoogleApi({ clientId, scopes = [SCOPES['drive.file']] }: Goog
   }, []);
 
   useNonInitialEffect(() => {
-    if (hasApisLoaded && gapi) {
+    if (hasApisLoaded && gapi && google?.accounts?.oauth2) {
       tokenClient.current = google.accounts.oauth2.initTokenClient({
         client_id: clientId,
         scope: scopes.join(' '),

--- a/libs/shared/ui-utils/src/lib/shared-ui-utils.ts
+++ b/libs/shared/ui-utils/src/lib/shared-ui-utils.ts
@@ -1068,6 +1068,7 @@ export async function parseFile(
   options?: {
     onParsedMultipleWorkbooks?: (worksheets: string[]) => Promise<string>;
     isBinaryString?: boolean;
+    isPasteFromClipboard?: boolean;
   }
 ): Promise<{
   data: any[];
@@ -1078,14 +1079,14 @@ export async function parseFile(
   if (!options.isBinaryString && isString(content)) {
     // csv - read from papaparse
     const csvResult = parseCsv(content, {
-      delimiter: detectDelimiter(),
+      delimiter: options.isPasteFromClipboard ? undefined : detectDelimiter(),
       header: true,
       skipEmptyLines: true,
     });
     return {
       data: csvResult.data,
       headers: Array.from(new Set(csvResult.meta.fields)), // remove duplicates, if any
-      errors: csvResult.errors.map((error) => `Row ${error.row}: ${error.message}`),
+      errors: csvResult.errors.map((error) => (error.row ? `Row ${error.row}: ${error.message}` : error.message)),
     };
   } else {
     // ArrayBuffer / binary string - xlsx file

--- a/libs/types/src/lib/ui/types.ts
+++ b/libs/types/src/lib/ui/types.ts
@@ -555,6 +555,7 @@ export interface InputReadFileContent<T = string | ArrayBuffer> {
   filename: string;
   extension: string;
   content: T;
+  isPasteFromClipboard?: boolean;
 }
 
 export interface ImageWithUpload extends InputReadFileContent<string> {

--- a/libs/ui/src/index.ts
+++ b/libs/ui/src/index.ts
@@ -10,7 +10,7 @@ export * from './lib/color-picker/ColorSwatches';
 export * from './lib/confirmation-dialog/ConfirmationDialog';
 export * from './lib/data-table/data-table-context';
 export * from './lib/data-table/data-table-formatters';
-export { ColumnWithFilter, RowWithKey } from './lib/data-table/data-table-types';
+export type { ColumnWithFilter, RowWithKey } from './lib/data-table/data-table-types';
 export { getColumnsForGenericTable, setColumnFromType } from './lib/data-table/data-table-utils';
 export * from './lib/data-table/DataTable';
 export * from './lib/data-table/DataTableRenderers';

--- a/libs/ui/src/lib/data-table/DataTableRenderers.tsx
+++ b/libs/ui/src/lib/data-table/DataTableRenderers.tsx
@@ -532,7 +532,7 @@ export function GenericRenderer(formatterProps: FormatterProps<RowWithKey>) {
     value = <ComplexDataRenderer {...formatterProps} />;
   }
 
-  return <div>{value}</div>;
+  return <div className="slds-truncate">{value}</div>;
 }
 
 export function SelectFormatter<T>(props: FormatterProps<T>) {

--- a/libs/ui/src/lib/data-table/data-table-utils.tsx
+++ b/libs/ui/src/lib/data-table/data-table-utils.tsx
@@ -69,10 +69,8 @@ export function getColumnsForGenericTable(
     const column: Mutable<ColumnWithFilter<RowWithKey>> = {
       name: label,
       key,
-      cellClass: 'slds-truncate',
       resizable: true,
       sortable: true,
-      width: 200,
       filters: ['TEXT', 'SET'],
       formatter: GenericRenderer,
       headerRenderer: (props) => (

--- a/libs/ui/src/lib/data-table/data-table-utils.tsx
+++ b/libs/ui/src/lib/data-table/data-table-utils.tsx
@@ -17,7 +17,7 @@ import isObject from 'lodash/isObject';
 import isString from 'lodash/isString';
 import uniqueId from 'lodash/uniqueId';
 import { SelectColumn, SELECT_COLUMN_KEY as _SELECT_COLUMN_KEY } from 'react-data-grid';
-import { FieldSubquery, getFlattenedFields, isFieldSubquery } from 'soql-parser-js';
+import { FieldSubquery, getField, getFlattenedFields, isFieldSubquery } from 'soql-parser-js';
 import {
   dataTableAddressValueFormatter,
   dataTableDateFormatter,
@@ -130,6 +130,14 @@ export function getColumnDefinitions(results: QueryResults<any>, isTooling: bool
       }
       return out;
     }, {});
+  }
+  // If there is a FIELDS('') clause in the query, then we know the data will not be shown
+  // in this case, fall back to Salesforce column data instead of the query results
+  const hasFieldsQuery = results.parsedQuery.fields.some(
+    (field) => field.type === 'FieldFunctionExpression' && field.functionName === 'FIELDS'
+  );
+  if (hasFieldsQuery) {
+    results.parsedQuery.fields = results.columns?.columns.map((column) => getField(column.columnFullPath));
   }
 
   // Base fields


### PR DESCRIPTION
Added ability to paste data from clipboard as a source to load records

Added warning message if error parsing CSV

Allow auto-width for load table preview columns

resolves https://github.com/jetstreamapp/jetstream/issues/71

-----

Prevent load from being set to true if not fully initialized

resolves https://github.com/jetstreamapp/jetstream/issues/79
resolves https://github.com/jetstreamapp/jetstream/issues/28

-----

Fallback as the easy option since it is complicated to figure out otherwise
and these queries would rarely be used in Jetstream since query builder
solves the need of these types of queries

resolves https://github.com/jetstreamapp/jetstream/issues/78