### PR TITLE
Fix custom metadata load results table

### DIFF
--- a/apps/jetstream/src/app/components/load-records/steps/PerformLoadCustomMetadata.tsx
+++ b/apps/jetstream/src/app/components/load-records/steps/PerformLoadCustomMetadata.tsx
@@ -151,7 +151,7 @@ export const PerformLoadCustomMetadata: FunctionComponent<PerformLoadCustomMetad
     );
     let header: string[] = [];
     let data = Object.keys(metadata).map((fullName) => {
-      if (!header) {
+      if (!header.length) {
         header = ['_id', '_success', '_error', '_created', '_changed', ...Object.keys(metadata[fullName].record)];
       }
       return {


### PR DESCRIPTION
Header was not set, causing the table to now show any data