### PR TITLE
Fix deploy metadata between orgs

### DIFF
--- a/apps/jetstream/src/app/components/deploy/deploy-to-different-org/DeployMetadataToOrg.tsx
+++ b/apps/jetstream/src/app/components/deploy/deploy-to-different-org/DeployMetadataToOrg.tsx
@@ -73,7 +73,7 @@ export const DeployMetadataToOrg: FunctionComponent<DeployMetadataToOrgProps> = 
       {configModalOpen && selectedMetadata && (
         <DeployMetadataToOrgConfigModal
           sourceOrg={selectedOrg}
-          initialOptions={deployMetadataOptions || {}}
+          initialOptions={deployMetadataOptions}
           initialSelectedDestinationOrg={destinationOrg}
           selectedMetadata={selectedMetadata}
           onClose={handleCloseConfigModal}

--- a/apps/jetstream/src/app/components/deploy/deploy-to-different-org/DeployMetadataToOrgConfigModal.tsx
+++ b/apps/jetstream/src/app/components/deploy/deploy-to-different-org/DeployMetadataToOrgConfigModal.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react';
 import { useNonInitialEffect } from '@jetstream/shared/ui-utils';
-import { DeployOptions, ListMetadataResult, MapOf, SalesforceOrgUi } from '@jetstream/types';
+import { DeployOptions, ListMetadataResult, MapOf, Maybe, SalesforceOrgUi } from '@jetstream/types';
 import { Grid, GridCol, Icon, Modal } from '@jetstream/ui';
 import { Fragment, FunctionComponent, useEffect, useRef, useState } from 'react';
 import { useRecoilValue } from 'recoil';
@@ -13,7 +13,7 @@ const DISABLED_OPTIONS = new Set<keyof DeployOptions>(['allowMissingFiles', 'aut
 
 export interface DeployMetadataToOrgConfigModalProps {
   sourceOrg: SalesforceOrgUi;
-  initialOptions?: DeployOptions;
+  initialOptions?: Maybe<DeployOptions>;
   initialSelectedDestinationOrg?: SalesforceOrgUi;
   selectedMetadata: MapOf<ListMetadataResult[]>;
   onSelection?: (deployOptions: DeployOptions) => void;


### PR DESCRIPTION
initialOptions was defaulted to an empty object causing the deployment to fail

resolves #198