### PR TITLE
Org fixes

### DIFF
--- a/apps/api/src/app/controllers/oauth.controller.ts
+++ b/apps/api/src/app/controllers/oauth.controller.ts
@@ -14,8 +14,7 @@ import { OauthLinkParams } from './auth.controller';
 export function salesforceOauthInitAuth(req: express.Request, res: express.Response) {
   const loginUrl = req.query.loginUrl as string;
   const clientUrl = req.query.clientUrl as string;
-  const replaceOrgUniqueId = req.query.replaceOrgUniqueId as string | undefined;
-  const state = new URLSearchParams({ loginUrl, clientUrl, replaceOrgUniqueId: replaceOrgUniqueId || '' }).toString();
+  const state = new URLSearchParams({ loginUrl, clientUrl }).toString();
 
   let options = {
     scope: 'api web refresh_token',
@@ -40,7 +39,6 @@ export async function salesforceOauthCallback(req: express.Request, res: express
   const state = new URLSearchParams(req.query.state as string);
   const loginUrl = state.get('loginUrl');
   const clientUrl = state.get('clientUrl') || new URL(ENV.JETSTREAM_CLIENT_URL!).origin;
-  const replaceOrgUniqueId = state.get('replaceOrgUniqueId') || undefined;
   const returnParams: OauthLinkParams = {
     type: 'salesforce',
     clientUrl,
@@ -65,7 +63,6 @@ export async function salesforceOauthCallback(req: express.Request, res: express
       userInfo,
       loginUrl: loginUrl as string,
       userId: user.id,
-      replaceOrgUniqueId,
     });
 
     // TODO: figure out what other data we need
@@ -95,13 +92,11 @@ export async function initConnectionFromOAuthResponse({
   userInfo,
   loginUrl,
   userId,
-  replaceOrgUniqueId,
 }: {
   conn: jsforce.Connection;
   userInfo: jsforce.UserInfo;
   loginUrl: string;
   userId: string;
-  replaceOrgUniqueId?: string;
 }) {
   const identity = await conn.identity();
   let companyInfoRecord: SObjectOrganization | undefined;
@@ -141,6 +136,6 @@ export async function initConnectionFromOAuthResponse({
     orgTrialExpirationDate: companyInfoRecord?.TrialExpirationDate,
   };
 
-  const salesforceOrg = await salesforceOrgsDb.createOrUpdateSalesforceOrg(userId, salesforceOrgUi, replaceOrgUniqueId);
+  const salesforceOrg = await salesforceOrgsDb.createOrUpdateSalesforceOrg(userId, salesforceOrgUi);
   return salesforceOrg;
 }

--- a/apps/api/src/app/controllers/orgs.controller.ts
+++ b/apps/api/src/app/controllers/orgs.controller.ts
@@ -1,5 +1,9 @@
+import { logger } from '@jetstream/api-config';
+import { ERROR_MESSAGES } from '@jetstream/shared/constants';
 import { UserProfileServer } from '@jetstream/types';
+import { SalesforceOrg } from '@prisma/client';
 import { NextFunction, Request, Response } from 'express';
+import * as jsforce from 'jsforce';
 import * as salesforceOrgsDb from '../db/salesforce-org.db';
 import { UserFacingError } from '../utils/error-handler';
 import { sendJson } from '../utils/response.handlers';
@@ -34,6 +38,39 @@ export async function deleteOrg(req: Request, res: Response, next: NextFunction)
     salesforceOrgsDb.deleteSalesforceOrg(user.id, req.params.uniqueId);
 
     sendJson(res, undefined, 204);
+  } catch (ex) {
+    next(new UserFacingError(ex.message));
+  }
+}
+
+/**
+ * Check if the org is still valid
+ * This can be used to retry an org that has been marked as invalid
+ */
+export async function checkOrgHealth(req: Request, res: Response, next: NextFunction) {
+  try {
+    const userInfo = req.user ? { username: (req.user as any)?.displayName, userId: (req.user as any)?.user_id } : undefined;
+    const conn: jsforce.Connection = res.locals.jsforceConn;
+    const org = res.locals.org as SalesforceOrg;
+
+    let connectionError = org.connectionError;
+
+    try {
+      await conn.identity();
+      connectionError = null;
+      logger.warn('[ORG CHECK][VALID ORG]');
+    } catch (ex) {
+      connectionError = ERROR_MESSAGES.SFDC_EXPIRED_TOKEN;
+      logger.warn('[ORG CHECK][INVALID ORG] %s', ex.message);
+    }
+
+    try {
+      await salesforceOrgsDb.updateOrg_UNSAFE(org, { connectionError });
+    } catch (ex) {
+      logger.warn('[ERROR UPDATING INVALID ORG] %s', ex.message, { error: ex.message, userInfo });
+    }
+
+    sendJson(res, undefined, 200);
   } catch (ex) {
     next(new UserFacingError(ex.message));
   }

--- a/apps/api/src/app/routes/api.routes.ts
+++ b/apps/api/src/app/routes/api.routes.ts
@@ -40,6 +40,7 @@ routes.get(
   validate(sfMiscController.routeValidators.streamFileDownload),
   sfMiscController.streamFileDownload
 );
+routes.post('/orgs/health-check', ensureOrgExists, orgsController.checkOrgHealth);
 
 routes.get('/orgs', orgsController.getOrgs);
 routes.patch('/orgs/:uniqueId', orgsController.updateOrg);

--- a/apps/electron/jetstream/src/app/app.ts
+++ b/apps/electron/jetstream/src/app/app.ts
@@ -573,12 +573,7 @@ export default class App {
       }
 
       if (_url.pathname === '/oauth/sfdc/auth') {
-        const redirectURL = sfdcOauth.getRedirectUrl(
-          windowId,
-          'jetstream',
-          _url.searchParams.get('loginUrl'),
-          _url.searchParams.get('replaceOrgUniqueId')
-        );
+        const redirectURL = sfdcOauth.getRedirectUrl(windowId, 'jetstream', _url.searchParams.get('loginUrl'));
         logger.log('[REDIRECT][SHELL]', redirectURL);
         shell.openExternal(redirectURL);
 

--- a/apps/electron/jetstream/src/app/services/sfdc-oauth.ts
+++ b/apps/electron/jetstream/src/app/services/sfdc-oauth.ts
@@ -3,9 +3,9 @@ import * as jsforce from 'jsforce';
 import { environment } from '../../environments/environment';
 import logger from './logger';
 
-export function getRedirectUrl(windowId: number, protocol: 'jetstream' | 'http', loginUrl: string, replaceOrgUniqueId?: string) {
+export function getRedirectUrl(windowId: number, protocol: 'jetstream' | 'http', loginUrl: string) {
   // TODO: we might need to determine if packaged or not and use a different url (e.x. jetstream://)
-  const state = new URLSearchParams({ loginUrl, replaceOrgUniqueId, windowId: `${windowId}` }).toString();
+  const state = new URLSearchParams({ loginUrl, windowId: `${windowId}` }).toString();
   const options = {
     scope: 'api web refresh_token',
     state,
@@ -28,8 +28,6 @@ export async function exchangeCodeForToken(protocol: 'jetstream' | 'http', param
 
   const state = new URLSearchParams(params.get('state'));
   const loginUrl = state.get('loginUrl');
-  // TODO: might want to send back to delete this old invalid org
-  const replaceOrgUniqueId = state.get('replaceOrgUniqueId');
 
   const conn = new jsforce.Connection({
     oauth2: new jsforce.OAuth2({

--- a/apps/electron/worker/src/app/controllers/app.controller.ts
+++ b/apps/electron/worker/src/app/controllers/app.controller.ts
@@ -60,3 +60,18 @@ export const handleDeleteOrg: ControllerFnParams<{ uniqueId: string }> = async (
     reject(ex);
   }
 };
+
+export const handleOrgHealthCheck: ControllerFnParams<{ uniqueId: string }> = async (
+  _,
+  __,
+  params,
+  { reject, resolve, connection, request }
+) => {
+  try {
+    // const orgs = await deleteOrg(params.uniqueId);
+    // TODO: implement for electron
+    resolve(null);
+  } catch (ex) {
+    reject(ex);
+  }
+};

--- a/apps/electron/worker/src/app/electron.routes.ts
+++ b/apps/electron/worker/src/app/electron.routes.ts
@@ -24,6 +24,7 @@ router.on('GET', '/api/me', appController.getUserProfile);
 router.on('GET', '/api/orgs', appController.handleGetOrgs);
 router.on('PATCH', '/api/orgs/:uniqueId', appController.handleUpdateOrg);
 router.on('DELETE', '/api/orgs/:uniqueId', appController.handleDeleteOrg);
+router.on('POST', '/api/orgs/:uniqueId/health-check', appController.handleOrgHealthCheck); // TODO:
 
 router.on('GET', '/api/images/upload-signature', appController.placeholder); // TODO:
 router.on('POST', '/api/feedback/submit', appController.placeholder); // TODO:

--- a/apps/jetstream/src/app/app-state.ts
+++ b/apps/jetstream/src/app/app-state.ts
@@ -90,7 +90,11 @@ async function getSelectedOrgFromStorage(): Promise<string | undefined> {
 }
 
 async function fetchAppVersion() {
-  return await checkHeartbeat();
+  try {
+    return await checkHeartbeat();
+  } catch (ex) {
+    return { version: 'unknown' };
+  }
 }
 
 async function fetchUserProfile(): Promise<UserProfileUi> {

--- a/apps/jetstream/src/app/components/core/OrgsCombobox.tsx
+++ b/apps/jetstream/src/app/components/core/OrgsCombobox.tsx
@@ -42,11 +42,11 @@ function getSelectedItemStyle(org: Maybe<SalesforceOrgUi>): SerializedStyles | u
 function getDropdownOrgStyle(org: Maybe<SalesforceOrgUi>): SerializedStyles | undefined {
   if (!org || !org.color) {
     return css({
-      borderLeft: `solid 0.3rem transparent`,
+      borderBottom: `solid 0.3rem transparent`,
     });
   }
   return css({
-    borderLeft: `solid 0.3rem ${org.color}`,
+    borderBottom: `solid 0.3rem ${org.color}`,
   });
 }
 
@@ -127,6 +127,7 @@ export const OrgsCombobox: FunctionComponent<OrgsComboboxProps> = ({
                 id={org.uniqueId}
                 label={org.label || org.username}
                 secondaryLabel={org.username !== org.label ? org.username : undefined}
+                secondaryLabelOnNewLine={org.username !== org.label}
                 hasError={orgHasError(org)}
                 selected={!!selectedOrg && selectedOrg.uniqueId === org.uniqueId}
                 textBodyCss={getDropdownOrgStyle(org)}

--- a/apps/jetstream/src/app/components/orgs/OrgInfoPopover.tsx
+++ b/apps/jetstream/src/app/components/orgs/OrgInfoPopover.tsx
@@ -44,7 +44,7 @@ export interface OrgInfoPopoverProps {
   org: SalesforceOrgUi;
   loading?: boolean;
   disableOrgActions?: boolean;
-  onAddOrg: (org: SalesforceOrgUi, switchActiveOrg: boolean, replaceOrgUniqueId?: string) => void;
+  onAddOrg: (org: SalesforceOrgUi, switchActiveOrg: boolean) => void;
   onRemoveOrg: (org: SalesforceOrgUi) => void;
   onUpdateOrg: (org: SalesforceOrgUi, updatedOrg: Partial<SalesforceOrgUi>) => void;
 }
@@ -117,16 +117,9 @@ export const OrgInfoPopover: FunctionComponent<OrgInfoPopoverProps> = ({
   }, [org]);
 
   function handleFixOrg() {
-    addOrg(
-      { serverUrl: applicationState.serverUrl, loginUrl: org.instanceUrl, replaceOrgUniqueId: org.uniqueId },
-      (addedOrg: SalesforceOrgUi) => {
-        let replaceOrgUniqueId: string | undefined = undefined;
-        if (addedOrg.uniqueId !== org.uniqueId) {
-          replaceOrgUniqueId = org.uniqueId;
-        }
-        onAddOrg(addedOrg, true, replaceOrgUniqueId);
-      }
-    );
+    addOrg({ serverUrl: applicationState.serverUrl, loginUrl: org.instanceUrl }, (addedOrg: SalesforceOrgUi) => {
+      onAddOrg(addedOrg, true);
+    });
   }
 
   function handleLabelChange(event: React.ChangeEvent<HTMLInputElement>) {

--- a/libs/shared/data/src/lib/client-data.ts
+++ b/libs/shared/data/src/lib/client-data.ts
@@ -105,6 +105,10 @@ export async function deleteOrg(org: SalesforceOrgUi): Promise<void> {
   return handleRequest({ method: 'DELETE', url: `/api/orgs/${org.uniqueId}` }).then(unwrapResponseIgnoreCache);
 }
 
+export async function checkOrgHealth(org: SalesforceOrgUi): Promise<void> {
+  return handleRequest({ method: 'POST', url: `/api/orgs/health-check` }, { org }).then(unwrapResponseIgnoreCache);
+}
+
 /**
  * First an upload signature is obtained from the server, if needed (good for 1 hour)
  * Then images are uploaded directly to cloudinary

--- a/libs/shared/ui-utils/src/lib/shared-ui-utils.ts
+++ b/libs/shared/ui-utils/src/lib/shared-ui-utils.ts
@@ -839,20 +839,14 @@ function handleWindowEvent(event: MessageEvent) {
   }
 }
 
-export function addOrg(
-  options: { serverUrl: string; loginUrl: string; replaceOrgUniqueId?: string },
-  callback: (org: SalesforceOrgUi) => void
-) {
-  const { serverUrl, loginUrl, replaceOrgUniqueId } = options;
+export function addOrg(options: { serverUrl: string; loginUrl: string }, callback: (org: SalesforceOrgUi) => void) {
+  const { serverUrl, loginUrl } = options;
   addOrgCallbackFn = callback;
   window.removeEventListener('message', handleWindowEvent);
   const strWindowFeatures = 'toolbar=no, menubar=no, width=1025, height=700';
   let url = `${serverUrl}/oauth/sfdc/auth?`;
   url += `loginUrl=${encodeURIComponent(loginUrl)}`;
   url += `&clientUrl=${encodeURIComponent(document.location.origin)}`;
-  if (replaceOrgUniqueId) {
-    url += `&replaceOrgUniqueId=${encodeURIComponent(replaceOrgUniqueId)}`;
-  }
   windowRef = window.open(url, 'Add Salesforce Org', strWindowFeatures);
   window.addEventListener('message', handleWindowEvent, false);
 }

--- a/libs/types/src/lib/ui/types.ts
+++ b/libs/types/src/lib/ui/types.ts
@@ -405,7 +405,6 @@ export type JetstreamEvents = JetstreamEventJobFinished | JetstreamEventLastActi
 export interface JetstreamEventAddOrgPayload {
   org: SalesforceOrgUi;
   switchActiveOrg: boolean;
-  replaceOrgUniqueId?: string;
 }
 export type JetstreamEventPayloads = AsyncJob | AsyncJobNew[] | JetstreamEventAddOrgPayload;
 


### PR DESCRIPTION
When an org is added, auto-delete any other org with same username

Deprecate replaceOrgUniqueId in favor of above logic which works for broader set of use-cases.

Org dropdown uses two lines to show items with a label

Use bottom border instead of left border for org color in dropdown menu

Added ability to check org health in case an org was marked as invalid for something like a network connection issue

resolves #220
resolves #221