### PR TITLE
SOQL query builder inserting values as strings #270

### DIFF
--- a/libs/shared/ui-utils/src/lib/shared-ui-utils.ts
+++ b/libs/shared/ui-utils/src/lib/shared-ui-utils.ts
@@ -664,7 +664,7 @@ export function unescapeSoqlString(value: string) {
 }
 
 function getLiteralType(selected: ExpressionConditionRowSelectedItems): LiteralType {
-  const field: Field = safeGet(selected, 'resourceMeta.metadata');
+  const field: Field = safeGet(selected, 'resourceMeta');
 
   if (selected.operator === 'isNull' || selected.operator === 'isNotNull') {
     return 'NULL';


### PR DESCRIPTION
Fix getLiteralType based on the type of the value, the path of object metadata changed and was not updated

resolves #270