### PR TITLE
Advanced query regression bugfixes #287 #288

### DIFF
--- a/apps/jetstream/src/app/components/query/QueryBuilder/QueryChildFields.tsx
+++ b/apps/jetstream/src/app/components/query/QueryBuilder/QueryChildFields.tsx
@@ -95,9 +95,8 @@ export const QueryChildFields: FunctionComponent<QueryChildFieldsProps> = ({
         const basePath = queryField.key.replace(/.+\|/, '');
         return sortQueryFieldsStr(Array.from(queryField.selectedFields)).map(
           (field): QueryFieldWithPolymorphic => ({
-            field,
+            field: `${basePath}${field}`,
             polymorphicObj: queryField.isPolymorphic ? queryField.sobject : undefined,
-            // path: `${basePath}${field}`,
             metadata: queryField.fields[field].metadata,
           })
         );

--- a/apps/jetstream/src/app/components/query/QueryOptions/QueryFieldFunction.tsx
+++ b/apps/jetstream/src/app/components/query/QueryOptions/QueryFieldFunction.tsx
@@ -20,7 +20,7 @@ export const QueryFieldFunction = ({ hasGroupByClause, selectedFields }: QueryFi
       selectedFields.map(
         (field): ListItem<string, QueryFieldWithPolymorphic> => ({
           id: field.field,
-          label: field.metadata.label,
+          label: field.metadata?.label || field.field,
           value: field.field,
           secondaryLabel: field.field,
           secondaryLabelOnNewLine: true,

--- a/apps/jetstream/src/app/components/query/utils/query-soql-utils.ts
+++ b/apps/jetstream/src/app/components/query/utils/query-soql-utils.ts
@@ -4,14 +4,15 @@ import { getFieldKey } from '@jetstream/shared/ui-utils';
 import { orderStringsBy } from '@jetstream/shared/utils';
 import { MapOf, Maybe, SalesforceOrgUi } from '@jetstream/types';
 import type { DescribeGlobalSObjectResult, DescribeSObjectResult, Field } from 'jsforce';
+import isString from 'lodash/isString';
 import {
+  OrderByFieldClause,
+  Query,
   FieldType as QueryFieldType,
+  WhereClause,
   isOrderByField,
   isValueCondition,
   isWhereOrHavingClauseWithRightCondition,
-  OrderByFieldClause,
-  Query,
-  WhereClause,
 } from 'soql-parser-js';
 import { getQueryFieldBaseKey, getSubqueryFieldBaseKey } from './query-fields-utils';
 
@@ -175,6 +176,11 @@ function getParsableFields(fields: QueryFieldType[]): ParsableFields {
     (output: ParsableFields, field) => {
       if (field.type === 'Field') {
         output.fields.push(field.field);
+      }
+      if (field.type === 'FieldFunctionExpression') {
+        if (isString(field.parameters[0])) {
+          output.fields.push(field.parameters[0]);
+        }
       } else if (field.type === 'FieldRelationship') {
         output.fields.push(field.rawValue || '');
       } else if (field.type === 'FieldTypeof') {

--- a/libs/shared/ui-utils/src/lib/shared-ui-utils.ts
+++ b/libs/shared/ui-utils/src/lib/shared-ui-utils.ts
@@ -235,6 +235,9 @@ export function sortQueryFieldsPolymorphicComparable(field1: QueryFieldWithPolym
 }
 
 export function polyfillFieldDefinition(field: Field): string {
+  if (!field) {
+    return '';
+  }
   const autoNumber: boolean = field.autoNumber;
   const { type, calculated, calculatedFormula, externalId, nameField, extraTypeInfo, length, precision, referenceTo, scale } = field;
   let prefix = '';


### PR DESCRIPTION
Fixed relationship field path for subquery related fields to fix relationship fields in subqueries

Fixed query restore for relationship fields, typeof fields, and field functions with relationship fields

Ensure all metadata for field functions is queried when restoring, including relationships within functions

#287
resolves #288