### PR TITLE
Enhancement 52 - Allow query record as json

### DIFF
--- a/apps/jetstream/src/app/components/query/QueryResults/QueryResults.tsx
+++ b/apps/jetstream/src/app/components/query/QueryResults/QueryResults.tsx
@@ -16,17 +16,7 @@ import {
   useObservable,
 } from '@jetstream/shared/ui-utils';
 import { getRecordIdFromAttributes, getSObjectNameFromAttributes, pluralizeIfMultiple } from '@jetstream/shared/utils';
-import {
-  AsyncJob,
-  AsyncJobNew,
-  BulkDownloadJob,
-  CloneEditView,
-  FileExtCsvXLSXJsonGSheet,
-  MapOf,
-  Maybe,
-  Record,
-  SalesforceOrgUi,
-} from '@jetstream/types';
+import { AsyncJob, AsyncJobNew, CloneEditView, MapOf, Maybe, Record, SalesforceOrgUi } from '@jetstream/types';
 import {
   AutoFullHeightContainer,
   CampingRainIllustration,
@@ -34,7 +24,6 @@ import {
   Grid,
   GridCol,
   Icon,
-  RecordDownloadModal,
   SalesforceRecordDataTable,
   Spinner,
   Toolbar,
@@ -44,11 +33,12 @@ import {
   useConfirmation,
 } from '@jetstream/ui';
 import classNames from 'classnames';
+import copyToClipboard from 'copy-to-clipboard';
 import React, { Fragment, FunctionComponent, useCallback, useEffect, useRef, useState } from 'react';
 import { Link, NavLink, useLocation, useNavigate } from 'react-router-dom';
 import { useRecoilState, useRecoilValue } from 'recoil';
 import { filter } from 'rxjs/operators';
-import { Query, WhereClause } from 'soql-parser-js';
+import { Query } from 'soql-parser-js';
 import { applicationCookieState, selectedOrgState } from '../../../app-state';
 import { useAmplitude } from '../../core/analytics';
 import * as fromJetstreamEvents from '../../core/jetstream-events';
@@ -64,9 +54,7 @@ import QueryResultsCopyToClipboard from './QueryResultsCopyToClipboard';
 import QueryResultsDownloadButton from './QueryResultsDownloadButton';
 import QueryResultsGetRecAsApexModal from './QueryResultsGetRecAsApexModal';
 import QueryResultsSoqlPanel from './QueryResultsSoqlPanel';
-import QueryResultsViewRecordFields from './QueryResultsViewRecordFields';
 import { useQueryResultsFetchMetadata } from './useQueryResultsFetchMetadata';
-import copyToClipboard from 'copy-to-clipboard';
 
 type SourceAction = 'STANDARD' | 'ORG_CHANGE' | 'BULK_DELETE' | 'HISTORY' | 'RECORD_ACTION' | 'MANUAL' | 'RELOAD';
 

--- a/apps/jetstream/src/app/components/query/QueryResults/QueryResults.tsx
+++ b/apps/jetstream/src/app/components/query/QueryResults/QueryResults.tsx
@@ -66,6 +66,7 @@ import QueryResultsGetRecAsApexModal from './QueryResultsGetRecAsApexModal';
 import QueryResultsSoqlPanel from './QueryResultsSoqlPanel';
 import QueryResultsViewRecordFields from './QueryResultsViewRecordFields';
 import { useQueryResultsFetchMetadata } from './useQueryResultsFetchMetadata';
+import copyToClipboard from 'copy-to-clipboard';
 
 type SourceAction = 'STANDARD' | 'ORG_CHANGE' | 'BULK_DELETE' | 'HISTORY' | 'RECORD_ACTION' | 'MANUAL' | 'RELOAD';
 
@@ -127,6 +128,8 @@ export const QueryResults: FunctionComponent<QueryResultsProps> = React.memo(() 
     recordId: string | null;
   } | null>(null);
   const [getRecordAsApex, setGetRecordAsApex] = useState<{ record: any; sobjectName: string } | null>(null);
+  const [getRecordAsJson, setGetRecordAsJson] = useState<{ record: any };
+
   const [restore] = useQueryRestore(soql, isTooling, { silent: true });
 
   const [allowContentDownload, setAllowContentDownload] = useState<{
@@ -434,6 +437,11 @@ export const QueryResults: FunctionComponent<QueryResultsProps> = React.memo(() 
     setGetRecordAsApex(null);
   }
 
+  function handleGetAsJson(record: any){
+    //setGetRecordAsJson();
+    copyToClipboard(JSON.stringify(record, null, 2), { format: 'text/plain' });
+  }
+
   function handleRestoreFromHistory(soql: string, tooling) {
     navigate(`/query`, { state: { soql, isTooling: tooling, fromHistory: true } });
   }
@@ -661,6 +669,9 @@ export const QueryResults: FunctionComponent<QueryResultsProps> = React.memo(() 
               }}
               onGetAsApex={(record) => {
                 handleGetAsApex(record);
+              }}
+              onGetAsJson={(record) => {
+                handleGetAsJson(record);
               }}
             />
           )}

--- a/apps/jetstream/src/app/components/query/QueryResults/QueryResults.tsx
+++ b/apps/jetstream/src/app/components/query/QueryResults/QueryResults.tsx
@@ -128,7 +128,7 @@ export const QueryResults: FunctionComponent<QueryResultsProps> = React.memo(() 
     recordId: string | null;
   } | null>(null);
   const [getRecordAsApex, setGetRecordAsApex] = useState<{ record: any; sobjectName: string } | null>(null);
-  const [getRecordAsJson, setGetRecordAsJson] = useState<{ record: any };
+  //const [getRecordAsJson, setGetRecordAsJson] = useState<{ record: any };
 
   const [restore] = useQueryRestore(soql, isTooling, { silent: true });
 
@@ -437,7 +437,7 @@ export const QueryResults: FunctionComponent<QueryResultsProps> = React.memo(() 
     setGetRecordAsApex(null);
   }
 
-  function handleGetAsJson(record: any){
+  function handleGetAsJson(record: any) {
     //setGetRecordAsJson();
     copyToClipboard(JSON.stringify(record, null, 2), { format: 'text/plain' });
   }

--- a/libs/ui/src/lib/data-table/DataTableRenderers.tsx
+++ b/libs/ui/src/lib/data-table/DataTableRenderers.tsx
@@ -646,19 +646,19 @@ export const ActionRenderer: FunctionComponent<{ row: any }> = ({ row }) => {
   return (
     <Fragment>
       <button className="slds-button slds-button_icon" title="View Full Record" onClick={() => row._action(row, 'view')}>
-        <Icon type="utility" icon="preview" className="slds-button__icon " omitContainer />
+        <Icon type="utility" icon="preview" className="slds-button__icon" omitContainer />
       </button>
       <button className="slds-button slds-button_icon" title="Edit Record" onClick={() => row._action(row, 'edit')}>
-        <Icon type="utility" icon="edit" className="slds-button__icon " omitContainer />
+        <Icon type="utility" icon="edit" className="slds-button__icon" omitContainer />
       </button>
       <button className="slds-button slds-button_icon" title="Clone Record" onClick={() => row._action(row, 'clone')}>
-        <Icon type="utility" icon="copy" className="slds-button__icon " omitContainer />
+        <Icon type="utility" icon="copy" className="slds-button__icon" omitContainer />
       </button>
       <button className="slds-button slds-button_icon" title="Turn Record Into Apex" onClick={() => row._action(row, 'apex')}>
-        <Icon type="utility" icon="apex" className="slds-button__icon " omitContainer />
+        <Icon type="utility" icon="apex" className="slds-button__icon" omitContainer />
       </button>
       <button className="slds-button slds-button_icon" title="Copy Record as JSON" onClick={() => row._action(row, 'json')}>
-        <Icon type="utility" icon="copy_to_clipboard" className="slds-button__icon " omitContainer />
+        <Icon type="utility" icon="copy_to_clipboard" className="slds-button__icon" omitContainer />
       </button>
     </Fragment>
   );

--- a/libs/ui/src/lib/data-table/DataTableRenderers.tsx
+++ b/libs/ui/src/lib/data-table/DataTableRenderers.tsx
@@ -658,7 +658,7 @@ export const ActionRenderer: FunctionComponent<{ row: any }> = ({ row }) => {
         <Icon type="utility" icon="apex" className="slds-button__icon " omitContainer />
       </button>
       <button className="slds-button slds-button_icon" title="Copy Record as JSON" onClick={() => row._action(row, 'json')}>
-        <Icon type="utility" icon="apex" className="slds-button__icon " omitContainer />
+        <Icon type="utility" icon="copy_to_clipboard" className="slds-button__icon " omitContainer />
       </button>
     </Fragment>
   );

--- a/libs/ui/src/lib/data-table/DataTableRenderers.tsx
+++ b/libs/ui/src/lib/data-table/DataTableRenderers.tsx
@@ -657,6 +657,9 @@ export const ActionRenderer: FunctionComponent<{ row: any }> = ({ row }) => {
       <button className="slds-button slds-button_icon" title="Turn Record Into Apex" onClick={() => row._action(row, 'apex')}>
         <Icon type="utility" icon="apex" className="slds-button__icon " omitContainer />
       </button>
+      <button className="slds-button slds-button_icon" title="Copy Record as JSON" onClick={() => row._action(row, 'json')}>
+        <Icon type="utility" icon="apex" className="slds-button__icon " omitContainer />
+      </button>
     </Fragment>
   );
 };

--- a/libs/ui/src/lib/data-table/DataTableSubqueryRenderer.tsx
+++ b/libs/ui/src/lib/data-table/DataTableSubqueryRenderer.tsx
@@ -51,7 +51,7 @@ export const SubqueryRenderer: FunctionComponent<FormatterProps<RowWithKey, unkn
   }, []);
 
   // Not yet supported
-  const handleRowAction = useCallback((row: any, action: 'view' | 'edit' | 'clone' | 'apex') => {
+  const handleRowAction = useCallback((row: any, action: 'view' | 'edit' | 'clone' | 'apex' | 'json') => {
     // logger.info('row action', row, action);
     // switch (action) {
     //   case 'edit':
@@ -185,7 +185,7 @@ interface ModalDataTableProps extends SubqueryContext {
   openDownloadModal: () => void;
   handleCloseModal: (cancelled?: boolean) => void;
   handleCopyToClipboard: (columns: ColumnWithFilter<any, unknown>[]) => void;
-  handleRowAction: (row: any, action: 'view' | 'edit' | 'clone' | 'apex') => void;
+  handleRowAction: (row: any, action: 'view' | 'edit' | 'clone' | 'apex' | 'json') => void;
   setSelectedRows: (rows: ReadonlySet<string>) => void;
 }
 

--- a/libs/ui/src/lib/data-table/SalesforceRecordDataTable.tsx
+++ b/libs/ui/src/lib/data-table/SalesforceRecordDataTable.tsx
@@ -61,6 +61,7 @@ export interface SalesforceRecordDataTableProps {
   onClone: (record: any) => void;
   onView: (record: any) => void;
   onGetAsApex: (record: any) => void;
+  onGetAsJson: (record: any) => void;
 }
 
 export const SalesforceRecordDataTable: FunctionComponent<SalesforceRecordDataTableProps> = memo<SalesforceRecordDataTableProps>(
@@ -83,6 +84,7 @@ export const SalesforceRecordDataTable: FunctionComponent<SalesforceRecordDataTa
     onClone,
     onView,
     onGetAsApex,
+    onGetAsJson,
   }) => {
     const isMounted = useRef(true);
     const rollbar = useRollbar();
@@ -154,7 +156,7 @@ export const SalesforceRecordDataTable: FunctionComponent<SalesforceRecordDataTa
       }
     }, [fieldMetadata, fieldMetadataSubquery, isTooling, queryResults]);
 
-    const handleRowAction = useCallback((row: RowWithKey, action: 'view' | 'edit' | 'clone' | 'apex') => {
+    const handleRowAction = useCallback((row: RowWithKey, action: 'view' | 'edit' | 'clone' | 'apex' | 'json') => {
       const record = row._record;
       logger.info('row action', record, action);
       switch (action) {
@@ -169,6 +171,9 @@ export const SalesforceRecordDataTable: FunctionComponent<SalesforceRecordDataTa
           break;
         case 'apex':
           onGetAsApex(record);
+          break;
+        case 'json':
+          onGetAsJson(record);
           break;
         default:
           break;

--- a/libs/ui/src/lib/data-table/data-table-types.ts
+++ b/libs/ui/src/lib/data-table/data-table-types.ts
@@ -3,7 +3,7 @@ import { Column } from 'react-data-grid';
 
 export type RowWithKey = Record<string, any> & { _key: string };
 export type RowSalesforceRecordWithKey = RowWithKey & {
-  _action: (row: RowWithKey, action: 'view' | 'edit' | 'clone' | 'apex') => void;
+  _action: (row: RowWithKey, action: 'view' | 'edit' | 'clone' | 'apex' | 'json') => void;
   _record: Record<string, any>;
 };
 export type ColumnType = 'text' | 'number' | 'subquery' | 'object' | 'location' | 'date' | 'time' | 'boolean' | 'address' | 'salesforceId';

--- a/libs/ui/src/lib/data-table/data-table-utils.tsx
+++ b/libs/ui/src/lib/data-table/data-table-utils.tsx
@@ -179,7 +179,7 @@ export function getColumnDefinitions(results: QueryResults<any>, isTooling: bool
         key: ACTION_COLUMN_KEY,
         name: '',
         resizable: false,
-        width: 100,
+        width: 115,
         formatter: ActionRenderer,
         frozen: true,
         sortable: false,


### PR DESCRIPTION
This PR is working through the following issue: https://github.com/jetstreamapp/jetstream/issues/52

I updated the record action section to now include a copy from JSON button and the corresponding functionality. I know there hasn't been any record action functionality added to sub-queries but I added the 'json' functionality for future use just in case.

Below is a screenshot of the UI with the update:
![image](https://user-images.githubusercontent.com/39092797/232129421-590f4442-ba65-4d51-9bdb-ccdd310c1ff8.png)

resolves https://github.com/jetstreamapp/jetstream/issues/52