### PR TITLE
Add ability to abort data load #301

### DIFF
--- a/apps/api/src/app/routes/api.routes.ts
+++ b/apps/api/src/app/routes/api.routes.ts
@@ -147,7 +147,12 @@ routes.post(
 
 routes.post('/bulk', ensureOrgExists, validate(bulkApiController.routeValidators.createJob), bulkApiController.createJob);
 routes.get('/bulk/:jobId', ensureOrgExists, validate(bulkApiController.routeValidators.getJob), bulkApiController.getJob);
-routes.delete('/bulk/:jobId', ensureOrgExists, validate(bulkApiController.routeValidators.closeJob), bulkApiController.closeJob);
+routes.delete(
+  '/bulk/:jobId/:action',
+  ensureOrgExists,
+  validate(bulkApiController.routeValidators.closeJob),
+  bulkApiController.closeOrAbortJob
+);
 routes.post('/bulk/:jobId', ensureOrgExists, validate(bulkApiController.routeValidators.addBatchToJob), bulkApiController.addBatchToJob);
 routes.post(
   '/bulk/zip/:jobId',

--- a/apps/electron/worker/src/app/electron.routes.ts
+++ b/apps/electron/worker/src/app/electron.routes.ts
@@ -4,8 +4,8 @@ import findMyWay, { HTTPMethod } from 'find-my-way';
 import * as jsforce from 'jsforce';
 import { isString } from 'lodash';
 import * as appController from './controllers/app.controller';
-import * as salesforceController from './controllers/salesforce.controller';
 import * as salesforceApiController from './controllers/salesforce-api.controller';
+import * as salesforceController from './controllers/salesforce.controller';
 import { ENV } from './env';
 import { getOrgs, updateOrg } from './storage';
 import { ElectronRequest, ElectronRequestData, SalesforceOrgElectron } from './types';
@@ -58,7 +58,7 @@ router.on('POST', '/api/request-manual', salesforceController.makeJsforceRequest
 
 router.on('POST', '/api/bulk', salesforceController.createJob);
 router.on('GET', '/api/bulk/:jobId', salesforceController.getJob);
-router.on('DELETE', '/api/bulk/:jobId', salesforceController.closeJob);
+router.on('DELETE', '/api/bulk/:jobId/:action', salesforceController.closeOrAbortJob);
 router.on('POST', '/api/bulk/:jobId', salesforceController.addBatchToJob);
 router.on('POST', '/api/bulk/zip/:jobId', salesforceController.addBatchToJobWithBinaryAttachment);
 router.on('GET', '/api/bulk/:jobId/:batchId', salesforceController.downloadBulkApiResults);

--- a/apps/jetstream/src/app/components/shared/load-records-results/LoadRecordsBulkApiResultsTable.tsx
+++ b/apps/jetstream/src/app/components/shared/load-records-results/LoadRecordsBulkApiResultsTable.tsx
@@ -1,9 +1,9 @@
 import { css } from '@emotion/react';
 import { BulkJobBatchInfo, BulkJobWithBatches, Maybe } from '@jetstream/types';
-import { FunctionComponent, useEffect, useState } from 'react';
-import { DownloadAction, DownloadType, PrepareDataResponseError } from './load-records-results-types';
+import { FunctionComponent } from 'react';
 import LoadRecordsBulkApiResultsTableRow from './LoadRecordsBulkApiResultsTableRow';
 import LoadRecordsResultsTableProcessingErrRow from './LoadRecordsResultsTableProcessingErrRow';
+import { DownloadAction, DownloadType, PrepareDataResponseError } from './load-records-results-types';
 export interface LoadRecordsBulkApiResultsTableProps {
   jobInfo: BulkJobWithBatches;
   processingErrors: PrepareDataResponseError[];
@@ -79,7 +79,7 @@ export const LoadRecordsBulkApiResultsTable: FunctionComponent<LoadRecordsBulkAp
         )}
         {jobInfo.batches.map((batch, i) => (
           <LoadRecordsBulkApiResultsTableRow
-            key={batch.id}
+            key={batch.id || i}
             batch={batch}
             onDownload={(type, batch) => onDownloadOrView('download', type, batch, i)}
             onView={(type, batch) => onDownloadOrView('view', type, batch, i)}

--- a/libs/shared/data/src/lib/client-data.ts
+++ b/libs/shared/data/src/lib/client-data.ts
@@ -36,8 +36,8 @@ import type {
   DescribeSObjectResult,
   ListMetadataQuery,
 } from 'jsforce';
-import isNil from 'lodash/isNil';
 import isFunction from 'lodash/isFunction';
+import isNil from 'lodash/isNil';
 import { handleExternalRequest, handleRequest, transformListMetadataResponse } from './client-data-data-helper';
 //// LANDING PAGE ROUTES
 
@@ -554,6 +554,10 @@ export async function bulkApiCreateJob(org: SalesforceOrgUi, payload: BulkApiCre
   return handleRequest({ method: 'POST', url: `/api/bulk`, data: payload }, { org }).then(unwrapResponseIgnoreCache);
 }
 
+export async function bulkApiCancelJob(org: SalesforceOrgUi, payload: BulkApiCreateJobRequestPayload): Promise<BulkJobWithBatches> {
+  return handleRequest({ method: 'POST', url: `/api/bulk`, data: payload }, { org }).then(unwrapResponseIgnoreCache);
+}
+
 export async function bulkApiGetJob(org: SalesforceOrgUi, jobId: string): Promise<BulkJobWithBatches> {
   return handleRequest<BulkJobWithBatches>({ method: 'GET', url: `/api/bulk/${jobId}` }, { org })
     .then(unwrapResponseIgnoreCache)
@@ -567,7 +571,11 @@ export async function bulkApiGetJob(org: SalesforceOrgUi, jobId: string): Promis
 }
 
 export async function bulkApiCloseJob(org: SalesforceOrgUi, jobId: string): Promise<BulkJob> {
-  return handleRequest({ method: 'DELETE', url: `/api/bulk/${jobId}` }, { org }).then(unwrapResponseIgnoreCache);
+  return handleRequest({ method: 'DELETE', url: `/api/bulk/${jobId}/close` }, { org }).then(unwrapResponseIgnoreCache);
+}
+
+export async function bulkApiAbortJob(org: SalesforceOrgUi, jobId: string): Promise<BulkJob> {
+  return handleRequest({ method: 'DELETE', url: `/api/bulk/${jobId}/abort` }, { org }).then(unwrapResponseIgnoreCache);
 }
 
 export async function bulkApiAddBatchToJob(

--- a/libs/shared/server-services/src/lib/salesforce-bulk.ts
+++ b/libs/shared/server-services/src/lib/salesforce-bulk.ts
@@ -11,7 +11,7 @@ import {
 import * as jsforce from 'jsforce';
 import isString from 'lodash/isString';
 import fetch from 'node-fetch';
-import { convert as xmlConverter, create as xmlBuilder } from 'xmlbuilder2';
+import { create as xmlBuilder, convert as xmlConverter } from 'xmlbuilder2';
 
 const { HEADERS, CONTENT_TYPE } = HTTP;
 
@@ -82,11 +82,15 @@ export async function sfBulkGetJobInfo(conn: jsforce.Connection, jobId: string):
   return { ...jobResults, batches: batchesResults || [] };
 }
 
-export async function sfBulkCloseJob(conn: jsforce.Connection, jobId: string): Promise<BulkJob> {
+export async function sfBulkCloseOrAbortJob(
+  conn: jsforce.Connection,
+  jobId: string,
+  state: 'Closed' | 'Aborted' = 'Closed'
+): Promise<BulkJob> {
   // prettier-ignore
   const xml = xmlBuilder({ version: '1.0', encoding: 'UTF-8' })
       .ele('jobInfo', { xmlns: 'http://www.force.com/2009/06/asyncapi/dataload' })
-        .ele('state').txt('Closed').up()
+        .ele('state').txt(state).up()
       .end({ prettyPrint: true });
 
   const requestOptions: jsforce.RequestInfo = {
@@ -134,7 +138,7 @@ export async function sfBulkAddBatchToJob(
   //   });
 
   if (closeJob) {
-    await sfBulkCloseJob(conn, jobId);
+    await sfBulkCloseOrAbortJob(conn, jobId, 'Closed');
   }
   return results;
 }
@@ -170,7 +174,7 @@ export async function sfBulkAddBatchWithZipAttachmentToJob(
   //   });
 
   if (closeJob) {
-    await sfBulkCloseJob(conn, jobId);
+    await sfBulkCloseOrAbortJob(conn, jobId, 'Closed');
   }
   return results;
 }

--- a/libs/shared/server-services/tsconfig.json
+++ b/libs/shared/server-services/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    "strictNullChecks": true
+    "strictNullChecks": true,
+    "allowSyntheticDefaultImports": true
   },
   "files": [],
   "include": [],


### PR DESCRIPTION
Added abort for bulk and batch API

Any records already sent to Salesforce may not be able to be aborted, depending on exact configuration and batch size

Demo https://jam.dev/c/582ce938-0d9f-41a8-853c-817eaf02dd83

resolves #301