### PR TITLE
Show full error message in load results #302

### DIFF
--- a/apps/jetstream/src/app/components/load-records/components/load-results/LoadRecordsResultsModal.tsx
+++ b/apps/jetstream/src/app/components/load-records/components/load-results/LoadRecordsResultsModal.tsx
@@ -6,8 +6,10 @@ import {
   CopyToClipboard,
   DataTable,
   Icon,
-  Modal, setColumnFromType,
-  Spinner, Tooltip
+  Modal,
+  setColumnFromType,
+  Spinner,
+  Tooltip,
 } from '@jetstream/ui';
 import { FunctionComponent, useCallback, useEffect, useRef, useState } from 'react';
 import { RowHeightArgs } from 'react-data-grid';

--- a/apps/jetstream/src/app/components/load-records/components/load-results/LoadRecordsResultsModal.tsx
+++ b/apps/jetstream/src/app/components/load-records/components/load-results/LoadRecordsResultsModal.tsx
@@ -1,6 +1,14 @@
 import { css } from '@emotion/react';
 import { useNonInitialEffect } from '@jetstream/shared/ui-utils';
-import { AutoFullHeightContainer, ColumnWithFilter, DataTable, Icon, Modal, setColumnFromType, Spinner } from '@jetstream/ui';
+import {
+  AutoFullHeightContainer,
+  ColumnWithFilter,
+  CopyToClipboard,
+  DataTable,
+  Icon,
+  Modal, setColumnFromType,
+  Spinner, Tooltip
+} from '@jetstream/ui';
 import { FunctionComponent, useCallback, useEffect, useRef, useState } from 'react';
 import { RowHeightArgs } from 'react-data-grid';
 
@@ -53,6 +61,15 @@ export const LoadRecordsResultsModal: FunctionComponent<LoadRecordsResultsModalP
                       line-height: normal;
                     `}
                   >
+                    {row._errors && (
+                      <Tooltip content={row._errors}>
+                        <CopyToClipboard
+                          icon={{ type: 'utility', icon: 'error', description: 'load error' }}
+                          content={row._errors}
+                          className="slds-text-color_error slds-p-right_x-small"
+                        />
+                      </Tooltip>
+                    )}
                     {row?._errors}
                   </p>
                 )


### PR DESCRIPTION
This PR is focused on resolving https://github.com/jetstreamapp/jetstream/issues/302.

The new functionality will display an error icon when a record errored out while loading. When you click on the icon, there will be the full error message and it will automatically copy to your clipboard. 

I assumed this would be a good place to put it since the modal is referenced in several other classes so let me know if you disagree!

![Screen Shot 2023-04-16 at 19 06 34](https://user-images.githubusercontent.com/39092797/232361154-8e35b04f-ff3c-4f84-9574-6733250717ee.png)
