### PR TITLE
Show filtered records in Query Records Display

### DIFF
--- a/libs/ui/src/lib/data-table/DataTable.tsx
+++ b/libs/ui/src/lib/data-table/DataTable.tsx
@@ -3,9 +3,9 @@ import { logger } from '@jetstream/shared/client-logger';
 import { useNonInitialEffect } from '@jetstream/shared/ui-utils';
 import { orderObjectsBy, orderStringsBy } from '@jetstream/shared/utils';
 import { SalesforceOrgUi } from '@jetstream/types';
-import uniqueId from 'lodash/uniqueId';
 import escapeRegExp from 'lodash/escapeRegExp';
 import isNil from 'lodash/isNil';
+import uniqueId from 'lodash/uniqueId';
 import { forwardRef, useCallback, useContext, useEffect, useImperativeHandle, useMemo, useReducer, useState } from 'react';
 import DataGrid, {
   DataGridProps,
@@ -176,6 +176,10 @@ export interface DataTableProps<T = RowWithKey, TContext = Record<string, any>>
   onSortedAndFilteredRowsChange?: (rows: readonly T[]) => void;
 }
 
+export const DataTableProperties = {
+  currentDisplayRecordCount: 0,
+};
+
 export const DataTable = forwardRef<any, DataTableProps<any>>(
   <T extends object>(
     {
@@ -310,6 +314,7 @@ export const DataTable = forwardRef<any, DataTableProps<any>>(
     }, [columnMap, filters, getRowKey, includeQuickFilter, quickFilterText, rowAlwaysVisible, rowFilterText, sortedRows]);
 
     useEffect(() => {
+      DataTableProperties.currentDisplayRecordCount = filteredRows.length;
       onSortedAndFilteredRowsChange && onSortedAndFilteredRowsChange(filteredRows);
     }, [filteredRows, onSortedAndFilteredRowsChange]);
 

--- a/libs/ui/src/lib/data-table/DataTable.tsx
+++ b/libs/ui/src/lib/data-table/DataTable.tsx
@@ -176,10 +176,6 @@ export interface DataTableProps<T = RowWithKey, TContext = Record<string, any>>
   onSortedAndFilteredRowsChange?: (rows: readonly T[]) => void;
 }
 
-export const DataTableProperties = {
-  currentDisplayRecordCount: 0,
-};
-
 export const DataTable = forwardRef<any, DataTableProps<any>>(
   <T extends object>(
     {
@@ -314,7 +310,6 @@ export const DataTable = forwardRef<any, DataTableProps<any>>(
     }, [columnMap, filters, getRowKey, includeQuickFilter, quickFilterText, rowAlwaysVisible, rowFilterText, sortedRows]);
 
     useEffect(() => {
-      DataTableProperties.currentDisplayRecordCount = filteredRows.length;
       onSortedAndFilteredRowsChange && onSortedAndFilteredRowsChange(filteredRows);
     }, [filteredRows, onSortedAndFilteredRowsChange]);
 

--- a/libs/ui/src/lib/data-table/DataTable.tsx
+++ b/libs/ui/src/lib/data-table/DataTable.tsx
@@ -3,9 +3,9 @@ import { logger } from '@jetstream/shared/client-logger';
 import { useNonInitialEffect } from '@jetstream/shared/ui-utils';
 import { orderObjectsBy, orderStringsBy } from '@jetstream/shared/utils';
 import { SalesforceOrgUi } from '@jetstream/types';
+import uniqueId from 'lodash/uniqueId';
 import escapeRegExp from 'lodash/escapeRegExp';
 import isNil from 'lodash/isNil';
-import uniqueId from 'lodash/uniqueId';
 import { forwardRef, useCallback, useContext, useEffect, useImperativeHandle, useMemo, useReducer, useState } from 'react';
 import DataGrid, {
   DataGridProps,

--- a/libs/ui/src/lib/data-table/SalesforceRecordDataTable.tsx
+++ b/libs/ui/src/lib/data-table/SalesforceRecordDataTable.tsx
@@ -23,7 +23,7 @@ import {
   NON_DATA_COLUMN_KEYS,
   TABLE_CONTEXT_MENU_ITEMS,
 } from './data-table-utils';
-import { DataTable } from './DataTable';
+import { DataTable, DataTableProperties } from './DataTable';
 
 const SFDC_EMPTY_ID = '000000000000000AAA';
 
@@ -255,7 +255,7 @@ export const SalesforceRecordDataTable: FunctionComponent<SalesforceRecordDataTa
         <Grid className="slds-p-around_xx-small" align="spread">
           <div className="slds-grid">
             <div className="slds-p-around_x-small">
-              Showing {formatNumber(records.length)} of {formatNumber(totalRecordCount || 0)} records
+              Showing {formatNumber(DataTableProperties.currentDisplayRecordCount)} of {formatNumber(totalRecordCount || 0)} records
             </div>
             {hasMoreRecords && (
               <div>

--- a/libs/ui/src/lib/data-table/SalesforceRecordDataTable.tsx
+++ b/libs/ui/src/lib/data-table/SalesforceRecordDataTable.tsx
@@ -23,7 +23,7 @@ import {
   NON_DATA_COLUMN_KEYS,
   TABLE_CONTEXT_MENU_ITEMS,
 } from './data-table-utils';
-import { DataTable, DataTableProperties } from './DataTable';
+import { DataTable } from './DataTable';
 
 const SFDC_EMPTY_ID = '000000000000000AAA';
 
@@ -99,6 +99,7 @@ export const SalesforceRecordDataTable: FunctionComponent<SalesforceRecordDataTa
     const [nextRecordsUrl, setNextRecordsUrl] = useState<Maybe<string>>(null);
     const [globalFilter, setGlobalFilter] = useState<string | null>(null);
     const [selectedRows, setSelectedRows] = useState<ReadonlySet<string>>(() => new Set());
+    const [visibleRecordCount, setVisibleRecordCount] = useState<number>(0);
 
     useEffect(() => {
       isMounted.current = true;
@@ -231,6 +232,8 @@ export const SalesforceRecordDataTable: FunctionComponent<SalesforceRecordDataTa
     const handleSortedAndFilteredRowsChange = useCallback(
       (rows: RowSalesforceRecordWithKey[]) => {
         onFilteredRowsChanged(rows.map(({ _record }) => _record));
+
+        setVisibleRecordCount(rows.length);
       },
       [onFilteredRowsChanged]
     );
@@ -255,7 +258,7 @@ export const SalesforceRecordDataTable: FunctionComponent<SalesforceRecordDataTa
         <Grid className="slds-p-around_xx-small" align="spread">
           <div className="slds-grid">
             <div className="slds-p-around_x-small">
-              Showing {formatNumber(DataTableProperties.currentDisplayRecordCount)} of {formatNumber(totalRecordCount || 0)} records
+              Showing {formatNumber(visibleRecordCount)} of {formatNumber(totalRecordCount || 0)} records
             </div>
             {hasMoreRecords && (
               <div>

--- a/libs/ui/src/lib/data-table/SalesforceRecordDataTable.tsx
+++ b/libs/ui/src/lib/data-table/SalesforceRecordDataTable.tsx
@@ -99,7 +99,7 @@ export const SalesforceRecordDataTable: FunctionComponent<SalesforceRecordDataTa
     const [nextRecordsUrl, setNextRecordsUrl] = useState<Maybe<string>>(null);
     const [globalFilter, setGlobalFilter] = useState<string | null>(null);
     const [selectedRows, setSelectedRows] = useState<ReadonlySet<string>>(() => new Set());
-    const [visibleRecordCount, setVisibleRecordCount] = useState<number>(0);
+    const [visibleRecordCount, setVisibleRecordCount] = useState(records?.length);
 
     useEffect(() => {
       isMounted.current = true;


### PR DESCRIPTION
This PR will resolve https://github.com/jetstreamapp/jetstream/issues/45

I updated the display of records section in SalesforceRecordDataTable to now account for filtering. This can be seen in the screenshot below. I know the design for this was not finalized but I decided to export a new const where we can hold different values related to DataTable. The goal would be that we could easily add to it in the future.

![Screen Shot 2023-04-22 at 20 56 04](https://user-images.githubusercontent.com/39092797/233818998-948efb70-a5d1-43f6-ab60-16388643af7f.png)
