### PR TITLE
Data load results do not have proper decoding to display in a friendly format

### DIFF
--- a/apps/jetstream/src/app/components/load-records/components/load-results/LoadRecordsBatchApiResults.tsx
+++ b/apps/jetstream/src/app/components/load-records/components/load-results/LoadRecordsBatchApiResults.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/react';
 import { logger } from '@jetstream/shared/client-logger';
 import { ANALYTICS_KEYS } from '@jetstream/shared/constants';
 import { convertDateToLocale, useBrowserNotifications, useRollbar } from '@jetstream/shared/ui-utils';
-import { flattenRecord, getSuccessOrFailureChar, pluralizeFromNumber } from '@jetstream/shared/utils';
+import { decodeHtmlEntity, flattenRecord, getSuccessOrFailureChar, pluralizeFromNumber } from '@jetstream/shared/utils';
 import { InsertUpdateUpsertDelete, Maybe, RecordResultWithRecord, SalesforceOrgUi, WorkerMessage } from '@jetstream/types';
 import { FileDownloadModal, Grid, ProgressRing, Spinner, Tooltip } from '@jetstream/ui';
 import { FunctionComponent, useEffect, useRef, useState } from 'react';
@@ -274,7 +274,10 @@ export const LoadRecordsBatchApiResults: FunctionComponent<LoadRecordsBatchApiRe
         combinedResults.push({
           _id: record.success ? record.id : record['Id'] || '',
           _success: record.success,
-          _errors: record.success === false ? record.errors.map((error) => `${error.statusCode}: ${error.message}`).join('\n') : '',
+          _errors:
+            record.success === false
+              ? record.errors.map((error) => `${error.statusCode}: ${decodeHtmlEntity(error.message)}`).join('\n')
+              : '',
           ...flattenRecord(record.record, fields),
         });
       }
@@ -300,7 +303,10 @@ export const LoadRecordsBatchApiResults: FunctionComponent<LoadRecordsBatchApiRe
         combinedResults.push({
           _id: record.success ? record.id : record['Id'] || '',
           _success: record.success,
-          _errors: record.success === false ? record.errors.map((error) => `${error.statusCode}: ${error.message}`).join('\n') : '',
+          _errors:
+            record.success === false
+              ? record.errors.map((error) => `${error.statusCode}: ${decodeHtmlEntity(error.message)}`).join('\n')
+              : '',
           ...flattenRecord(record.record, fields),
         });
       }

--- a/apps/jetstream/src/app/components/load-records/components/load-results/LoadRecordsBulkApiResults.tsx
+++ b/apps/jetstream/src/app/components/load-records/components/load-results/LoadRecordsBulkApiResults.tsx
@@ -3,7 +3,7 @@ import { logger } from '@jetstream/shared/client-logger';
 import { ANALYTICS_KEYS } from '@jetstream/shared/constants';
 import { bulkApiAbortJob, bulkApiGetJob, bulkApiGetRecords } from '@jetstream/shared/data';
 import { checkIfBulkApiJobIsDone, convertDateToLocale, useBrowserNotifications, useRollbar } from '@jetstream/shared/ui-utils';
-import { decodeHtmlEntity } from '@jetstream/shared/utils';
+import { decodeHtmlEntity, getSuccessOrFailureChar, pluralizeFromNumber } from '@jetstream/shared/utils';
 import {
   BulkJobBatchInfo,
   BulkJobResultRecord,

--- a/apps/jetstream/src/app/components/load-records/components/load-results/LoadRecordsBulkApiResults.tsx
+++ b/apps/jetstream/src/app/components/load-records/components/load-results/LoadRecordsBulkApiResults.tsx
@@ -3,7 +3,7 @@ import { logger } from '@jetstream/shared/client-logger';
 import { ANALYTICS_KEYS } from '@jetstream/shared/constants';
 import { bulkApiAbortJob, bulkApiGetJob, bulkApiGetRecords } from '@jetstream/shared/data';
 import { checkIfBulkApiJobIsDone, convertDateToLocale, useBrowserNotifications, useRollbar } from '@jetstream/shared/ui-utils';
-import { getSuccessOrFailureChar, pluralizeFromNumber } from '@jetstream/shared/utils';
+import { decodeHtmlEntity } from '@jetstream/shared/utils';
 import {
   BulkJobBatchInfo,
   BulkJobResultRecord,
@@ -18,11 +18,11 @@ import { FileDownloadModal, Grid, ProgressRing, SalesforceLogin, Spinner, Toolti
 import { FunctionComponent, useEffect, useRef, useState } from 'react';
 import { useRecoilState } from 'recoil';
 import { applicationCookieState } from '../../../../app-state';
-import { fireToast } from '../../../core/AppToast';
 import { useAmplitude } from '../../../core/analytics';
+import { fireToast } from '../../../core/AppToast';
 import * as fromJetstreamEvents from '../../../core/jetstream-events';
-import LoadRecordsBulkApiResultsTable from '../../../shared/load-records-results/LoadRecordsBulkApiResultsTable';
 import { DownloadAction, DownloadType } from '../../../shared/load-records-results/load-records-results-types';
+import LoadRecordsBulkApiResultsTable from '../../../shared/load-records-results/LoadRecordsBulkApiResultsTable';
 import {
   ApiMode,
   DownloadModalData,
@@ -33,7 +33,7 @@ import {
   PrepareDataResponse,
   ViewModalData,
 } from '../../load-records-types';
-import { LoadRecordsBatchError, getFieldHeaderFromMapping } from '../../utils/load-records-utils';
+import { getFieldHeaderFromMapping, LoadRecordsBatchError } from '../../utils/load-records-utils';
 import { getLoadWorker } from '../../utils/load-records-worker';
 import LoadRecordsResultsModal from './LoadRecordsResultsModal';
 
@@ -408,7 +408,7 @@ export const LoadRecordsBulkApiResults: FunctionComponent<LoadRecordsBulkApiResu
           combinedResults.push({
             _id: resultRecord.Id || records[i].Id || null,
             _success: resultRecord.Success,
-            _errors: resultRecord.Error,
+            _errors: decodeHtmlEntity(resultRecord.Error),
             ...records[i],
           });
         }

--- a/apps/jetstream/src/app/components/load-records/components/load-results/LoadRecordsResultsModal.tsx
+++ b/apps/jetstream/src/app/components/load-records/components/load-results/LoadRecordsResultsModal.tsx
@@ -1,5 +1,6 @@
 import { css } from '@emotion/react';
 import { useNonInitialEffect } from '@jetstream/shared/ui-utils';
+import { decodeHtmlEntity } from '@jetstream/shared/utils';
 import {
   AutoFullHeightContainer,
   ColumnWithFilter,
@@ -64,15 +65,15 @@ export const LoadRecordsResultsModal: FunctionComponent<LoadRecordsResultsModalP
                     `}
                   >
                     {row._errors && (
-                      <Tooltip content={row._errors}>
+                      <Tooltip content={decodeHtmlEntity(row._errors)}>
                         <CopyToClipboard
                           icon={{ type: 'utility', icon: 'error', description: 'load error' }}
-                          content={row._errors}
+                          content={decodeHtmlEntity(row._errors)}
                           className="slds-text-color_error slds-p-right_x-small"
                         />
                       </Tooltip>
                     )}
-                    {row?._errors}
+                    {decodeHtmlEntity(row?._errors)}
                   </p>
                 )
               : undefined,

--- a/apps/jetstream/src/app/components/load-records/components/load-results/LoadRecordsResultsModal.tsx
+++ b/apps/jetstream/src/app/components/load-records/components/load-results/LoadRecordsResultsModal.tsx
@@ -1,6 +1,5 @@
 import { css } from '@emotion/react';
 import { useNonInitialEffect } from '@jetstream/shared/ui-utils';
-import { decodeHtmlEntity } from '@jetstream/shared/utils';
 import {
   AutoFullHeightContainer,
   ColumnWithFilter,
@@ -47,9 +46,6 @@ export const LoadRecordsResultsModal: FunctionComponent<LoadRecordsResultsModalP
 
   useEffect(() => {
     if (header) {
-      rows = rows.map((row, i) => ({ ...row, _errors: decodeHtmlEntity(row?._errors) }));
-      console.log('row', rows[0]._errors);
-
       setColumns(
         header.map((item) => ({
           ...setColumnFromType(item, 'text'),
@@ -76,7 +72,7 @@ export const LoadRecordsResultsModal: FunctionComponent<LoadRecordsResultsModalP
                         />
                       </Tooltip>
                     )}
-                    {decodeHtmlEntity(row?._errors)}
+                    {row?._errors}
                   </p>
                 )
               : undefined,

--- a/apps/jetstream/src/app/components/load-records/components/load-results/LoadRecordsResultsModal.tsx
+++ b/apps/jetstream/src/app/components/load-records/components/load-results/LoadRecordsResultsModal.tsx
@@ -47,6 +47,9 @@ export const LoadRecordsResultsModal: FunctionComponent<LoadRecordsResultsModalP
 
   useEffect(() => {
     if (header) {
+      rows = rows.map((row, i) => ({ ...row, _errors: decodeHtmlEntity(row?._errors) }));
+      console.log('row', rows[0]._errors);
+
       setColumns(
         header.map((item) => ({
           ...setColumnFromType(item, 'text'),
@@ -65,10 +68,10 @@ export const LoadRecordsResultsModal: FunctionComponent<LoadRecordsResultsModalP
                     `}
                   >
                     {row._errors && (
-                      <Tooltip content={decodeHtmlEntity(row._errors)}>
+                      <Tooltip content={row._errors}>
                         <CopyToClipboard
                           icon={{ type: 'utility', icon: 'error', description: 'load error' }}
-                          content={decodeHtmlEntity(row._errors)}
+                          content={row._errors}
                           className="slds-text-color_error slds-p-right_x-small"
                         />
                       </Tooltip>

--- a/apps/jetstream/src/app/components/shared/mass-update-records/MassUpdateRecordsDeploymentRow.tsx
+++ b/apps/jetstream/src/app/components/shared/mass-update-records/MassUpdateRecordsDeploymentRow.tsx
@@ -2,7 +2,7 @@ import { logger } from '@jetstream/shared/client-logger';
 import { ANALYTICS_KEYS } from '@jetstream/shared/constants';
 import { bulkApiGetRecords } from '@jetstream/shared/data';
 import { formatNumber } from '@jetstream/shared/ui-utils';
-import { pluralizeFromNumber } from '@jetstream/shared/utils';
+import { decodeHtmlEntity, pluralizeFromNumber } from '@jetstream/shared/utils';
 import { BulkJobBatchInfo, BulkJobResultRecord, SalesforceOrgUi } from '@jetstream/types';
 import { Card, FileDownloadModal, Grid, SalesforceLogin, ScopedNotification, Spinner, SupportLink } from '@jetstream/ui';
 import { Fragment, FunctionComponent, useEffect, useState } from 'react';
@@ -84,7 +84,7 @@ export const MassUpdateRecordsDeploymentRow: FunctionComponent<MassUpdateRecords
           combinedResults.push({
             _id: resultRecord.Id || records[i].Id || null,
             _success: resultRecord.Success,
-            _errors: resultRecord.Error,
+            _errors: decodeHtmlEntity(resultRecord.Error),
             ...records[i],
           });
         }

--- a/libs/shared/utils/src/lib/utils.ts
+++ b/libs/shared/utils/src/lib/utils.ts
@@ -771,3 +771,8 @@ export function getFlattenedListItems(items: ListItemGroup[] = []): ListItem[] {
     return output;
   }, []);
 }
+
+// https://stackoverflow.com/questions/7394748/whats-the-right-way-to-decode-a-string-that-has-special-html-entities-in-it
+export function decodeHtmlEntity(value: Maybe<string>) {
+  return value?.replace(/&#(\d+);/g, (match, dec) => String.fromCharCode(dec)) || '';
+}

--- a/libs/shared/utils/src/lib/utils.ts
+++ b/libs/shared/utils/src/lib/utils.ts
@@ -774,5 +774,5 @@ export function getFlattenedListItems(items: ListItemGroup[] = []): ListItem[] {
 
 // https://stackoverflow.com/questions/7394748/whats-the-right-way-to-decode-a-string-that-has-special-html-entities-in-it
 export function decodeHtmlEntity(value: Maybe<string>) {
-  return value?.replace(/&#(\d+);/g, (match, dec) => String.fromCharCode(dec)) || '';
+  return value?.replace(/&amp;|&#(\d+);/g, (match, dec) => String.fromCharCode(dec)) || '';
 }

--- a/libs/shared/utils/src/lib/utils.ts
+++ b/libs/shared/utils/src/lib/utils.ts
@@ -774,5 +774,9 @@ export function getFlattenedListItems(items: ListItemGroup[] = []): ListItem[] {
 
 // https://stackoverflow.com/questions/7394748/whats-the-right-way-to-decode-a-string-that-has-special-html-entities-in-it
 export function decodeHtmlEntity(value: Maybe<string>) {
-  return value?.replace(/&amp;|&#(\d+);/g, (match, dec) => String.fromCharCode(dec)) || '';
+  return (value?.replace(/&amp;|&#(\d+);/g, (match, dec) => String.fromCharCode(dec)) || '')
+    .replaceAll('&quot;', '"')
+    .replaceAll('\x00', '&')
+    .replaceAll('&lt;', '<')
+    .replaceAll('&gt;', '>');
 }


### PR DESCRIPTION
This PR resolves https://github.com/jetstreamapp/jetstream/issues/340

Issue: 
Data load errors show the input field in an encoded format, these should be decoded in our table formatter when the data is being displayed.

Solution:
Create an utility method that will decode html and update each instance of where we are setting _errors to make sure we pass it through the decoder before it is set. 

![Screen Shot 2023-05-06 at 08 54 49](https://user-images.githubusercontent.com/39092797/236634329-7724cab7-f2e8-4013-8ba3-f6a4a35648e3.png)


