### PR TITLE
Fix Global Picklist Creation

### DIFF
--- a/apps/jetstream/src/app/components/create-object-and-fields/CreateNewGlobalPicklistModal.tsx
+++ b/apps/jetstream/src/app/components/create-object-and-fields/CreateNewGlobalPicklistModal.tsx
@@ -30,7 +30,7 @@ const defaultValues: PicklistData = {
 
 function getPayload(data: PicklistData): GlobalValueSetRequest {
   return {
-    FullName: data.name,
+    FullName: `${data.name}__gvs`,
     Metadata: {
       customValue: data.values
         .trim()


### PR DESCRIPTION
Breaking change in API version 57 which requires having __gvs appended to the end of the API name

resolves #375