### PR TITLE
Fix copy to clipboard

### DIFF
--- a/apps/jetstream/src/app/components/query/QueryResults/QueryResultsCopyToClipboard.tsx
+++ b/apps/jetstream/src/app/components/query/QueryResults/QueryResultsCopyToClipboard.tsx
@@ -1,7 +1,7 @@
 import { ANALYTICS_KEYS } from '@jetstream/shared/constants';
 import { copyRecordsToClipboard } from '@jetstream/shared/ui-utils';
 import { Maybe, Record } from '@jetstream/types';
-import { ButtonGroupContainer, DropDown, Icon, Modal, Radio, RadioGroup } from '@jetstream/ui';
+import { ButtonGroupContainer, DropDown, Icon, Modal, Radio, RadioGroup, Tooltip } from '@jetstream/ui';
 import classNames from 'classnames';
 import { Fragment, FunctionComponent, useEffect, useState } from 'react';
 import { useAmplitude } from '../../core/analytics';
@@ -60,7 +60,7 @@ export const QueryResultsCopyToClipboard: FunctionComponent<QueryResultsCopyToCl
       return;
     }
 
-    copyRecordsToClipboard(records, format);
+    copyRecordsToClipboard(records, format, fields);
     trackEvent(ANALYTICS_KEYS.query_CopyToClipboard, { isTooling, whichRecords, format });
   }
 
@@ -81,7 +81,7 @@ export const QueryResultsCopyToClipboard: FunctionComponent<QueryResultsCopyToCl
       recordsToCopy = selectedRows;
     }
 
-    copyRecordsToClipboard(recordsToCopy, format);
+    copyRecordsToClipboard(recordsToCopy, format, fields);
     trackEvent(ANALYTICS_KEYS.query_CopyToClipboard, { isTooling, whichRecords, format });
 
     setFormat('excel');
@@ -92,15 +92,20 @@ export const QueryResultsCopyToClipboard: FunctionComponent<QueryResultsCopyToCl
     <Fragment>
       {/* TODO */}
       <ButtonGroupContainer>
-        <button
-          className={classNames('slds-button slds-button_neutral', className)}
-          onClick={() => handleCopyToClipboard()}
-          disabled={!hasRecords}
-          title="Copy the queried records to the clipboard. The records can then be pasted into a spreadsheet."
+        <Tooltip
+          delay={[1000, null]}
+          content="This will copy in a format compatible with a spreadsheet program, such as Excel or Google Sheets. Use the dropdown for additional options."
         >
-          <Icon type="utility" icon="copy_to_clipboard" className="slds-button__icon slds-button__icon_left" omitContainer />
-          <span>Copy to Clipboard</span>
-        </button>
+          <button
+            className={classNames('slds-button slds-button_neutral', className)}
+            onClick={() => handleCopyToClipboard()}
+            disabled={!hasRecords}
+            title="Copy the queried records to the clipboard. The records can then be pasted into a spreadsheet."
+          >
+            <Icon type="utility" icon="copy_to_clipboard" className="slds-button__icon slds-button__icon_left" omitContainer />
+            <span>Copy to Clipboard</span>
+          </button>
+        </Tooltip>
         <DropDown
           className="slds-button_last"
           dropDownClassName="slds-dropdown_actions"

--- a/libs/shared/ui-utils/src/lib/shared-ui-data-utils.ts
+++ b/libs/shared/ui-utils/src/lib/shared-ui-data-utils.ts
@@ -8,6 +8,7 @@ import type {
   FieldWithExtendedType,
   FieldWrapper,
   MapOf,
+  Maybe,
   QueryFields,
   SalesforceOrgUi,
   UserTrace,
@@ -295,7 +296,7 @@ export async function fetchActiveLog(org: SalesforceOrgUi, id: string): Promise<
 /**
  * Copy records to clipboard in various formats
  */
-export function copyRecordsToClipboard(recordsToCopy: any, copyFormat: 'excel' | 'text' | 'json', fields?: string[]) {
+export function copyRecordsToClipboard(recordsToCopy: any, copyFormat: 'excel' | 'text' | 'json', fields?: Maybe<string[]>) {
   if (copyFormat === 'excel' && fields) {
     const flattenedData = flattenRecords(recordsToCopy, fields);
     copyToClipboard(transformTabularDataToHtml(flattenedData, fields), { format: 'text/html' });

--- a/libs/ui/src/lib/widgets/Tooltip.tsx
+++ b/libs/ui/src/lib/widgets/Tooltip.tsx
@@ -8,6 +8,11 @@ export interface TooltipProps {
   id?: string;
   className?: string;
   content: Maybe<string | JSX.Element>;
+  /**
+   * number controls hide delay in ms
+   * array controls show and hide delay, [openDelay, closeDelay]
+   */
+  delay?: TippyProps['delay'];
   onClick?: (event: MouseEvent<HTMLElement>) => void;
   children?: React.ReactNode;
 }
@@ -37,7 +42,7 @@ const LazyTippy = (props: LazyTippyProps) => {
   return <Tippy {...computedProps} />;
 };
 
-export const Tooltip: FunctionComponent<TooltipProps> = ({ className, content, onClick, children }) => {
+export const Tooltip: FunctionComponent<TooltipProps> = ({ className, content, delay, onClick, children }) => {
   const [visible, setVisible] = useState(false);
   const [arrowElement, setArrowElement] = useState<HTMLElement | null>(null);
 
@@ -48,6 +53,7 @@ export const Tooltip: FunctionComponent<TooltipProps> = ({ className, content, o
         content && setVisible(true);
       }}
       hideOnClick={false}
+      delay={delay}
       allowHTML
       popperOptions={{
         modifiers: [


### PR DESCRIPTION
A regression was introduced causing copy to clipboard to be broken except for JSON since fields was not passed in

Added a tooltip explaining what copying to clipboard does by default since it will not work in a text editor