### PR TITLE
Clicking refresh on metadata page does not work for items with folders

### DIFF
--- a/libs/connected/connected-ui/src/lib/useListMetadata.tsx
+++ b/libs/connected/connected-ui/src/lib/useListMetadata.tsx
@@ -256,7 +256,7 @@ export function useListMetadata(selectedOrg: SalesforceOrgUi) {
    */
   const loadListMetadataItem = useCallback(
     async (item: ListMetadataResultItem) => {
-      const { type } = item;
+      const { type, inFolder } = item;
       try {
         setListMetadataItems((previousItems) =>
           previousItems && previousItems[type]
@@ -266,7 +266,16 @@ export function useListMetadata(selectedOrg: SalesforceOrgUi) {
               }
             : previousItems
         );
-        const responseItem = await fetchListMetadata(selectedOrg, item, true);
+
+        let responseItem = await fetchListMetadata(selectedOrg, item, true);
+
+        if (inFolder) {
+          // handle additional fetches required if type is in folder
+          responseItem = await fetchListMetadataForItemsInFolder(selectedOrg, item, true);
+        } else {
+          responseItem = await fetchListMetadata(selectedOrg, item, true);
+        }
+
         if (!isMounted.current) {
           return;
         }


### PR DESCRIPTION
When the metadata list is initially rendered, there are two options for how we are fetching the data (inFolder vs not). In this scenario, everything works as expected. However, when refreshing an individual item we are not mimicking the two options mentioned above and the data for inFolder items does not return any data. 

This PR should now fix the issue and allow for both the initial render (or Refresh All) and the individual refresh to have the same logic in both scenarios.

resolves #381