### PR TITLE
Fix header cell renderer

### DIFF
--- a/libs/ui/src/lib/data-table/DataTable.tsx
+++ b/libs/ui/src/lib/data-table/DataTable.tsx
@@ -336,7 +336,7 @@ export const DataTable = forwardRef<any, DataTableProps<any>>(
         if (column.preventReorder || column.frozen) {
           return column;
         }
-        return { ...column, renderHeaderCell, _priorrenderHeaderCell: column.renderHeaderCell };
+        return { ...column, renderHeaderCell, _priorHeaderRenderer: column.renderHeaderCell };
       });
     }, [columns, allowReorder]);
 


### PR DESCRIPTION
There was a typo on the draggable column when upgrading to latest react-data-grid library

resolves #437