### PR TITLE
Query Results Inline Editor Improvements

### DIFF
--- a/apps/jetstream/src/app/components/query/QueryResults/QueryResults.tsx
+++ b/apps/jetstream/src/app/components/query/QueryResults/QueryResults.tsx
@@ -639,6 +639,7 @@ export const QueryResults: FunctionComponent<QueryResultsProps> = React.memo(() 
           {!!(records && !!records.length) && (
             <SalesforceRecordDataTable
               org={selectedOrg}
+              defaultApiVersion={defaultApiVersion}
               google_apiKey={google_apiKey}
               google_appId={google_appId}
               google_clientId={google_clientId}
@@ -656,6 +657,9 @@ export const QueryResults: FunctionComponent<QueryResultsProps> = React.memo(() 
               onFields={handleFieldsChanged}
               onFilteredRowsChanged={setFilteredRows}
               onLoadMoreRecords={handleLoadMore}
+              onSavedRecords={(data) => {
+                trackEvent(ANALYTICS_KEYS.query_InlineEditSave, data);
+              }}
               onEdit={(record) => {
                 handleCloneEditView(record, 'edit');
               }}

--- a/libs/shared/constants/src/lib/shared-constants.ts
+++ b/libs/shared/constants/src/lib/shared-constants.ts
@@ -183,6 +183,7 @@ export const ANALYTICS_KEYS = {
   query_RecordAction: 'query_RecordAction',
   query_UpdateRecordsInline: 'query_UpdateRecordsInline',
   query_ResetPage: 'query_ResetPage',
+  query_InlineEditSave: 'query_InlineEditSave',
   /** DOWNLOAD FILES */
   attachment_QueriedEligibleObject: 'attachment_QueriedEligibleObject',
   attachment_ModalOpened: 'attachment_ModalOpened',

--- a/libs/shared/ui-utils/src/lib/shared-ui-keyboard.ts
+++ b/libs/shared/ui-utils/src/lib/shared-ui-keyboard.ts
@@ -134,6 +134,10 @@ export function isMKey(event: KeyboardEvent<unknown>): boolean {
   return event.key === 'm' || event.key === 'M' || event.keyCode === 77;
 }
 
+export function isVKey(event: KeyboardEvent<unknown>): boolean {
+  return event.key === 'v' || event.code === 'KeyV' || event.keyCode === 86;
+}
+
 export function isArrowKey(event: KeyboardEvent<unknown>): boolean {
   return isArrowLeftKey(event) || isArrowUpKey(event) || isArrowRightKey(event) || isArrowDownKey(event);
 }

--- a/libs/ui/src/lib/data-table/DataTableEditors.tsx
+++ b/libs/ui/src/lib/data-table/DataTableEditors.tsx
@@ -1,11 +1,19 @@
-import { css } from '@emotion/react';
-import { ListItem } from '@jetstream/types';
+import { logger } from '@jetstream/shared/client-logger';
+import { describeSObject, query } from '@jetstream/shared/data';
+import { isEnterKey, isEscapeKey } from '@jetstream/shared/ui-utils';
+import { ListItem, SalesforceOrgUi } from '@jetstream/types';
 import formatISO from 'date-fns/formatISO';
 import parseISO from 'date-fns/parseISO';
-import { useRef, useState } from 'react';
+import isString from 'lodash/isString';
+import { ReactNode, useCallback, useContext, useEffect, useRef, useState } from 'react';
 import { RenderEditCellProps } from 'react-data-grid';
+import ComboboxWithItems from '../form/combobox/ComboboxWithItems';
+import ComboboxWithItemsTypeAhead from '../form/combobox/ComboboxWithItemsTypeAhead';
 import DatePicker from '../form/date/DatePicker';
 import Input from '../form/input/Input';
+import PopoverContainer from '../popover/PopoverContainer';
+import Tabs from '../tabs/Tabs';
+import { DataTableGenericContext } from './data-table-context';
 import { getRowId } from './data-table-utils';
 
 function autoFocusAndSelect(input: HTMLInputElement | null) {
@@ -13,61 +21,109 @@ function autoFocusAndSelect(input: HTMLInputElement | null) {
   input?.select();
 }
 
-export function DataTableEditorText<TRow, TSummaryRow>({ row, column, onRowChange, onClose }: RenderEditCellProps<TRow, TSummaryRow>) {
+function DataTableEditorPopover({
+  rowIdx,
+  colIdx,
+  onClose,
+  children,
+}: {
+  rowIdx: number;
+  colIdx: number;
+  onClose: (commitChanges?: boolean, shouldFocusCell?: boolean) => void;
+  children: ReactNode;
+}) {
+  const popoverRef = useRef<HTMLDivElement | null>(null);
+  /** This is not set on initial render because the date picker is open on render and the reference element must exist to render correctly */
+  const [referenceElement, setReferenceElement] = useState<Element | null>(null);
+  useEffect(() => {
+    setReferenceElement(document.querySelector(`[aria-rowindex="${rowIdx + 2}"] > [aria-colindex="${colIdx + 1}"]`));
+  }, [colIdx, rowIdx]);
   return (
-    <Input>
-      <input
-        css={css`
-          color: #000;
-          width: 100%;
-        `}
-        ref={autoFocusAndSelect}
-        value={(row[column.key as keyof TRow] as unknown as string) || ''}
-        onChange={(event) => {
-          const _touchedColumns = new Set((row as any)._touchedColumns || []);
-          _touchedColumns.add(column.key);
-          onRowChange({ ...row, [column.key]: event.target.value, _touchedColumns });
-        }}
-        onBlur={() => {
-          onClose(true, true);
-        }}
-      />
-    </Input>
+    <PopoverContainer
+      ref={popoverRef}
+      isOpen
+      referenceElement={referenceElement as any}
+      className={`slds-popover slds-popover slds-popover_edit`}
+      role="dialog"
+      offset={[0, -28.5]}
+      usePortal
+      onKeyDown={(event) => {
+        if (isEscapeKey(event)) {
+          onClose();
+        }
+      }}
+    >
+      {referenceElement && <div className="slds-p-around_x-small">{children}</div>}
+    </PopoverContainer>
   );
 }
 
-export function DataTableEditorBoolean<TRow, TSummaryRow>({ row, column, onRowChange, onClose }: RenderEditCellProps<TRow, TSummaryRow>) {
+export function DataTableEditorText<TRow extends { _idx: number }, TSummaryRow>({
+  row,
+  column,
+  onRowChange,
+  onClose,
+}: RenderEditCellProps<TRow, TSummaryRow>) {
+  return (
+    <DataTableEditorPopover rowIdx={row._idx} colIdx={column.idx} onClose={onClose}>
+      <Input>
+        <input
+          className="slds-input"
+          ref={autoFocusAndSelect}
+          value={(row[column.key as keyof TRow] as unknown as string) || ''}
+          onChange={(event) => {
+            const _touchedColumns = new Set((row as any)._touchedColumns || []);
+            _touchedColumns.add(column.key);
+            onRowChange({ ...row, [column.key]: event.target.value, _touchedColumns });
+          }}
+          onBlur={() => {
+            onClose(true);
+          }}
+        />
+      </Input>
+    </DataTableEditorPopover>
+  );
+}
+
+export function DataTableEditorBoolean<TRow extends { _idx: number }, TSummaryRow>({
+  row,
+  column,
+  onRowChange,
+  onClose,
+}: RenderEditCellProps<TRow, TSummaryRow>) {
   const value = (row[column.key as keyof TRow] as unknown as boolean) || false;
   const id = `${getRowId(row)}_${column.key}_checkbox`;
   return (
-    <div className="slds-form-element slds-align_absolute-center slds-m-top_x-small">
-      <label className="slds-form-element__label slds-assistive-text" htmlFor={id}>
-        Edit {column.name}
-      </label>
-      <div className="slds-form-element__control">
-        <div className="slds-checkbox slds-checkbox_standalone">
-          <input
-            id={id}
-            type="checkbox"
-            name="options"
-            checked={value}
-            onChange={(event) => {
-              const _touchedColumns = new Set((row as any)._touchedColumns || []);
-              _touchedColumns.add(column.key);
-              onRowChange({ ...row, [column.key]: event.target.checked, _touchedColumns });
-            }}
-            onBlur={() => {
-              onClose(true, true);
-            }}
-          />
-          <span className="slds-checkbox_faux"></span>
+    <DataTableEditorPopover rowIdx={row._idx} colIdx={column.idx} onClose={onClose}>
+      <div className="slds-form-element slds-align_absolute-center slds-m-top_x-small">
+        <label className="slds-form-element__label slds-assistive-text" htmlFor={id}>
+          Edit {column.name}
+        </label>
+        <div className="slds-form-element__control">
+          <div className="slds-checkbox slds-checkbox_standalone">
+            <input
+              id={id}
+              type="checkbox"
+              name="options"
+              checked={value}
+              onChange={(event) => {
+                const _touchedColumns = new Set((row as any)._touchedColumns || []);
+                _touchedColumns.add(column.key);
+                onRowChange({ ...row, [column.key]: event.target.checked, _touchedColumns });
+              }}
+              onBlur={() => {
+                onClose(true);
+              }}
+            />
+            <span className="slds-checkbox_faux"></span>
+          </div>
         </div>
       </div>
-    </div>
+    </DataTableEditorPopover>
   );
 }
 
-export function dataTableEditorDropdownWrapper<TRow, TSummaryRow>({ values: _values }: { values: ListItem[] }) {
+export function dataTableEditorDropdownWrapper<TRow extends { _idx: number }, TSummaryRow>({ values: _values }: { values: ListItem[] }) {
   return ({ row, column, onRowChange, onClose }: RenderEditCellProps<TRow, TSummaryRow>) => {
     const allValues = useRef(new Set(_values.map((v) => v.value)));
     const [values, setValues] = useState<ListItem[]>(_values);
@@ -80,32 +136,35 @@ export function dataTableEditorDropdownWrapper<TRow, TSummaryRow>({ values: _val
     }
 
     return (
-      <select
-        css={css`
-          color: #000;
-          width: 100%;
-          height: calc(1.5rem + (1px * 2));
-        `}
-        className="slds-select"
-        value={(row[column.key as keyof TRow] as unknown as string) || ''}
-        onChange={(event) => {
-          const _touchedColumns = new Set((row as any)._touchedColumns || []);
-          _touchedColumns.add(column.key);
-          onRowChange({ ...row, [column.key]: event.target.value, _touchedColumns }, true);
-        }}
-        autoFocus
-      >
-        {values.map((value) => (
-          <option key={value.id} value={value.value}>
-            {value.label}
-          </option>
-        ))}
-      </select>
+      <DataTableEditorPopover rowIdx={row._idx} colIdx={column.idx} onClose={onClose}>
+        <ComboboxWithItems
+          comboboxProps={{
+            label: isString(column.name) ? column.name : column.key,
+            hideLabel: true,
+            itemLength: 10,
+            inputProps: {
+              autoFocus: true,
+            },
+          }}
+          items={values}
+          selectedItemId={row[column.key as keyof TRow] as unknown as string}
+          onSelected={(item) => {
+            const _touchedColumns = new Set((row as any)._touchedColumns || []);
+            _touchedColumns.add(column.key);
+            onRowChange({ ...row, [column.key]: item.value, _touchedColumns }, true);
+          }}
+        />
+      </DataTableEditorPopover>
     );
   };
 }
 
-export function DataTableEditorDate<TRow, TSummaryRow>({ row, column, onRowChange, onClose }: RenderEditCellProps<TRow, TSummaryRow>) {
+export function DataTableEditorDate<TRow extends { _idx: number }, TSummaryRow>({
+  row,
+  column,
+  onRowChange,
+  onClose,
+}: RenderEditCellProps<TRow, TSummaryRow>) {
   const currValue = row[column.key as keyof TRow] as unknown as string;
   let currDate: Date | undefined;
   if (currValue) {
@@ -113,23 +172,153 @@ export function DataTableEditorDate<TRow, TSummaryRow>({ row, column, onRowChang
   }
 
   return (
-    <DatePicker
-      css={css`
-        input {
-          min-height: calc(1.5rem + (1px * 2));
-          max-height: calc(1.5rem + (1px * 2));
-        }
-      `}
-      label="Edit Date"
-      hideLabel
-      usePortal
-      containerDisplay="contents"
-      initialSelectedDate={currDate}
-      onChange={(value) => {
-        const _touchedColumns = new Set((row as any)._touchedColumns || []);
-        _touchedColumns.add(column.key);
-        onRowChange({ ...row, [column.key]: value ? formatISO(value, { representation: 'date' }) : null, _touchedColumns }, true);
-      }}
-    />
+    <DataTableEditorPopover rowIdx={row._idx} colIdx={column.idx} onClose={onClose}>
+      <DatePicker
+        label="Edit Date"
+        hideLabel
+        usePortal
+        containerDisplay="contents"
+        className="d-block"
+        initialSelectedDate={currDate}
+        openOnInit
+        onChange={(value) => {
+          /** setTimeout is used to avoid a React error about flushSync being called during a render */
+          setTimeout(() => {
+            const _touchedColumns = new Set((row as any)._touchedColumns || []);
+            _touchedColumns.add(column.key);
+            onRowChange({ ...row, [column.key]: value ? formatISO(value, { representation: 'date' }) : null, _touchedColumns }, true);
+          });
+        }}
+      />
+    </DataTableEditorPopover>
   );
 }
+
+type Tab = 'lookup' | 'text';
+
+export const dataTableEditorRecordLookup = ({ sobject }: { sobject: string }) => {
+  return function DataTableEditorRecordLookup<TRow extends { _idx: number }, TSummaryRow>({
+    row,
+    column,
+    onRowChange,
+    onClose,
+  }: RenderEditCellProps<TRow, TSummaryRow>) {
+    const currValue = row[column.key as keyof TRow] as unknown as string;
+    const { org } = useContext(DataTableGenericContext) as { org: SalesforceOrgUi; defaultApiVersion: string };
+    const nameField = useRef<{ sobject: string; nameField: string }>();
+    const [records, setRecords] = useState<ListItem<string, any>[]>([]);
+    const [selectedRecord, setSelectedRecords] = useState<ListItem<string, any> | null>(null);
+    const [activeTab, setActiveTab] = useState<Tab>('text');
+
+    const handleSearch = useCallback(
+      async (searchTerm: string) => {
+        searchTerm = (searchTerm || '').trim();
+        logger.log('search', searchTerm);
+        setSelectedRecords(null);
+        try {
+          if (!sobject) {
+            setRecords([]);
+            return;
+          }
+          if (!nameField.current || nameField.current.sobject !== sobject) {
+            nameField.current = {
+              sobject,
+              nameField: await describeSObject(org, sobject).then(
+                (result) => result.data.fields.find((field) => field.nameField)?.name || 'Name'
+              ),
+            };
+          }
+          const name = nameField.current.nameField;
+
+          let soql = `SELECT Id, ${name} FROM ${sobject} ORDER BY ${name} LIMIT 50`;
+          if (searchTerm) {
+            if (searchTerm.length === 15 || searchTerm.length === 18) {
+              soql = `SELECT Id, ${name} FROM ${sobject} WHERE Id = '${searchTerm}' OR ${name} LIKE '%${searchTerm}%' ORDER BY ${name} LIMIT 50`;
+            } else {
+              soql = `SELECT Id, ${name} FROM ${sobject} WHERE ${name} LIKE '%${searchTerm}%' ORDER BY ${name} LIMIT 50`;
+            }
+          }
+          const { queryResults } = await query(org, soql);
+          setRecords(
+            queryResults.records.map((record) => ({
+              id: record.Id,
+              label: record[name],
+              title: record.Id,
+              secondaryLabel: record.Id,
+              secondaryLabelOnNewLine: true,
+              value: record.Id,
+              meta: record,
+            }))
+          );
+        } catch (ex) {
+          logger.warn('Error searching records', ex);
+          setRecords([]);
+        }
+      },
+      [org]
+    );
+
+    if (!org || !sobject) {
+      return <DataTableEditorText column={column} onClose={onClose} onRowChange={onRowChange} row={row} />;
+    }
+
+    return (
+      <DataTableEditorPopover rowIdx={row._idx} colIdx={column.idx} onClose={onClose}>
+        <Tabs
+          initialActiveId={activeTab}
+          contentClassname="slds-p-bottom_none"
+          onChange={(value: Tab) => {
+            setActiveTab(value);
+          }}
+          tabs={[
+            {
+              id: 'text',
+              title: 'Text',
+              content: (
+                <Input>
+                  <input
+                    className="slds-input"
+                    ref={autoFocusAndSelect}
+                    value={(row[column.key as keyof TRow] as unknown as string) || ''}
+                    onChange={(event) => {
+                      const _touchedColumns = new Set((row as any)._touchedColumns || []);
+                      _touchedColumns.add(column.key);
+                      onRowChange({ ...row, [column.key]: event.target.value, _touchedColumns });
+                    }}
+                    onKeyDown={(event) => {
+                      if (isEnterKey(event)) {
+                        onClose(true);
+                      }
+                    }}
+                  />
+                </Input>
+              ),
+            },
+            {
+              id: 'lookup',
+              title: 'Lookup Search',
+              content: (
+                <ComboboxWithItemsTypeAhead
+                  comboboxProps={{
+                    label: 'Record',
+                    hideLabel: true,
+                    className: 'w-100',
+                    placeholder: sobject ? `Search ${sobject} by name or id` : 'Select and object',
+                  }}
+                  items={records}
+                  onSearch={handleSearch}
+                  selectedItemId={selectedRecord?.id || currValue}
+                  onSelected={(item) => {
+                    const _touchedColumns = new Set((row as any)._touchedColumns || []);
+                    _touchedColumns.add(column.key);
+                    onRowChange({ ...row, [column.key]: item?.value || null, _touchedColumns }, true);
+                  }}
+                />
+              ),
+            },
+          ]}
+        />
+      </DataTableEditorPopover>
+    );
+  };
+};

--- a/libs/ui/src/lib/data-table/data-table-styles.scss
+++ b/libs/ui/src/lib/data-table/data-table-styles.scss
@@ -31,5 +31,9 @@
       outline-offset: -2px;
       outline-style: solid;
     }
+    &.edited {
+      background: #faffbd;
+      border: 1px solid #a86403;
+    }
   }
 }

--- a/libs/ui/src/lib/data-table/data-table-types.ts
+++ b/libs/ui/src/lib/data-table/data-table-types.ts
@@ -4,6 +4,7 @@ import { Column } from 'react-data-grid';
 export type RowWithKey = Record<string, any> & { _key: string };
 export type RowSalesforceRecordWithKey = RowWithKey & {
   _action: (row: RowWithKey, action: 'view' | 'edit' | 'clone' | 'apex') => void;
+  _idx: number;
   _record: Record<string, any>;
   _touchedColumns: Set<string>;
   _saveError?: Maybe<string>;

--- a/libs/ui/src/lib/data-table/data-table-utils.tsx
+++ b/libs/ui/src/lib/data-table/data-table-utils.tsx
@@ -21,7 +21,13 @@ import uniqueId from 'lodash/uniqueId';
 import { SelectColumn, SELECT_COLUMN_KEY as _SELECT_COLUMN_KEY } from 'react-data-grid';
 import { FieldSubquery, getField, getFlattenedFields, isFieldSubquery } from 'soql-parser-js';
 import { ContextMenuItem } from '../popover/ContextMenu';
-import { DataTableEditorBoolean, DataTableEditorDate, DataTableEditorText, dataTableEditorDropdownWrapper } from './DataTableEditors';
+import {
+  DataTableEditorBoolean,
+  DataTableEditorDate,
+  DataTableEditorText,
+  dataTableEditorDropdownWrapper,
+  dataTableEditorRecordLookup,
+} from './DataTableEditors';
 import {
   ActionRenderer,
   BooleanRenderer,
@@ -230,7 +236,7 @@ function getQueryResultColumn({
     cellClass: (row: any) => {
       const classes = ['slds-truncate'];
       if (row._touchedColumns instanceof Set && (row._touchedColumns as Set<string>).has(field) && row[field] !== row._record?.[field]) {
-        classes.push('active-item-yellow-bg');
+        classes.push('edited');
         if (row._saveError) {
           classes.push('active-item-error');
         }
@@ -445,7 +451,9 @@ export function updateColumnWithEditMode(
         .filter(({ active }) => active)
         .map(({ value, label }) => ({
           id: value,
-          label: label || value,
+          label: value,
+          secondaryLabel: label !== value ? label : undefined,
+          secondaryLabelOnNewLine: label !== value,
           value: value,
         })),
     });
@@ -454,6 +462,13 @@ export function updateColumnWithEditMode(
     // } else if (type === 'id' || apexType === 'Id') {
     // } else if (type === 'datetime' || apexType === 'Datetime') {
     // } else if (type === 'time' || apexType === 'Time') {
+  } else if (type === 'reference' && field.referenceTo?.length === 1) {
+    column.editable = true;
+    column.editorOptions = {
+      commitOnOutsideClick: false,
+      displayCellContent: true,
+    };
+    column.renderEditCell = dataTableEditorRecordLookup({ sobject: field.referenceTo[0] });
   } else {
     // textType
     column.editable = true;

--- a/libs/ui/src/lib/form/combobox/Combobox.tsx
+++ b/libs/ui/src/lib/form/combobox/Combobox.tsx
@@ -64,6 +64,7 @@ export interface ComboboxProps {
   noItemsPlaceholder?: string;
   disabled?: boolean;
   loading?: boolean;
+  inputProps?: React.InputHTMLAttributes<HTMLInputElement>;
   /** Set to true if there are groups */
   /**
    * Text shown for the selected item when the menu is closed.
@@ -156,6 +157,7 @@ export const Combobox = forwardRef<ComboboxPropsRef, ComboboxProps>(
       noItemsPlaceholder = 'There are no items for selection',
       disabled,
       loading,
+      inputProps,
       selectedItemLabel,
       selectedItemTitle,
       leadingDropdown,
@@ -431,6 +433,7 @@ export const Combobox = forwardRef<ComboboxPropsRef, ComboboxProps>(
                       value={value}
                       title={selectedItemTitle || value}
                       onBlur={handleBlur}
+                      {...inputProps}
                     />
                     {loading ? iconLoading : iconNotLoading}
                   </div>

--- a/libs/ui/src/lib/form/date/DatePicker.tsx
+++ b/libs/ui/src/lib/form/date/DatePicker.tsx
@@ -39,6 +39,7 @@ export interface DatePickerProps {
   readOnly?: boolean;
   inputProps?: React.DetailedHTMLProps<React.InputHTMLAttributes<HTMLInputElement>, HTMLInputElement>;
   usePortal?: boolean;
+  openOnInit?: boolean;
   onChange: (date: Date | null) => void;
 }
 
@@ -62,6 +63,7 @@ export const DatePicker: FunctionComponent<DatePickerProps> = ({
   disabled,
   readOnly,
   inputProps,
+  openOnInit = false,
   usePortal = false,
   onChange,
 }) => {
@@ -72,7 +74,7 @@ export const DatePicker: FunctionComponent<DatePickerProps> = ({
   const [id] = useState<string>(`${_id || 'date-picker'}-${Date.now()}`); // used to avoid auto-complete
   const [value, setValue] = useState<string>('');
   const [selectedDate, setSelectedDate] = useState(() => (isValidDate(initialSelectedDate) ? initialSelectedDate : undefined));
-  const [isOpen, setIsOpen] = useState(false);
+  const [isOpen, setIsOpen] = useState(openOnInit);
   const [availableYears, setAvailableYears] = useState(() => getDatePickerYears(initialMinAvailableDate, initialMaxAvailableDate));
 
   const [minAvailableDate, setMinAvailableDate] = useState(initialMinAvailableDate);

--- a/libs/ui/src/lib/popover/PopoverContainer.tsx
+++ b/libs/ui/src/lib/popover/PopoverContainer.tsx
@@ -1,14 +1,25 @@
 import { css } from '@emotion/react';
-import { forwardRef, HTMLAttributes, ReactNode, useEffect, useState } from 'react';
+import type { Placement } from '@popperjs/core';
+import { HTMLAttributes, ReactNode, forwardRef, useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { usePopper } from 'react-popper';
 
 interface PopoverContainerProps extends Omit<HTMLAttributes<HTMLDivElement>, 'children'> {
   className?: string;
   isOpen: boolean;
+  /** Used to know where to place popover */
   referenceElement: HTMLElement | null;
   usePortal?: boolean;
+  /** Load content into dom even if not open */
   isEager?: boolean;
+  /** Popper.js offset {@link https://popper.js.org/docs/v2/tutorial/#offset} */
+  offset?: number[];
+  /** Popper.js offset {@link https://popper.js.org/docs/v2/utils/detect-overflow/#placement} */
+  placement?: Placement;
+  /** Min width in CSS unit */
+  minWidth?: string;
+  /** Max width in CSS unit. If provided classname includes "_fluid", no max width wil be set */
+  maxWidth?: string;
   children: ReactNode;
 }
 
@@ -16,11 +27,26 @@ interface PopoverContainerProps extends Omit<HTMLAttributes<HTMLDivElement>, 'ch
  * Generic popover container used for dropdown menus, date pickers, etc.
  */
 export const PopoverContainer = forwardRef<HTMLDivElement, PopoverContainerProps>(
-  ({ className, isOpen, referenceElement, usePortal = false, isEager = false, children, ...rest }, ref) => {
+  (
+    {
+      className,
+      isOpen,
+      referenceElement,
+      usePortal = false,
+      isEager = false,
+      placement = 'bottom-start',
+      offset = [0, 1.75],
+      minWidth = '15rem',
+      maxWidth = '20rem',
+      children,
+      ...rest
+    },
+    ref
+  ) => {
     const [popperElement, setPopperElement] = useState<HTMLDivElement | null>(null);
     const { styles, attributes, update } = usePopper(referenceElement, popperElement, {
-      placement: 'bottom-start',
-      modifiers: [{ name: 'offset', options: { offset: [0, 1.75] } }],
+      placement,
+      modifiers: [{ name: 'offset', options: { offset: offset as any } }],
     });
 
     useEffect(() => {
@@ -54,7 +80,7 @@ export const PopoverContainer = forwardRef<HTMLDivElement, PopoverContainerProps
         // Selectively picked from `slds-dropdown` - removed margin as that must be set via popper offset
         css={css`
           z-index: 7000;
-          ${className?.includes('_fluid') ? 'min-width: 15rem;' : 'min-width: 15rem; max-width: 20rem;'}
+          ${className?.includes('_fluid') ? `min-width: ${minWidth};` : `min-width: ${minWidth}; max-width: ${maxWidth};`}
           border: 1px solid #e5e5e5;
           border-radius: 0.25rem;
           padding: 0.25rem 0;


### PR DESCRIPTION
Improved input editor to match Salesforce experience (popover + dirty cell style)

Ensure that ctrl+c does not put editor into edit mode

Added option for record search lookup

Open date picker popover by default when starting edit

Improve save/cancel button placement

Use combobox instead of native `<select />` for picklist editing

![image](https://github.com/jetstreamapp/jetstream/assets/5461649/edefe949-9742-4827-accb-f04282874587)

![image](https://github.com/jetstreamapp/jetstream/assets/5461649/5690f290-d20b-472b-8391-2988b41c2710)

