### PR TITLE
Close inline edit on blur

### DIFF
--- a/libs/shared/constants/src/lib/shared-constants.ts
+++ b/libs/shared/constants/src/lib/shared-constants.ts
@@ -4,6 +4,7 @@ export const ORG_VERSION_PLACEHOLDER = '_DEFAULT_VERSION_';
 
 export const SESSION_EXP_DAYS = 5;
 export const SFDC_BULK_API_NULL_VALUE = '#N/A';
+export const SFDC_BLANK_PICKLIST_VALUE = '--None--';
 
 export const FEATURE_FLAGS = Object.freeze({
   ALL: 'all',

--- a/libs/shared/ui-record-form/src/lib/ui-record-form-utils.ts
+++ b/libs/shared/ui-record-form/src/lib/ui-record-form-utils.ts
@@ -1,3 +1,4 @@
+import { SFDC_BLANK_PICKLIST_VALUE } from '@jetstream/shared/constants';
 import { sortQueryFields } from '@jetstream/shared/ui-utils';
 import { CloneEditView, PicklistFieldValues, Record } from '@jetstream/types';
 import type { DescribeSObjectResult, Field, FieldType } from 'jsforce';
@@ -8,8 +9,8 @@ import {
   EditableFieldDateTime,
   EditableFieldInput,
   EditableFieldPicklist,
-  EditableFields,
   EditableFieldTextarea,
+  EditableFields,
 } from './ui-record-form-types';
 
 const IGNORED_FIELD_TYPES = new Set<FieldType>(['address', 'location', 'complexvalue']);
@@ -94,9 +95,9 @@ export function convertMetadataToEditableFields(
           // Empty value to allow clearing picklist
           {
             id: '',
-            label: '--None--',
+            label: SFDC_BLANK_PICKLIST_VALUE,
             value: '',
-            meta: { attributes: null, validFor: null, label: '--None--', value: '' },
+            meta: { attributes: null, validFor: null, label: SFDC_BLANK_PICKLIST_VALUE, value: '' },
           },
         ].concat(
           picklist.values.map((item) => ({

--- a/libs/ui/src/lib/form/input/Input.tsx
+++ b/libs/ui/src/lib/form/input/Input.tsx
@@ -1,16 +1,17 @@
 // https://www.lightningdesignsystem.com/components/input/#Fixed-Text
 
+import { IconName, IconType } from '@jetstream/icon-factory';
 import classNames from 'classnames';
 import { Fragment, FunctionComponent, MouseEvent } from 'react';
 import HelpText from '../../widgets/HelpText';
 import Icon from '../../widgets/Icon';
-import { IconType, IconName } from '@jetstream/icon-factory';
 
 export interface InputProps {
   id?: string;
   className?: string;
   formControlClassName?: string;
   label?: string;
+  hideLabel?: boolean;
   labelHelp?: string | null;
   helpText?: React.ReactNode | string;
   hasError?: boolean;
@@ -33,6 +34,7 @@ export const Input: FunctionComponent<InputProps> = ({
   className,
   formControlClassName,
   label,
+  hideLabel = false,
   labelHelp,
   helpText,
   isRequired = false,
@@ -59,7 +61,7 @@ export const Input: FunctionComponent<InputProps> = ({
     <div className={classNames('slds-form-element', className, { 'slds-has-error': hasError })}>
       {label && (
         <Fragment>
-          <label className="slds-form-element__label" htmlFor={id}>
+          <label className={classNames('slds-form-element__label', { 'slds-assistive-text': hideLabel })} htmlFor={id}>
             {isRequired && (
               <abbr className="slds-required" title="required">
                 *{' '}


### PR DESCRIPTION
Ensure inline edit is closed on blur even if clicking on table area without any cells

Improve lookup - clear value does not close the picklist, user must choose "--None--"

Other minor tweaks to improve process