### PR TITLE
Bug/510 - List metadata item fix, update verbiage of open selected records in new tab

### DIFF
--- a/apps/jetstream/src/app/components/query/QueryResults/QueryResultsMoreActions.tsx
+++ b/apps/jetstream/src/app/components/query/QueryResults/QueryResultsMoreActions.tsx
@@ -157,7 +157,7 @@ export const QueryResultsMoreActions: FunctionComponent<QueryResultsMoreActionsP
             },
             {
               id: 'open-in-new-tab',
-              value: 'Open each record in Salesforce',
+              value: 'Open selected records in Salesforce',
               icon: {
                 icon: 'new_window',
                 type: 'utility',

--- a/libs/connected/connected-ui/src/lib/useListMetadata.tsx
+++ b/libs/connected/connected-ui/src/lib/useListMetadata.tsx
@@ -118,10 +118,12 @@ async function fetchListMetadataForItemsInFolder(
 
       if (!ParentId) {
         foldersByPath[DeveloperName] = DeveloperName;
-      } else {
+      } else if (foldersById[ParentId]?.DeveloperName) {
         const parentFolder = foldersById[ParentId];
         const parentPath = foldersByPath[parentFolder.DeveloperName];
         foldersByPath[DeveloperName] = `${parentPath}/${DeveloperName}`;
+      } else {
+        logger.warn('[ERROR] Could not find parent folder for folder', folder);
       }
       return foldersByPath;
     }, foldersByPath);


### PR DESCRIPTION

TypeError: List Metadata Failed for item 

Handle case where a particular folder is not found.

This case is unexpected, but better to handle as much as possible instead having a full failure

resolves #509
resolves #510

Update verbiage for opening selected record 

resolves #501