### PR TITLE
Remember rearranged columns on re-load query

### DIFF
--- a/libs/shared/ui-utils/src/lib/shared-ui-data-utils.ts
+++ b/libs/shared/ui-utils/src/lib/shared-ui-data-utils.ts
@@ -3,6 +3,7 @@ import { REGEX, flattenRecords, getMapOf, splitArrayToMaxSize } from '@jetstream
 import type {
   CompositeRequestBody,
   CompositeResponse,
+  CopyToClipboardFormat,
   DebugLevel,
   DescribeSObjectResultWithExtendedField,
   FieldWithExtendedType,
@@ -21,6 +22,7 @@ import { composeQuery, getField } from 'soql-parser-js';
 import {
   isRelationshipField,
   polyfillFieldDefinition,
+  prepareCsvFile,
   sortQueryFields,
   transformTabularDataToExcelStr,
   transformTabularDataToHtml,
@@ -296,13 +298,16 @@ export async function fetchActiveLog(org: SalesforceOrgUi, id: string): Promise<
 /**
  * Copy records to clipboard in various formats
  */
-export function copyRecordsToClipboard(recordsToCopy: any, copyFormat: 'excel' | 'text' | 'json', fields?: Maybe<string[]>) {
+export function copyRecordsToClipboard(recordsToCopy: any, copyFormat: CopyToClipboardFormat, fields?: Maybe<string[]>) {
   if (copyFormat === 'excel' && fields) {
     const flattenedData = flattenRecords(recordsToCopy, fields);
     copyToClipboard(transformTabularDataToHtml(flattenedData, fields), { format: 'text/html' });
   } else if (copyFormat === 'text' && fields) {
     const flattenedData = flattenRecords(recordsToCopy, fields);
     copyToClipboard(transformTabularDataToExcelStr(flattenedData, fields), { format: 'text/plain' });
+  } else if (copyFormat === 'csv' && fields) {
+    const flattenedData = flattenRecords(recordsToCopy, fields);
+    copyToClipboard(prepareCsvFile(flattenedData, fields), { format: 'text/plain' });
   } else if (copyFormat === 'json') {
     copyToClipboard(JSON.stringify(recordsToCopy, null, 2), { format: 'text/plain' });
   }

--- a/libs/types/src/lib/types.ts
+++ b/libs/types/src/lib/types.ts
@@ -4,6 +4,8 @@ import { InsertUpdateUpsertDeleteQuery, SalesforceOrgEdition, SalesforceOrgLocal
 export type Maybe<T> = T | null | undefined;
 export type Nullable<T> = T | null;
 
+export type CopyToClipboardFormat = 'excel' | 'text' | 'csv' | 'json';
+
 export const isNotNullish = <T>(input: T | null | undefined): input is T => input != null;
 export const isNotEmpty = <T>(input: T[]) => input.length !== 0;
 

--- a/libs/ui/src/index.ts
+++ b/libs/ui/src/index.ts
@@ -10,6 +10,7 @@ export * from './lib/color-picker/ColorSwatches';
 export * from './lib/confirmation-dialog/ConfirmationDialog';
 export * from './lib/data-table/DataTable';
 export * from './lib/data-table/DataTableRenderers';
+export * from './lib/data-table/QueryResultsCopyToClipboard';
 export * from './lib/data-table/SalesforceRecordDataTable';
 export * from './lib/data-table/data-table-context';
 export * from './lib/data-table/data-table-formatters';

--- a/libs/ui/src/lib/data-table/DataTable.tsx
+++ b/libs/ui/src/lib/data-table/DataTable.tsx
@@ -244,9 +244,10 @@ export const DataTable = forwardRef<any, DataTableProps<any>>(
       setColumns(_columns);
     }, [_columns]);
 
-    useNonInitialEffect(() => {
+    useEffect(() => {
       onReorderColumns && onReorderColumns(columns.filter((column) => !NON_DATA_COLUMN_KEYS.has(column.key)).map(({ key }) => key));
-    }, [columns, onReorderColumns]);
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [columns]);
 
     useEffect(() => {
       if (Array.isArray(columns) && columns.length && Array.isArray(data) && data.length) {

--- a/libs/ui/src/lib/data-table/SalesforceRecordDataTable.tsx
+++ b/libs/ui/src/lib/data-table/SalesforceRecordDataTable.tsx
@@ -7,7 +7,7 @@ import { flattenRecord, getIdFromRecordUrl } from '@jetstream/shared/utils';
 import { CloneEditView, MapOf, Maybe, SalesforceOrgUi, SobjectCollectionResponse } from '@jetstream/types';
 import type { Field } from 'jsforce';
 import uniqueId from 'lodash/uniqueId';
-import { Fragment, FunctionComponent, ReactNode, memo, useCallback, useEffect, useRef, useState } from 'react';
+import { Fragment, FunctionComponent, ReactNode, useCallback, useEffect, useRef, useState } from 'react';
 import { Column, RowsChangeData } from 'react-data-grid';
 import SearchInput from '../form/search-input/SearchInput';
 import Grid from '../grid/Grid';
@@ -63,7 +63,7 @@ export interface SalesforceRecordDataTableProps {
   onSelectionChanged: (rows: any[]) => void;
   onFilteredRowsChanged: (rows: any[]) => void;
   /** Fired when query is loaded OR user changes column order */
-  onFields: (fields: { allFields: string[]; visibleFields: string[] }) => void;
+  onFields: (fields: string[]) => void;
   onLoadMoreRecords?: (queryResults: QueryResults<any>) => void;
   onEdit: (record: any, source: 'ROW_ACTION' | 'RELATED_RECORD_POPOVER') => void;
   onClone: (record: any, source: 'ROW_ACTION' | 'RELATED_RECORD_POPOVER') => void;
@@ -74,396 +74,385 @@ export interface SalesforceRecordDataTableProps {
   onReloadQuery: () => void;
 }
 
-export const SalesforceRecordDataTable: FunctionComponent<SalesforceRecordDataTableProps> = memo<SalesforceRecordDataTableProps>(
-  ({
-    org,
-    defaultApiVersion,
-    google_apiKey,
-    google_appId,
-    google_clientId,
-    isTooling,
-    serverUrl,
-    queryResults,
-    fieldMetadata,
-    fieldMetadataSubquery,
-    summaryHeaderRightContent,
-    onSelectionChanged,
-    onFilteredRowsChanged,
-    onFields,
-    onLoadMoreRecords,
-    onEdit,
-    onClone,
-    onView,
-    onUpdateRecords,
-    onGetAsApex,
-    onSavedRecords,
-    onReloadQuery,
-  }) => {
-    const isMounted = useRef(true);
-    const rollbar = useRollbar();
-    const [columns, setColumns] = useState<Column<RowSalesforceRecordWithKey>[]>();
-    const [subqueryColumnsMap, setSubqueryColumnsMap] = useState<MapOf<ColumnWithFilter<RowSalesforceRecordWithKey, unknown>[]>>();
-    const [records, setRecords] = useState<any[]>();
-    // Same as records but with additional data added
-    const [fields, setFields] = useState<string[]>([]);
-    const [rows, setRows] = useState<RowSalesforceRecordWithKey[]>();
-    const [dirtyRows, setDirtyRows] = useState<RowSalesforceRecordWithKey[]>([]);
-    const [saveErrors, setSaveErrors] = useState<string[]>([]);
+export const SalesforceRecordDataTable: FunctionComponent<SalesforceRecordDataTableProps> = ({
+  org,
+  defaultApiVersion,
+  google_apiKey,
+  google_appId,
+  google_clientId,
+  isTooling,
+  serverUrl,
+  queryResults,
+  fieldMetadata,
+  fieldMetadataSubquery,
+  summaryHeaderRightContent,
+  onSelectionChanged,
+  onFilteredRowsChanged,
+  onFields,
+  onLoadMoreRecords,
+  onEdit,
+  onClone,
+  onView,
+  onUpdateRecords,
+  onGetAsApex,
+  onSavedRecords,
+  onReloadQuery,
+}) => {
+  const isMounted = useRef(true);
+  const rollbar = useRollbar();
+  const [columns, setColumns] = useState<Column<RowSalesforceRecordWithKey>[]>();
+  const [subqueryColumnsMap, setSubqueryColumnsMap] = useState<MapOf<ColumnWithFilter<RowSalesforceRecordWithKey, unknown>[]>>();
+  const [records, setRecords] = useState<any[]>();
+  // Same as records but with additional data added
+  const [fields, setFields] = useState<string[]>([]);
+  const [rows, setRows] = useState<RowSalesforceRecordWithKey[]>();
+  const [dirtyRows, setDirtyRows] = useState<RowSalesforceRecordWithKey[]>([]);
+  const [saveErrors, setSaveErrors] = useState<string[]>([]);
 
-    const [totalRecordCount, setTotalRecordCount] = useState<number>();
-    const [isLoadingMore, setIsLoadingMore] = useState(false);
-    const [loadMoreErrorMessage, setLoadMoreErrorMessage] = useState<string | null>(null);
-    const [hasMoreRecords, setHasMoreRecords] = useState(false);
-    const [nextRecordsUrl, setNextRecordsUrl] = useState<Maybe<string>>(null);
-    const [globalFilter, setGlobalFilter] = useState<string | null>(null);
-    const [selectedRows, setSelectedRows] = useState<ReadonlySet<string>>(() => new Set());
-    const [visibleRecordCount, setVisibleRecordCount] = useState(records?.length);
+  const [totalRecordCount, setTotalRecordCount] = useState<number>();
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
+  const [loadMoreErrorMessage, setLoadMoreErrorMessage] = useState<string | null>(null);
+  const [hasMoreRecords, setHasMoreRecords] = useState(false);
+  const [nextRecordsUrl, setNextRecordsUrl] = useState<Maybe<string>>(null);
+  const [globalFilter, setGlobalFilter] = useState<string | null>(null);
+  const [selectedRows, setSelectedRows] = useState<ReadonlySet<string>>(() => new Set());
+  const [visibleRecordCount, setVisibleRecordCount] = useState(records?.length);
 
-    const [isSavingRecords, setIsSavingRecords] = useState(false);
+  const [isSavingRecords, setIsSavingRecords] = useState(false);
 
-    useEffect(() => {
-      isMounted.current = true;
-      return () => {
-        isMounted.current = false;
-      };
-    }, []);
+  useEffect(() => {
+    isMounted.current = true;
+    return () => {
+      isMounted.current = false;
+    };
+  }, []);
 
-    useEffect(() => {
-      if (queryResults) {
-        const { parentColumns, subqueryColumns } = getColumnDefinitions(queryResults, isTooling, fieldMetadata);
-        const fields = parentColumns.filter((column) => column.key && !NON_DATA_COLUMN_KEYS.has(column.key)).map((column) => column.key);
-        setColumns(parentColumns);
-        setFields(fields);
-        onFields({ allFields: fields, visibleFields: fields });
-        setSubqueryColumnsMap(subqueryColumns);
-        setRecords(queryResults.queryResults.records);
-        onFilteredRowsChanged(queryResults.queryResults.records);
-        setTotalRecordCount(queryResults.queryResults.totalSize);
-        if (!queryResults.queryResults.done && queryResults.queryResults.nextRecordsUrl) {
-          setHasMoreRecords(true);
-          setNextRecordsUrl(queryResults.queryResults.nextRecordsUrl);
-        }
-      }
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [queryResults]);
-
-    useEffect(() => {
-      if (onSelectionChanged && Array.isArray(rows) && selectedRows) {
-        onSelectionChanged(rows.filter((row) => selectedRows.has(getRowId(row))).map((row) => row._record));
-      }
-    }, [onSelectionChanged, rows, selectedRows]);
-
-    /**
-     * When metadata is obtained, update the grid columns to include field labels
-     */
-    useEffect(() => {
-      if (fieldMetadata && queryResults) {
-        const { parentColumns, subqueryColumns } = getColumnDefinitions(queryResults, isTooling, fieldMetadata);
-
-        setColumns(addFieldLabelToColumn(parentColumns, fieldMetadata));
-
-        // If there are subqueries, update field definition
-        if (fieldMetadataSubquery) {
-          for (const key in subqueryColumns) {
-            if (fieldMetadataSubquery[key.toLowerCase()]) {
-              subqueryColumns[key] = addFieldLabelToColumn(subqueryColumns[key], fieldMetadataSubquery[key.toLowerCase()]);
-            }
-          }
-        }
-
-        setSubqueryColumnsMap(subqueryColumns);
-      }
-    }, [fieldMetadata, fieldMetadataSubquery, isTooling, queryResults]);
-
-    useEffect(() => {
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      setSaveErrors(dirtyRows.filter((row) => row._saveError).map((row) => row._saveError!));
-    }, [dirtyRows]);
-
-    const handleRowAction = useCallback((row: RowWithKey, action: 'view' | 'edit' | 'clone' | 'apex') => {
-      const record = row._record;
-      logger.info('row action', record, action);
-      switch (action) {
-        case 'edit':
-          onEdit(record, 'ROW_ACTION');
-          break;
-        case 'clone':
-          onClone(record, 'ROW_ACTION');
-          break;
-        case 'view':
-          onView(record, 'ROW_ACTION');
-          break;
-        case 'apex':
-          onGetAsApex(record);
-          break;
-        default:
-          break;
-      }
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, []);
-
-    const handleContextMenuAction = useCallback(
-      (item: ContextMenuItem<ContextAction>, data: ContextMenuActionData<RowWithKey>) => {
-        copySalesforceRecordTableDataToClipboard(item.value, fields, data);
-      },
-      [fields]
-    );
-
-    useEffect(() => {
-      const columnKeys = columns?.map((col) => col.key) || null;
-      setRows(
-        (records || []).map((row, i): RowSalesforceRecordWithKey => {
-          return {
-            _action: handleRowAction,
-            _idx: i,
-            _record: row,
-            ...(columnKeys ? flattenRecord(row, columnKeys, false) : row),
-            _key: getRowId(row),
-            _touchedColumns: new Set(),
-            _saveError: null,
-          };
-        })
-      );
-      setDirtyRows([]);
-    }, [columns, handleRowAction, records]);
-
-    async function loadRemaining() {
-      try {
-        if (
-          dirtyRows?.length &&
-          !(await ConfirmationModalPromise({
-            content: 'If you load all records your unsaved changes will not be saved.',
-          }))
-        ) {
-          return;
-        }
-
-        if (!nextRecordsUrl) {
-          return;
-        }
-        setIsLoadingMore(true);
-        setLoadMoreErrorMessage(null);
-        const results = await queryRemaining(org, nextRecordsUrl, isTooling);
-        if (!isMounted.current) {
-          return;
-        }
-        setNextRecordsUrl(results.queryResults.nextRecordsUrl);
-        if (results.queryResults.done) {
-          setHasMoreRecords(false);
-        }
-        setRecords((records || []).concat(results.queryResults.records));
-        setIsLoadingMore(false);
-        if (onLoadMoreRecords) {
-          onLoadMoreRecords(results);
-        }
-      } catch (ex) {
-        if (!isMounted.current) {
-          return;
-        }
-        // oops. show the user an error
-        setIsLoadingMore(false);
-        setLoadMoreErrorMessage('There was a problem loading the rest of the records.');
-        rollbar.error('Load Remaining Records failed', { message: ex.message, stack: ex.stack });
+  useEffect(() => {
+    if (queryResults) {
+      const { parentColumns, subqueryColumns } = getColumnDefinitions(queryResults, isTooling, fieldMetadata);
+      const fields = parentColumns.filter((column) => column.key && !NON_DATA_COLUMN_KEYS.has(column.key)).map((column) => column.key);
+      setColumns(parentColumns);
+      setFields(fields);
+      onFields(fields);
+      setSubqueryColumnsMap(subqueryColumns);
+      setRecords(queryResults.queryResults.records);
+      onFilteredRowsChanged(queryResults.queryResults.records);
+      setTotalRecordCount(queryResults.queryResults.totalSize);
+      if (!queryResults.queryResults.done && queryResults.queryResults.nextRecordsUrl) {
+        setHasMoreRecords(true);
+        setNextRecordsUrl(queryResults.queryResults.nextRecordsUrl);
       }
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [queryResults]);
 
-    const handleSortedAndFilteredRowsChange = useCallback(
-      (rows: RowSalesforceRecordWithKey[]) => {
-        onFilteredRowsChanged(rows.map(({ _record }) => _record));
+  useEffect(() => {
+    if (onSelectionChanged && Array.isArray(rows) && selectedRows) {
+      onSelectionChanged(rows.filter((row) => selectedRows.has(getRowId(row))).map((row) => row._record));
+    }
+  }, [onSelectionChanged, rows, selectedRows]);
 
-        setVisibleRecordCount(rows.length);
-      },
-      [onFilteredRowsChanged]
-    );
+  /**
+   * When metadata is obtained, update the grid columns to include field labels
+   */
+  useEffect(() => {
+    if (fieldMetadata && queryResults) {
+      const { parentColumns, subqueryColumns } = getColumnDefinitions(queryResults, isTooling, fieldMetadata);
 
-    const handleSelectedRowsChange = useCallback((rows: Set<string>) => {
-      setSelectedRows(rows);
-    }, []);
+      setColumns(addFieldLabelToColumn(parentColumns, fieldMetadata));
 
-    const handleColumnReorder = useCallback((newFields: string[]) => {
-      onFields({ allFields: newFields, visibleFields: newFields });
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, []);
-
-    const handleRowsChange = useCallback((rows: RowSalesforceRecordWithKey[], data: RowsChangeData<RowSalesforceRecordWithKey[]>) => {
-      setRows(rows);
-      setDirtyRows(
-        rows.filter((row) => row._touchedColumns.size > 0 && Array.from(row._touchedColumns).some((col) => row[col] !== row._record[col]))
-      );
-    }, []);
-
-    const handleCancelEditMode = () => {
-      setRecords((records) => (records ? [...records] : records));
-    };
-
-    const handleSaveRecords = async () => {
-      try {
-        if (!rows) {
-          return;
+      // If there are subqueries, update field definition
+      if (fieldMetadataSubquery) {
+        for (const key in subqueryColumns) {
+          if (fieldMetadataSubquery[key.toLowerCase()]) {
+            subqueryColumns[key] = addFieldLabelToColumn(subqueryColumns[key], fieldMetadataSubquery[key.toLowerCase()]);
+          }
         }
-        if (!dirtyRows.length) {
-          setRecords((records) => (records ? [...records] : records));
-          return;
-        }
-        setIsSavingRecords(true);
-        const modifiedRecords = dirtyRows.map((row) =>
-          Array.from(row._touchedColumns).reduce(
-            (acc, column) => {
-              acc[column] = row[column];
-              return acc;
-            },
-            { attributes: row._record.attributes, Id: getIdFromRecordUrl(row._record.attributes.url) }
-          )
-        );
-        const results = await onUpdateRecords(modifiedRecords);
-
-        const failedResultsById = results.reduce((acc, result, i) => {
-          if (!result.success) {
-            const id = result.id || getIdFromRecordUrl(dirtyRows[i]._record.attributes.url);
-            if (id) {
-              acc[id] = result;
-            }
-          }
-          return acc;
-        }, {});
-
-        /** Reset all successful rows, add error message to failed rows */
-        const newRows = rows.map((row): RowSalesforceRecordWithKey => {
-          if (row._touchedColumns.size > 0) {
-            const id = getIdFromRecordUrl(row._record.attributes.url);
-            if (failedResultsById[id]) {
-              return { ...row, _saveError: failedResultsById[id].errors[0].message };
-            } else {
-              return { ...row, _touchedColumns: new Set(), _saveError: null };
-            }
-          }
-          if (row._saveError) {
-            return { ...row, _saveError: null };
-          }
-          return row;
-        });
-        setRows(newRows);
-        setDirtyRows(
-          newRows.filter(
-            (row) => row._touchedColumns.size > 0 && Array.from(row._touchedColumns).some((col: string) => row[col] !== row._record[col])
-          )
-        );
-        onSavedRecords({ recordCount: modifiedRecords.length, failureCount: Object.values(failedResultsById).length });
-      } catch (ex) {
-        // This happens if exception thrown, normal behavior is to get records with result success/error
-        logger.warn('Error saving records', ex);
-        fireToast({
-          message: `There was a problem saving your records. ${ex?.message || ''}`,
-          type: 'error',
-        });
-        rollbar.error('Error saving records - inline query', { message: ex.message, stack: ex.stack });
-      } finally {
-        setIsSavingRecords(false);
       }
-    };
 
-    return records ? (
-      <Fragment>
-        <Grid className="slds-p-around_xx-small" align="spread">
-          <div className="slds-grid">
-            <div className="slds-p-around_x-small">
-              Showing {formatNumber(visibleRecordCount)} of {formatNumber(totalRecordCount || 0)} records
-            </div>
-            {hasMoreRecords && (
-              <div>
-                <button
-                  className="slds-button slds-button_brand slds-m-left_x-small slds-is-relative"
-                  onClick={loadRemaining}
-                  disabled={isLoadingMore}
-                >
-                  Load All Records
-                  {isLoadingMore && <Spinner size="small" />}
-                </button>
-                {loadMoreErrorMessage && <PopoverErrorButton errors={loadMoreErrorMessage} />}
-              </div>
-            )}
-          </div>
-          <div className="slds-p-top_xx-small">
-            <SearchInput id="record-filter" placeholder="Search records..." onChange={setGlobalFilter} />
-          </div>
-          <div>{summaryHeaderRightContent}</div>
-        </Grid>
-        {!!dirtyRows?.length && (
-          <Grid
-            css={css`
-              background-color: #f3f3f3;
-            `}
-            className="slds-p-around_x-small"
-            align="center"
-          >
-            {saveErrors?.length > 0 && <PopoverErrorButton header="Save Errors" initOpenState={false} errors={saveErrors} />}
-            <button
-              className="slds-button slds-button_neutral slds-m-left_x-small"
-              onClick={handleCancelEditMode}
-              disabled={isSavingRecords}
-            >
-              Cancel
-            </button>
-            <button
-              className="slds-button slds-button_brand slds-m-left_x-small slds-is-relative"
-              onClick={handleSaveRecords}
-              disabled={isSavingRecords}
-            >
-              Save
-              {isSavingRecords && <Spinner size="small" />}
-            </button>
-          </Grid>
-        )}
-        <AutoFullHeightContainer fillHeight setHeightAttr bottomBuffer={dirtyRows?.length ? 58 : 10}>
-          <DataTableSubqueryContext.Provider
-            value={{
-              serverUrl,
-              org,
-              isTooling,
-              columnDefinitions: subqueryColumnsMap,
-              google_apiKey,
-              google_appId,
-              google_clientId,
-            }}
-          >
-            <DataTable
-              serverUrl={serverUrl}
-              org={org}
-              data={rows || []}
-              columns={columns || []}
-              allowReorder
-              includeQuickFilter
-              quickFilterText={globalFilter}
-              getRowKey={getRowId}
-              rowHeight={28.5}
-              selectedRows={selectedRows}
-              rowClass={getRowClass}
-              onReorderColumns={handleColumnReorder}
-              onSelectedRowsChange={handleSelectedRowsChange}
-              onSortedAndFilteredRowsChange={handleSortedAndFilteredRowsChange}
-              onRowsChange={handleRowsChange}
-              context={{
-                org,
-                defaultApiVersion,
-                onRecordAction: (action: CloneEditView, recordId: string, sobjectName: string) => {
-                  switch (action) {
-                    case 'view':
-                      onView({ Id: recordId, attributes: { type: sobjectName } }, 'RELATED_RECORD_POPOVER');
-                      break;
-                    case 'edit':
-                      onEdit({ Id: recordId, attributes: { type: sobjectName } }, 'RELATED_RECORD_POPOVER');
-                      break;
-                  }
-                },
-              }}
-              contextMenuItems={TABLE_CONTEXT_MENU_ITEMS}
-              contextMenuAction={handleContextMenuAction}
-            />
-          </DataTableSubqueryContext.Provider>
-        </AutoFullHeightContainer>
-      </Fragment>
-    ) : null;
+      setSubqueryColumnsMap(subqueryColumns);
+    }
+  }, [fieldMetadata, fieldMetadataSubquery, isTooling, queryResults]);
+
+  useEffect(() => {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    setSaveErrors(dirtyRows.filter((row) => row._saveError).map((row) => row._saveError!));
+  }, [dirtyRows]);
+
+  const handleRowAction = useCallback((row: RowWithKey, action: 'view' | 'edit' | 'clone' | 'apex') => {
+    const record = row._record;
+    logger.info('row action', record, action);
+    switch (action) {
+      case 'edit':
+        onEdit(record, 'ROW_ACTION');
+        break;
+      case 'clone':
+        onClone(record, 'ROW_ACTION');
+        break;
+      case 'view':
+        onView(record, 'ROW_ACTION');
+        break;
+      case 'apex':
+        onGetAsApex(record);
+        break;
+      default:
+        break;
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const handleContextMenuAction = useCallback(
+    (item: ContextMenuItem<ContextAction>, data: ContextMenuActionData<RowWithKey>) => {
+      copySalesforceRecordTableDataToClipboard(item.value, fields, data);
+    },
+    [fields]
+  );
+
+  useEffect(() => {
+    const columnKeys = columns?.map((col) => col.key) || null;
+    setRows(
+      (records || []).map((row, i): RowSalesforceRecordWithKey => {
+        return {
+          _action: handleRowAction,
+          _idx: i,
+          _record: row,
+          ...(columnKeys ? flattenRecord(row, columnKeys, false) : row),
+          _key: getRowId(row),
+          _touchedColumns: new Set(),
+          _saveError: null,
+        };
+      })
+    );
+    setDirtyRows([]);
+  }, [columns, handleRowAction, records]);
+
+  async function loadRemaining() {
+    try {
+      if (
+        dirtyRows?.length &&
+        !(await ConfirmationModalPromise({
+          content: 'If you load all records your unsaved changes will not be saved.',
+        }))
+      ) {
+        return;
+      }
+
+      if (!nextRecordsUrl) {
+        return;
+      }
+      setIsLoadingMore(true);
+      setLoadMoreErrorMessage(null);
+      const results = await queryRemaining(org, nextRecordsUrl, isTooling);
+      if (!isMounted.current) {
+        return;
+      }
+      setNextRecordsUrl(results.queryResults.nextRecordsUrl);
+      if (results.queryResults.done) {
+        setHasMoreRecords(false);
+      }
+      setRecords((records || []).concat(results.queryResults.records));
+      setIsLoadingMore(false);
+      if (onLoadMoreRecords) {
+        onLoadMoreRecords(results);
+      }
+    } catch (ex) {
+      if (!isMounted.current) {
+        return;
+      }
+      // oops. show the user an error
+      setIsLoadingMore(false);
+      setLoadMoreErrorMessage('There was a problem loading the rest of the records.');
+      rollbar.error('Load Remaining Records failed', { message: ex.message, stack: ex.stack });
+    }
   }
-);
+
+  const handleSortedAndFilteredRowsChange = useCallback(
+    (rows: RowSalesforceRecordWithKey[]) => {
+      onFilteredRowsChanged(rows.map(({ _record }) => _record));
+
+      setVisibleRecordCount(rows.length);
+    },
+    [onFilteredRowsChanged]
+  );
+
+  const handleSelectedRowsChange = useCallback((rows: Set<string>) => {
+    setSelectedRows(rows);
+  }, []);
+
+  const handleRowsChange = useCallback((rows: RowSalesforceRecordWithKey[], data: RowsChangeData<RowSalesforceRecordWithKey[]>) => {
+    setRows(rows);
+    setDirtyRows(
+      rows.filter((row) => row._touchedColumns.size > 0 && Array.from(row._touchedColumns).some((col) => row[col] !== row._record[col]))
+    );
+  }, []);
+
+  const handleCancelEditMode = () => {
+    setRecords((records) => (records ? [...records] : records));
+  };
+
+  const handleSaveRecords = async () => {
+    try {
+      if (!rows) {
+        return;
+      }
+      if (!dirtyRows.length) {
+        setRecords((records) => (records ? [...records] : records));
+        return;
+      }
+      setIsSavingRecords(true);
+      const modifiedRecords = dirtyRows.map((row) =>
+        Array.from(row._touchedColumns).reduce(
+          (acc, column) => {
+            acc[column] = row[column];
+            return acc;
+          },
+          { attributes: row._record.attributes, Id: getIdFromRecordUrl(row._record.attributes.url) }
+        )
+      );
+      const results = await onUpdateRecords(modifiedRecords);
+
+      const failedResultsById = results.reduce((acc, result, i) => {
+        if (!result.success) {
+          const id = result.id || getIdFromRecordUrl(dirtyRows[i]._record.attributes.url);
+          if (id) {
+            acc[id] = result;
+          }
+        }
+        return acc;
+      }, {});
+
+      /** Reset all successful rows, add error message to failed rows */
+      const newRows = rows.map((row): RowSalesforceRecordWithKey => {
+        if (row._touchedColumns.size > 0) {
+          const id = getIdFromRecordUrl(row._record.attributes.url);
+          if (failedResultsById[id]) {
+            return { ...row, _saveError: failedResultsById[id].errors[0].message };
+          } else {
+            return { ...row, _touchedColumns: new Set(), _saveError: null };
+          }
+        }
+        if (row._saveError) {
+          return { ...row, _saveError: null };
+        }
+        return row;
+      });
+      setRows(newRows);
+      setDirtyRows(
+        newRows.filter(
+          (row) => row._touchedColumns.size > 0 && Array.from(row._touchedColumns).some((col: string) => row[col] !== row._record[col])
+        )
+      );
+      onSavedRecords({ recordCount: modifiedRecords.length, failureCount: Object.values(failedResultsById).length });
+    } catch (ex) {
+      // This happens if exception thrown, normal behavior is to get records with result success/error
+      logger.warn('Error saving records', ex);
+      fireToast({
+        message: `There was a problem saving your records. ${ex?.message || ''}`,
+        type: 'error',
+      });
+      rollbar.error('Error saving records - inline query', { message: ex.message, stack: ex.stack });
+    } finally {
+      setIsSavingRecords(false);
+    }
+  };
+
+  return records ? (
+    <Fragment>
+      <Grid className="slds-p-around_xx-small" align="spread">
+        <div className="slds-grid">
+          <div className="slds-p-around_x-small">
+            Showing {formatNumber(visibleRecordCount)} of {formatNumber(totalRecordCount || 0)} records
+          </div>
+          {hasMoreRecords && (
+            <div>
+              <button
+                className="slds-button slds-button_brand slds-m-left_x-small slds-is-relative"
+                onClick={loadRemaining}
+                disabled={isLoadingMore}
+              >
+                Load All Records
+                {isLoadingMore && <Spinner size="small" />}
+              </button>
+              {loadMoreErrorMessage && <PopoverErrorButton errors={loadMoreErrorMessage} />}
+            </div>
+          )}
+        </div>
+        <div className="slds-p-top_xx-small">
+          <SearchInput id="record-filter" placeholder="Search records..." onChange={setGlobalFilter} />
+        </div>
+        <div>{summaryHeaderRightContent}</div>
+      </Grid>
+      {!!dirtyRows?.length && (
+        <Grid
+          css={css`
+            background-color: #f3f3f3;
+          `}
+          className="slds-p-around_x-small"
+          align="center"
+        >
+          {saveErrors?.length > 0 && <PopoverErrorButton header="Save Errors" initOpenState={false} errors={saveErrors} />}
+          <button className="slds-button slds-button_neutral slds-m-left_x-small" onClick={handleCancelEditMode} disabled={isSavingRecords}>
+            Cancel
+          </button>
+          <button
+            className="slds-button slds-button_brand slds-m-left_x-small slds-is-relative"
+            onClick={handleSaveRecords}
+            disabled={isSavingRecords}
+          >
+            Save
+            {isSavingRecords && <Spinner size="small" />}
+          </button>
+        </Grid>
+      )}
+      <AutoFullHeightContainer fillHeight setHeightAttr bottomBuffer={dirtyRows?.length ? 58 : 10}>
+        <DataTableSubqueryContext.Provider
+          value={{
+            serverUrl,
+            org,
+            isTooling,
+            columnDefinitions: subqueryColumnsMap,
+            google_apiKey,
+            google_appId,
+            google_clientId,
+          }}
+        >
+          <DataTable
+            serverUrl={serverUrl}
+            org={org}
+            data={rows || []}
+            columns={columns || []}
+            allowReorder
+            includeQuickFilter
+            quickFilterText={globalFilter}
+            getRowKey={getRowId}
+            rowHeight={28.5}
+            selectedRows={selectedRows}
+            rowClass={getRowClass}
+            onReorderColumns={onFields}
+            onSelectedRowsChange={handleSelectedRowsChange}
+            onSortedAndFilteredRowsChange={handleSortedAndFilteredRowsChange}
+            onRowsChange={handleRowsChange}
+            context={{
+              org,
+              defaultApiVersion,
+              onRecordAction: (action: CloneEditView, recordId: string, sobjectName: string) => {
+                switch (action) {
+                  case 'view':
+                    onView({ Id: recordId, attributes: { type: sobjectName } }, 'RELATED_RECORD_POPOVER');
+                    break;
+                  case 'edit':
+                    onEdit({ Id: recordId, attributes: { type: sobjectName } }, 'RELATED_RECORD_POPOVER');
+                    break;
+                }
+              },
+            }}
+            contextMenuItems={TABLE_CONTEXT_MENU_ITEMS}
+            contextMenuAction={handleContextMenuAction}
+          />
+        </DataTableSubqueryContext.Provider>
+      </AutoFullHeightContainer>
+    </Fragment>
+  ) : null;
+};
 
 export default SalesforceRecordDataTable;


### PR DESCRIPTION
If query is ran a second time, remember order of fields in case they were changed

Ensure copy to clipboard honors current column order

Improve copy to clipboard for subquery modal to have same options as normal query

Add CSV as a copy format

#423