### PR TITLE
Use correct delimiter for bulk API

### DIFF
--- a/apps/jetstream/src/app/components/load-records/utils/load-records-process.ts
+++ b/apps/jetstream/src/app/components/load-records/utils/load-records-process.ts
@@ -54,7 +54,7 @@ export async function loadBulkApiData(
     const jobId = results.id!;
     let batches: LoadDataBulkApi[] = [];
     batches = splitArrayToMaxSize(data, batchSize)
-      .map((batch) => generateCsv(batch))
+      .map((batch) => generateCsv(batch, { delimiter: ',' }))
       .map((data, i) => ({ data, batchNumber: i, completed: false, success: false }));
 
     statusCallback(getBatchSummary(results, batches));

--- a/apps/jetstream/src/app/components/shared/mass-update-records/useDeployRecords.ts
+++ b/apps/jetstream/src/app/components/shared/mass-update-records/useDeployRecords.ts
@@ -80,7 +80,7 @@ export function useDeployRecords(
       const jobId = jobInfo.id || '';
       const batches = splitArrayToMaxSize(records, batchSize).map((batch) => ({
         records: batch,
-        csv: generateCsv(batch, { header: true, columns: fields }),
+        csv: generateCsv(batch, { header: true, columns: fields, delimiter: ',' }),
       }));
 
       deployResults.jobInfo = jobInfo;


### PR DESCRIPTION
Ensure the delimiter for CSV is always ',' for bulk API uploads

resolves #563