### PR TITLE
Namespace fields not included in record to apex

### DIFF
--- a/apps/jetstream/src/app/components/query/QueryResults/QueryResultsGetRecAsApexModal.tsx
+++ b/apps/jetstream/src/app/components/query/QueryResults/QueryResultsGetRecAsApexModal.tsx
@@ -46,16 +46,8 @@ export const QueryResultsGetRecAsApexModal: FunctionComponent<QueryResultsGetRec
       setFieldMetadata([]);
       setFieldTypesByName({});
       const metadata = await describeSObject(org, sobjectName);
-      // metadata will include namespace, but when we get the record from Salesforce it will not include the namespace
-      if (org.orgNamespacePrefix) {
-        const replaceRegex = new RegExp(`^${org.orgNamespacePrefix}__`);
-        metadata.data.fields = metadata.data.fields.map((field) => {
-          return { ...field, name: field.name.replace(replaceRegex, '') };
-        });
-      }
       const fieldTypeByApiName = metadata.data.fields.reduce((output: MapOf<FieldType>, field) => {
-        const replaceNamespace = org.orgNamespacePrefix ? `${org.orgNamespacePrefix}__` : '';
-        output[field.name.replace(replaceNamespace, '')] = field.type;
+        output[field.name] = field.type;
         return output;
       }, {});
       setLoading(false);


### PR DESCRIPTION
For orgs with a namespace, apex was not working correctly as returned record included namespace fields but the namespace was stripped from the metadata.

resolves #586