### PR TITLE
Provide multiple copy to clipboard formats

### DIFF
--- a/apps/jetstream/src/app/components/core/ViewEditCloneRecord.tsx
+++ b/apps/jetstream/src/app/components/core/ViewEditCloneRecord.tsx
@@ -423,7 +423,7 @@ export const ViewEditCloneRecord: FunctionComponent<ViewEditCloneRecordProps> = 
     });
   }
 
-  function handleCopyToClipboard(format: 'excel' | 'text' | 'json' = 'excel') {
+  function handleCopyToClipboard(format: 'excel' | 'json' = 'excel') {
     if (!initialRecord) {
       return;
     }
@@ -589,11 +589,8 @@ export const ViewEditCloneRecord: FunctionComponent<ViewEditCloneRecordProps> = 
                       className="slds-button_last"
                       dropDownClassName="slds-dropdown_actions"
                       position="right"
-                      items={[
-                        { id: 'text', value: 'Copy as Text' },
-                        { id: 'json', value: 'Copy as JSON' },
-                      ]}
-                      onSelected={(item) => handleCopyToClipboard(item as 'excel' | 'text' | 'json')}
+                      items={[{ id: 'json', value: 'Copy as JSON' }]}
+                      onSelected={(item) => handleCopyToClipboard(item as 'excel' | 'json')}
                     />
                   </ButtonGroupContainer>
                   <button

--- a/apps/jetstream/src/app/components/deploy/DeployMetadataDeployment.tsx
+++ b/apps/jetstream/src/app/components/deploy/DeployMetadataDeployment.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/react';
 import { ListMetadataResultItem, useListMetadata } from '@jetstream/connected-ui';
 import { ANALYTICS_KEYS } from '@jetstream/shared/constants';
-import { formatNumber, transformTabularDataToExcelStr } from '@jetstream/shared/ui-utils';
+import { copyRecordsToClipboard, formatNumber } from '@jetstream/shared/ui-utils';
 import { pluralizeIfMultiple } from '@jetstream/shared/utils';
 import { ListMetadataResult, MapOf, SalesforceOrgUi } from '@jetstream/types';
 import {
@@ -17,7 +17,6 @@ import {
   ToolbarItemActions,
   ToolbarItemGroup,
 } from '@jetstream/ui';
-import copyToClipboard from 'copy-to-clipboard';
 import addMinutes from 'date-fns/addMinutes';
 import formatISODate from 'date-fns/formatISO';
 import isAfter from 'date-fns/isAfter';
@@ -29,19 +28,19 @@ import { useRecoilState, useRecoilValue } from 'recoil';
 import { applicationCookieState, selectedOrgState } from '../../app-state';
 import { useAmplitude } from '../core/analytics';
 import * as fromJetstreamEvents from '../core/jetstream-events';
+import DeployMetadataDeploymentSidePanel from './DeployMetadataDeploymentSidePanel';
+import DeployMetadataDeploymentTable from './DeployMetadataDeploymentTable';
+import DeployMetadataLastRefreshedPopover from './DeployMetadataLastRefreshedPopover';
 import AddToChangeset from './add-to-changeset/AddToChangeset';
 import DeleteMetadataModal from './delete-metadata/DeleteMetadataModal';
 import DeployMetadataHistoryModal from './deploy-metadata-history/DeployMetadataHistoryModal';
 import DeployMetadataPackage from './deploy-metadata-package/DeployMetadataPackage';
 import * as fromDeployMetadataState from './deploy-metadata.state';
-import { AllUser, DeployMetadataTableRow, SidePanelType, YesNo } from './deploy-metadata.types';
+import { DeployMetadataTableRow, SidePanelType } from './deploy-metadata.types';
 import DeployMetadataToOrg from './deploy-to-different-org/DeployMetadataToOrg';
-import DeployMetadataDeploymentSidePanel from './DeployMetadataDeploymentSidePanel';
-import DeployMetadataDeploymentTable from './DeployMetadataDeploymentTable';
-import DeployMetadataLastRefreshedPopover from './DeployMetadataLastRefreshedPopover';
-import { convertRowsForExport, convertRowsToMapOfListMetadataResults, getRows } from './utils/deploy-metadata.utils';
 import DeployMetadataSelectedItemsBadge from './utils/DeployMetadataSelectedItemsBadge';
 import DownloadPackageWithFileSelector from './utils/DownloadPackageWithFileSelector';
+import { convertRowsForExport, convertRowsToMapOfListMetadataResults, getRows } from './utils/deploy-metadata.utils';
 import ViewOrCompareMetadataModal from './view-or-compare-metadata/ViewOrCompareMetadataModal';
 
 const TABLE_ACTION_CLIPBOARD = 'table-copy-to-clipboard';
@@ -211,9 +210,9 @@ export const DeployMetadataDeployment: FunctionComponent<DeployMetadataDeploymen
     if (id === TABLE_ACTION_DOWNLOAD_MANIFEST) {
       handleDownloadActive('manifest');
     } else if (id === TABLE_ACTION_CLIPBOARD) {
-      copyToClipboard(transformTabularDataToExcelStr(convertRowsForExport(rows || [], selectedRows)), { format: 'text/plain' });
+      copyRecordsToClipboard(convertRowsForExport(rows || [], selectedRows));
     } else if (id === TABLE_ACTION_CLIPBOARD_SELECTED) {
-      copyToClipboard(transformTabularDataToExcelStr(convertRowsForExport(rows || [], selectedRows, true)), { format: 'text/plain' });
+      copyRecordsToClipboard(convertRowsForExport(rows || [], selectedRows, true));
     } else if (id === TABLE_ACTION_DOWNLOAD) {
       setExportData(convertRowsForExport(rows || [], selectedRows));
     } else if (id === TABLE_ACTION_DOWNLOAD_SELECTED) {

--- a/apps/jetstream/src/app/components/query/QueryResults/QueryResultsCopyToClipboard.tsx
+++ b/apps/jetstream/src/app/components/query/QueryResults/QueryResultsCopyToClipboard.tsx
@@ -29,7 +29,7 @@ export const QueryResultsCopyToClipboard: FunctionComponent<QueryResultsCopyToCl
 }) => {
   const { trackEvent } = useAmplitude();
   const [isModalOpen, setIsModalOpen] = useState(false);
-  const [format, setFormat] = useState<'excel' | 'text' | 'json'>('excel');
+  const [format, setFormat] = useState<'excel' | 'json'>('excel');
   const [whichRecords, setWhichRecords] = useState<WhichRecords>('all');
   const [hasFilteredRows, setHasFilteredRows] = useState<boolean>(false);
   const [hasPartialSelectedRows, setHasPartialSelectedRows] = useState<boolean>(false);
@@ -50,7 +50,7 @@ export const QueryResultsCopyToClipboard: FunctionComponent<QueryResultsCopyToCl
     setWhichRecords('all');
   }, [records, filteredRows, selectedRows]);
 
-  async function handleCopyToClipboard(format: 'excel' | 'text' | 'json' = 'excel') {
+  async function handleCopyToClipboard(format: 'excel' | 'json' = 'excel') {
     if (
       (records && hasFilteredRows && filteredRows.length < records.length) ||
       (records && hasPartialSelectedRows && selectedRows.length < records.length)
@@ -59,7 +59,6 @@ export const QueryResultsCopyToClipboard: FunctionComponent<QueryResultsCopyToCl
       setIsModalOpen(true);
       return;
     }
-
     copyRecordsToClipboard(records, format, fields);
     trackEvent(ANALYTICS_KEYS.query_CopyToClipboard, { isTooling, whichRecords, format });
   }
@@ -110,11 +109,8 @@ export const QueryResultsCopyToClipboard: FunctionComponent<QueryResultsCopyToCl
           dropDownClassName="slds-dropdown_actions"
           position="right"
           disabled={!hasRecords}
-          items={[
-            { id: 'text', value: 'Copy as Text' },
-            { id: 'json', value: 'Copy as JSON' },
-          ]}
-          onSelected={(item) => handleCopyToClipboard(item as 'excel' | 'text' | 'json')}
+          items={[{ id: 'json', value: 'Copy as JSON' }]}
+          onSelected={(item) => handleCopyToClipboard(item as 'excel' | 'json')}
         />
       </ButtonGroupContainer>
       {isModalOpen && (

--- a/libs/shared/ui-utils/src/lib/shared-ui-utils.ts
+++ b/libs/shared/ui-utils/src/lib/shared-ui-utils.ts
@@ -1272,7 +1272,7 @@ export function getValueForExcel(value: any) {
  */
 export function transformTabularDataToExcelStr<T = Record<string, unknown>>(
   data: Maybe<T>[],
-  fields?: string[],
+  fields?: Maybe<string[]>,
   includeHeader = true
 ): string {
   if (!Array.isArray(data) || data.length === 0) {
@@ -1308,7 +1308,7 @@ export function transformTabularDataToExcelStr<T = Record<string, unknown>>(
  * @param includeHeader
  * @returns
  */
-export function transformTabularDataToHtml<T = unknown>(data: T[], fields?: string[], includeHeader = true): string {
+export function transformTabularDataToHtml<T = unknown>(data: T[], fields?: Maybe<string[]>, includeHeader = true): string {
   if (!Array.isArray(data) || data.length === 0) {
     return '';
   }

--- a/libs/ui/src/lib/data-table/DataTableSubqueryRenderer.tsx
+++ b/libs/ui/src/lib/data-table/DataTableSubqueryRenderer.tsx
@@ -1,8 +1,7 @@
 import { queryMore } from '@jetstream/shared/data';
-import { formatNumber, transformTabularDataToExcelStr } from '@jetstream/shared/ui-utils';
-import { flattenRecord, flattenRecords } from '@jetstream/shared/utils';
+import { copyRecordsToClipboard, formatNumber } from '@jetstream/shared/ui-utils';
+import { flattenRecord } from '@jetstream/shared/utils';
 import { Maybe, SalesforceOrgUi } from '@jetstream/types';
-import copyToClipboard from 'copy-to-clipboard';
 import type { QueryResult } from 'jsforce';
 import { FunctionComponent, useCallback, useEffect, useRef, useState } from 'react';
 import { RenderCellProps } from 'react-data-grid';
@@ -100,8 +99,7 @@ export const SubqueryRenderer: FunctionComponent<RenderCellProps<RowWithKey, unk
 
   function handleCopyToClipboard(columns: ColumnWithFilter<any, unknown>[]) {
     const fields = columns.map((column) => column.key);
-    const flattenedData = flattenRecords(records, fields);
-    copyToClipboard(transformTabularDataToExcelStr(flattenedData, fields), { format: 'text/plain' });
+    copyRecordsToClipboard(records, 'excel', fields);
   }
 
   async function loadMore(org: SalesforceOrgUi, isTooling: boolean) {

--- a/libs/ui/src/lib/data-table/data-table-utils.tsx
+++ b/libs/ui/src/lib/data-table/data-table-utils.tsx
@@ -1,10 +1,9 @@
 import { QueryResults, QueryResultsColumn } from '@jetstream/api-interfaces';
 import { logger } from '@jetstream/shared/client-logger';
 import { DATE_FORMATS, RECORD_PREFIX_MAP } from '@jetstream/shared/constants';
-import { transformTabularDataToExcelStr, transformTabularDataToHtml } from '@jetstream/shared/ui-utils';
-import { ensureBoolean, flattenRecords, getIdFromRecordUrl, pluralizeFromNumber } from '@jetstream/shared/utils';
+import { copyRecordsToClipboard } from '@jetstream/shared/ui-utils';
+import { ensureBoolean, getIdFromRecordUrl, pluralizeFromNumber } from '@jetstream/shared/utils';
 import { MapOf, Maybe } from '@jetstream/types';
-import copyToClipboard from 'copy-to-clipboard';
 import isAfter from 'date-fns/isAfter';
 import isBefore from 'date-fns/isBefore';
 import isSameDay from 'date-fns/isSameDay';
@@ -821,13 +820,9 @@ export function copySalesforceRecordTableDataToClipboard(
   }
   if (recordsToCopy.length) {
     if (format === 'json') {
-      copyToClipboard(JSON.stringify(recordsToCopy, null, 2), { format: 'text/plain' });
-    } else if (format === 'excel') {
-      const flattenedData = flattenRecords(recordsToCopy, fieldsToCopy);
-      copyToClipboard(transformTabularDataToHtml(flattenedData, fieldsToCopy), { format: 'text/html' });
+      copyRecordsToClipboard(recordsToCopy, 'json');
     } else {
-      const flattenedData = flattenRecords(recordsToCopy, fieldsToCopy);
-      copyToClipboard(transformTabularDataToExcelStr(flattenedData, fieldsToCopy, includeHeader), { format: 'text/plain' });
+      copyRecordsToClipboard(recordsToCopy, 'excel', fieldsToCopy, includeHeader);
     }
   }
 }

--- a/libs/ui/src/lib/sobject-field-list/SobjectFieldListTypeRollupSummaryDetails.tsx
+++ b/libs/ui/src/lib/sobject-field-list/SobjectFieldListTypeRollupSummaryDetails.tsx
@@ -3,7 +3,7 @@ import { queryWithCache } from '@jetstream/shared/data';
 import { useRollbar } from '@jetstream/shared/ui-utils';
 import { FieldWrapper, SalesforceOrgUi } from '@jetstream/types';
 import copyToClipboard from 'copy-to-clipboard';
-import React, { Fragment, FunctionComponent, useCallback, useEffect, useRef, useState } from 'react';
+import { Fragment, FunctionComponent, useCallback, useEffect, useRef, useState } from 'react';
 import { Spinner } from '../..';
 import ErrorBoundaryWithoutContent from '../utils/ErrorBoundaryWithoutContent';
 import Icon from '../widgets/Icon';

--- a/libs/ui/src/lib/sobject-field-list/WhereIsThisFieldUsed.tsx
+++ b/libs/ui/src/lib/sobject-field-list/WhereIsThisFieldUsed.tsx
@@ -1,7 +1,6 @@
 import { css } from '@emotion/react';
-import { transformTabularDataToExcelStr, useNonInitialEffect } from '@jetstream/shared/ui-utils';
+import { copyRecordsToClipboard, useNonInitialEffect } from '@jetstream/shared/ui-utils';
 import { ListItem, SalesforceOrgUi } from '@jetstream/types';
-import copyToClipboard from 'copy-to-clipboard';
 import { Fragment, FunctionComponent, useState } from 'react';
 import FileDownloadModal from '../file-download-modal/FileDownloadModal';
 import EmptyState from '../illustrations/EmptyState';
@@ -61,9 +60,7 @@ export const QueryWhereIsThisUsed: FunctionComponent<QueryWhereIsThisUsedProps> 
   }
 
   function handleCopyToClipboard() {
-    copyToClipboard(transformTabularDataToExcelStr(exportData, ['Reference Type', 'Reference Label', 'Namespace']), {
-      format: 'text/plain',
-    });
+    copyRecordsToClipboard(exportData, 'excel', ['Reference Type', 'Reference Label', 'Namespace']);
   }
 
   return (


### PR DESCRIPTION
Copy both text and html formats to clipboard when copying tabular data to allow pasting to be more universally compatible with other programs

resolves #620