### PR TITLE
Fix datatable bugs

### DIFF
--- a/apps/jetstream/src/app/components/automation-control/AutomationControlEditorTable.tsx
+++ b/apps/jetstream/src/app/components/automation-control/AutomationControlEditorTable.tsx
@@ -1,13 +1,12 @@
 import { SalesforceOrgUi } from '@jetstream/types';
 import { ColumnWithFilter, DataTable, setColumnFromType } from '@jetstream/ui';
 import { forwardRef, useMemo } from 'react';
-import { RowHeightArgs } from 'react-data-grid';
 import { isTableRow } from './automation-control-data-utils';
 import { AdditionalDetailRenderer, ExpandingLabelRenderer, LoadingAndActiveRenderer } from './automation-control-table-renderers';
 import { TableRowOrItemOrChild } from './automation-control-types';
 
-const getRowHeight = ({ row, type }: RowHeightArgs<TableRowOrItemOrChild>) => {
-  if (type === 'GROUP' || isTableRow(row)) {
+const getRowHeight = (row: TableRowOrItemOrChild) => {
+  if (isTableRow(row)) {
     return 28.5;
   }
   if (row.additionalData.length > 1) {
@@ -85,7 +84,7 @@ export const AutomationControlEditorTable = forwardRef<any, AutomationControlEdi
         {
           name: 'Additional Information',
           key: 'additionalInfo',
-          width: 400,
+          width: 1000,
           filters: null,
           sortable: false,
           renderCell: AdditionalDetailRenderer,

--- a/apps/jetstream/src/app/components/deploy/DeployMetadataDeploymentTable.tsx
+++ b/apps/jetstream/src/app/components/deploy/DeployMetadataDeploymentTable.tsx
@@ -1,5 +1,5 @@
 import { formatNumber } from '@jetstream/shared/ui-utils';
-import { AutoFullHeightContainer, ColumnWithFilter, DataTableSelectedContext, DataTree, Grid, Icon, SearchInput } from '@jetstream/ui';
+import { AutoFullHeightContainer, DataTableSelectedContext, DataTree, Grid, Icon, SearchInput } from '@jetstream/ui';
 import groupBy from 'lodash/groupBy';
 import { FunctionComponent, useEffect, useState } from 'react';
 import { DeployMetadataTableRow } from './deploy-metadata.types';
@@ -18,13 +18,14 @@ function getRowId(row: DeployMetadataTableRow): string {
 
 const groupedRows = ['typeLabel'] as const;
 
+const COLUMNS = getColumnDefinitions();
+
 export const DeployMetadataDeploymentTable: FunctionComponent<DeployMetadataDeploymentTableProps> = ({
   rows,
   hasSelectedRows,
   onSelectedRows,
   onViewOrCompareOpen,
 }) => {
-  const [columns, setColumns] = useState<ColumnWithFilter<DeployMetadataTableRow>[]>([]);
   const [visibleRows, setVisibleRows] = useState<DeployMetadataTableRow[]>(rows);
   const [globalFilter, setGlobalFilter] = useState<string | null>(null);
   const [selectedRowIds, setSelectedRowIds] = useState(new Set<any>());
@@ -34,10 +35,6 @@ export const DeployMetadataDeploymentTable: FunctionComponent<DeployMetadataDepl
     setVisibleRows(rows);
     setExpandedGroupIds(new Set(rows.map(({ typeLabel }) => typeLabel)));
   }, [rows]);
-
-  useEffect(() => {
-    setColumns(getColumnDefinitions());
-  }, []);
 
   useEffect(() => {
     onSelectedRows(new Set(rows.filter((row) => selectedRowIds.has(getRowId(row)))));
@@ -61,7 +58,7 @@ export const DeployMetadataDeploymentTable: FunctionComponent<DeployMetadataDepl
       )}
       <AutoFullHeightContainer fillHeight setHeightAttr delayForSecondTopCalc bottomBuffer={15}>
         <DataTree
-          columns={columns}
+          columns={COLUMNS}
           data={rows}
           getRowKey={getRowId}
           includeQuickFilter

--- a/apps/jetstream/src/app/components/deploy/deploy-metadata-history/DeployMetadataHistoryTable.tsx
+++ b/apps/jetstream/src/app/components/deploy/deploy-metadata-history/DeployMetadataHistoryTable.tsx
@@ -1,7 +1,6 @@
 import { MapOf, SalesforceDeployHistoryItem, SalesforceOrgUi } from '@jetstream/types';
 import { ColumnWithFilter, DataTable, setColumnFromType } from '@jetstream/ui';
 import { FunctionComponent, useMemo } from 'react';
-import { RowHeightArgs } from 'react-data-grid';
 import { DeployHistoryTableContext } from '../deploy-metadata.types';
 import { ActionRenderer, OrgRenderer, StatusRenderer } from './DeployMetadataHistoryTableRenderers';
 
@@ -56,22 +55,18 @@ const COLUMNS: ColumnWithFilter<SalesforceDeployHistoryItem>[] = [
   },
 ];
 
-const getRowHeight =
-  (orgsById: MapOf<SalesforceOrgUi>) =>
-  ({ row: item, type }: RowHeightArgs<SalesforceDeployHistoryItem>) => {
-    const rowHeight = 27.5;
-    let numberOfRows = 3;
-    if (type === 'ROW') {
-      if (item.type === 'orgToOrg') {
-        /** we need 3 rows plus a little buffer */
-        numberOfRows = 3.5;
-      } else if (item.fileKey || (item.sourceOrg && orgsById[item.sourceOrg.uniqueId])) {
-        /** we need 3 rows */
-        return 27.5 * 3;
-      }
-    }
-    return rowHeight * numberOfRows;
-  };
+const getRowHeight = (orgsById: MapOf<SalesforceOrgUi>) => (row: SalesforceDeployHistoryItem) => {
+  const rowHeight = 27.5;
+  let numberOfRows = 3;
+  if (row.type === 'orgToOrg') {
+    /** we need 3 rows plus a little buffer */
+    numberOfRows = 3.5;
+  } else if (row.fileKey || (row.sourceOrg && orgsById[row.sourceOrg.uniqueId])) {
+    /** we need 3 rows */
+    return 27.5 * 3;
+  }
+  return rowHeight * numberOfRows;
+};
 const getRowId = ({ key }: SalesforceDeployHistoryItem) => key;
 
 export interface DeployMetadataHistoryTableProps {

--- a/apps/jetstream/src/app/components/load-records/components/LoadRecordsDataPreview.tsx
+++ b/apps/jetstream/src/app/components/load-records/components/LoadRecordsDataPreview.tsx
@@ -9,7 +9,9 @@ import type { DescribeGlobalSObjectResult } from 'jsforce';
 import isNil from 'lodash/isNil';
 import { FunctionComponent, useEffect, useRef, useState } from 'react';
 import { Column } from 'react-data-grid';
+import { ErrorBoundary } from 'react-error-boundary';
 import { useRecoilState } from 'recoil';
+import ErrorBoundaryFallback from '../../core/ErrorBoundaryFallback';
 import * as fromLoadRecordsState from '../load-records.state';
 
 const MAX_RECORD_FOR_PREVIEW = 100_000;
@@ -180,7 +182,7 @@ export const LoadRecordsDataPreview: FunctionComponent<LoadRecordsDataPreviewPro
         </GridCol>
         <GridCol className="slds-is-relative">
           {tooLargeToShowPreview && <p className="slds-text-heading_small">Your file is too large to show a preview</p>}
-          {columns && rows && (
+          {Array.isArray(columns) && Array.isArray(rows) && (
             <div
               css={css`
                 position: absolute;
@@ -189,9 +191,11 @@ export const LoadRecordsDataPreview: FunctionComponent<LoadRecordsDataPreviewPro
               `}
             >
               <p className="slds-text-heading_small">File Preview</p>
-              <AutoFullHeightContainer fillHeight setHeightAttr bottomBuffer={25}>
-                <DataTable columns={columns} data={rows} getRowKey={getRowId} />
-              </AutoFullHeightContainer>
+              <ErrorBoundary FallbackComponent={ErrorBoundaryFallback}>
+                <AutoFullHeightContainer fillHeight setHeightAttr bottomBuffer={25}>
+                  <DataTable columns={columns} data={rows} getRowKey={getRowId} />
+                </AutoFullHeightContainer>
+              </ErrorBoundary>
             </div>
           )}
         </GridCol>

--- a/apps/jetstream/src/app/components/load-records/components/load-results/LoadRecordsResultsModal.tsx
+++ b/apps/jetstream/src/app/components/load-records/components/load-results/LoadRecordsResultsModal.tsx
@@ -12,7 +12,6 @@ import {
   Spinner,
 } from '@jetstream/ui';
 import { FunctionComponent, useCallback, useEffect, useRef, useState } from 'react';
-import { RowHeightArgs } from 'react-data-grid';
 
 const COL_WIDTH_MAP = {
   _id: 195,
@@ -20,7 +19,7 @@ const COL_WIDTH_MAP = {
   _errors: 450,
 };
 
-const getRowHeight = ({ row, type }: RowHeightArgs<any>) => (type === 'ROW' && row?._errors ? 75 : 25);
+const getRowHeight = (row: any) => (row?._errors ? 75 : 25);
 
 export interface LoadRecordsResultsModalProps {
   type: 'results' | 'failures';
@@ -117,7 +116,7 @@ export const LoadRecordsResultsModal: FunctionComponent<LoadRecordsResultsModalP
         <div className="slds-is-relative slds-scrollable_x">
           <AutoFullHeightContainer fillHeight setHeightAttr bottomBuffer={300}>
             {loading && <Spinner />}
-            {rows && columns && (
+            {Array.isArray(rows) && Array.isArray(columns) && (
               <DataTable
                 columns={columns}
                 data={rows}

--- a/apps/jetstream/src/app/components/manage-permissions/ManagePermissionsEditorObjectTable.tsx
+++ b/apps/jetstream/src/app/components/manage-permissions/ManagePermissionsEditorObjectTable.tsx
@@ -2,7 +2,6 @@ import { useNonInitialEffect } from '@jetstream/shared/ui-utils';
 import { MapOf } from '@jetstream/types';
 import { AutoFullHeightContainer, ColumnWithFilter, DataTable } from '@jetstream/ui';
 import { forwardRef, useCallback, useImperativeHandle, useState } from 'react';
-import { RowHeightArgs } from 'react-data-grid';
 import { resetGridChanges, updateRowsFromColumnAction } from './utils/permission-manager-table-utils';
 import {
   DirtyRow,
@@ -15,13 +14,6 @@ import {
 
 function getRowKey(row: PermissionTableObjectCell) {
   return row.key;
-}
-
-function getRowHeight({ type, row }: RowHeightArgs<PermissionTableObjectCell>) {
-  if (type === 'ROW') {
-    return 24;
-  }
-  return 34;
 }
 
 // summary row is just a placeholder for rendered content
@@ -83,7 +75,7 @@ export const ManagePermissionsEditorObjectTable = forwardRef<any, ManagePermissi
                 onBulkAction: onBulkUpdate,
               } as PermissionManagerTableContext
             }
-            rowHeight={getRowHeight}
+            rowHeight={24}
             summaryRowHeight={38}
           />
         </AutoFullHeightContainer>

--- a/libs/shared/utils/src/lib/utils.ts
+++ b/libs/shared/utils/src/lib/utils.ts
@@ -524,7 +524,7 @@ const DATE_ERR_MESSAGE =
   'There was an error reading one or more date fields in your file. Ensure date fields are properly formatted with a four character year.';
 
 const TIME_ERR_MESSAGE =
-  'There was an error reading one or more time fields in your file. Ensure date fields are properly formatted with a four character year.';
+  'There was an error reading one or more time fields in your file. Ensure time fields are properly formatted using or 00:00:00Z or 00:00:00.000Z.';
 
 function transformDate(value: any, dateFormat: string): Maybe<string> {
   if (!value) {
@@ -609,7 +609,7 @@ function transformTime(value: string | null) {
 
   try {
     // Already in proper format
-    if (isMatch('HH:mm:ss.SSSZ', value) || isMatch('HH:mm:ssZ', value)) {
+    if (isMatch(value, `HH:mm:ss.SSS'Z'`) || isMatch(value, `HH:mm:ss'Z'`)) {
       return value;
     }
     // match local format first and convert to ISO

--- a/libs/ui/src/index.ts
+++ b/libs/ui/src/index.ts
@@ -14,7 +14,7 @@ export * from './lib/data-table/DataTree';
 export * from './lib/data-table/SalesforceRecordDataTable';
 export * from './lib/data-table/data-table-context';
 export * from './lib/data-table/data-table-formatters';
-export type { ColumnWithFilter, RowWithKey } from './lib/data-table/data-table-types';
+export type { ColumnWithFilter, ContextAction, ContextMenuActionData, RowWithKey } from './lib/data-table/data-table-types';
 export { getColumnsForGenericTable, getRowTypeFromValue, getSfdcRetUrl, setColumnFromType } from './lib/data-table/data-table-utils';
 export * from './lib/docked-composer/DockedComposer';
 export * from './lib/expression-group/ExpressionContainer';

--- a/libs/ui/src/lib/data-table/useDataTable.tsx
+++ b/libs/ui/src/lib/data-table/useDataTable.tsx
@@ -108,6 +108,7 @@ export function useDataTable<T = RowWithKey>({
 
   useNonInitialEffect(() => {
     setColumns(_columns);
+    setColumnsOrder(_columns.map((_, index) => index));
   }, [_columns]);
 
   useNonInitialEffect(() => {


### PR DESCRIPTION
Deploy metadata did not set columns on first render which caused the data table to not render properly. This was fixed in the useDataTable to make sure that the columnOrder was reset properly and also fixed in the metadata data table to ensure the columns were available on the first render.

Updated rowHeight functions for regular data tables to match changes with latest version of react data table (only TreeGrid has a type property)

Increased column width on the automation control component

Fix incorrect use of isMatch with dateFns when loading time fields