### PR TITLE
Deploy: Correct fullName for layouts

### DIFF
--- a/libs/shared/utils/src/lib/__tests__/utils.spec.ts
+++ b/libs/shared/utils/src/lib/__tests__/utils.spec.ts
@@ -1,4 +1,4 @@
-import { getExcelSafeSheetName } from '../utils';
+import { getExcelSafeSheetName, getFullNameFromListMetadata } from '../utils';
 
 describe('utils.getExcelSafeSheetName', () => {
   it('should handle simple cases', () => {
@@ -35,5 +35,44 @@ describe('utils.getExcelSafeSheetName', () => {
         'recordsrecordsrecordsrecordsr12',
       ])
     ).toEqual('recordsrecordsrecordsrecordsr13');
+  });
+});
+
+describe('utils.getFullNameFromListMetadata', () => {
+  it('Should convert layout name', () => {
+    expect(
+      getFullNameFromListMetadata({
+        fullName: 'SBQQ__AttributeSet__c-Attribute Set Layout',
+        metadataType: 'Layout',
+        namespace: 'SBQQ',
+      })
+    ).toEqual('SBQQ__AttributeSet__c-SBQQ__Attribute Set Layout');
+  });
+  it('Should not double add namespace if already correct', () => {
+    expect(
+      getFullNameFromListMetadata({
+        fullName: 'SBQQ__AttributeSet__c-SBQQ__Attribute Set Layout',
+        metadataType: 'Layout',
+        namespace: 'SBQQ',
+      })
+    ).toEqual('SBQQ__AttributeSet__c-SBQQ__Attribute Set Layout');
+  });
+  it('Should not add namespace if non-managed', () => {
+    expect(
+      getFullNameFromListMetadata({
+        fullName: 'AttributeSet__c-Attribute Set Layout',
+        metadataType: 'Layout',
+        namespace: null,
+      })
+    ).toEqual('AttributeSet__c-Attribute Set Layout');
+  });
+  it('Should not apply to other managed package types', () => {
+    expect(
+      getFullNameFromListMetadata({
+        fullName: 'AttributeSet__c-Attribute Set Layout',
+        metadataType: 'ApexClass',
+        namespace: 'TEST',
+      })
+    ).toEqual('AttributeSet__c-Attribute Set Layout');
   });
 });

--- a/libs/shared/utils/src/lib/utils.ts
+++ b/libs/shared/utils/src/lib/utils.ts
@@ -819,3 +819,24 @@ export function decodeHtmlEntity(value: Maybe<string>) {
     .replaceAll('&lt;', '<')
     .replaceAll('&gt;', '>');
 }
+
+/**
+ * Some fullNames from listMetadata need to be modified
+ */
+export function getFullNameFromListMetadata({
+  metadataType,
+  namespace,
+  fullName,
+}: {
+  metadataType: string;
+  fullName: string;
+  namespace: Maybe<string>;
+}) {
+  // Fix fullName for managed package layouts
+  if (namespace && metadataType === 'Layout' && !fullName.slice(fullName.indexOf('-') + 1).startsWith(`${namespace}__`)) {
+    const objectName = fullName.slice(0, fullName.indexOf('-') + 1);
+    const layoutName = fullName.slice(fullName.indexOf('-') + 1);
+    return `${objectName}${namespace}__${layoutName}`;
+  }
+  return fullName;
+}


### PR DESCRIPTION
SFDC returns an incorrect fullName for Layouts for managed packages, where the namespace is omitted from the layout name and is now re-added

resolves #639