### PR TITLE
Ensure number in id column does not break table

### DIFF
--- a/apps/jetstream/src/app/components/query/QueryBuilder/QueryChildFields.tsx
+++ b/apps/jetstream/src/app/components/query/QueryBuilder/QueryChildFields.tsx
@@ -97,7 +97,7 @@ export const QueryChildFields: FunctionComponent<QueryChildFieldsProps> = ({
           (field): QueryFieldWithPolymorphic => ({
             field: `${basePath}${field}`,
             polymorphicObj: queryField.isPolymorphic ? queryField.sobject : undefined,
-            metadata: queryField.fields[field].metadata,
+            metadata: queryField.fields[field]?.metadata,
           })
         );
       });

--- a/apps/jetstream/src/app/components/query/utils/query-fields-utils.ts
+++ b/apps/jetstream/src/app/components/query/utils/query-fields-utils.ts
@@ -49,7 +49,7 @@ export function getSelectedFieldsFromQueryFields(fieldsMap: MapOf<QueryFields>):
           return {
             field: `${basePath}${field}`,
             polymorphicObj: queryField.isPolymorphic ? queryField.sobject : undefined,
-            metadata: queryField.fields[field].metadata,
+            metadata: queryField.fields[field]?.metadata,
           };
         });
       }),

--- a/libs/ui/src/lib/data-table/data-table-utils.tsx
+++ b/libs/ui/src/lib/data-table/data-table-utils.tsx
@@ -76,7 +76,7 @@ export function getRowId(data: any): string {
     return uniqueId('row-id');
   }
   let nodeId = data?.attributes?.url || data.Id || data.id || data.key;
-  if (!nodeId || nodeId.endsWith(SFDC_EMPTY_ID) || data.Id === SFDC_EMPTY_ID) {
+  if (!nodeId || (isString(nodeId) && nodeId.endsWith(SFDC_EMPTY_ID)) || data.Id === SFDC_EMPTY_ID) {
     nodeId = uniqueId('row-id');
   }
   return nodeId;


### PR DESCRIPTION
Users loading an excel file with a numeric field for id caused issue with getting table id

Don't crash if query fields does not have metadata