### PR TITLE
Fixed deploying objects and fields to orgs with namespace

### DIFF
--- a/apps/jetstream/src/app/components/create-object-and-fields/create-new-object/CreateNewObjectModal.tsx
+++ b/apps/jetstream/src/app/components/create-object-and-fields/create-new-object/CreateNewObjectModal.tsx
@@ -31,7 +31,7 @@ export const CreateNewObjectModal: FunctionComponent<CreateNewObjectModalProps> 
   const modalBodyRef = useRef<HTMLDivElement>(null);
   const tabsRef = useRef<TabsRef>();
 
-  const apiName = useRecoilValue(fromCreateObjectState.apiNameState);
+  const apiNameWithoutNamespace = useRecoilValue(fromCreateObjectState.apiNameState);
   const createTab = useRecoilValue(fromCreateObjectState.createTabState);
   const selectedTabIcon = useRecoilValue(fromCreateObjectState.selectedTabIconState);
   const objectPermissions = useRecoilValue(fromCreateObjectState.objectPermissionsState);
@@ -39,6 +39,8 @@ export const CreateNewObjectModal: FunctionComponent<CreateNewObjectModalProps> 
   const selectedProfiles = useRecoilValue(fromCreateObjectState.selectedProfilesState);
   const payload = useRecoilValue(fromCreateObjectState.payloadSelector);
   const isValid = useRecoilValue(fromCreateObjectState.isFormValid);
+
+  const apiName = `${selectedOrg.orgNamespacePrefix ? `${selectedOrg.orgNamespacePrefix}__` : ''}${apiNameWithoutNamespace}`;
 
   const { results, deployMetadata, status, errorMessage, hasError, loading, permissionRecordResults } = useCreateObject({
     apiVersion: defaultApiVersion,

--- a/apps/jetstream/src/app/components/create-object-and-fields/create-new-object/create-object-state.ts
+++ b/apps/jetstream/src/app/components/create-object-and-fields/create-new-object/create-object-state.ts
@@ -66,6 +66,7 @@ export const payloadSelector = selector<CreateObjectPayload>({
       allowInChatterGroups: get(allowInChatterGroupsState),
       compactLayoutAssignment: 'SYSTEM',
       deploymentStatus: 'Deployed',
+      description: get(descriptionState),
       enableActivities: get(allowActivitiesState),
       enableBulkApi: get(allowSharingBulkStreamingState),
       enableEnhancedLookup: false,

--- a/apps/jetstream/src/app/components/create-object-and-fields/create-new-object/create-object-types.ts
+++ b/apps/jetstream/src/app/components/create-object-and-fields/create-new-object/create-object-types.ts
@@ -12,6 +12,7 @@ export interface CreateObjectPayload {
   allowInChatterGroups: boolean;
   compactLayoutAssignment: 'SYSTEM';
   deploymentStatus: 'Deployed';
+  description?: string;
   enableActivities: boolean;
   enableBulkApi: boolean;
   enableEnhancedLookup: false;

--- a/apps/jetstream/src/app/components/create-object-and-fields/create-new-object/create-object-utils.ts
+++ b/apps/jetstream/src/app/components/create-object-and-fields/create-new-object/create-object-utils.ts
@@ -1,6 +1,6 @@
 import { queryAll, sobjectOperation } from '@jetstream/shared/data';
 import { REGEX, splitArrayToMaxSize } from '@jetstream/shared/utils';
-import { ObjectPermissionRecordInsert, RecordResult, SalesforceOrgUi, TabPermissionRecordInsert } from '@jetstream/types';
+import { Maybe, ObjectPermissionRecordInsert, RecordResult, SalesforceOrgUi, TabPermissionRecordInsert } from '@jetstream/types';
 import JSZip from 'jszip';
 import partition from 'lodash/partition';
 import { composeQuery, getField } from 'soql-parser-js';
@@ -24,7 +24,11 @@ export function generateApiNameFromLabel(value: string) {
   return apiNameLabel ? `${apiNameLabel}__c` : '';
 }
 
-export function getObjectAndTabPermissionRecords({ apiName, createTab, profiles, permissionSets, objectPermissions }: CreateFieldParams) {
+export function getObjectAndTabPermissionRecords(
+  { apiName: apiNameWithoutNamespace, createTab, profiles, permissionSets, objectPermissions }: CreateFieldParams,
+  orgNamespacePrefix?: Maybe<string>
+) {
+  const apiName = orgNamespacePrefix ? `${orgNamespacePrefix}__${apiNameWithoutNamespace}` : apiNameWithoutNamespace;
   const _objectPermissions: ObjectPermissionRecordInsert[] = [];
   const tabPermissions: TabPermissionRecordInsert[] = [];
 
@@ -162,6 +166,7 @@ export function getObjectXml(payload: CreateObjectPayload) {
   <allowInChatterGroups>${payload.allowInChatterGroups}</allowInChatterGroups>
   <compactLayoutAssignment>${payload.compactLayoutAssignment}</compactLayoutAssignment>
   <deploymentStatus>${payload.deploymentStatus}</deploymentStatus>
+  <description>${payload.description || ''}</description>
   <enableActivities>${payload.enableActivities}</enableActivities>
   <enableBulkApi>${payload.enableBulkApi}</enableBulkApi>
   <enableEnhancedLookup>${payload.enableEnhancedLookup}</enableEnhancedLookup>

--- a/apps/jetstream/src/app/components/create-object-and-fields/create-new-object/useCreateObject.ts
+++ b/apps/jetstream/src/app/components/create-object-and-fields/create-new-object/useCreateObject.ts
@@ -59,10 +59,11 @@ export default function useCreateObject({ apiVersion, serverUrl, selectedOrg }: 
     async (data: CreateFieldParams) => {
       try {
         const { apiName } = data;
+        const { orgNamespacePrefix } = selectedOrg;
         logger.info('[deployMetadata]', data);
         setStatus('LOADING_METADATA');
         setPermissionRecordResults(null);
-        const permissionRecords = getObjectAndTabPermissionRecords(data);
+        const permissionRecords = getObjectAndTabPermissionRecords(data, orgNamespacePrefix);
         const file = await getMetadataPackage(apiVersion, data);
 
         try {

--- a/apps/jetstream/src/app/components/deploy/view-or-compare-metadata/ViewOrCompareMetadataModal.tsx
+++ b/apps/jetstream/src/app/components/deploy/view-or-compare-metadata/ViewOrCompareMetadataModal.tsx
@@ -2,19 +2,19 @@ import { css } from '@emotion/react';
 import { logger } from '@jetstream/shared/client-logger';
 import { useNonInitialEffect } from '@jetstream/shared/ui-utils';
 import { unSanitizeXml } from '@jetstream/shared/utils';
+import { SplitWrapper as Split } from '@jetstream/splitjs';
 import { FileExtAllTypes, ListMetadataResult, MapOf, SalesforceOrgUi } from '@jetstream/types';
 import { AutoFullHeightContainer, FileDownloadModal, Modal, Spinner, TreeItems } from '@jetstream/ui';
 import Editor, { DiffEditor } from '@monaco-editor/react';
 import type { editor } from 'monaco-editor';
 import { Fragment, FunctionComponent, useCallback, useEffect, useRef, useState } from 'react';
-import { SplitWrapper as Split } from '@jetstream/splitjs';
 import { useRecoilState } from 'recoil';
 import { applicationCookieState } from '../../../app-state';
 import * as fromJetstreamEvents from '../../core/jetstream-events';
-import { useViewOrCompareMetadata } from './useViewOrCompareMetadata';
 import ViewOrCompareMetadataEditorSummary from './ViewOrCompareMetadataEditorSummary';
 import ViewOrCompareMetadataModalFooter from './ViewOrCompareMetadataModalFooter';
 import ViewOrCompareMetadataSidebar from './ViewOrCompareMetadataSidebar';
+import { useViewOrCompareMetadata } from './useViewOrCompareMetadata';
 import { EditorType, FileItemMetadata, OrgType } from './viewOrCompareMetadataTypes';
 import { generateExport, getEditorLanguage } from './viewOrCompareMetadataUtils';
 
@@ -157,6 +157,11 @@ export const ViewOrCompareMetadataModal: FunctionComponent<ViewOrCompareMetadata
     fetchMetadata(org, 'TARGET');
   }
 
+  function handleReload() {
+    sourceOrg && fetchMetadata(sourceOrg, 'SOURCE');
+    targetOrg && fetchMetadata(targetOrg, 'TARGET');
+  }
+
   async function handleDownload(which: OrgType) {
     const fileNameParts = ['metadata-package'];
     if (which === 'SOURCE' && sourceResults) {
@@ -234,6 +239,7 @@ export const ViewOrCompareMetadataModal: FunctionComponent<ViewOrCompareMetadata
               sourceLastChecked={sourceLastChecked}
               targetLoading={targetLoading}
               targetLastChecked={targetLastChecked}
+              reloadMetadata={handleReload}
               onDownloadPackage={handleDownload}
               onExportSummary={handleExport}
               onClose={onClose}

--- a/apps/jetstream/src/app/components/deploy/view-or-compare-metadata/ViewOrCompareMetadataModalFooter.tsx
+++ b/apps/jetstream/src/app/components/deploy/view-or-compare-metadata/ViewOrCompareMetadataModalFooter.tsx
@@ -10,6 +10,7 @@ export interface ViewOrCompareMetadataModalFooterProps {
   sourceLastChecked: Date | null;
   targetLoading: boolean;
   targetLastChecked: Date | null;
+  reloadMetadata?: () => void;
   onDownloadPackage: (which: OrgType) => void;
   onExportSummary: () => void;
   onClose: () => void;
@@ -23,6 +24,7 @@ export const ViewOrCompareMetadataModalFooter: FunctionComponent<ViewOrCompareMe
   sourceLastChecked,
   targetLoading,
   targetLastChecked,
+  reloadMetadata,
   onDownloadPackage,
   onExportSummary,
   onClose,
@@ -31,6 +33,11 @@ export const ViewOrCompareMetadataModalFooter: FunctionComponent<ViewOrCompareMe
   return (
     <Grid align="spread" verticalAlign="center">
       <div>
+        {reloadMetadata && !sourceLoading && !targetLoading && (
+          <button className="slds-button slds-button_neutral" onClick={() => reloadMetadata()}>
+            Reload Metadata
+          </button>
+        )}
         {sourceLoading && (
           <div className="slds-truncate" title={`last checked at ${sourceLastChecked?.toLocaleTimeString() || '<waiting>'}`}>
             Loading metadata from Salesforce {sourceLastChecked && <span>- last checked at {sourceLastChecked.toLocaleTimeString()}</span>}

--- a/apps/jetstream/src/app/components/orgs/AddOrg.tsx
+++ b/apps/jetstream/src/app/components/orgs/AddOrg.tsx
@@ -116,7 +116,9 @@ export const AddOrg: FunctionComponent<AddOrgProps> = ({ className, label = 'Add
                 className="slds-input"
                 placeholder="org-domain"
                 value={customUrl}
-                onChange={(event) => setCustomUrl(event.target.value)}
+                onChange={(event) =>
+                  setCustomUrl((prevValue) => (event.target.value || '').replaceAll(/(https:\/\/)|(\.my\.salesforce\.com)/g, ''))
+                }
               />
             </Input>
           )}

--- a/apps/jetstream/src/app/components/shared/create-fields/create-fields-utils.tsx
+++ b/apps/jetstream/src/app/components/shared/create-fields/create-fields-utils.tsx
@@ -2,7 +2,7 @@
 import { logger } from '@jetstream/shared/client-logger';
 import { describeGlobal, genericRequest, queryAllFromList, queryWithCache } from '@jetstream/shared/data';
 import { REGEX, ensureBoolean, splitArrayToMaxSize } from '@jetstream/shared/utils';
-import { CompositeResponse, GlobalValueSetRequest, MapOf, SalesforceOrgUi, ToolingApiResponse } from '@jetstream/types';
+import { CompositeResponse, GlobalValueSetRequest, MapOf, Maybe, SalesforceOrgUi, ToolingApiResponse } from '@jetstream/types';
 import type { DescribeGlobalSObjectResult } from 'jsforce';
 import isBoolean from 'lodash/isBoolean';
 import isNil from 'lodash/isNil';
@@ -800,11 +800,11 @@ export function isFieldValues(input: FieldValues | FieldDefinitionMetadata): inp
   return !isNil((input as any)?._key);
 }
 
-export function preparePayload(sobjects: string[], rows: FieldValues[]): FieldDefinitionMetadata[] {
-  return rows.flatMap((row) => sobjects.map((sobject) => prepareFieldPayload(sobject, row)));
+export function preparePayload(sobjects: string[], rows: FieldValues[], orgNamespace?: Maybe<string>): FieldDefinitionMetadata[] {
+  return rows.flatMap((row) => sobjects.map((sobject) => prepareFieldPayload(sobject, row, orgNamespace)));
 }
 
-function prepareFieldPayload(sobject: string, fieldValues: FieldValues): FieldDefinitionMetadata {
+function prepareFieldPayload(sobject: string, fieldValues: FieldValues, orgNamespace?: Maybe<string>): FieldDefinitionMetadata {
   const fieldMetadata: FieldDefinitionMetadata = [
     ...baseFields,
     ...fieldTypeDependencies[fieldValues.type.value as FieldDefinitionType],
@@ -816,7 +816,8 @@ function prepareFieldPayload(sobject: string, fieldValues: FieldValues): FieldDe
     return output;
   }, {});
   // prefix with object
-  fieldMetadata.fullName = `${sobject}.${fieldMetadata.fullName}__c`;
+  const fieldApiName = orgNamespace ? `${orgNamespace}__${fieldMetadata.fullName}__c` : `${fieldMetadata.fullName}__c`;
+  fieldMetadata.fullName = `${sobject}.${fieldApiName}`;
 
   if (fieldValues.type.value === 'Formula') {
     fieldMetadata.type = fieldValues.secondaryType.value;

--- a/apps/jetstream/src/app/components/shared/create-fields/useCreateFields.ts
+++ b/apps/jetstream/src/app/components/shared/create-fields/useCreateFields.ts
@@ -101,7 +101,7 @@ export default function useCreateFields({
     (rows: FieldValues[]) => {
       if (rows?.length && sObjects?.length) {
         try {
-          const payload: CreateFieldsResults[] = preparePayload(sObjects, rows).map(
+          const payload: CreateFieldsResults[] = preparePayload(sObjects, rows, selectedOrg.orgNamespacePrefix).map(
             (field): CreateFieldsResults => ({
               key: `${(field.fullName as string).replace('.', '_').replace(REGEX.CONSECUTIVE_UNDERSCORES, '_')}`,
               label: field.fullName,
@@ -127,7 +127,7 @@ export default function useCreateFields({
       }
       return false;
     },
-    [rollbar, sObjects]
+    [rollbar, sObjects, selectedOrg.orgNamespacePrefix]
   );
 
   /**


### PR DESCRIPTION
Ensure namespace is included in permission records when deploying a custom object

Add namespace to field fullName when creating a custom field so that all other deploy logic (FLS/layouts) uses the correct fullName

resolves #652