### PR TITLE
Add Tab Visibility to Permissions Editor

### DIFF
--- a/apps/jetstream/src/app/components/core/AppStateResetOnOrgChange.tsx
+++ b/apps/jetstream/src/app/components/core/AppStateResetOnOrgChange.tsx
@@ -1,5 +1,5 @@
 import { SalesforceOrgUi } from '@jetstream/types';
-import { Fragment, FunctionComponent, useEffect, useState } from 'react';
+import { FunctionComponent, useEffect, useState } from 'react';
 import { Resetter, useRecoilValue, useResetRecoilState } from 'recoil';
 import * as fromAppState from '../../app-state';
 import * as fromAutomationControlState from '../automation-control/automation-control.state';
@@ -49,6 +49,7 @@ export const AppStateResetOnOrgChange: FunctionComponent<AppStateResetOnOrgChang
     useResetRecoilState(fromPermissionsState.fieldsByKey),
     useResetRecoilState(fromPermissionsState.objectPermissionMap),
     useResetRecoilState(fromPermissionsState.fieldPermissionMap),
+    useResetRecoilState(fromPermissionsState.tabVisibilityPermissionMap),
     // Deploy
     useResetRecoilState(fromDeployMetadataState.metadataItemsState),
     useResetRecoilState(fromDeployMetadataState.metadataItemsMapState),
@@ -77,7 +78,7 @@ export const AppStateResetOnOrgChange: FunctionComponent<AppStateResetOnOrgChang
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedOrg, priorSelectedOrg]);
 
-  return <Fragment />;
+  return null;
 };
 
 export default AppStateResetOnOrgChange;

--- a/apps/jetstream/src/app/components/manage-permissions/ManagePermissions.tsx
+++ b/apps/jetstream/src/app/components/manage-permissions/ManagePermissions.tsx
@@ -25,6 +25,7 @@ export const ManagePermissions: FunctionComponent<ManagePermissionsProps> = () =
   const resetFieldsByKey = useResetRecoilState(fromPermissionsState.fieldsByKey);
   const resetObjectPermissionMap = useResetRecoilState(fromPermissionsState.objectPermissionMap);
   const resetFieldPermissionMap = useResetRecoilState(fromPermissionsState.fieldPermissionMap);
+  const resetTabVisibilityPermissionMap = useResetRecoilState(fromPermissionsState.tabVisibilityPermissionMap);
   const [priorSelectedOrg, setPriorSelectedOrg] = useState<string | null>(null);
 
   const hasSelectionsMade = useRecoilValue(fromPermissionsState.hasSelectionsMade);
@@ -45,6 +46,7 @@ export const ManagePermissions: FunctionComponent<ManagePermissionsProps> = () =
       resetFieldsByKey();
       resetObjectPermissionMap();
       resetFieldPermissionMap();
+      resetTabVisibilityPermissionMap();
     } else if (!selectedOrg) {
       resetProfilesState();
       resetSelectedProfilesPermSetState();
@@ -56,6 +58,7 @@ export const ManagePermissions: FunctionComponent<ManagePermissionsProps> = () =
       resetFieldsByKey();
       resetObjectPermissionMap();
       resetFieldPermissionMap();
+      resetTabVisibilityPermissionMap();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedOrg, priorSelectedOrg]);
@@ -75,6 +78,7 @@ export const ManagePermissions: FunctionComponent<ManagePermissionsProps> = () =
           ['fieldsByKey', fromPermissionsState.fieldsByKey],
           ['objectPermissionMap', fromPermissionsState.objectPermissionMap],
           ['fieldPermissionMap', fromPermissionsState.fieldPermissionMap],
+          ['tabVisibilityPermissionMap', fromPermissionsState.tabVisibilityPermissionMap],
         ]}
       />
       {location.pathname.endsWith('/editor') && !hasSelectionsMade ? <Navigate to="." /> : <Outlet />}

--- a/apps/jetstream/src/app/components/manage-permissions/ManagePermissionsEditorTabVisibilityTable.tsx
+++ b/apps/jetstream/src/app/components/manage-permissions/ManagePermissionsEditorTabVisibilityTable.tsx
@@ -8,33 +8,33 @@ import {
   FieldPermissionTypes,
   ManagePermissionsEditorTableRef,
   PermissionManagerTableContext,
-  PermissionTableObjectCell,
   PermissionTableSummaryRow,
+  PermissionTableTabVisibilityCell,
 } from './utils/permission-manager-types';
 
-function getRowKey(row: PermissionTableObjectCell) {
+function getRowKey(row: PermissionTableTabVisibilityCell) {
   return row.key;
 }
 
 // summary row is just a placeholder for rendered content
 const SUMMARY_ROWS: PermissionTableSummaryRow[] = [{ type: 'HEADING' }, { type: 'ACTION' }];
 
-export interface ManagePermissionsEditorObjectTableProps {
-  columns: ColumnWithFilter<PermissionTableObjectCell, PermissionTableSummaryRow>[];
-  rows: PermissionTableObjectCell[];
+export interface ManagePermissionsEditorTabVisibilityTableProps {
+  columns: ColumnWithFilter<PermissionTableTabVisibilityCell, PermissionTableSummaryRow>[];
+  rows: PermissionTableTabVisibilityCell[];
   totalCount: number;
   onFilter: (value: string) => void;
-  onBulkUpdate: (rows: PermissionTableObjectCell[], indexes?: number[]) => void;
-  onDirtyRows?: (values: MapOf<DirtyRow<PermissionTableObjectCell>>) => void;
+  onBulkUpdate: (rows: PermissionTableTabVisibilityCell[], indexes?: number[]) => void;
+  onDirtyRows?: (values: MapOf<DirtyRow<PermissionTableTabVisibilityCell>>) => void;
 }
 
-export const ManagePermissionsEditorObjectTable = forwardRef<any, ManagePermissionsEditorObjectTableProps>(
+export const ManagePermissionsEditorTabVisibilityTable = forwardRef<any, ManagePermissionsEditorTabVisibilityTableProps>(
   ({ columns, rows, totalCount, onFilter, onBulkUpdate, onDirtyRows }, ref) => {
-    const [dirtyRows, setDirtyRows] = useState<MapOf<DirtyRow<PermissionTableObjectCell>>>({});
+    const [dirtyRows, setDirtyRows] = useState<MapOf<DirtyRow<PermissionTableTabVisibilityCell>>>({});
 
     useImperativeHandle<any, ManagePermissionsEditorTableRef>(ref, () => ({
       resetChanges() {
-        resetGridChanges({ rows, type: 'object' });
+        resetGridChanges({ rows, type: 'tabVisibility' });
         setDirtyRows({});
       },
     }));
@@ -45,11 +45,11 @@ export const ManagePermissionsEditorObjectTable = forwardRef<any, ManagePermissi
 
     function handleColumnAction(action: 'selectAll' | 'unselectAll' | 'reset', columnKey: string) {
       const [id, typeLabel] = columnKey.split('-');
-      onBulkUpdate(updateRowsFromColumnAction('object', action, typeLabel as FieldPermissionTypes, id, rows));
+      onBulkUpdate(updateRowsFromColumnAction('tabVisibility', action, typeLabel as FieldPermissionTypes, id, rows));
     }
 
     const handleRowsChange = useCallback(
-      (rows: PermissionTableObjectCell[], { indexes }) => {
+      (rows: PermissionTableTabVisibilityCell[], { indexes }) => {
         onBulkUpdate(rows, indexes);
       },
       [onBulkUpdate]
@@ -66,7 +66,7 @@ export const ManagePermissionsEditorObjectTable = forwardRef<any, ManagePermissi
             onRowsChange={handleRowsChange}
             context={
               {
-                type: 'object',
+                type: 'tabVisibility',
                 totalCount,
                 onFilterRows: onFilter,
                 onColumnAction: handleColumnAction,
@@ -82,4 +82,4 @@ export const ManagePermissionsEditorObjectTable = forwardRef<any, ManagePermissi
   }
 );
 
-export default ManagePermissionsEditorObjectTable;
+export default ManagePermissionsEditorTabVisibilityTable;

--- a/apps/jetstream/src/app/components/manage-permissions/ManagePermissionsSelection.tsx
+++ b/apps/jetstream/src/app/components/manage-permissions/ManagePermissionsSelection.tsx
@@ -43,6 +43,7 @@ export const ManagePermissionsSelection: FunctionComponent<ManagePermissionsSele
   const resetFieldsByKey = useResetRecoilState(fromPermissionsState.fieldsByKey);
   const resetObjectPermissionMap = useResetRecoilState(fromPermissionsState.objectPermissionMap);
   const resetFieldPermissionMap = useResetRecoilState(fromPermissionsState.fieldPermissionMap);
+  const resetTabVisibilityPermissionMap = useResetRecoilState(fromPermissionsState.tabVisibilityPermissionMap);
 
   const profilesAndPermSetsData = useProfilesAndPermSets(selectedOrg, profiles, permissionSets);
 
@@ -67,6 +68,7 @@ export const ManagePermissionsSelection: FunctionComponent<ManagePermissionsSele
     resetFieldsByKey();
     resetObjectPermissionMap();
     resetFieldPermissionMap();
+    resetTabVisibilityPermissionMap();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedProfiles, selectedPermissionSets, selectedSObjects]);
 

--- a/apps/jetstream/src/app/components/manage-permissions/manage-permissions.state.ts
+++ b/apps/jetstream/src/app/components/manage-permissions/manage-permissions.state.ts
@@ -7,7 +7,11 @@ import {
 } from '@jetstream/types';
 import type { DescribeGlobalSObjectResult } from 'jsforce';
 import { atom, selector } from 'recoil';
-import { FieldPermissionDefinitionMap, ObjectPermissionDefinitionMap } from './utils/permission-manager-types';
+import {
+  FieldPermissionDefinitionMap,
+  ObjectPermissionDefinitionMap,
+  TabVisibilityPermissionDefinitionMap,
+} from './utils/permission-manager-types';
 
 export const sObjectsState = atom<DescribeGlobalSObjectResult[] | null>({
   key: 'permission-manager.sObjectsState',
@@ -51,24 +55,6 @@ export const fieldsByKey = atom<MapOf<EntityParticlePermissionsRecord> | null>({
   default: null,
 });
 
-// // key = either Sobject name or field name with object prefix
-// export const permissionsByObjectAndField = atom<MapOf<string[]>>({
-//   key: 'permission-manager.permissionsByObjectAndField',
-//   default: null,
-// });
-
-// //KEY = {Id-SObjectName} ex: `${record.ParentId}-${record.Field}`
-// export const objectPermissionsByKey = atom<MapOf<ObjectPermissionRecord>>({
-//   key: 'permission-manager.objectPermissionsByKey',
-//   default: null,
-// });
-
-// //KEY = {Id-FieldName} ex: `${record.ParentId}-${record.Field}`
-// export const fieldPermissionsByKey = atom<MapOf<FieldPermissionRecord>>({
-//   key: 'permission-manager.fieldPermissionsByKey',
-//   default: null,
-// });
-
 export const objectPermissionMap = atom<MapOf<ObjectPermissionDefinitionMap> | null>({
   key: 'permission-manager.objectPermissionMap',
   default: null,
@@ -76,6 +62,11 @@ export const objectPermissionMap = atom<MapOf<ObjectPermissionDefinitionMap> | n
 
 export const fieldPermissionMap = atom<MapOf<FieldPermissionDefinitionMap> | null>({
   key: 'permission-manager.fieldPermissionMap',
+  default: null,
+});
+
+export const tabVisibilityPermissionMap = atom<MapOf<TabVisibilityPermissionDefinitionMap> | null>({
+  key: 'permission-manager.tabVisibilityPermissionMap',
   default: null,
 });
 

--- a/apps/jetstream/src/app/components/manage-permissions/usePermissionRecords.tsx
+++ b/apps/jetstream/src/app/components/manage-permissions/usePermissionRecords.tsx
@@ -1,14 +1,29 @@
 import { logger } from '@jetstream/shared/client-logger';
 import { queryAll, queryAllUsingOffset } from '@jetstream/shared/data';
 import { useRollbar } from '@jetstream/shared/ui-utils';
-import { EntityParticlePermissionsRecord, FieldPermissionRecord, MapOf, ObjectPermissionRecord, SalesforceOrgUi } from '@jetstream/types';
+import { getMapOf } from '@jetstream/shared/utils';
+import {
+  EntityParticlePermissionsRecord,
+  FieldPermissionRecord,
+  MapOf,
+  ObjectPermissionRecord,
+  SalesforceOrgUi,
+  TabDefinitionRecord,
+  TabVisibilityPermissionRecord,
+} from '@jetstream/types';
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { FieldPermissionDefinitionMap, ObjectPermissionDefinitionMap } from './utils/permission-manager-types';
+import {
+  FieldPermissionDefinitionMap,
+  ObjectPermissionDefinitionMap,
+  TabVisibilityPermissionDefinitionMap,
+} from './utils/permission-manager-types';
 import {
   getFieldDefinitionKey,
   getQueryForAllPermissionableFields,
   getQueryForFieldPermissions,
   getQueryObjectPermissions,
+  getQueryTabDefinition,
+  getQueryTabVisibilityPermissions,
 } from './utils/permission-manager-utils';
 
 export function usePermissionRecords(selectedOrg: SalesforceOrgUi, sobjects: string[], profilePermSetIds: string[], permSetIds: string[]) {
@@ -22,6 +37,7 @@ export function usePermissionRecords(selectedOrg: SalesforceOrgUi, sobjects: str
 
   const [objectPermissionMap, setObjectPermissionMap] = useState<MapOf<ObjectPermissionDefinitionMap> | null>(null);
   const [fieldPermissionMap, setFieldPermissionMap] = useState<MapOf<FieldPermissionDefinitionMap> | null>(null);
+  const [tabVisibilityPermissionMap, setTabVisibilityPermissionMap] = useState<MapOf<TabVisibilityPermissionDefinitionMap> | null>(null);
 
   useEffect(() => {
     isMounted.current = true;
@@ -50,12 +66,26 @@ export function usePermissionRecords(selectedOrg: SalesforceOrgUi, sobjects: str
         queryAndCombineResults<EntityParticlePermissionsRecord>(selectedOrg, getQueryForAllPermissionableFields(sobjects), true, true),
         queryAndCombineResults<ObjectPermissionRecord>(selectedOrg, getQueryObjectPermissions(sobjects, permSetIds, profilePermSetIds)),
         queryAndCombineResults<FieldPermissionRecord>(selectedOrg, getQueryForFieldPermissions(sobjects, permSetIds, profilePermSetIds)),
-      ]).then(([fieldDefinition, objectPermissions, fieldPermissions]) => {
+        queryAndCombineResults<TabVisibilityPermissionRecord>(
+          selectedOrg,
+          getQueryTabVisibilityPermissions(sobjects, permSetIds, profilePermSetIds)
+        ).then((record) => record.map((item) => ({ ...item, Name: item.Name.replace('standard-', '') }))),
+        queryAndCombineResults<TabDefinitionRecord>(selectedOrg, getQueryTabDefinition(sobjects), false, true).then((tabs) =>
+          getMapOf(tabs, 'SobjectName')
+        ),
+      ]).then(([fieldDefinition, objectPermissions, fieldPermissions, tabVisibilityPermissions, tabDefinitions]) => {
         return {
           fieldsByObject: getAllFieldsByObject(fieldDefinition),
           fieldsByKey: groupFields(fieldDefinition),
           objectPermissionMap: getObjectPermissionMap(sobjects, profilePermSetIds, permSetIds, objectPermissions),
           fieldPermissionMap: getFieldPermissionMap(fieldDefinition, profilePermSetIds, permSetIds, fieldPermissions),
+          tabVisibilityPermissionMap: getTabVisibilityPermissionMap(
+            sobjects,
+            profilePermSetIds,
+            permSetIds,
+            tabVisibilityPermissions,
+            tabDefinitions
+          ),
         };
       });
       if (isMounted.current) {
@@ -63,6 +93,7 @@ export function usePermissionRecords(selectedOrg: SalesforceOrgUi, sobjects: str
         setFieldsByKey(output.fieldsByKey);
         setObjectPermissionMap(output.objectPermissionMap);
         setFieldPermissionMap(output.fieldPermissionMap);
+        setTabVisibilityPermissionMap(output.tabVisibilityPermissionMap);
       }
     } catch (ex) {
       logger.warn('[useProfilesAndPermSets][ERROR]', ex.message);
@@ -85,6 +116,7 @@ export function usePermissionRecords(selectedOrg: SalesforceOrgUi, sobjects: str
     /** permissionsByObjectAndField, objectPermissionsByKey, fieldPermissionsByKey, */
     objectPermissionMap,
     fieldPermissionMap,
+    tabVisibilityPermissionMap,
     hasError,
   };
 }
@@ -223,6 +255,57 @@ function getFieldPermissionMap(
     selectedPermissionSets.forEach(processProfileAndPermSet);
 
     output[fieldKey] = currItem;
+    return output;
+  }, {});
+}
+
+function getTabVisibilityPermissionMap(
+  sobjects: string[],
+  selectedProfiles: string[],
+  selectedPermissionSets: string[],
+  permissions: TabVisibilityPermissionRecord[],
+  tabDefinitions: MapOf<TabDefinitionRecord>
+): MapOf<TabVisibilityPermissionDefinitionMap> {
+  const objectPermissionsByFieldByParentId = permissions.reduce((output: MapOf<MapOf<TabVisibilityPermissionRecord>>, item) => {
+    output[item.Name] = output[item.Name] || {};
+    output[item.Name][item.ParentId] = item;
+    return output;
+  }, {});
+
+  return sobjects.reduce((output: MapOf<TabVisibilityPermissionDefinitionMap>, item) => {
+    const currItem: TabVisibilityPermissionDefinitionMap = {
+      apiName: item,
+      label: item,
+      metadata: item,
+      permissions: {},
+      permissionKeys: [],
+      canSetPermission: !!tabDefinitions[item],
+    };
+
+    function processProfileAndPermSet(id: string) {
+      const permissionRecord = objectPermissionsByFieldByParentId[item]?.[id];
+      currItem.permissionKeys.push(id);
+      if (permissionRecord) {
+        currItem.permissions[id] = {
+          available: true,
+          visible: permissionRecord.Visibility === 'DefaultOn' ? true : false,
+          record: permissionRecord,
+          canSetPermission: true,
+        };
+      } else {
+        currItem.permissions[id] = {
+          available: false,
+          visible: false,
+          record: null,
+          canSetPermission: !!tabDefinitions[item],
+        };
+      }
+    }
+
+    selectedProfiles.forEach(processProfileAndPermSet);
+    selectedPermissionSets.forEach(processProfileAndPermSet);
+
+    output[item] = currItem;
     return output;
   }, {});
 }

--- a/apps/jetstream/src/app/components/manage-permissions/utils/permission-manager-export-utils.ts
+++ b/apps/jetstream/src/app/components/manage-permissions/utils/permission-manager-export-utils.ts
@@ -1,29 +1,38 @@
 import { excelWorkbookToArrayBuffer, getMaxWidthFromColumnContent, initXlsx } from '@jetstream/shared/ui-utils';
 import { ColumnWithFilter } from '@jetstream/ui';
 import * as XLSX from 'xlsx';
-import { PermissionTableFieldCell, PermissionTableObjectCell, PermissionTableSummaryRow } from './permission-manager-types';
+import {
+  PermissionTableFieldCell,
+  PermissionTableObjectCell,
+  PermissionTableSummaryRow,
+  PermissionTableTabVisibilityCell,
+} from './permission-manager-types';
 
 initXlsx(XLSX);
 
-type ObjectOrFieldColumn =
+type ObjectOrFieldOrTabVisibilityColumn =
   | ColumnWithFilter<PermissionTableObjectCell, PermissionTableSummaryRow>
-  | ColumnWithFilter<PermissionTableFieldCell, PermissionTableSummaryRow>;
+  | ColumnWithFilter<PermissionTableFieldCell, PermissionTableSummaryRow>
+  | ColumnWithFilter<PermissionTableTabVisibilityCell, PermissionTableSummaryRow>;
 
 export function generateExcelWorkbookFromTable(
-  objectData: { columns: ObjectOrFieldColumn[]; rows: PermissionTableObjectCell[] },
-  fieldData: { columns: ObjectOrFieldColumn[]; rows: PermissionTableFieldCell[] }
+  objectData: { columns: ObjectOrFieldOrTabVisibilityColumn[]; rows: PermissionTableObjectCell[] },
+  tabVisibilityData: { columns: ObjectOrFieldOrTabVisibilityColumn[]; rows: PermissionTableTabVisibilityCell[] },
+  fieldData: { columns: ObjectOrFieldOrTabVisibilityColumn[]; rows: PermissionTableFieldCell[] }
 ) {
   const workbook = XLSX.utils.book_new();
   const objectWorksheet = generateObjectWorksheet(objectData.columns, objectData.rows);
+  const tabVisibilityWorksheet = generateTabVisibilityWorksheet(tabVisibilityData.columns, tabVisibilityData.rows);
   const fieldWorksheet = generateFieldWorksheet(fieldData.columns, fieldData.rows);
 
   XLSX.utils.book_append_sheet(workbook, objectWorksheet, 'Object Permissions');
+  XLSX.utils.book_append_sheet(workbook, tabVisibilityWorksheet, 'Tab Visibility');
   XLSX.utils.book_append_sheet(workbook, fieldWorksheet, 'Field Permissions');
 
   return excelWorkbookToArrayBuffer(workbook);
 }
 
-function generateObjectWorksheet(columns: ObjectOrFieldColumn[], rows: PermissionTableObjectCell[]) {
+function generateObjectWorksheet(columns: ObjectOrFieldOrTabVisibilityColumn[], rows: PermissionTableObjectCell[]) {
   const merges: XLSX.Range[] = [];
   const header1: string[] = [''];
   const header2: string[] = ['Object'];
@@ -77,7 +86,7 @@ function generateObjectWorksheet(columns: ObjectOrFieldColumn[], rows: Permissio
   return worksheet;
 }
 
-function generateFieldWorksheet(columns: ObjectOrFieldColumn[], rows: PermissionTableFieldCell[]) {
+function generateFieldWorksheet(columns: ObjectOrFieldOrTabVisibilityColumn[], rows: PermissionTableFieldCell[]) {
   const merges: XLSX.Range[] = [];
   const header1: string[] = ['', '', ''];
   const header2: string[] = ['Object', 'Field Api Name', 'Field Label'];
@@ -112,6 +121,49 @@ function generateFieldWorksheet(columns: ObjectOrFieldColumn[], rows: Permission
       const permission = row.permissions[key];
       currRow.push(permission.read ? 'TRUE' : 'FALSE');
       currRow.push(permission.edit ? 'TRUE' : 'FALSE');
+    });
+    excelRows.push(currRow);
+  });
+
+  const worksheet = XLSX.utils.aoa_to_sheet(excelRows);
+  worksheet['!cols'] = getMaxWidthFromColumnContent(excelRows, new Set([0]));
+  worksheet['!merges'] = merges;
+  return worksheet;
+}
+
+function generateTabVisibilityWorksheet(columns: ObjectOrFieldOrTabVisibilityColumn[], rows: PermissionTableTabVisibilityCell[]) {
+  const merges: XLSX.Range[] = [];
+  const header1: string[] = [''];
+  const header2: string[] = ['Object'];
+  const excelRows = [header1, header2];
+
+  const permissionKeys: string[] = [];
+
+  columns
+    .filter((col) => col.key?.endsWith('-available'))
+    .forEach((col) => {
+      // header 1
+      header1.push(col.name as string);
+      header1.push('');
+      // header1.push('');
+      // merge the added cells
+      merges.push({
+        s: { r: 0, c: header1.length - 2 },
+        e: { r: 0, c: header1.length - 1 },
+      });
+      // header 2
+      header2.push('Available');
+      header2.push('Visible');
+      // keep track of group order to ensure same across all rows
+      permissionKeys.push(col.key.split('-')[0]);
+    });
+
+  rows.forEach((row, i) => {
+    const currRow = [row.sobject];
+    permissionKeys.forEach((key) => {
+      const permission = row.permissions[key];
+      currRow.push(permission.available ? 'TRUE' : 'FALSE');
+      currRow.push(permission.visible ? 'TRUE' : 'FALSE');
     });
     excelRows.push(currRow);
   });

--- a/apps/jetstream/src/app/components/manage-permissions/utils/permission-manager-types.ts
+++ b/apps/jetstream/src/app/components/manage-permissions/utils/permission-manager-types.ts
@@ -6,22 +6,28 @@ import {
   ObjectPermissionRecord,
   RecordAttributes,
   RecordResult,
+  TabVisibilityPermissionRecord,
 } from '@jetstream/types';
 
-export type PermissionType = 'object' | 'field';
+export type PermissionType = 'object' | 'field' | 'tabVisibility';
 export type ObjectPermissionTypes = 'create' | 'read' | 'edit' | 'delete' | 'viewAll' | 'modifyAll';
 export type FieldPermissionTypes = 'read' | 'edit';
+export type TabVisibilityPermissionTypes = 'available' | 'visible';
+
+export type PermissionTypes = ObjectPermissionTypes | FieldPermissionTypes | TabVisibilityPermissionTypes;
 
 export type BulkActionCheckbox = {
-  id: ObjectPermissionTypes;
+  id: PermissionTypes;
   label: string;
   value: boolean;
   disabled: boolean;
 };
 
+export type PermissionDefinitionMap = ObjectPermissionDefinitionMap | FieldPermissionDefinitionMap | TabVisibilityPermissionDefinitionMap;
+
 export interface ObjectPermissionDefinitionMap {
   apiName: string;
-  label: string; // TODO: ;(
+  label: string;
   metadata: string; // FIXME: this should probably be Describe metadata
   // used to retain order of permissions
   permissionKeys: string[]; // this is permission set ids, which could apply to profile or perm set
@@ -55,6 +61,31 @@ export interface FieldPermissionItem {
   errorMessage?: Maybe<string>;
 }
 
+export interface TabVisibilityPermissionDefinitionMap {
+  apiName: string;
+  label: string;
+  metadata: string;
+  /**
+   * False if a tab does not exist for this object
+   */
+  canSetPermission: boolean;
+  // used to retain order of permissions
+  permissionKeys: string[]; // this is permission set ids, which could apply to profile or perm set
+  permissions: MapOf<TabVisibilityPermissionItem>;
+}
+
+export interface TabVisibilityPermissionItem {
+  available: boolean;
+  visible: boolean;
+  record?: Maybe<TabVisibilityPermissionRecord>;
+  /**
+   * False if a tab does not exist for this object
+   * In which case, permissions cannot be set
+   */
+  canSetPermission: boolean;
+  errorMessage?: string;
+}
+
 export interface ObjectPermissionRecordForSave extends Omit<ObjectPermissionRecord, 'Id' | 'Parent'> {
   attributes: Partial<RecordAttributes>;
   Id?: Maybe<string>;
@@ -65,11 +96,18 @@ export interface FieldPermissionRecordForSave extends Omit<FieldPermissionRecord
   Id?: string;
 }
 
+export interface TabVisibilityPermissionRecordForSave extends Pick<TabVisibilityPermissionRecord, 'Visibility'> {
+  attributes: Partial<RecordAttributes>;
+  Id?: string;
+  Name?: string;
+  ParentId?: string;
+}
+
 export interface PermissionSaveResults<RecordType, DirtyPermType> {
   dirtyPermission: DirtyPermType;
   dirtyPermissionIdx: number;
-  operation: 'insert' | 'update';
-  record: RecordType;
+  operation: 'insert' | 'update' | 'delete';
+  record?: RecordType;
   recordIdx: number;
   response?: Maybe<RecordResult>;
 }
@@ -83,6 +121,8 @@ export interface PermissionTableCell<T = PermissionTableFieldCellPermission | Pe
   permissions: MapOf<T>;
 }
 
+export type PermissionTableCellExtended = PermissionTableObjectCell | PermissionTableFieldCell | PermissionTableTabVisibilityCell;
+
 export interface PermissionTableObjectCell extends PermissionTableCell<PermissionTableObjectCellPermission> {
   allowEditPermission: boolean; // TODO: what other permissions may be restricted here??
 }
@@ -92,11 +132,15 @@ export interface PermissionTableFieldCell extends PermissionTableCell<Permission
   allowEditPermission: boolean;
 }
 
+export interface PermissionTableTabVisibilityCell extends PermissionTableCell<PermissionTableTabVisibilityCellPermission> {
+  canSetPermission: boolean;
+}
+
 export interface PermissionTableSummaryRow {
   type: 'HEADING' | 'ACTION';
 }
 
-export interface PermissionTableObjectCellPermissionBase<T = ObjectPermissionItem | FieldPermissionItem> {
+export interface PermissionTableObjectCellPermissionBase<T = ObjectPermissionItem | FieldPermissionItem | TabVisibilityPermissionItem> {
   rowKey: string;
   parentId: string; // permissions set (placeholder profile or permission set Id)
   sobject: string;
@@ -126,6 +170,18 @@ export interface PermissionTableFieldCellPermission extends PermissionTableObjec
   editIsDirty: boolean;
 }
 
+export interface PermissionTableTabVisibilityCellPermission extends PermissionTableObjectCellPermissionBase<TabVisibilityPermissionItem> {
+  available: boolean;
+  availableIsDirty: boolean;
+  visible: boolean;
+  visibleIsDirty: boolean;
+}
+
+export type PermissionTableCellPermission =
+  | PermissionTableObjectCellPermission
+  | PermissionTableFieldCellPermission
+  | PermissionTableTabVisibilityCellPermission;
+
 export interface ManagePermissionsEditorTableProps {
   fieldsByObject: MapOf<string[]>;
 }
@@ -144,20 +200,29 @@ export interface PermissionObjectSaveData {
   permissionSaveResults: PermissionSaveResults<ObjectPermissionRecordForSave, PermissionTableObjectCellPermission>[];
   recordsToInsert: ObjectPermissionRecordForSave[];
   recordsToUpdate: ObjectPermissionRecordForSave[];
+  recordsToDelete: string[];
 }
 
 export interface PermissionFieldSaveData {
   permissionSaveResults: PermissionSaveResults<FieldPermissionRecordForSave, PermissionTableFieldCellPermission>[];
   recordsToInsert: FieldPermissionRecordForSave[];
   recordsToUpdate: FieldPermissionRecordForSave[];
+  recordsToDelete: string[];
+}
+
+export interface PermissionTabVisibilitySaveData {
+  permissionSaveResults: PermissionSaveResults<TabVisibilityPermissionRecordForSave, PermissionTableTabVisibilityCellPermission>[];
+  recordsToInsert: TabVisibilityPermissionRecordForSave[];
+  recordsToUpdate: TabVisibilityPermissionRecordForSave[];
+  recordsToDelete: string[];
 }
 
 export interface PermissionManagerTableContext {
   type: PermissionType;
-  rows: (PermissionTableObjectCell | PermissionTableFieldCell)[];
+  rows: PermissionTableCellExtended[];
   totalCount: number;
   onFilterRows: (value: string) => void;
   onRowAction: (action: 'selectAll' | 'unselectAll' | 'reset', columnKey: string) => void;
   onColumnAction: (action: 'selectAll' | 'unselectAll' | 'reset', columnKey: string) => void;
-  onBulkAction: (rows: (PermissionTableObjectCell | PermissionTableFieldCell)[]) => void;
+  onBulkAction: (rows: PermissionTableCellExtended[]) => void;
 }

--- a/libs/icon-factory/src/lib/icon-factory.tsx
+++ b/libs/icon-factory/src/lib/icon-factory.tsx
@@ -31,6 +31,7 @@ import StandardIcon_MultiPicklist from './icons/standard/MultiPicklist';
 import StandardIcon_Opportunity from './icons/standard/Opportunity';
 import StandardIcon_Outcome from './icons/standard/Outcome';
 import StandardIcon_Portal from './icons/standard/Portal';
+import StandardIcon_PortalRolesAndSubordinates from './icons/standard/PortalRolesAndSubordinates';
 import StandardIcon_ProductConsumed from './icons/standard/ProductConsumed';
 import StandardIcon_Record from './icons/standard/Record';
 import StandardIcon_RecordCreate from './icons/standard/RecordCreate';
@@ -171,6 +172,7 @@ const standardIcons = {
   opportunity: StandardIcon_Opportunity,
   outcome: StandardIcon_Outcome,
   portal: StandardIcon_Portal,
+  portal_roles_and_subordinates: StandardIcon_PortalRolesAndSubordinates,
   product_consumed: StandardIcon_ProductConsumed,
   record_create: StandardIcon_RecordCreate,
   record_lookup: StandardIcon_RecordLookup,

--- a/libs/types/src/lib/salesforce/types.ts
+++ b/libs/types/src/lib/salesforce/types.ts
@@ -289,6 +289,25 @@ export type TabPermissionRecordInsert = {
   Visibility: 'DefaultOn' | 'DefaultOff';
 };
 
+export interface TabVisibilityPermissionRecord {
+  Id: string;
+  Name: string;
+  Visibility: 'DefaultOff' | 'DefaultOn';
+  ParentId: string;
+  Parent: PermissionPermissionSetRecord;
+}
+
+export interface TabDefinitionRecord {
+  Id: string;
+  Name: string;
+  Label: string;
+  SobjectName: string;
+}
+
+export type TabVisibilityPermissionRecordInsert = Omit<TabVisibilityPermissionRecord, 'Id' | 'Parent'> & {
+  attributes?: { type: 'ObjectPermissions' };
+};
+
 export type BulkJobWithBatches = BulkJob & { batches: BulkJobBatchInfo[] };
 
 export interface BulkJob {


### PR DESCRIPTION
Added tab visibility to permissions editor because this is often desired to be adjusted at the same time as other permissions

Some objects do not have a tab, in which case the user is unable to adjust tab permissions for those objects.

Tab visibility objects for standard objects have a prefix of 'standard-' instead of the full object name, in addition, the records need to be manually deleted to indicate no permissions.

resolves #663