### PR TITLE
Add client to API calls

### DIFF
--- a/apps/api/src/app/routes/route.middleware.ts
+++ b/apps/api/src/app/routes/route.middleware.ts
@@ -287,6 +287,7 @@ export async function getOrgForRequest(
       // http://www.fishofprey.com/2016/03/salesforce-forcecom-ide-superpowers.html
       // FIXME: this breaks some orgs
       // client: `apex_eclipse/v${apiVersion || org.apiVersion || ENV.SFDC_API_VERSION}`,
+      client: 'jetstream',
     },
   };
 


### PR DESCRIPTION
Adding client appears to have calls show up using the client id on the API usage report, but it does not seem to be consistent, SOAP API calls appear to be missing from the report completely.

resolves #672