### PR TITLE
Load: Show warning or error if record id is mapped #679

### DIFF
--- a/apps/jetstream/src/app/components/load-records/LoadRecords.tsx
+++ b/apps/jetstream/src/app/components/load-records/LoadRecords.tsx
@@ -241,9 +241,9 @@ export const LoadRecords: FunctionComponent<LoadRecordsProps> = ({ featureFlags 
 
   useEffect(() => {
     if (mappableFields && inputFileHeader) {
-      setFieldMapping(autoMapFields(inputFileHeader, mappableFields, binaryAttachmentBodyField));
+      setFieldMapping(autoMapFields(inputFileHeader, mappableFields, binaryAttachmentBodyField, loadType, externalId));
     }
-  }, [mappableFields, inputFileHeader, loadType, setFieldMapping, binaryAttachmentBodyField]);
+  }, [mappableFields, inputFileHeader, loadType, setFieldMapping, binaryAttachmentBodyField, externalId]);
 
   useEffect(() => {
     setExternalIdFields(fields.filter((field) => field.name === 'Id' || field.externalId));

--- a/apps/jetstream/src/app/components/load-records/components/LoadRecordsFieldMappingRow.tsx
+++ b/apps/jetstream/src/app/components/load-records/components/LoadRecordsFieldMappingRow.tsx
@@ -217,9 +217,9 @@ export const LoadRecordsFieldMappingRow: FunctionComponent<LoadRecordsFieldMappi
           comboboxProps={{
             hideLabel: true,
             label: 'Salesforce Fields',
-            hasError: fieldMappingItem.isDuplicateMappedField,
-            errorMessage: 'Each Salesforce field should only be mapped once',
-            errorMessageId: `${csvField}-${fieldMappingItem.targetField}-duplicate-field-error`,
+            hasError: !!fieldMappingItem.fieldErrorMsg,
+            errorMessage: fieldMappingItem.fieldErrorMsg,
+            errorMessageId: `${csvField}-${fieldMappingItem.targetField}-mapping-error`,
           }}
           items={fieldListItems}
           selectedItemId={fieldMappingItem.targetField}

--- a/apps/jetstream/src/app/components/load-records/load-records-types.ts
+++ b/apps/jetstream/src/app/components/load-records/load-records-types.ts
@@ -74,6 +74,7 @@ export interface FieldMappingItemBase {
   fieldMetadata: Maybe<FieldWithRelatedEntities>;
   relatedFieldMetadata?: FieldRelatedEntity;
   isDuplicateMappedField?: boolean;
+  fieldErrorMsg?: string;
   lookupOptionUseFirstMatch: NonExtIdLookupOption;
   lookupOptionNullIfNoMatch: boolean;
   isBinaryBodyField: boolean;

--- a/apps/jetstream/src/app/components/load-records/steps/FieldMapping.tsx
+++ b/apps/jetstream/src/app/components/load-records/steps/FieldMapping.tsx
@@ -23,6 +23,7 @@ import {
 import { LoadSavedMappingItem } from '../load-records.state';
 import {
   autoMapFields,
+  checkFieldsForMappingError,
   checkForDuplicateFieldMappings,
   initStaticFieldMappingItem,
   loadFieldMappingFromSavedMapping,
@@ -134,7 +135,7 @@ export const LoadRecordsFieldMapping = memo<LoadRecordsFieldMappingProps>(
         }
       }
       setWarningMessage(null);
-    }, [externalId, fieldMapping, loadType]);
+    }, [externalId, fieldMapping, isCustomMetadataObject, loadType]);
 
     useNonInitialEffect(() => {
       let tempVisibleHeaders = inputHeader;
@@ -158,7 +159,9 @@ export const LoadRecordsFieldMapping = memo<LoadRecordsFieldMappingProps>(
      *
      */
     function handleFieldMappingChange(csvField: string, fieldMappingItem: FieldMappingItem) {
-      setFieldMapping((fieldMapping) => checkForDuplicateFieldMappings({ ...fieldMapping, [csvField]: fieldMappingItem }));
+      setFieldMapping((fieldMapping) =>
+        checkFieldsForMappingError({ ...fieldMapping, [csvField]: fieldMappingItem }, loadType, externalId)
+      );
     }
 
     function handleAction(id: DropDownAction) {
@@ -170,7 +173,7 @@ export const LoadRecordsFieldMapping = memo<LoadRecordsFieldMappingProps>(
           break;
         case MAPPING_RESET:
           setStaticRowHeaders([]);
-          setFieldMapping(autoMapFields(inputHeader, fields, binaryAttachmentBodyField));
+          setFieldMapping(autoMapFields(inputHeader, fields, binaryAttachmentBodyField, loadType, externalId));
           setFilter(FILTER_ALL);
           trackEvent(ANALYTICS_KEYS.load_MappingAutomationChanged, { action: id });
           break;


### PR DESCRIPTION
Give user a nice indicator that the load will most likely fail. We could have made this slightly better by not auto-mapping the record id for upsert, but there could be some edge-cases so the easy path was taken to show an error.

Mapping errors are considered "soft" as the uer can still continue if they so choose to.

resolves #679

<img width="1408" alt="image" src="https://github.com/jetstreamapp/jetstream/assets/5461649/404d0575-2b0e-4cc0-b9ee-1ee649c24559">
