### PR TITLE
Ensure empty strings are set to null

### DIFF
--- a/libs/shared/utils/src/lib/__tests__/utils.spec.ts
+++ b/libs/shared/utils/src/lib/__tests__/utils.spec.ts
@@ -1,4 +1,4 @@
-import { getExcelSafeSheetName, getFullNameFromListMetadata } from '../utils';
+import { getExcelSafeSheetName, getFullNameFromListMetadata, nullifyEmptyStrings } from '../utils';
 
 describe('utils.getExcelSafeSheetName', () => {
   it('should handle simple cases', () => {
@@ -74,5 +74,64 @@ describe('utils.getFullNameFromListMetadata', () => {
         namespace: 'TEST',
       })
     ).toEqual('AttributeSet__c-Attribute Set Layout');
+  });
+});
+
+describe('utils.nullifyEmptyStrings', () => {
+  it('should nullify empty strings in a map', () => {
+    const input = {
+      name: 'John',
+      age: '',
+      address: {
+        street: '123 Main St',
+        city: '',
+        postalCode: '      ',
+        state: 'CA',
+      },
+    };
+
+    const expectedOutput = {
+      name: 'John',
+      age: null,
+      address: {
+        street: '123 Main St',
+        city: null,
+        postalCode: null,
+        state: 'CA',
+      },
+    };
+
+    expect(nullifyEmptyStrings(input)).toEqual(expectedOutput);
+  });
+
+  it('should nullify empty strings in a map without trimming', () => {
+    const input = {
+      name: 'John',
+      age: '',
+      address: {
+        street: '123 Main St',
+        city: '',
+        postalCode: '      ',
+        state: 'CA',
+      },
+    };
+
+    const expectedOutput = {
+      name: 'John',
+      age: null,
+      address: {
+        street: '123 Main St',
+        city: null,
+        postalCode: '      ',
+        state: 'CA',
+      },
+    };
+
+    expect(nullifyEmptyStrings(input, false)).toEqual(expectedOutput);
+  });
+
+  it('should return the same map if it is null or undefined', () => {
+    expect(nullifyEmptyStrings(null as any)).toBeNull();
+    expect(nullifyEmptyStrings(undefined as any)).toBeUndefined();
   });
 });

--- a/libs/shared/utils/src/lib/utils.ts
+++ b/libs/shared/utils/src/lib/utils.ts
@@ -244,6 +244,29 @@ export function getIdFromRecordUrl(url: string): string {
 }
 
 /**
+ * Convert empty strings to null
+ * Optionally trim all strings as well
+ */
+export function nullifyEmptyStrings<T extends MapOf<unknown>>(value: T, trimStrings = true): T {
+  if (!value) {
+    return value;
+  }
+  return Object.keys(value).reduce((obj, key) => {
+    obj[key] = value[key];
+    if (trimStrings && isString(obj[key])) {
+      obj[key] = (obj[key] as string).trim();
+    }
+    if (obj[key] === '') {
+      obj[key] = null;
+    }
+    if (isObject(obj[key])) {
+      obj[key] = nullifyEmptyStrings(obj[key] as MapOf<unknown>, trimStrings) as unknown;
+    }
+    return obj;
+  }, {}) as T;
+}
+
+/**
  * Remove query wrapper from child records
  * NOTE: this ignores instances where there are more records
  * @param results

--- a/libs/ui/src/lib/data-table/SalesforceRecordDataTable.tsx
+++ b/libs/ui/src/lib/data-table/SalesforceRecordDataTable.tsx
@@ -3,7 +3,7 @@ import { QueryResults } from '@jetstream/api-interfaces';
 import { logger } from '@jetstream/shared/client-logger';
 import { queryRemaining } from '@jetstream/shared/data';
 import { formatNumber, useRollbar } from '@jetstream/shared/ui-utils';
-import { flattenRecord, getIdFromRecordUrl } from '@jetstream/shared/utils';
+import { flattenRecord, getIdFromRecordUrl, nullifyEmptyStrings } from '@jetstream/shared/utils';
 import { CloneEditView, MapOf, Maybe, SalesforceOrgUi, SobjectCollectionResponse } from '@jetstream/types';
 import type { Field } from 'jsforce';
 import uniqueId from 'lodash/uniqueId';
@@ -314,12 +314,14 @@ export const SalesforceRecordDataTable: FunctionComponent<SalesforceRecordDataTa
         }
         setIsSavingRecords(true);
         const modifiedRecords = dirtyRows.map((row) =>
-          Array.from(row._touchedColumns).reduce(
-            (acc, column) => {
-              acc[column] = row[column];
-              return acc;
-            },
-            { attributes: row._record.attributes, Id: getIdFromRecordUrl(row._record.attributes.url) }
+          nullifyEmptyStrings(
+            Array.from(row._touchedColumns).reduce(
+              (acc, column) => {
+                acc[column] = row[column];
+                return acc;
+              },
+              { attributes: row._record.attributes, Id: getIdFromRecordUrl(row._record.attributes.url) }
+            )
           )
         );
         const results = await onUpdateRecords(modifiedRecords);


### PR DESCRIPTION
Salesforce apparently converts empty string to 0 when using the batch API, so we make sure that all empty strings are converted to null

resolves #747