### PR TITLE
Ensure invalid queries are properly handled for restore

### DIFF
--- a/apps/jetstream/src/app/components/query/utils/useQueryRestore.tsx
+++ b/apps/jetstream/src/app/components/query/utils/useQueryRestore.tsx
@@ -161,7 +161,7 @@ export const useQueryRestore = (
         } else {
           logger.warn('[QUERY RESTORE][ERROR]', ex);
           setErrorMessage('An unknown error has ocurred while restoring your query');
-          rollbar.error(ex.message, { ex, query: currSoql });
+          rollbar.error('Query Restore Error', { message: ex.message, stack: ex.stack, query: currSoql });
         }
         endRestore(true, toolingOverride ?? isTooling);
       }

--- a/libs/shared/ui-utils/src/lib/shared-ui-utils.ts
+++ b/libs/shared/ui-utils/src/lib/shared-ui-utils.ts
@@ -479,6 +479,8 @@ export function convertFiltersToWhereClause<T extends WhereClause | HavingClause
 }
 
 export function getOperatorFromWhereClause(operator: Operator, value: string, hasNegation = false): QueryFilterOperator {
+  // Some invalid queries have value as an array
+  value = !value || typeof value !== 'string' ? '' : value;
   operator = (operator?.toUpperCase() as Operator) || operator;
   switch (operator) {
     case '=':


### PR DESCRIPTION
Some specific syntaxes that were syntactically valid, but actually invalid, would cause a query restore error

Improve query restore rollbar entry

resolves #783