### PR TITLE
Automation Control does not disable triggers

### DIFF
--- a/apps/jetstream/src/app/components/automation-control/automation-control-data-utils.tsx
+++ b/apps/jetstream/src/app/components/automation-control/automation-control-data-utils.tsx
@@ -10,7 +10,7 @@ import { getToolingRecords, logErrorToRollbar, pollMetadataResultsUntilDone } fr
 import { getMapOf, splitArrayToMaxSize } from '@jetstream/shared/utils';
 import { CompositeRequest, CompositeRequestBody, CompositeResponse, MapOf, SalesforceOrgUi } from '@jetstream/types';
 import formatRelative from 'date-fns/formatRelative';
-import { from, Observable, of, Subject } from 'rxjs';
+import { Observable, Subject, from, of } from 'rxjs';
 import { catchError, mergeMap } from 'rxjs/operators';
 import {
   getApexTriggersQuery,
@@ -543,7 +543,7 @@ export function deployMetadata(
       }
 
       // perform deployments that are not supported using tooling api
-      const metadataDeployResults = await deployMetadataFileBased(selectedOrg, itemsByKey, Number(apiVersion));
+      const metadataDeployResults = await deployMetadataFileBased(selectedOrg, itemsByKey, Number(apiVersion.replace(/[^0-9\.]/g, '')));
 
       if (metadataDeployResults) {
         const deployResults = await pollMetadataResultsUntilDone(selectedOrg, metadataDeployResults.deployResultsId);


### PR DESCRIPTION
apiVersion was improperly converted to a number, resulting in NaN for the package version, which caused Salesforce to ignore the request

resolves #788