### PR TITLE
Fix org unable to save

### DIFF
--- a/apps/api/src/app/controllers/orgs.controller.ts
+++ b/apps/api/src/app/controllers/orgs.controller.ts
@@ -19,7 +19,7 @@ export const routeDefinition = {
       }),
       body: z.object({
         label: z.string(),
-        color: z.string().optional(),
+        color: z.string().nullish(),
       }),
       hasSourceOrg: false,
     },

--- a/apps/api/src/app/controllers/sf-bulk-api.controller.ts
+++ b/apps/api/src/app/controllers/sf-bulk-api.controller.ts
@@ -25,7 +25,7 @@ export const routeDefinition = {
   closeOrAbortJob: {
     controllerFn: () => closeOrAbortJob,
     validators: {
-      params: z.object({ jobId: z.string().min(1), action: z.enum(['close', 'abort']).optional() }),
+      params: z.object({ jobId: z.string().min(1), action: z.enum(['close', 'abort']).nullish() }),
     },
   },
   downloadResults: {
@@ -51,7 +51,7 @@ export const routeDefinition = {
       query: z.object({
         type: z.enum(['request', 'result']),
         isQuery: BooleanQueryParamSchema,
-        fileName: z.string().optional(),
+        fileName: z.string().nullish(),
       }),
     },
   },

--- a/apps/api/src/app/controllers/sf-bulk-query-20-api.controller.ts
+++ b/apps/api/src/app/controllers/sf-bulk-query-20-api.controller.ts
@@ -1,4 +1,5 @@
 import { BooleanQueryParamSchema, CreateQueryJobRequestSchema } from '@jetstream/api-types';
+import { ensureBoolean } from '@jetstream/shared/utils';
 import { z } from 'zod';
 import { UserFacingError } from '../utils/error-handler';
 import { sendJson } from '../utils/response.handlers';
@@ -16,9 +17,9 @@ export const routeDefinition = {
     validators: {
       query: z.object({
         isPkChunkingEnabled: BooleanQueryParamSchema,
-        jobType: z.enum(['Classic', 'V2Query', 'V2Ingest']).optional(),
-        concurrencyMode: z.enum(['parallel']).optional(),
-        queryLocator: z.string().optional(),
+        jobType: z.enum(['Classic', 'V2Query', 'V2Ingest']).nullish(),
+        concurrencyMode: z.enum(['parallel']).nullish(),
+        queryLocator: z.string().nullish(),
       }),
     },
   },
@@ -47,7 +48,7 @@ export const routeDefinition = {
       query: z.object({
         maxRecords: z
           .string()
-          .optional()
+          .nullish()
           .refine((val) => {
             if (!val) {
               return true;
@@ -64,7 +65,7 @@ const createJob = createRoute(routeDefinition.createJob.validators, async ({ bod
   try {
     const { query, queryAll } = body;
 
-    const results = await jetstreamConn.bulkQuery20.createJob(query, queryAll);
+    const results = await jetstreamConn.bulkQuery20.createJob(query, ensureBoolean(queryAll));
 
     sendJson(res, results);
   } catch (ex) {

--- a/apps/api/src/app/controllers/sf-record.controller.ts
+++ b/apps/api/src/app/controllers/sf-record.controller.ts
@@ -15,7 +15,7 @@ export const routeDefinition = {
       }),
       body: RecordOperationRequestSchema,
       query: z.object({
-        externalId: z.string().optional(),
+        externalId: z.string().nullish(),
         allOrNone: BooleanQueryParamSchema,
       }),
     },

--- a/apps/api/src/app/controllers/user.controller.ts
+++ b/apps/api/src/app/controllers/user.controller.ts
@@ -61,7 +61,7 @@ export const routeDefinition = {
     validators: {
       hasSourceOrg: false,
       body: z.object({
-        reason: z.string().optional(),
+        reason: z.string().nullish(),
       }),
     },
   },

--- a/apps/api/src/app/db/salesforce-org.db.ts
+++ b/apps/api/src/app/db/salesforce-org.db.ts
@@ -4,7 +4,7 @@ import { decryptString, encryptString, hexToBase64 } from '@jetstream/shared/nod
 import { Maybe, SalesforceOrgUi } from '@jetstream/types';
 import { Prisma, SalesforceOrg } from '@prisma/client';
 import parseISO from 'date-fns/parseISO';
-import { isUndefined } from 'lodash';
+import isUndefined from 'lodash/isUndefined';
 
 const SELECT = Prisma.validator<Prisma.SalesforceOrgSelect>()({
   uniqueId: true,

--- a/libs/api-types/src/lib/api-bulk-api.types.ts
+++ b/libs/api-types/src/lib/api-bulk-api.types.ts
@@ -12,6 +12,6 @@ export type CreateJobRequest = z.infer<typeof CreateJobRequestSchema>;
 
 export const CreateQueryJobRequestSchema = z.object({
   query: z.string(),
-  queryAll: z.boolean().optional(),
+  queryAll: z.boolean().nullish(),
 });
 export type CreateQueryJobRequest = z.infer<typeof CreateQueryJobRequestSchema>;

--- a/libs/api-types/src/lib/api-misc.types.ts
+++ b/libs/api-types/src/lib/api-misc.types.ts
@@ -3,15 +3,15 @@ import { z } from 'zod';
 export const SalesforceApiRequestSchema = z.object({
   url: z.string().min(1),
   method: z.enum(['GET', 'POST', 'PUT', 'PATCH', 'DELETE']),
-  isTooling: z.boolean().optional(),
-  body: z.any().optional(),
-  headers: z.record(z.string()).optional(),
+  isTooling: z.boolean().nullish(),
+  body: z.any().nullish(),
+  headers: z.record(z.string()).nullish(),
   options: z
     .object({
-      responseType: z.enum(['json', 'text']).optional(),
-      noContentResponse: z.any().optional(),
+      responseType: z.enum(['json', 'text']).nullish(),
+      noContentResponse: z.any().nullish(),
     })
-    .optional(),
+    .nullish(),
 });
 export type SalesforceApiRequest = z.infer<typeof SalesforceApiRequestSchema>;
 
@@ -24,7 +24,7 @@ export const SalesforceRequestManualRequestSchema = SalesforceApiRequestSchema.p
 export type SalesforceRequestManualRequest = z.infer<typeof SalesforceRequestManualRequestSchema>;
 
 export const RecordOperationRequestSchema = z.object({
-  ids: z.string().array().optional(),
-  records: z.any().optional(),
+  ids: z.string().array().nullish(),
+  records: z.any().nullish(),
 });
 export type RecordOperationRequest = z.infer<typeof RecordOperationRequestSchema>;

--- a/libs/api-types/src/lib/api-shared.types.ts
+++ b/libs/api-types/src/lib/api-shared.types.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 
 export const BooleanQueryParamSchema = z
   .enum(['true', 'false'])
-  .optional()
+  .nullish()
   .transform((value) => value === 'true');
 
 export const DeployOptionsSchema = z

--- a/libs/api-types/src/lib/api-user.types.ts
+++ b/libs/api-types/src/lib/api-user.types.ts
@@ -11,17 +11,17 @@ export const UpdateProfileRequestSchema = z.object({
   userId: z.string(),
   name: z.string(),
   email: z.string(),
-  emailVerified: z.boolean().optional().transform(ensureBoolean),
-  picture: z.string().optional(),
+  emailVerified: z.boolean().nullish().transform(ensureBoolean),
+  picture: z.string().nullish(),
   username: z.string(),
-  nickname: z.string().optional(),
+  nickname: z.string().nullish(),
   identities: z.any().array(),
-  createdAt: z.string().optional(),
-  updatedAt: z.string().optional(),
+  createdAt: z.string().nullish(),
+  updatedAt: z.string().nullish(),
   preferences: z
     .object({
-      skipFrontdoorLogin: z.boolean().optional(),
+      skipFrontdoorLogin: z.boolean().nullish(),
     })
-    .optional(),
+    .nullish(),
 });
 export type UpdateProfileRequest = z.infer<typeof UpdateProfileRequestSchema>;

--- a/libs/salesforce-api/src/lib/api-bulk-query-2.0.ts
+++ b/libs/salesforce-api/src/lib/api-bulk-query-2.0.ts
@@ -1,5 +1,5 @@
 import { HTTP } from '@jetstream/shared/constants';
-import { BulkQuery20Job, BulkQuery20JobResults, BulkQuery20Response } from '@jetstream/types';
+import { BulkQuery20Job, BulkQuery20JobResults, BulkQuery20Response, Maybe } from '@jetstream/types';
 import { ApiConnection } from './connection';
 import { SalesforceApi } from './utils';
 
@@ -31,9 +31,9 @@ export class ApiBulkQuery20 extends SalesforceApi {
     queryLocator,
   }: {
     isPkChunkingEnabled?: boolean;
-    jobType?: 'Classic' | 'V2Query' | 'V2Ingest';
-    concurrencyMode?: 'parallel';
-    queryLocator?: string;
+    jobType?: Maybe<'Classic' | 'V2Query' | 'V2Ingest'>;
+    concurrencyMode?: Maybe<'parallel'>;
+    queryLocator?: Maybe<string>;
   } = {}) {
     const params = new URLSearchParams();
     if (isPkChunkingEnabled) {

--- a/libs/salesforce-api/src/lib/api-request.ts
+++ b/libs/salesforce-api/src/lib/api-request.ts
@@ -26,7 +26,7 @@ export class ApiRequest extends SalesforceApi {
       url,
       method: method,
       body: body,
-      headers: headers,
+      headers: headers || {},
       outputType,
     });
 

--- a/libs/salesforce-api/src/lib/callout-adapter.ts
+++ b/libs/salesforce-api/src/lib/callout-adapter.ts
@@ -94,6 +94,8 @@ export function getApiRequestFactoryFn(fetch: fetchFn) {
               logger.warn('Unable to refresh accessToken');
               responseText = ERROR_MESSAGES.SFDC_EXPIRED_TOKEN;
             }
+          } else if (response.status === 420 && response.headers.get(HTTP.HEADERS.CONTENT_TYPE) === 'text/html') {
+            responseText = 'An unexpected response was received from Salesforce. Please try again.';
           }
           // don't throw if caller wants the response back
           if (outputType === 'response') {


### PR DESCRIPTION
Org label was unable to be saved if the color was null because of route validation

Changed all zod "optional" to "nullish" to allow accepting of null values and fixed places that had type errors after change

Added Rollbar log for route validation errors

Handled Salesforce HTML responses for deleted scratch orgs, which return 420 with html, this fixes having to log huge html for no reason

resolves #801