### PR TITLE
🎉 🌮 Fix platform event streaming with Salesforce Edge

### DIFF
--- a/apps/api/src/app/routes/platform-event.routes.ts
+++ b/apps/api/src/app/routes/platform-event.routes.ts
@@ -1,11 +1,8 @@
 import { ENV, getExceptionLog, logger } from '@jetstream/api-config';
-import { ApiConnection } from '@jetstream/salesforce-api';
 import { HTTP } from '@jetstream/shared/constants';
 import * as express from 'express';
 import Router from 'express-promise-router';
-import type * as http from 'http';
-import { createProxyMiddleware } from 'http-proxy-middleware';
-import { Url } from 'url';
+import https from 'https';
 import { checkAuth, getOrgFromHeaderOrQuery } from './route.middleware';
 
 const routes: express.Router = Router();
@@ -18,45 +15,61 @@ routes.use((req: express.Request, res: express.Response, next: express.NextFunct
 });
 
 /**
- * All requests are proxied to Salesforce based on the org mentioned in the URL
+ * Proxy platform event requests to Salesforce
+ * We limit the headers we pass along to known working headers
+ * The cookie path is re-written to match the proxy path
+ * response are streamed back to the client
  */
-routes.use(
-  '/',
-  createProxyMiddleware({
-    logLevel: 'debug',
-    onError: (err: Error, req: http.IncomingMessage, res: http.ServerResponse, target?: string | Partial<Url>) => {
-      logger.warn({ target, ...getExceptionLog(err) }, '[PROXY][ERROR]');
-    },
-    //TODO: make sure that if we throw here the world does not blow up (ensure server does not freeze)
-    router: async (req) => {
-      const result = await getOrgFromHeaderOrQuery(req, HTTP.HEADERS.X_SFDC_ID, HTTP.HEADERS.X_SFDC_API_VERSION);
-      if (!result) {
-        throw new Error('A valid salesforce org must be included with the request');
-      }
-      (req as any).locals = {
-        jetstreamConn: result.jetstreamConn,
-      };
-      return result.jetstreamConn.sessionInfo.instanceUrl;
-    },
-    pathRewrite: {
-      '^/platform-event': `/cometd/${ENV.SFDC_API_VERSION}`,
-    },
-    secure: false, // required or else SSL certificate validation will fail
-    cookiePathRewrite: {
-      // Required for browser to include cookie with request
-      '/cometd/': '/platform-event',
-    },
-    onProxyReq: (proxyReq: http.ClientRequest, req: http.IncomingMessage, res: http.ServerResponse, options) => {
-      try {
-        const jetstreamConn = (req as any).locals.jetstreamConn as ApiConnection;
-        proxyReq.setHeader('Authorization', `Bearer ${jetstreamConn.sessionInfo.accessToken}`);
-        // not sure if this one is required
-        res.setHeader('Access-Control-Allow-Credentials', 'true');
-      } catch (ex) {
-        logger.error(getExceptionLog(ex), '[PROXY][EXCEPTION]');
-      }
-    },
-  })
-);
+routes.use('/', async (req: express.Request, res: express.Response, next: express.NextFunction) => {
+  try {
+    const result = await getOrgFromHeaderOrQuery(req, HTTP.HEADERS.X_SFDC_ID, HTTP.HEADERS.X_SFDC_API_VERSION);
+    if (!result) {
+      throw new Error('A valid salesforce org must be included with the request');
+    }
+    const jetstreamConn = result.jetstreamConn;
+    const proxyPath = req.originalUrl.replace('/platform-event', `/cometd/${ENV.SFDC_API_VERSION}`);
+    const proxyUrl = `${jetstreamConn.sessionInfo.instanceUrl}${proxyPath}`;
+
+    res.log.debug({ proxyUrl }, '[PROXY][REQUEST]');
+
+    const headers = {
+      Authorization: `Bearer ${jetstreamConn.sessionInfo.accessToken}`,
+      Accept: req.headers.accept,
+      'Accept-Encoding': req.headers['accept-encoding'],
+      Connection: req.headers.connection,
+      Cookie: req.headers.cookie,
+      'user-agent': req.headers['user-agent'],
+    };
+
+    if (req.method === 'POST' || req.method === 'PUT' || req.method === 'PATCH') {
+      headers['Content-Type'] = req.headers['content-type'];
+    }
+
+    // stream request body to Salesforce
+    req.pipe(
+      https
+        .request(proxyUrl, {
+          method: req.method,
+          headers,
+        })
+        .on('response', (proxyResponse) => {
+          // re-write cookie path to match Jetstream's path
+          proxyResponse.headers['set-cookie'] = proxyResponse.headers['set-cookie']?.map((cookie) =>
+            cookie.replaceAll('/cometd/', '/platform-event')
+          );
+          // stream response back to user
+          res.writeHead(proxyResponse.statusCode || 500, { ...proxyResponse.headers, 'Access-Control-Allow-Credentials': 'true' });
+          proxyResponse.pipe(res, { end: true });
+        })
+        .on('error', (err) => {
+          logger.error(getExceptionLog(err), '[PROXY][EXCEPTION]');
+          next(err);
+        })
+    );
+  } catch (err) {
+    logger.error(getExceptionLog(err), '[PROXY][EXCEPTION]');
+    next(err);
+  }
+});
 
 export default routes;

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -231,6 +231,7 @@ if (ENV.NODE_ENV === 'production' && cluster.isPrimary) {
         res.setHeader(
           'Access-Control-Expose-Headers',
           [
+            'BAYEUX_BROWSER',
             HTTP.HEADERS.X_LOGOUT,
             HTTP.HEADERS.X_LOGOUT_URL,
             HTTP.HEADERS.X_SFDC_ID,
@@ -259,6 +260,7 @@ if (ENV.NODE_ENV === 'production' && cluster.isPrimary) {
       cors({
         origin: true,
         exposedHeaders: [
+          'BAYEUX_BROWSER',
           HTTP.HEADERS.X_LOGOUT,
           HTTP.HEADERS.X_LOGOUT_URL,
           HTTP.HEADERS.X_SFDC_ID,
@@ -277,6 +279,7 @@ if (ENV.NODE_ENV === 'production' && cluster.isPrimary) {
     );
     app.use('/platform-event', cors({ origin: /http:\/\/localhost:[0-9]+$/ }), platformEventRoutes);
   } else {
+    // This must come before body parser to ensure that the raw body is available to be streamed to Salesforce
     app.use('/platform-event', platformEventRoutes);
   }
 

--- a/apps/jetstream-e2e/src/fixtures/fixtures.ts
+++ b/apps/jetstream-e2e/src/fixtures/fixtures.ts
@@ -1,6 +1,7 @@
 import { test as base } from '@playwright/test';
 import * as dotenv from 'dotenv';
 import { LoadSingleObjectPage } from '../pageObjectModels/LoadSingleObjectPage.model';
+import { PlatformEventPage } from '../pageObjectModels/PlatformEventPage.model';
 import { QueryPage } from '../pageObjectModels/QueryPage.model';
 import { ApiRequestUtils } from './ApiRequestUtils';
 
@@ -15,6 +16,7 @@ type MyFixtures = {
   apiRequestUtils: ApiRequestUtils;
   queryPage: QueryPage;
   loadSingleObjectPage: LoadSingleObjectPage;
+  platformEventPage: PlatformEventPage;
 };
 
 export const test = base.extend<MyFixtures>({
@@ -37,6 +39,9 @@ export const test = base.extend<MyFixtures>({
   },
   loadSingleObjectPage: async ({ page, request, apiRequestUtils }, use) => {
     await use(new LoadSingleObjectPage(page, request, apiRequestUtils));
+  },
+  platformEventPage: async ({ page, request, apiRequestUtils }, use) => {
+    await use(new PlatformEventPage(page, request, apiRequestUtils));
   },
 });
 

--- a/apps/jetstream-e2e/src/pageObjectModels/PlatformEventPage.model.ts
+++ b/apps/jetstream-e2e/src/pageObjectModels/PlatformEventPage.model.ts
@@ -1,0 +1,47 @@
+import { APIRequestContext, Locator, Page, expect } from '@playwright/test';
+import { ApiRequestUtils } from '../fixtures/ApiRequestUtils';
+
+export class PlatformEventPage {
+  readonly apiRequestUtils: ApiRequestUtils;
+  readonly page: Page;
+  readonly request: APIRequestContext;
+  readonly listenerCard: Locator;
+  readonly publisherCard: Locator;
+
+  constructor(page: Page, request: APIRequestContext, apiRequestUtils: ApiRequestUtils) {
+    this.apiRequestUtils = apiRequestUtils;
+    this.page = page;
+    this.request = request;
+    this.listenerCard = page.getByTestId('platform-event-monitor-listener-card');
+    this.publisherCard = page.getByTestId('platform-event-monitor-publisher-card');
+  }
+
+  async goto() {
+    await this.page.getByRole('button', { name: 'Developer Tools' }).click();
+    await this.page.getByRole('menuitemcheckbox', { name: 'Platform Events' }).click();
+    await this.page.waitForURL('**/platform-event-monitor');
+  }
+
+  async subscribeToEvent(eventName: string) {
+    await this.listenerCard.getByPlaceholder('Select an Option').click();
+    await this.listenerCard.getByRole('option', { name: `(${eventName}) /event/${eventName}` }).click();
+    await this.listenerCard.getByRole('button', { name: 'Subscribe', exact: true }).click();
+    // Ensure subscription was successful
+    await expect(this.listenerCard.getByRole('button', { name: 'Unsubscribe' })).toBeVisible();
+    await expect(this.listenerCard.getByPlaceholder('-1')).toBeDisabled();
+  }
+
+  async unsubscribeToEvent() {
+    await this.listenerCard.getByRole('button', { name: 'Unsubscribe' }).click();
+    await expect(this.listenerCard.getByPlaceholder('-1')).toBeEnabled();
+    await expect(this.listenerCard.getByRole('button', { name: 'Subscribe', exact: true })).toBeVisible();
+  }
+
+  async publishEvent(eventName: string, fieldName: string, fieldValue: string) {
+    await this.publisherCard.getByPlaceholder('Select an Option').click();
+    await this.publisherCard.getByRole('option', { name: eventName }).click();
+    await this.publisherCard.getByLabel(`(${fieldName})`).fill(fieldValue);
+    await this.publisherCard.getByRole('button', { name: 'Publish Event' }).click();
+    await expect(this.publisherCard.getByText(/informationEvent Id: [0-9a-fA-F-]+/)).toBeVisible();
+  }
+}

--- a/apps/jetstream-e2e/src/tests/platform-event/platform-event.spec.ts
+++ b/apps/jetstream-e2e/src/tests/platform-event/platform-event.spec.ts
@@ -1,0 +1,23 @@
+import { expect, test } from '../../fixtures/fixtures';
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('/app');
+});
+
+test.describe.configure({ mode: 'parallel' });
+
+test.describe('PLATFORM EVENTS', () => {
+  test('Should subscribe to and get published event', async ({ platformEventPage }) => {
+    const platformEventName = 'Example_Event__e';
+    const testField = 'Test_Field__c';
+    const testValue = String(new Date().getTime());
+
+    await platformEventPage.goto();
+    await platformEventPage.subscribeToEvent(platformEventName);
+    await platformEventPage.publishEvent(platformEventName, testField, testValue);
+
+    await expect(platformEventPage.listenerCard.getByText(`{"${testField}":"${testValue}"`)).toBeVisible();
+
+    await platformEventPage.unsubscribeToEvent();
+  });
+});

--- a/apps/jetstream/src/app/components/platform-event-monitor/PlatformEventMonitorListenerCard.tsx
+++ b/apps/jetstream/src/app/components/platform-event-monitor/PlatformEventMonitorListenerCard.tsx
@@ -33,6 +33,7 @@ export const PlatformEventMonitorListenerCard: FunctionComponent<PlatformEventMo
 }) => {
   return (
     <Card
+      testId="platform-event-monitor-listener-card"
       className="slds-grow"
       icon={{ type: 'standard', icon: 'events' }}
       title={

--- a/apps/jetstream/src/app/components/platform-event-monitor/PlatformEventMonitorPublisherCard.tsx
+++ b/apps/jetstream/src/app/components/platform-event-monitor/PlatformEventMonitorPublisherCard.tsx
@@ -138,6 +138,7 @@ export const PlatformEventMonitorPublisherCard: FunctionComponent<PlatformEventM
 
   return (
     <Card
+      testId="platform-event-monitor-publisher-card"
       className="slds-grow"
       icon={{ type: 'standard', icon: 'record_create' }}
       title="Publish Event"

--- a/package.json
+++ b/package.json
@@ -298,7 +298,6 @@
     "fs-extra": "^9.0.1",
     "helmet": "^4.1.1",
     "history": "^5.3.0",
-    "http-proxy-middleware": "^2.0.1",
     "jsforce": "^1.11.1",
     "jsonwebtoken": "^9.0.0",
     "jszip": "^3.10.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -17561,7 +17561,7 @@ http-proxy-agent@^4.0.0, http-proxy-agent@^4.0.1:
     agent-base "6"
     debug "4"
 
-http-proxy-middleware@^2.0.1, http-proxy-middleware@^2.0.3:
+http-proxy-middleware@^2.0.3:
   version "2.0.6"
   resolved "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.6.tgz"
   integrity sha512-ya/UeJ6HVBYxrgYotAZo1KvPWlgB48kUJLDePFeneHsVujFaW5WNj2NgWCAE//B1Dl02BIfYlpNgBy8Kf8Rjmw==


### PR DESCRIPTION
Remove http-proxy-middleware which must have been setting some http header to indicate this was a proxy request, so Salesforce blocked it.

Instead the proxy was implemented from scratch and all the same details were worked through about which headers to set and how to handle cookies.

resolves #600