### PR TITLE
Fix datatable renderer for boolean fields

### DIFF
--- a/libs/ui/src/lib/data-table/data-table-utils.tsx
+++ b/libs/ui/src/lib/data-table/data-table-utils.tsx
@@ -375,6 +375,7 @@ export function updateColumnFromType(column: Mutable<ColumnWithFilter<any>>, fie
   column.filters = ['TEXT', 'SET'];
   switch (fieldType) {
     case 'text':
+      column.renderCell = GenericRenderer;
       break;
     case 'number':
       // TODO:


### PR DESCRIPTION
For some fields where the data type is dynamic, like field history, the data table would not display the value for boolean values.

Text fields now use the GenericRenderer to account for a few different data types

resolves #820