### PR TITLE
Avoid running bulk 2.0 flaky test

### DIFF
--- a/apps/jetstream-e2e/src/tests/api/bulk-query-20.api.spec.ts
+++ b/apps/jetstream-e2e/src/tests/api/bulk-query-20.api.spec.ts
@@ -5,7 +5,10 @@ import { expect, test } from '../../fixtures/fixtures';
 test.describe.configure({ mode: 'parallel' });
 
 test.describe('API - Bulk Query 2.0', () => {
-  test('Create and get job', async ({ apiRequestUtils }) => {
+  /**
+   * This test is super flaky because it relies on how fast salesforce starts processing the job
+   */
+  test.skip('Create and get job', async ({ apiRequestUtils }) => {
     const createJobResponse = await apiRequestUtils.makeRequest<BulkQuery20Response>('POST', `/api/bulk-query`, {
       query: `SELECT Id, Name, AnnualRevenue, City, Company, Country, CreatedDate, Description, Email, IsConverted, IsDeleted FROM Lead`,
       queryAll: true,
@@ -21,6 +24,7 @@ test.describe('API - Bulk Query 2.0', () => {
     const getJobResponse = await apiRequestUtils.makeRequest<BulkQuery20Job>('GET', `/api/bulk-query/${createJobResponse.id}`);
 
     expect(getJobResponse.id).toBeTruthy();
+    // FIXME: sometimes getJobResponse.numberRecordsProcessed is undefined :shrug:
     expect(getJobResponse.numberRecordsProcessed).toEqual(0);
     expect(['UploadComplete', 'InProgress', 'JobComplete'].includes(getJobResponse.state)).toBeTruthy();
 


### PR DESCRIPTION
This API endpoint is not used anywhere by application but the test is flaky 🗡️