### PR TITLE
Retry requests for certain failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     env:
+      LOG_LEVEL: warn
       AUTH0_CLIENT_ID: 'shxza1G0595Ut2htmAd3NfbMMsqelrE5'
       AUTH0_CLIENT_SECRET: 'NOT-NEEDED'
       AUTH0_DOMAIN: 'getjetstream-dev.us.auth0.com'

--- a/apps/api/src/app/controllers/image.controller.ts
+++ b/apps/api/src/app/controllers/image.controller.ts
@@ -27,6 +27,6 @@ const getUploadSignature = createRoute(routeDefinition.getUploadSignature.valida
 
     sendJson(res, { signature: signature, timestamp, cloudName: cloudName, apiKey: apiKey, context }, 200);
   } catch (ex) {
-    next(new UserFacingError(ex.message));
+    next(new UserFacingError(ex));
   }
 });

--- a/apps/api/src/app/controllers/orgs.controller.ts
+++ b/apps/api/src/app/controllers/orgs.controller.ts
@@ -45,7 +45,7 @@ const getOrgs = createRoute(routeDefinition.getOrgs.validators, async ({ user },
 
     sendJson(res, orgs);
   } catch (ex) {
-    next(new UserFacingError(ex.message));
+    next(new UserFacingError(ex));
   }
 });
 
@@ -56,7 +56,7 @@ const updateOrg = createRoute(routeDefinition.updateOrg.validators, async ({ bod
 
     sendJson(res, salesforceOrg, 201);
   } catch (ex) {
-    next(new UserFacingError(ex.message));
+    next(new UserFacingError(ex));
   }
 });
 
@@ -66,7 +66,7 @@ const deleteOrg = createRoute(routeDefinition.deleteOrg.validators, async ({ par
 
     sendJson(res, undefined, 204);
   } catch (ex) {
-    next(new UserFacingError(ex.message));
+    next(new UserFacingError(ex));
   }
 });
 
@@ -101,6 +101,6 @@ const checkOrgHealth = createRoute(routeDefinition.checkOrgHealth.validators, as
 
     sendJson(res, undefined, 200);
   } catch (ex) {
-    next(new UserFacingError(ex.message));
+    next(new UserFacingError(ex));
   }
 });

--- a/apps/api/src/app/controllers/salesforce-api-requests.controller.ts
+++ b/apps/api/src/app/controllers/salesforce-api-requests.controller.ts
@@ -15,6 +15,6 @@ const getSalesforceApiRequests = createRoute(routeDefinition.getSalesforceApiReq
     const results = await salesforceApiDb.findAll();
     sendJson(res, results);
   } catch (ex) {
-    next(new UserFacingError(ex.message));
+    next(new UserFacingError(ex));
   }
 });

--- a/apps/api/src/app/controllers/sf-bulk-api.controller.ts
+++ b/apps/api/src/app/controllers/sf-bulk-api.controller.ts
@@ -86,7 +86,7 @@ const createJob = createRoute(routeDefinition.createJob.validators, async ({ bod
 
     sendJson(res, results);
   } catch (ex) {
-    next(new UserFacingError(ex.message));
+    next(new UserFacingError(ex));
   }
 });
 
@@ -98,7 +98,7 @@ const getJob = createRoute(routeDefinition.getJob.validators, async ({ params, j
 
     sendJson(res, results);
   } catch (ex) {
-    next(new UserFacingError(ex.message));
+    next(new UserFacingError(ex));
   }
 });
 
@@ -111,7 +111,7 @@ const closeOrAbortJob = createRoute(routeDefinition.closeOrAbortJob.validators, 
 
     sendJson(res, results);
   } catch (ex) {
-    next(new UserFacingError(ex.message));
+    next(new UserFacingError(ex));
   }
 });
 
@@ -127,7 +127,7 @@ const addBatchToJob = createRoute(
 
       sendJson(res, results);
     } catch (ex) {
-      next(new UserFacingError(ex.message));
+      next(new UserFacingError(ex));
     }
   }
 );
@@ -144,7 +144,7 @@ const addBatchToJobWithBinaryAttachment = createRoute(
 
       sendJson(res, results);
     } catch (ex) {
-      next(new UserFacingError(ex.message));
+      next(new UserFacingError(ex));
     }
   }
 );
@@ -178,7 +178,7 @@ const downloadResultsFile = createRoute(
       const results = await jetstreamConn.bulk.downloadRecords(jobId, batchId, type, resultId);
       Readable.fromWeb(results as any).pipe(res);
     } catch (ex) {
-      next(new UserFacingError(ex.message));
+      next(new UserFacingError(ex));
     }
   }
 );
@@ -244,7 +244,7 @@ const downloadResults = createRoute(
         }
       });
     } catch (ex) {
-      next(new UserFacingError(ex.message));
+      next(new UserFacingError(ex));
     }
   }
 );

--- a/apps/api/src/app/controllers/sf-bulk-query-20-api.controller.ts
+++ b/apps/api/src/app/controllers/sf-bulk-query-20-api.controller.ts
@@ -69,7 +69,7 @@ const createJob = createRoute(routeDefinition.createJob.validators, async ({ bod
 
     sendJson(res, results);
   } catch (ex) {
-    next(new UserFacingError(ex.message));
+    next(new UserFacingError(ex));
   }
 });
 
@@ -81,7 +81,7 @@ const getJobs = createRoute(routeDefinition.getJobs.validators, async ({ query, 
 
     sendJson(res, results);
   } catch (ex) {
-    next(new UserFacingError(ex.message));
+    next(new UserFacingError(ex));
   }
 });
 
@@ -93,7 +93,7 @@ const getJob = createRoute(routeDefinition.getJob.validators, async ({ params, j
 
     sendJson(res, results);
   } catch (ex) {
-    next(new UserFacingError(ex.message));
+    next(new UserFacingError(ex));
   }
 });
 
@@ -105,7 +105,7 @@ const abortJob = createRoute(routeDefinition.abortJob.validators, async ({ param
 
     sendJson(res, results);
   } catch (ex) {
-    next(new UserFacingError(ex.message));
+    next(new UserFacingError(ex));
   }
 });
 
@@ -117,7 +117,7 @@ const deleteJob = createRoute(routeDefinition.deleteJob.validators, async ({ par
 
     res.status(204).end();
   } catch (ex) {
-    next(new UserFacingError(ex.message));
+    next(new UserFacingError(ex));
   }
 });
 
@@ -126,7 +126,7 @@ const deleteJob = createRoute(routeDefinition.deleteJob.validators, async ({ par
  */
 const downloadResults = createRoute(
   routeDefinition.downloadResults.validators,
-  async ({ params, query, jetstreamConn, requestId }, req, res, next) => {
+  async ({ params, query, jetstreamConn }, req, res, next) => {
     try {
       res.setHeader('Content-Type', 'text/csv');
 
@@ -142,7 +142,7 @@ const downloadResults = createRoute(
       // End the response when the stream is complete
       res.end();
     } catch (ex) {
-      next(new UserFacingError(ex.message));
+      next(new UserFacingError(ex));
     }
   }
 );

--- a/apps/api/src/app/controllers/sf-metadata-tooling.controller.ts
+++ b/apps/api/src/app/controllers/sf-metadata-tooling.controller.ts
@@ -119,7 +119,7 @@ const describeMetadata = createRoute(routeDefinition.describeMetadata.validators
 
     sendJson(res, results);
   } catch (ex) {
-    next(new UserFacingError(ex.message));
+    next(new UserFacingError(ex));
   }
 });
 
@@ -129,7 +129,7 @@ const listMetadata = createRoute(routeDefinition.listMetadata.validators, async 
 
     sendJson(res, results);
   } catch (ex) {
-    next(new UserFacingError(ex.message));
+    next(new UserFacingError(ex));
   }
 });
 
@@ -142,7 +142,7 @@ const readMetadata = createRoute(routeDefinition.readMetadata.validators, async 
 
     sendJson(res, results);
   } catch (ex) {
-    next(new UserFacingError(ex.message));
+    next(new UserFacingError(ex));
   }
 });
 
@@ -155,7 +155,7 @@ const deployMetadata = createRoute(routeDefinition.deployMetadata.validators, as
 
     sendJson(res, results);
   } catch (ex) {
-    next(new UserFacingError(ex.message));
+    next(new UserFacingError(ex));
   }
 });
 
@@ -171,7 +171,7 @@ const deployMetadataZip = createRoute(
 
       sendJson(res, results);
     } catch (ex) {
-      next(new UserFacingError(ex.message));
+      next(new UserFacingError(ex));
     }
   }
 );
@@ -187,7 +187,7 @@ const checkMetadataResults = createRoute(
 
       sendJson(res, results);
     } catch (ex) {
-      next(new UserFacingError(ex.message));
+      next(new UserFacingError(ex));
     }
   }
 );

--- a/apps/api/src/app/controllers/sf-misc.controller.ts
+++ b/apps/api/src/app/controllers/sf-misc.controller.ts
@@ -75,7 +75,7 @@ const salesforceRequest = createRoute(routeDefinition.salesforceRequest.validato
 
     sendJson(res, results);
   } catch (ex) {
-    next(new UserFacingError(ex.message));
+    next(new UserFacingError(ex));
   }
 });
 
@@ -103,7 +103,7 @@ const salesforceRequestManual = createRoute(
 
       sendJson<ManualRequestResponse>(res, results);
     } catch (ex) {
-      next(new UserFacingError(ex.message));
+      next(new UserFacingError(ex));
     }
   }
 );

--- a/apps/api/src/app/controllers/sf-query.controller.ts
+++ b/apps/api/src/app/controllers/sf-query.controller.ts
@@ -44,7 +44,7 @@ const describe = createRoute(routeDefinition.describe.validators, async ({ query
     const results = await jetstreamConn.sobject.describe(isTooling);
     sendJson(res, results);
   } catch (ex) {
-    next(new UserFacingError(ex.message));
+    next(new UserFacingError(ex));
   }
 });
 
@@ -57,7 +57,7 @@ const describeSObject = createRoute(
 
       sendJson(res, results);
     } catch (ex) {
-      next(new UserFacingError(ex.message));
+      next(new UserFacingError(ex));
     }
   }
 );
@@ -72,7 +72,7 @@ const query = createRoute(routeDefinition.query.validators, async ({ body, query
 
     sendJson(res, results);
   } catch (ex) {
-    next(new UserFacingError(ex.message));
+    next(new UserFacingError(ex));
   }
 });
 
@@ -84,6 +84,6 @@ const queryMore = createRoute(routeDefinition.queryMore.validators, async ({ que
 
     sendJson(res, results);
   } catch (ex) {
-    next(new UserFacingError(ex.message));
+    next(new UserFacingError(ex));
   }
 });

--- a/apps/api/src/app/controllers/sf-record.controller.ts
+++ b/apps/api/src/app/controllers/sf-record.controller.ts
@@ -47,7 +47,7 @@ const recordOperation = createRoute(
 
       sendJson(res, results);
     } catch (ex) {
-      next(new UserFacingError(ex.message));
+      next(new UserFacingError(ex));
     }
   }
 );

--- a/apps/api/src/app/routes/route.middleware.ts
+++ b/apps/api/src/app/routes/route.middleware.ts
@@ -146,7 +146,7 @@ export async function checkAuth(req: express.Request, res: express.Response, nex
               );
             }
             rollbarServer.error('Error updating Auth0 activityExp', req, {
-              context: `route#createRoute`,
+              context: `route#activityExp`,
               custom: {
                 ...getExceptionLog(err),
                 url: req.url,

--- a/apps/api/src/app/utils/error-handler.ts
+++ b/apps/api/src/app/utils/error-handler.ts
@@ -1,8 +1,16 @@
 import { logger } from '@jetstream/api-config';
+import { ApiRequestError } from '@jetstream/salesforce-api';
 import { ZodError } from 'zod';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 export class UserFacingError extends Error {
+  /**
+   * This data is propagated so that response can include the http status code
+   */
+  apiRequestError?: ApiRequestError;
+  /**
+   * additionalData will be included in http response
+   */
   additionalData?: any;
   constructor(message: string | Error | ZodError, additionalData?: any) {
     if (message instanceof ZodError) {
@@ -39,6 +47,10 @@ export class UserFacingError extends Error {
       }
       super(message);
       this.additionalData = additionalData;
+    }
+
+    if (message instanceof ApiRequestError) {
+      this.apiRequestError = message;
     }
   }
 }

--- a/apps/api/src/app/utils/response.handlers.ts
+++ b/apps/api/src/app/utils/response.handlers.ts
@@ -88,7 +88,7 @@ export async function uncaughtErrorHandler(err: any, req: express.Request, res: 
     }
 
     if (err instanceof UserFacingError) {
-      res.status(400);
+      res.status(err.apiRequestError?.status || 400);
       // TODO: should we log 400s?
       responseLogger.debug({ ...getExceptionLog(err), statusCode: 400 }, '[RESPONSE][ERROR]');
       return res.json({

--- a/apps/api/src/app/utils/response.handlers.ts
+++ b/apps/api/src/app/utils/response.handlers.ts
@@ -88,9 +88,11 @@ export async function uncaughtErrorHandler(err: any, req: express.Request, res: 
     }
 
     if (err instanceof UserFacingError) {
-      res.status(err.apiRequestError?.status || 400);
-      // TODO: should we log 400s?
-      responseLogger.debug({ ...getExceptionLog(err), statusCode: 400 }, '[RESPONSE][ERROR]');
+      // Attempt to use response code from 3rd party request if we have it available
+      const statusCode = err.apiRequestError?.status || 400;
+      res.status(statusCode);
+      // TODO: should we log 400s? They happen a lot and are not necessarily errors we care about
+      responseLogger.debug({ ...getExceptionLog(err), statusCode }, '[RESPONSE][ERROR]');
       return res.json({
         error: true,
         message: err.message,

--- a/apps/api/src/app/utils/route.utils.ts
+++ b/apps/api/src/app/utils/route.utils.ts
@@ -77,15 +77,18 @@ export function createRoute<TParamsSchema extends z.ZodTypeAny, TBodySchema exte
       }
       await controllerFn(data, req, res, next);
     } catch (ex) {
-      rollbarServer.error('Route Validation Error', {
-        message: ex.message,
-        stack: ex.stack,
-        url: req.url,
-        params: req.params,
-        query: req.query,
-        body: req.body,
-        userId: (req.user as UserProfileServer)?.id,
-        requestId: res.locals.requestId,
+      rollbarServer.error('Route Validation Error', req, {
+        context: `route#createRoute`,
+        custom: {
+          message: ex.message,
+          stack: ex.stack,
+          url: req.url,
+          params: req.params,
+          query: req.query,
+          body: req.body,
+          userId: (req.user as UserProfileServer)?.id,
+          requestId: res.locals.requestId,
+        },
       });
       req.log.error(getExceptionLog(ex), '[ROUTE][VALIDATION ERROR]');
       next(new UserFacingError(ex));

--- a/apps/jetstream/src/app/components/query/QueryOptions/QueryCount.tsx
+++ b/apps/jetstream/src/app/components/query/QueryOptions/QueryCount.tsx
@@ -22,14 +22,15 @@ export const QueryCount = ({ org }: QueryCountProps) => {
   const querySoqlCount = useRecoilValue(fromQueryState.querySoqlCountState);
   const debouncedQuerySoqlCount = useDebounce(querySoqlCount);
   const [recordCount, setRecordCount] = useState<number | null>(null);
-  const [loading, setLoading] = useState(false);
 
   const fetchRecordCount = useCallback(
     async (soql: string) => {
       try {
+        if (!soql) {
+          return;
+        }
         currentReq.current++;
         const reqId = currentReq.current;
-        setLoading(true);
         const results = await query(org, soql, isTooling, includeDeleted);
         // in case results are out of order, ignore any stale results
         if (!isMounted.current || reqId !== currentReq.current) {
@@ -39,8 +40,6 @@ export const QueryCount = ({ org }: QueryCountProps) => {
       } catch (ex) {
         logger.warn('Error getting record count');
         setRecordCount(null);
-      } finally {
-        setLoading(false);
       }
     },
     [includeDeleted, isTooling, org]

--- a/libs/api-config/src/lib/api-logger.ts
+++ b/libs/api-config/src/lib/api-logger.ts
@@ -16,7 +16,6 @@ export const logger = pino({
 
 export const httpLogger = pinoHttp<express.Request, express.Response>({
   logger,
-  level: 'debug',
   genReqId: (req, res) => res.locals.requestId || uuid(),
   customSuccessMessage: function (req, res) {
     if (res.statusCode === 404) {

--- a/libs/api-config/src/lib/api-logger.ts
+++ b/libs/api-config/src/lib/api-logger.ts
@@ -35,6 +35,8 @@ export const httpLogger = pinoHttp<express.Request, express.Response>({
           'user-agent': req.raw.headers['user-agent'],
           referer: req.raw.headers.referer,
           'x-sfdc-id': req.raw.headers['x-sfdc-id'],
+          'x-client-request-id': req.raw.headers['x-client-request-id'],
+          'x-retry': req.raw.headers['x-retry'],
           ip: req.raw.headers['cf-connecting-ip'] || req.raw.headers['x-forwarded-for'] || req.raw.socket.remoteAddress,
           country: req.headers['cf-ipcountry'],
         },

--- a/libs/shared/constants/src/lib/shared-constants.ts
+++ b/libs/shared/constants/src/lib/shared-constants.ts
@@ -47,6 +47,9 @@ export const HTTP = {
   },
   HEADERS: {
     ACCEPT: 'Accept',
+    X_CLIENT_REQUEST_ID: 'X-Client-Request-Id',
+    X_REQUEST_ID: 'X-Request-Id',
+    X_RETRY: 'X-RETRY',
     X_LOGOUT: 'X-AUTH-LOGOUT', // 1=true
     X_LOGOUT_URL: 'X-LOGOUT-URL',
     X_SFDC_ID: 'X-SFDC-ID',


### PR DESCRIPTION
SFDC has suddenly started responding with gateway/edge errors that are temporary AFAIK.

The browser will not attempt a retry for a handful of GET request endpoints

Added clientRequestId to logs to make it easier to troubleshoot.

Propogate SFDC HTTP response code for jetstream responses, this should make it much more obvious what actual errors are happening and help identify areas where we might need more targeted retries

resolves #835