### PR TITLE
Allow pausing polling for new debug logs

### DIFF
--- a/apps/jetstream/src/app/components/debug-log-viewer/DebugLogViewer.tsx
+++ b/apps/jetstream/src/app/components/debug-log-viewer/DebugLogViewer.tsx
@@ -12,10 +12,12 @@ import {
   Icon,
   SalesforceLogin,
   Spinner,
+  Tooltip,
   ViewDocsLink,
   dataTableFileSizeFormatter,
 } from '@jetstream/ui';
 import Editor from '@monaco-editor/react';
+import classNames from 'classnames';
 import formatDate from 'date-fns/format';
 import escapeRegExp from 'lodash/escapeRegExp';
 import type { editor } from 'monaco-editor';
@@ -57,7 +59,7 @@ export const DebugLogViewer: FunctionComponent<DebugLogViewerProps> = () => {
     fromJetstreamEvents.getObservable('jobFinished').pipe(filter((ev: AsyncJob) => ev.type === 'BulkDelete'))
   );
 
-  const { fetchLogs, loading, lastChecked, logs, errorMessage, pollInterval } = useDebugLogs(selectedOrg, {
+  const { togglePause, fetchLogs, isPaused, loading, lastChecked, logs, pollInterval } = useDebugLogs(selectedOrg, {
     limit: showLogsFromAllUsers ? 200 : 100,
     userId: showLogsFromAllUsers ? undefined : selectedOrg.userId,
   });
@@ -245,19 +247,34 @@ export const DebugLogViewer: FunctionComponent<DebugLogViewerProps> = () => {
                     onChange={setShowLogsFromAllUsers}
                   />
                 </div>
-                <div>
+                <Grid>
                   {lastChecked && (
-                    <p title={pollTitle} className="slds-text-color_weak slds-truncate">
-                      <button
-                        className="slds-button slds-button_icon slds-button_icon-container slds-m-around_xxx-small"
-                        onClick={() => fetchLogs()}
-                      >
-                        <Icon type="utility" icon="refresh" className="slds-button__icon" omitContainer />
-                      </button>
-                      Last Checked {formatDate(lastChecked, 'h:mm:ss')}
-                    </p>
+                    <>
+                      <Tooltip content={isPaused ? 'Resume checking for logs' : 'Pause checking for new logs'}>
+                        <button
+                          className="slds-button slds-button_icon slds-button_icon-container slds-m-around_xxx-small"
+                          onClick={() => togglePause()}
+                        >
+                          <Icon type="utility" icon={isPaused ? 'play' : 'pause'} className="slds-button__icon" omitContainer />
+                        </button>
+                      </Tooltip>
+                      <p title={pollTitle} className="slds-text-color_weak slds-truncate">
+                        <button
+                          className="slds-button slds-button_icon slds-button_icon-container slds-m-around_xxx-small"
+                          onClick={() => fetchLogs()}
+                        >
+                          <Icon
+                            type="utility"
+                            icon="refresh"
+                            className={classNames('slds-button__icon', { spin: loading })}
+                            omitContainer
+                          />
+                        </button>
+                        Last Checked {formatDate(lastChecked, 'h:mm:ss')}
+                      </p>
+                    </>
                   )}
-                </div>
+                </Grid>
               </Grid>
               <DebugLogViewerTable logs={logsWithViewedFlag} onRowSelection={handleActiveLogChange} />
             </Fragment>

--- a/apps/jetstream/src/app/components/debug-log-viewer/useDebugLogs.tsx
+++ b/apps/jetstream/src/app/components/debug-log-viewer/useDebugLogs.tsx
@@ -15,6 +15,7 @@ export function useDebugLogs(org: SalesforceOrgUi, { limit, pollInterval, userId
   /** Used so that if multiple requests come in at about the same time, we can ignore results from intermediate requests as they may not be valid */
   const currentFetchToken = useRef<number>(new Date().getTime());
   const numPollErrors = useRef<number>(0);
+  const [isPaused, setIsPaused] = useState(false);
   const [loading, setLoading] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [logs, setLogs] = useState<ApexLog[]>([]);
@@ -76,8 +77,12 @@ export function useDebugLogs(org: SalesforceOrgUi, { limit, pollInterval, userId
   );
 
   const handlePoll = useCallback(() => {
-    fetchLogs();
-  }, [fetchLogs]);
+    !isPaused && fetchLogs();
+  }, [isPaused, fetchLogs]);
+
+  const togglePause = useCallback(() => {
+    setIsPaused((prevValue) => !prevValue);
+  }, []);
 
   useInterval(handlePoll, numPollErrors.current > MAX_POLL_ATTEMPTS ? null : intervalDelay);
 
@@ -92,5 +97,5 @@ export function useDebugLogs(org: SalesforceOrgUi, { limit, pollInterval, userId
     numPollErrors.current = 0;
   }, [fetchLogs, org]);
 
-  return { fetchLogs, loading, lastChecked, logs, pollInterval, errorMessage };
+  return { togglePause, fetchLogs, isPaused, loading, lastChecked, logs, pollInterval, errorMessage };
 }

--- a/apps/jetstream/src/main.scss
+++ b/apps/jetstream/src/main.scss
@@ -525,3 +525,28 @@ button.ql-active {
     margin-top: var(--title-bar-height);
   }
 }
+
+.spin {
+  -webkit-animation: rotation 1s infinite linear;
+  animation: rotation 1s infinite linear;
+}
+
+@keyframes rotation {
+  from {
+    -webkit-transform: rotate(0deg);
+    transform: rotate(0deg);
+  }
+  to {
+    -webkit-transform: rotate(359deg);
+    transform: rotate(359deg);
+  }
+}
+
+@-webkit-keyframes rotation {
+  from {
+    -webkit-transform: rotate(0deg);
+  }
+  to {
+    -webkit-transform: rotate(359deg);
+  }
+}

--- a/libs/icon-factory/src/lib/icon-factory.tsx
+++ b/libs/icon-factory/src/lib/icon-factory.tsx
@@ -100,6 +100,7 @@ import UtilityIcon_Open from './icons/utility/Open';
 import UtilityIcon_OpenFolder from './icons/utility/OpenFolder';
 import UtilityIcon_Page from './icons/utility/Page';
 import UtilityIcon_Paste from './icons/utility/Paste';
+import UtilityIcon_Pause from './icons/utility/Pause';
 import UtilityIcon_Play from './icons/utility/Play';
 import UtilityIcon_Preview from './icons/utility/Preview';
 import UtilityIcon_PromptEdit from './icons/utility/PromptEdit';
@@ -265,6 +266,7 @@ const utilityIcons = {
   open: UtilityIcon_Open,
   page: UtilityIcon_Page,
   paste: UtilityIcon_Paste,
+  pause: UtilityIcon_Pause,
   play: UtilityIcon_Play,
   preview: UtilityIcon_Preview,
   prompt_edit: UtilityIcon_PromptEdit,


### PR DESCRIPTION
Added button to allow pausing logs, this is useful when a user is looking for a specific log and does not want to keep having the table get reset while searching

resolves #849