### PR TITLE
Fix permission table blk column actions

### DIFF
--- a/apps/jetstream/src/app/components/manage-permissions/ManagePermissionsEditorFieldTable.tsx
+++ b/apps/jetstream/src/app/components/manage-permissions/ManagePermissionsEditorFieldTable.tsx
@@ -1,8 +1,8 @@
 import { useNonInitialEffect } from '@jetstream/shared/ui-utils';
 import { MapOf } from '@jetstream/types';
-import { AutoFullHeightContainer, ColumnWithFilter, DataTree } from '@jetstream/ui';
+import { AutoFullHeightContainer, ColumnWithFilter, DataTableRef, DataTree } from '@jetstream/ui';
 import groupBy from 'lodash/groupBy';
-import { forwardRef, useCallback, useImperativeHandle, useState } from 'react';
+import { forwardRef, useCallback, useImperativeHandle, useRef, useState } from 'react';
 import { RowHeightArgs } from 'react-data-grid';
 import { resetGridChanges, updateRowsFromColumnAction } from './utils/permission-manager-table-utils';
 import {
@@ -40,6 +40,7 @@ export interface ManagePermissionsEditorFieldTableProps {
 
 export const ManagePermissionsEditorFieldTable = forwardRef<any, ManagePermissionsEditorFieldTableProps>(
   ({ columns, rows, totalCount, onFilter, onDirtyRows, onBulkUpdate }, ref) => {
+    const tableRef = useRef<DataTableRef<PermissionTableFieldCell>>();
     const [dirtyRows, setDirtyRows] = useState<MapOf<DirtyRow<PermissionTableFieldCell>>>({});
     const [expandedGroupIds, setExpandedGroupIds] = useState(() => new Set<any>(rows.map((row) => row.sobject)));
 
@@ -56,7 +57,8 @@ export const ManagePermissionsEditorFieldTable = forwardRef<any, ManagePermissio
 
     function handleColumnAction(action: 'selectAll' | 'unselectAll' | 'reset', columnKey: string) {
       const [id, typeLabel] = columnKey.split('-');
-      onBulkUpdate(updateRowsFromColumnAction('field', action, typeLabel as FieldPermissionTypes, id, rows));
+      const visibleRows = [...(tableRef.current?.getFilteredAndSortedRows() || rows)];
+      onBulkUpdate(updateRowsFromColumnAction('field', action, typeLabel as FieldPermissionTypes, id, visibleRows));
     }
 
     const handleRowsChange = useCallback(
@@ -70,6 +72,7 @@ export const ManagePermissionsEditorFieldTable = forwardRef<any, ManagePermissio
       <div>
         <AutoFullHeightContainer fillHeight setHeightAttr bottomBuffer={15}>
           <DataTree
+            ref={tableRef}
             columns={columns}
             data={rows}
             getRowKey={getRowKey}

--- a/apps/jetstream/src/app/components/manage-permissions/ManagePermissionsEditorObjectTable.tsx
+++ b/apps/jetstream/src/app/components/manage-permissions/ManagePermissionsEditorObjectTable.tsx
@@ -1,7 +1,7 @@
 import { useNonInitialEffect } from '@jetstream/shared/ui-utils';
 import { MapOf } from '@jetstream/types';
-import { AutoFullHeightContainer, ColumnWithFilter, DataTable } from '@jetstream/ui';
-import { forwardRef, useCallback, useImperativeHandle, useState } from 'react';
+import { AutoFullHeightContainer, ColumnWithFilter, DataTable, DataTableRef } from '@jetstream/ui';
+import { forwardRef, useCallback, useImperativeHandle, useRef, useState } from 'react';
 import { resetGridChanges, updateRowsFromColumnAction } from './utils/permission-manager-table-utils';
 import {
   DirtyRow,
@@ -30,6 +30,7 @@ export interface ManagePermissionsEditorObjectTableProps {
 
 export const ManagePermissionsEditorObjectTable = forwardRef<any, ManagePermissionsEditorObjectTableProps>(
   ({ columns, rows, totalCount, onFilter, onBulkUpdate, onDirtyRows }, ref) => {
+    const tableRef = useRef<DataTableRef<PermissionTableObjectCell>>();
     const [dirtyRows, setDirtyRows] = useState<MapOf<DirtyRow<PermissionTableObjectCell>>>({});
 
     useImperativeHandle<any, ManagePermissionsEditorTableRef>(ref, () => ({
@@ -45,7 +46,8 @@ export const ManagePermissionsEditorObjectTable = forwardRef<any, ManagePermissi
 
     function handleColumnAction(action: 'selectAll' | 'unselectAll' | 'reset', columnKey: string) {
       const [id, typeLabel] = columnKey.split('-');
-      onBulkUpdate(updateRowsFromColumnAction('object', action, typeLabel as FieldPermissionTypes, id, rows));
+      const visibleRows = [...(tableRef.current?.getFilteredAndSortedRows() || rows)];
+      onBulkUpdate(updateRowsFromColumnAction('object', action, typeLabel as FieldPermissionTypes, id, visibleRows));
     }
 
     const handleRowsChange = useCallback(
@@ -59,6 +61,7 @@ export const ManagePermissionsEditorObjectTable = forwardRef<any, ManagePermissi
       <div>
         <AutoFullHeightContainer fillHeight setHeightAttr bottomBuffer={15}>
           <DataTable
+            ref={tableRef}
             columns={columns}
             data={rows}
             getRowKey={getRowKey}

--- a/apps/jetstream/src/app/components/manage-permissions/ManagePermissionsEditorTabVisibilityTable.tsx
+++ b/apps/jetstream/src/app/components/manage-permissions/ManagePermissionsEditorTabVisibilityTable.tsx
@@ -1,7 +1,7 @@
 import { useNonInitialEffect } from '@jetstream/shared/ui-utils';
 import { MapOf } from '@jetstream/types';
-import { AutoFullHeightContainer, ColumnWithFilter, DataTable } from '@jetstream/ui';
-import { forwardRef, useCallback, useImperativeHandle, useState } from 'react';
+import { AutoFullHeightContainer, ColumnWithFilter, DataTable, DataTableRef } from '@jetstream/ui';
+import { forwardRef, useCallback, useImperativeHandle, useRef, useState } from 'react';
 import { resetGridChanges, updateRowsFromColumnAction } from './utils/permission-manager-table-utils';
 import {
   DirtyRow,
@@ -30,6 +30,7 @@ export interface ManagePermissionsEditorTabVisibilityTableProps {
 
 export const ManagePermissionsEditorTabVisibilityTable = forwardRef<any, ManagePermissionsEditorTabVisibilityTableProps>(
   ({ columns, rows, totalCount, onFilter, onBulkUpdate, onDirtyRows }, ref) => {
+    const tableRef = useRef<DataTableRef<PermissionTableTabVisibilityCell>>();
     const [dirtyRows, setDirtyRows] = useState<MapOf<DirtyRow<PermissionTableTabVisibilityCell>>>({});
 
     useImperativeHandle<any, ManagePermissionsEditorTableRef>(ref, () => ({
@@ -45,7 +46,8 @@ export const ManagePermissionsEditorTabVisibilityTable = forwardRef<any, ManageP
 
     function handleColumnAction(action: 'selectAll' | 'unselectAll' | 'reset', columnKey: string) {
       const [id, typeLabel] = columnKey.split('-');
-      onBulkUpdate(updateRowsFromColumnAction('tabVisibility', action, typeLabel as FieldPermissionTypes, id, rows));
+      const visibleRows = [...(tableRef.current?.getFilteredAndSortedRows() || rows)];
+      onBulkUpdate(updateRowsFromColumnAction('tabVisibility', action, typeLabel as FieldPermissionTypes, id, visibleRows));
     }
 
     const handleRowsChange = useCallback(
@@ -59,6 +61,7 @@ export const ManagePermissionsEditorTabVisibilityTable = forwardRef<any, ManageP
       <div>
         <AutoFullHeightContainer fillHeight setHeightAttr bottomBuffer={15}>
           <DataTable
+            ref={tableRef}
             columns={columns}
             data={rows}
             getRowKey={getRowKey}

--- a/libs/ui/src/index.ts
+++ b/libs/ui/src/index.ts
@@ -14,7 +14,7 @@ export * from './lib/data-table/DataTree';
 export * from './lib/data-table/SalesforceRecordDataTable';
 export * from './lib/data-table/data-table-context';
 export * from './lib/data-table/data-table-formatters';
-export type { ColumnWithFilter, ContextAction, ContextMenuActionData, RowWithKey } from './lib/data-table/data-table-types';
+export type { ColumnWithFilter, ContextAction, ContextMenuActionData, DataTableRef, RowWithKey } from './lib/data-table/data-table-types';
 export { getColumnsForGenericTable, getRowTypeFromValue, getSfdcRetUrl, setColumnFromType } from './lib/data-table/data-table-utils';
 export * from './lib/docked-composer/DockedComposer';
 export * from './lib/expression-group/ExpressionContainer';


### PR DESCRIPTION
Column actions were operating on all rows instead of honoring filters

resolves #845