### PR TITLE
Add duplicate rules to Automation Control

### DIFF
--- a/apps/jetstream/src/app/components/automation-control/AutomationControlEditor.tsx
+++ b/apps/jetstream/src/app/components/automation-control/AutomationControlEditor.tsx
@@ -19,18 +19,18 @@ import {
   ToolbarItemGroup,
   Tooltip,
 } from '@jetstream/ui';
-import { applicationCookieState, fromJetstreamEvents, selectSkipFrontdoorAuth, selectedOrgState } from '@jetstream/ui-core';
+import { applicationCookieState, fromJetstreamEvents, selectSkipFrontdoorAuth, selectedOrgState, useAmplitude } from '@jetstream/ui-core';
 import classNames from 'classnames';
 import { FunctionComponent, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { useRecoilValue } from 'recoil';
-import { useAmplitude } from '@jetstream/ui-core';
 import { RequireMetadataApiBanner } from '../core/RequireMetadataApiBanner';
 import AutomationControlEditorReviewModal from './AutomationControlEditorReviewModal';
 import AutomationControlEditorTable from './AutomationControlEditorTable';
 import AutomationControlLastRefreshedPopover from './AutomationControlLastRefreshedPopover';
 import {
   getAutomationDeployType,
+  isDuplicateRecord,
   isTableRow,
   isTableRowChild,
   isTableRowItem,
@@ -145,6 +145,9 @@ export const AutomationControlEditor: FunctionComponent<AutomationControlEditorP
           if (isToolingApexRecord(item.type, record)) {
             fullName = record.Name;
             fileName = `triggers/${record.Name}.trigger`;
+          } else if (isDuplicateRecord(item.type, record)) {
+            fullName = record.DeveloperName;
+            fileName = `objects/${record.SobjectType}.duplicateRule`;
           } else if (isValidationRecord(item.type, record)) {
             fullName = record.FullName;
             fileName = `objects/${record.EntityDefinition.QualifiedApiName}.object`;

--- a/apps/jetstream/src/app/components/automation-control/AutomationControlEditorReviewModal.tsx
+++ b/apps/jetstream/src/app/components/automation-control/AutomationControlEditorReviewModal.tsx
@@ -10,12 +10,15 @@ import { deployMetadata, getAutomationTypeLabel, preparePayloads } from './autom
 import { AutomationDeployStatusRenderer, BooleanAndVersionRenderer } from './automation-control-table-renderers';
 import {
   AutomationControlDeploymentItem,
+  AutomationMetadataType,
   DeploymentItem,
   DeploymentItemMap,
   DeploymentItemRow,
   FlowViewRecord,
   TableRowItem,
 } from './automation-control-types';
+
+const REQUIRE_METADATA_API = new Set<AutomationMetadataType>(['ApexTrigger', 'DuplicateRule']);
 
 const COLUMNS: Column<DeploymentItemRow>[] = [
   {
@@ -68,7 +71,7 @@ function getDeploymentItemMap(rows: TableRowItem[]): DeploymentItemMap {
             : row.record.Id,
         activeVersionNumber: row.activeVersionNumber,
         value: row.isActive,
-        requireMetadataApi: row.type === 'ApexTrigger',
+        requireMetadataApi: REQUIRE_METADATA_API.has(row.type),
         metadataRetrieve: null,
         metadataDeploy: null,
         retrieveError: null,

--- a/apps/jetstream/src/app/components/automation-control/automation-control-soql-utils.tsx
+++ b/apps/jetstream/src/app/components/automation-control/automation-control-soql-utils.tsx
@@ -84,10 +84,10 @@ export function getDuplicateRuleQuery(sobjects: string[]) {
       operator: 'AND',
       right: {
         left: {
-          field: 'ManageableState',
+          field: 'NamespacePrefix',
           operator: '=',
-          value: 'unmanaged',
-          literalType: 'STRING',
+          value: 'NULL',
+          literalType: 'NULL',
         },
       },
     },

--- a/apps/jetstream/src/app/components/automation-control/automation-control-soql-utils.tsx
+++ b/apps/jetstream/src/app/components/automation-control/automation-control-soql-utils.tsx
@@ -54,6 +54,56 @@ export function getApexTriggersQuery(sobjects: string[]) {
   return soql;
 }
 
+export function getDuplicateRuleQuery(sobjects: string[]) {
+  const soql = composeQuery({
+    fields: [
+      getField('Id'),
+      getField('CreatedBy.Id'),
+      getField('CreatedBy.Name'),
+      getField('CreatedBy.Username'),
+      getField('DeveloperName'),
+      getField('IsActive'),
+      getField('LastModifiedBy.Id'),
+      getField('LastModifiedBy.Name'),
+      getField('LastModifiedBy.Username'),
+      getField('MasterLabel'),
+      getField('NamespacePrefix'),
+      getField('SobjectSubtype'),
+      getField('SobjectType'),
+      getField('FORMAT(CreatedDate)'),
+      getField('FORMAT(LastModifiedDate)'),
+    ],
+    sObject: 'DuplicateRule',
+    where: {
+      left: {
+        field: 'SobjectType',
+        operator: 'IN',
+        value: sobjects,
+        literalType: 'STRING',
+      },
+      operator: 'AND',
+      right: {
+        left: {
+          field: 'ManageableState',
+          operator: '=',
+          value: 'unmanaged',
+          literalType: 'STRING',
+        },
+      },
+    },
+    orderBy: [
+      {
+        field: 'SobjectType',
+      },
+      {
+        field: 'MasterLabel',
+      },
+    ],
+  });
+  logger.info('getDuplicateRuleQuery()', { soql });
+  return soql;
+}
+
 export function getValidationRulesQuery(sobjects: string[]) {
   const soql = composeQuery({
     fields: [

--- a/apps/jetstream/src/app/components/automation-control/automation-control-types.ts
+++ b/apps/jetstream/src/app/components/automation-control/automation-control-types.ts
@@ -5,12 +5,18 @@ export type WorkflowRule = 'WorkflowRule';
 export type FlowProcessBuilder = 'FlowProcessBuilder';
 export type FlowRecordTriggered = 'FlowRecordTriggered';
 export type ApexTrigger = 'ApexTrigger';
+export type DuplicateRule = 'DuplicateRule';
 
-export type AutomationMetadataType = ValidationRule | WorkflowRule | FlowProcessBuilder | FlowRecordTriggered | ApexTrigger;
+export type AutomationMetadataType = DuplicateRule | ValidationRule | WorkflowRule | FlowProcessBuilder | FlowRecordTriggered | ApexTrigger;
 
 export interface FetchSuccessPayload {
   type: keyof StateData;
-  records: ToolingApexTriggerRecord[] | ToolingValidationRuleRecord[] | ToolingWorkflowRuleRecord[] | FlowViewRecord[];
+  records:
+    | DuplicateRuleRecord[]
+    | ToolingApexTriggerRecord[]
+    | ToolingValidationRuleRecord[]
+    | ToolingWorkflowRuleRecord[]
+    | FlowViewRecord[];
 }
 
 export interface FetchErrorPayload {
@@ -24,6 +30,13 @@ export interface StateData {
     skip: boolean;
     error?: string;
     records: ToolingApexTriggerRecord[];
+    tableRow: TableRow;
+  };
+  DuplicateRule: {
+    loading: boolean;
+    skip: boolean;
+    error?: string;
+    records: DuplicateRuleRecord[];
     tableRow: TableRow;
   };
   ValidationRule: {
@@ -82,7 +95,7 @@ export interface DeploymentItemRow extends TableRowItem {
 export type MetadataCompositeResponseSuccessOrError = MetadataCompositeResponseSuccess | MetadataCompositeResponseError[];
 
 export interface MetadataCompositeResponseSuccess {
-  Id: string;
+  Id?: string;
   FullName: string;
   Body?: string; // ApexTrigger
   ApiVersion?: number; // ApexTrigger
@@ -109,9 +122,10 @@ export interface AutomationControlDeploymentItem {
 }
 
 export interface DeploymentItemByType {
+  apexTriggers: AutomationControlDeploymentItem[];
+  duplicateRules: AutomationControlDeploymentItem[];
   validationRules: AutomationControlDeploymentItem[];
   workflowRules: AutomationControlDeploymentItem[];
-  apexTriggers: AutomationControlDeploymentItem[];
   flows: AutomationControlDeploymentItem[];
 }
 
@@ -147,6 +161,17 @@ export interface ToolingApexTriggerRecord extends SystemFields {
   EntityDefinitionId: string;
   EntityDefinition: { QualifiedApiName: string };
   Status: 'Inactive' | 'Active' | 'Deleted';
+}
+
+/** This is not tooling */
+export interface DuplicateRuleRecord extends SystemFields {
+  Id: string;
+  DeveloperName: string;
+  IsActive: boolean;
+  MasterLabel: string;
+  NamespacePrefix: string;
+  SobjectSubtype: string;
+  SobjectType: string;
 }
 
 export interface ToolingWorkflowRuleRecord extends SystemFields {
@@ -343,7 +368,7 @@ export interface TableRowItem {
   parentKey: string;
   type: AutomationMetadataType;
   sobject: string;
-  record: ToolingApexTriggerRecord | ToolingValidationRuleRecord | ToolingWorkflowRuleRecord | FlowViewRecord;
+  record: DuplicateRuleRecord | ToolingApexTriggerRecord | ToolingValidationRuleRecord | ToolingWorkflowRuleRecord | FlowViewRecord;
   link: string;
   /** True for Flow and PB as this is controlled from children */
   readOnly: boolean;

--- a/apps/jetstream/src/app/components/automation-control/automation-control.state.ts
+++ b/apps/jetstream/src/app/components/automation-control/automation-control.state.ts
@@ -21,9 +21,9 @@ export const automationTypes = atom<ListItem<AutomationMetadataType>[]>({
   key: 'automation-control.automationTypes',
   default: [
     { id: 'ApexTrigger', value: 'ApexTrigger', label: 'Apex Triggers', title: 'Apex Triggers' },
+    { id: 'DuplicateRule', value: 'DuplicateRule', label: 'Duplicate Rules', title: 'Duplicate Rules' },
     { id: 'ValidationRule', value: 'ValidationRule', label: 'Validation Rules', title: 'Validation Rules' },
     { id: 'WorkflowRule', value: 'WorkflowRule', label: 'Workflow Rules', title: 'Workflow Rules' },
-    { id: 'DuplicateRule', value: 'DuplicateRule', label: 'Duplicate Rules', title: 'Duplicate Rules' },
     { id: 'FlowRecordTriggered', value: 'FlowRecordTriggered', label: 'Record Triggered Flows', title: 'Record Triggered Flows' },
     {
       id: 'FlowProcessBuilder',

--- a/apps/jetstream/src/app/components/automation-control/automation-control.state.ts
+++ b/apps/jetstream/src/app/components/automation-control/automation-control.state.ts
@@ -23,6 +23,7 @@ export const automationTypes = atom<ListItem<AutomationMetadataType>[]>({
     { id: 'ApexTrigger', value: 'ApexTrigger', label: 'Apex Triggers', title: 'Apex Triggers' },
     { id: 'ValidationRule', value: 'ValidationRule', label: 'Validation Rules', title: 'Validation Rules' },
     { id: 'WorkflowRule', value: 'WorkflowRule', label: 'Workflow Rules', title: 'Workflow Rules' },
+    { id: 'DuplicateRule', value: 'DuplicateRule', label: 'Duplicate Rules', title: 'Duplicate Rules' },
     { id: 'FlowRecordTriggered', value: 'FlowRecordTriggered', label: 'Record Triggered Flows', title: 'Record Triggered Flows' },
     {
       id: 'FlowProcessBuilder',
@@ -36,7 +37,7 @@ export const automationTypes = atom<ListItem<AutomationMetadataType>[]>({
 
 export const selectedAutomationTypes = atom<AutomationMetadataType[]>({
   key: 'automation-control.selectedAutomationTypes',
-  default: ['ApexTrigger', 'ValidationRule', 'WorkflowRule', 'FlowProcessBuilder', 'FlowRecordTriggered'],
+  default: ['ApexTrigger', 'DuplicateRule', 'ValidationRule', 'WorkflowRule', 'FlowRecordTriggered'],
 });
 
 export const hasSelectionsMade = selector({


### PR DESCRIPTION
Allow duplicate rules to be included for duplicate rules.

These require metadata api to be deployed, so adjusted automation deployment process to account for this.

resolves #880