### PR TITLE
Prevent crash if invalid field configuration

### DIFF
--- a/libs/shared/ui-core/src/create-fields/create-fields-utils.tsx
+++ b/libs/shared/ui-core/src/create-fields/create-fields-utils.tsx
@@ -866,11 +866,12 @@ function prepareFieldPayload(sobject: string, fieldValues: FieldValues, orgNames
         valueSetDefinition: {
           sorted: false,
           // sorted: fieldValues.sorted.value,
-          value: (fieldValues.valueSet.value as string).split('\n').map((value, i) => ({
-            fullName: value,
-            label: value,
-            default: fieldValues.firstAsDefault.value && i === 0,
-          })),
+          value:
+            (fieldValues.valueSet.value as string)?.split('\n').map((value, i) => ({
+              fullName: value,
+              label: value,
+              default: fieldValues.firstAsDefault.value && i === 0,
+            })) || [],
         },
       };
     }


### PR DESCRIPTION
Ensure that if fieldValues.valueSet.value is not a string, we fallback to an empty array to avoid application crash

Was unable to reproduce the report situation, so not sure exactly what the root cause is

resolves #936