### PR TITLE
Add Jetstream Organizations

### DIFF
--- a/apps/api/src/app/controllers/jetstream-organizations.controller.ts
+++ b/apps/api/src/app/controllers/jetstream-organizations.controller.ts
@@ -1,0 +1,86 @@
+import { z } from 'zod';
+import * as jetstreamOrganizationsDb from '../db/organization.db';
+import { UserFacingError } from '../utils/error-handler';
+import { sendJson } from '../utils/response.handlers';
+import { createRoute } from '../utils/route.utils';
+
+export const routeDefinition = {
+  getOrganizations: {
+    controllerFn: () => getOrganizations,
+    validators: {
+      hasSourceOrg: false,
+    },
+  },
+  createOrganization: {
+    controllerFn: () => createOrganization,
+    validators: {
+      body: z.object({
+        name: z.string(),
+        description: z.string().optional(),
+      }),
+      hasSourceOrg: false,
+    },
+  },
+  updateOrganization: {
+    controllerFn: () => updateOrganization,
+    validators: {
+      params: z.object({
+        id: z.string().uuid(),
+      }),
+      body: z.object({
+        name: z.string(),
+        description: z.string().optional(),
+      }),
+      hasSourceOrg: false,
+    },
+  },
+  deleteOrganization: {
+    controllerFn: () => deleteOrganization,
+    validators: {
+      params: z.object({
+        id: z.string().uuid(),
+      }),
+      hasSourceOrg: false,
+    },
+  },
+};
+
+const getOrganizations = createRoute(routeDefinition.getOrganizations.validators, async ({ user, query }, req, res, next) => {
+  try {
+    const organizations = await jetstreamOrganizationsDb.findByUserId({ userId: user.id });
+
+    sendJson(res, organizations);
+  } catch (ex) {
+    next(new UserFacingError(ex));
+  }
+});
+
+const createOrganization = createRoute(routeDefinition.createOrganization.validators, async ({ user, body }, req, res, next) => {
+  try {
+    const organization = await jetstreamOrganizationsDb.create(user.id, body);
+
+    sendJson(res, organization);
+  } catch (ex) {
+    next(new UserFacingError(ex));
+  }
+});
+
+const updateOrganization = createRoute(routeDefinition.updateOrganization.validators, async ({ body, params, user }, req, res, next) => {
+  try {
+    const organization = await jetstreamOrganizationsDb.update(user.id, params.id, body);
+
+    sendJson(res, organization, 201);
+  } catch (ex) {
+    next(new UserFacingError(ex));
+  }
+});
+
+const deleteOrganization = createRoute(routeDefinition.deleteOrganization.validators, async ({ params, user }, req, res, next) => {
+  try {
+    await jetstreamOrganizationsDb.deleteOrganization(user.id, params.id);
+
+    sendJson(res, undefined, 204);
+  } catch (ex) {
+    next(new UserFacingError(ex));
+  }
+});

--- a/apps/api/src/app/controllers/orgs.controller.ts
+++ b/apps/api/src/app/controllers/orgs.controller.ts
@@ -39,6 +39,18 @@ export const routeDefinition = {
     controllerFn: () => checkOrgHealth,
     validators: {},
   },
+  moveOrg: {
+    controllerFn: () => moveOrg,
+    validators: {
+      params: z.object({
+        uniqueId: z.string().min(1),
+      }),
+      body: z.object({
+        jetstreamOrganizationId: z.string().uuid().nullish(),
+      }),
+      hasSourceOrg: false,
+    },
+  },
 };
 
 const getOrgs = createRoute(routeDefinition.getOrgs.validators, async ({ user }, req, res, next) => {
@@ -117,6 +129,17 @@ const checkOrgHealth = createRoute(routeDefinition.checkOrgHealth.validators, as
     }
 
     sendJson(res, undefined, 200);
+  } catch (ex) {
+    next(new UserFacingError(ex));
+  }
+});
+
+const moveOrg = createRoute(routeDefinition.moveOrg.validators, async ({ body, params, user }, req, res, next) => {
+  try {
+    const { uniqueId } = params;
+    const salesforceOrg = await salesforceOrgsDb.moveSalesforceOrg(user.id, uniqueId, body);
+
+    sendJson(res, salesforceOrg, 201);
   } catch (ex) {
     next(new UserFacingError(ex));
   }

--- a/apps/api/src/app/db/organization.db.ts
+++ b/apps/api/src/app/db/organization.db.ts
@@ -1,0 +1,67 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+import { prisma } from '@jetstream/api-config';
+import { Maybe } from '@jetstream/types';
+import { Prisma } from '@prisma/client';
+import { findIdByUserId } from './user.db';
+
+const SELECT = Prisma.validator<Prisma.JetstreamOrganizationSelect>()({
+  id: true,
+  orgs: {
+    select: { uniqueId: true },
+  },
+  name: true,
+  description: true,
+  createdAt: true,
+  updatedAt: true,
+});
+
+export const findByUserId = async ({ userId }: { userId: string }) => {
+  return await prisma.jetstreamOrganization.findMany({ where: { user: { userId } }, select: SELECT });
+};
+
+export const findById = async ({ id, userId }: { id: string; userId: string }) => {
+  return await prisma.jetstreamOrganization.findFirstOrThrow({ where: { id, user: { userId } }, select: SELECT });
+};
+
+export const create = async (
+  userId: string,
+  payload: {
+    name: string;
+    description?: Maybe<string>;
+  }
+) => {
+  const userActualId = await findIdByUserId({ userId });
+  return await prisma.jetstreamOrganization.create({
+    select: SELECT,
+    data: {
+      userId: userActualId,
+      name: payload.name.trim(),
+      description: payload.description?.trim(),
+    },
+  });
+};
+
+export const update = async (
+  userId,
+  id,
+  payload: {
+    name: string;
+    description?: Maybe<string>;
+  }
+) => {
+  return await prisma.jetstreamOrganization.update({
+    select: SELECT,
+    where: { user: { userId }, id },
+    data: {
+      name: payload.name.trim(),
+      description: payload.description?.trim() ?? null,
+    },
+  });
+};
+
+export const deleteOrganization = async (userId, id) => {
+  return await prisma.jetstreamOrganization.delete({
+    select: SELECT,
+    where: { user: { userId }, id },
+  });
+};

--- a/apps/api/src/app/db/user.db.ts
+++ b/apps/api/src/app/db/user.db.ts
@@ -19,6 +19,10 @@ const userSelect: Prisma.UserSelect = {
   userId: true,
 };
 
+export const findIdByUserId = ({ userId }: { userId: string }) => {
+  return prisma.user.findFirstOrThrow({ where: { userId }, select: { id: true } }).then(({ id }) => id);
+};
+
 /**
  * Find by Auth0 userId, not Jetstream Id
  */
@@ -72,6 +76,7 @@ export async function createOrUpdateUser(user: UserProfileServer): Promise<{ cre
         where: { userId: user.id },
         data: {
           appMetadata: JSON.stringify(user._json[ENV.AUTH_AUDIENCE!]),
+          deletedAt: null,
           preferences: {
             upsert: {
               create: { skipFrontdoorLogin: false },
@@ -92,6 +97,7 @@ export async function createOrUpdateUser(user: UserProfileServer): Promise<{ cre
           nickname: user._json.nickname,
           picture: user._json.picture,
           appMetadata: JSON.stringify(user._json[ENV.AUTH_AUDIENCE!]),
+          deletedAt: null,
           preferences: { create: { skipFrontdoorLogin: false } },
         },
         select: userSelect,

--- a/apps/api/src/app/routes/api.routes.ts
+++ b/apps/api/src/app/routes/api.routes.ts
@@ -3,6 +3,7 @@ import express from 'express';
 import Router from 'express-promise-router';
 import multer from 'multer';
 import { routeDefinition as imageController } from '../controllers/image.controller';
+import { routeDefinition as jetstreamOrganizationsController } from '../controllers/jetstream-organizations.controller';
 import { routeDefinition as orgsController } from '../controllers/orgs.controller';
 import { routeDefinition as salesforceApiReqController } from '../controllers/salesforce-api-requests.controller';
 import { routeDefinition as bulkApiController } from '../controllers/sf-bulk-api.controller';
@@ -50,6 +51,12 @@ routes.post('/orgs/health-check', orgsController.checkOrgHealth.controllerFn());
 routes.get('/orgs', orgsController.getOrgs.controllerFn());
 routes.patch('/orgs/:uniqueId', orgsController.updateOrg.controllerFn());
 routes.delete('/orgs/:uniqueId', orgsController.deleteOrg.controllerFn());
+routes.put('/orgs/:uniqueId/move', orgsController.moveOrg.controllerFn());
+
+routes.get('/jetstream-organizations', jetstreamOrganizationsController.getOrganizations.controllerFn());
+routes.post('/jetstream-organizations', jetstreamOrganizationsController.createOrganization.controllerFn());
+routes.put('/jetstream-organizations/:id', jetstreamOrganizationsController.updateOrganization.controllerFn());
+routes.delete('/jetstream-organizations/:id', jetstreamOrganizationsController.deleteOrganization.controllerFn());
 
 /**
  * ************************************

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -1,6 +1,7 @@
 import '@jetstream/api-config'; // this gets imported first to ensure as some items require early initialization
 import { ENV, getExceptionLog, httpLogger, logger, pgPool } from '@jetstream/api-config';
 import { HTTP, SESSION_EXP_DAYS } from '@jetstream/shared/constants';
+import { Maybe } from '@jetstream/types';
 import { json, raw, urlencoded } from 'body-parser';
 import cluster from 'cluster';
 import pgSimple from 'connect-pg-simple';
@@ -28,7 +29,7 @@ import { environment } from './environments/environment';
 declare module 'express-session' {
   interface SessionData {
     activityExp: number;
-    orgAuth?: { code_verifier: string; nonce: string; state: string; loginUrl: string };
+    orgAuth?: { code_verifier: string; nonce: string; state: string; loginUrl: string; jetstreamOrganizationId?: Maybe<string> };
   }
 }
 
@@ -61,6 +62,7 @@ if (ENV.NODE_ENV === 'production' && cluster.isPrimary) {
       path: '/',
       // httpOnly: true,
       secure: !ENV.IS_LOCAL_DOCKER && environment.production,
+      // Set to two - if you don't login for 48 hours, then expire session - consider changing to 1
       maxAge: 1000 * 60 * 60 * 24 * SESSION_EXP_DAYS,
       // sameSite: 'strict',
     },

--- a/apps/docs/docs/getting-started/oarganizations.mdx
+++ b/apps/docs/docs/getting-started/oarganizations.mdx
@@ -1,0 +1,48 @@
+---
+id: organizations
+title: Organizations
+description: Organizations provide a way to group your Salesforce Orgs.
+keywords: [salesforce, salesforce admin, salesforce developer, salesforce automation, salesforce workbench]
+sidebar_label: Organizations
+slug: /organizations
+---
+
+Organizations allow you to group your Salesforce orgs so you can work in isolation.
+
+# Overview
+
+Let's say that you are a consultant and you are working with multiple clients. You can create an Organization per client so that when you are doing work for that client, only the Salesforce orgs associated with that client will show up.
+
+# Creating and Managing Organizations
+
+If you don't yet have organizations, you can get to the [organizations](http://getjetstream.app/app/organizations) page by navigating to the home page (click the waffle icon in the navbar) and then click **Manage Organizations**.
+
+If you already have an organization created, you will see the organization switcher above the Salesforce Org dropdown at the top of the page.
+
+## Creating an Organization
+
+To create an Organization, click the **+ Create New Organization** button at the top of the page and choose a name.
+
+:::tip
+
+The organization page is also a great place to manage all of your Salesforce orgs!
+
+:::
+
+## Assigning Salesforce Orgs to an Organization
+
+You can move orgs by dragging and dropping them on the desired organization or to the **Salesforce Orgs Not Assigned to Organization** card.
+
+## Choosing an Organization
+
+To make an organization active, click the **Make Active** button on the organization card. Alternatively, you can use the organization switcher at the top of the page to quickly do so.
+
+## Deleting an Organization
+
+You can delete an organization by clicking the dropdown menu and choosing **Delete**.
+
+:::tip
+
+Any Salesforce orgs associated with a deleted organization will still exist without an organization.
+
+:::

--- a/apps/docs/sidebars.ts
+++ b/apps/docs/sidebars.ts
@@ -3,7 +3,7 @@ const sidebar = {
     {
       type: 'category',
       label: 'Getting Started',
-      items: ['getting-started/overview', 'getting-started/feedback'],
+      items: ['getting-started/overview', 'getting-started/organizations', 'getting-started/feedback'],
     },
     {
       type: 'category',

--- a/apps/jetstream/src/app/AppRoutes.tsx
+++ b/apps/jetstream/src/app/AppRoutes.tsx
@@ -4,6 +4,8 @@ import { useEffect } from 'react';
 import { Navigate, Route, Routes, useLocation } from 'react-router-dom';
 import lazy from './components/core/LazyLoad';
 
+const Organizations = lazy(() => import('@jetstream/feature/organizations').then((module) => ({ default: module.Organizations })));
+
 const LoadRecords = lazy(() => import('@jetstream/feature/load-records').then((module) => ({ default: module.LoadRecords })));
 const LoadRecordsMultiObject = lazy(() =>
   import('@jetstream/feature/load-records-multi-object').then((module) => ({ default: module.LoadRecordsMultiObject }))
@@ -119,6 +121,7 @@ export const AppRoutes = ({ featureFlags, userProfile }: AppRoutesProps) => {
         <Route path="results" element={<QueryResults />} />
         <Route path="*" element={<Navigate to=".." />} />
       </Route>
+      <Route path={APP_ROUTES.ORGANIZATIONS.ROUTE} element={<Organizations />} />
       <Route
         path={APP_ROUTES.LOAD.ROUTE}
         element={

--- a/libs/features/organizations/.babelrc
+++ b/libs/features/organizations/.babelrc
@@ -1,0 +1,13 @@
+{
+  "presets": [
+    [
+      "@nx/react/babel",
+      {
+        "runtime": "automatic",
+        "useBuiltIns": "usage",
+        "importSource": "@emotion/react"
+      }
+    ]
+  ],
+  "plugins": ["@emotion/babel-plugin"]
+}

--- a/libs/features/organizations/.eslintrc.json
+++ b/libs/features/organizations/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+  "extends": ["plugin:@nx/react", "../../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.ts", "*.tsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.js", "*.jsx"],
+      "rules": {}
+    }
+  ]
+}

--- a/libs/features/organizations/README.md
+++ b/libs/features/organizations/README.md
@@ -1,0 +1,7 @@
+# features-organizations
+
+This library was generated with [Nx](https://nx.dev).
+
+## Running unit tests
+
+Run `nx test features-organizations` to execute the unit tests via [Jest](https://jestjs.io).

--- a/libs/features/organizations/jest.config.ts
+++ b/libs/features/organizations/jest.config.ts
@@ -1,0 +1,10 @@
+/* eslint-disable */
+export default {
+  displayName: 'features-query',
+  preset: '../../../jest.preset.js',
+  transform: {
+    '^(?!.*\\.(js|jsx|ts|tsx|css|json)$)': '@nx/react/plugins/jest',
+    '^.+\\.[tj]sx?$': ['babel-jest', { presets: ['@nx/react/babel'] }],
+  },
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
+};

--- a/libs/features/organizations/project.json
+++ b/libs/features/organizations/project.json
@@ -1,0 +1,16 @@
+{
+  "name": "features-organizations",
+  "$schema": "../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/features/organizations/src",
+  "projectType": "library",
+  "tags": [],
+  "targets": {
+    "test": {
+      "executor": "@nx/jest:jest",
+      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+      "options": {
+        "jestConfig": "libs/features/organizations/jest.config.ts"
+      }
+    }
+  }
+}

--- a/libs/features/organizations/src/index.ts
+++ b/libs/features/organizations/src/index.ts
@@ -1,0 +1,1 @@
+export * from './lib/OrganizationPage';

--- a/libs/features/organizations/src/lib/OrganizationCard.tsx
+++ b/libs/features/organizations/src/lib/OrganizationCard.tsx
@@ -1,0 +1,145 @@
+import { css } from '@emotion/react';
+import { formatNumber } from '@jetstream/shared/ui-utils';
+import { JetstreamOrganizationWithOrgs } from '@jetstream/types';
+import { ButtonGroupContainer, Card, DropDown, Grid, Icon } from '@jetstream/ui';
+import classNames from 'classnames';
+import { useDrop } from 'react-dnd';
+import SalesforceOrgCardDraggable from './SalesforceOrgCardDraggable';
+import { DraggableSfdcCard } from './organization.types';
+
+interface OrganizationCardProps {
+  isActive: boolean;
+  organization: JetstreamOrganizationWithOrgs;
+  activeSalesforceOrgId?: string;
+  onSelected: () => void;
+  onEditOrg: () => void;
+  onMoveOrg: (data: { jetstreamOrganizationId: string; sfdcOrgUniqueId: string; action: 'add' }) => void;
+  onDeleteOrg: () => void;
+}
+
+export function OrganizationCard({
+  isActive,
+  organization,
+  activeSalesforceOrgId,
+  onSelected,
+  onEditOrg,
+  onMoveOrg,
+  onDeleteOrg,
+}: OrganizationCardProps) {
+  const { id, name, description, orgs } = organization;
+  const orgCount = organization.orgs.length;
+  const [{ isOver, canDrop }, dropRef] = useDrop<DraggableSfdcCard, any, { isOver: boolean; canDrop: boolean }>(
+    {
+      accept: 'SalesforceOrg',
+      collect: (monitor) => {
+        return {
+          isOver: monitor.isOver(),
+          canDrop: monitor.canDrop(),
+        };
+      },
+      canDrop: (item, monitor) => {
+        return item.organizationId !== id && monitor.isOver();
+      },
+      drop: (item, monitor) => {
+        onMoveOrg({
+          jetstreamOrganizationId: id,
+          sfdcOrgUniqueId: item.uniqueId,
+          action: 'add',
+        });
+      },
+    },
+    [id, onMoveOrg]
+  );
+
+  function handleActions(action: 'delete') {
+    switch (action) {
+      case 'delete':
+        onDeleteOrg();
+        break;
+    }
+  }
+
+  return (
+    <div
+      css={css`
+        position: relative;
+      `}
+    >
+      <Card
+        ref={dropRef}
+        css={css`
+          ${isActive
+            ? `
+            border: 1px solid var(--slds-g-color-border-brand-2, #1b96ff) !important;
+            -webkit-box-shadow: 0 0 0 1px var(--slds-g-color-border-brand-2, #1b96ff) inset !important;
+            ::after {
+            content: '';
+            position: absolute;
+            top: 0;
+            right: 0;
+            border-radius: 0 0.25rem 0 0;
+            border-left: 1rem solid transparent;
+            border-bottom: 1rem solid transparent;
+            border-right: 1rem solid transparent;
+            border-right-color: var(--slds-g-color-brand-base-60, #1b96ff);
+            border-top: 1rem solid transparent;
+            border-top-color: var(--slds-g-color-brand-base-60, #1b96ff);
+          }`
+            : ''}
+        `}
+        nestedBorder
+        className={classNames({ 'slds-drop-zone slds-drop-zone_drag': isOver && canDrop })}
+        title={
+          <Grid>
+            {name} ({formatNumber(orgCount)})
+          </Grid>
+        }
+        actions={
+          <ButtonGroupContainer className="slds-m-right_medium">
+            {!isActive && (
+              <button className="slds-button slds-button_neutral slds-button_first" onClick={() => onSelected()}>
+                Make Active
+              </button>
+            )}
+            <button className="slds-button slds-button_neutral slds-button_middle" onClick={() => onEditOrg()}>
+              Edit
+            </button>
+            <DropDown
+              className="slds-button_last"
+              dropDownClassName="slds-dropdown_actions"
+              position="right"
+              items={[{ id: 'delete', value: 'Delete', icon: { type: 'utility', icon: 'delete', description: 'Delete' } }]}
+              onSelected={(action) => handleActions(action as 'delete')}
+            />
+          </ButtonGroupContainer>
+        }
+        bodyClassName="slds-card__body"
+      >
+        {description && <p className="slds-p-left_small">{description}</p>}
+        <Grid
+          wrap
+          css={css`
+            min-height: 8rem;
+          `}
+        >
+          {orgs.map((org) => (
+            <div key={org.uniqueId} className="slds-m-around_x-small">
+              <SalesforceOrgCardDraggable org={org} isActive={activeSalesforceOrgId === org.uniqueId} />
+            </div>
+          ))}
+          {!orgs.length && <p className="slds-align_absolute-center">Drag and drop to move salesforce orgs between organizations.</p>}
+        </Grid>
+      </Card>
+      {isActive && (
+        <Icon
+          type="utility"
+          icon="check"
+          className="slds-icon slds-icon-text-check slds-icon_x-small"
+          containerClassname="slds-icon_container slds-visual-picker__text-check"
+        />
+      )}
+    </div>
+  );
+}
+
+export default OrganizationCard;

--- a/libs/features/organizations/src/lib/OrganizationCardNoOrganization.tsx
+++ b/libs/features/organizations/src/lib/OrganizationCardNoOrganization.tsx
@@ -1,0 +1,114 @@
+import { css } from '@emotion/react';
+import { formatNumber } from '@jetstream/shared/ui-utils';
+import { SalesforceOrgUi } from '@jetstream/types';
+import { Card, Grid, Icon } from '@jetstream/ui';
+import classNames from 'classnames';
+import { useDrop } from 'react-dnd';
+import SalesforceOrgCardDraggable from './SalesforceOrgCardDraggable';
+import { DraggableSfdcCard } from './organization.types';
+
+interface OrganizationCardNoOrganizationProps {
+  isActive: boolean;
+  orgs: SalesforceOrgUi[];
+  activeSalesforceOrgId?: string;
+  onSelected: () => void;
+  onMoveOrg: (data: { jetstreamOrganizationId: null; sfdcOrgUniqueId: string; action: 'remove' }) => void;
+}
+
+export function OrganizationCardNoOrganization({
+  isActive,
+  orgs,
+  activeSalesforceOrgId,
+  onSelected,
+  onMoveOrg,
+}: OrganizationCardNoOrganizationProps) {
+  const [{ isOver, canDrop }, dropRef] = useDrop<DraggableSfdcCard, any, { isOver: boolean; canDrop: boolean }>(
+    {
+      accept: 'SalesforceOrg',
+      collect: (monitor) => {
+        return {
+          isOver: monitor.isOver(),
+          canDrop: monitor.canDrop(),
+        };
+      },
+      canDrop: (item, monitor) => {
+        return !!item.organizationId && monitor.isOver();
+      },
+      drop: (item, monitor) => {
+        onMoveOrg({
+          jetstreamOrganizationId: null,
+          sfdcOrgUniqueId: item.uniqueId,
+          action: 'remove',
+        });
+      },
+    },
+    [onMoveOrg]
+  );
+
+  return (
+    <div
+      css={css`
+        position: relative;
+      `}
+    >
+      <Card
+        ref={dropRef}
+        css={css`
+          ${isActive
+            ? `
+            border: 1px solid var(--slds-g-color-border-brand-2, #1b96ff) !important;
+            -webkit-box-shadow: 0 0 0 1px var(--slds-g-color-border-brand-2, #1b96ff) inset !important;
+            ::after {
+            content: '';
+            position: absolute;
+            top: 0;
+            right: 0;
+            border-radius: 0 0.25rem 0 0;
+            border-left: 1rem solid transparent;
+            border-bottom: 1rem solid transparent;
+            border-right: 1rem solid transparent;
+            border-right-color: var(--slds-g-color-brand-base-60, #1b96ff);
+            border-top: 1rem solid transparent;
+            border-top-color: var(--slds-g-color-brand-base-60, #1b96ff);
+          }`
+            : ''}
+        `}
+        nestedBorder
+        className={classNames({ 'slds-drop-zone slds-drop-zone_drag': isOver && canDrop })}
+        actions={
+          <div className="slds-m-right_medium">
+            {!isActive && (
+              <button className="slds-button slds-button_neutral" onClick={() => onSelected()}>
+                Make Active
+              </button>
+            )}
+          </div>
+        }
+        title={<Grid>Salesforce Orgs Not Assigned to Organization ({formatNumber(orgs.length)})</Grid>}
+        bodyClassName="slds-card__body"
+      >
+        <Grid
+          wrap
+          css={css`
+            min-height: 8rem;
+          `}
+        >
+          {orgs.map((org) => (
+            <div key={org.uniqueId} className="slds-m-around_x-small">
+              <SalesforceOrgCardDraggable org={org} isActive={activeSalesforceOrgId === org.uniqueId} />
+            </div>
+          ))}
+          {!orgs.length && <p className="slds-align_absolute-center">Drag and drop to move salesforce orgs between organizations.</p>}
+        </Grid>
+      </Card>
+      {isActive && (
+        <Icon
+          type="utility"
+          icon="check"
+          className="slds-icon slds-icon-text-check slds-icon_x-small"
+          containerClassname="slds-icon_container slds-visual-picker__text-check"
+        />
+      )}
+    </div>
+  );
+}

--- a/libs/features/organizations/src/lib/OrganizationModal.tsx
+++ b/libs/features/organizations/src/lib/OrganizationModal.tsx
@@ -1,0 +1,100 @@
+import { useRollbar } from '@jetstream/shared/ui-utils';
+import { getErrorMessage, getErrorMessageAndStackObj } from '@jetstream/shared/utils';
+import { JetstreamOrganizationCreateUpdatePayload, JetstreamOrganizationWithOrgs, Maybe } from '@jetstream/types';
+import { fireToast, Grid, Input, Modal, Textarea } from '@jetstream/ui';
+import { ConfirmPageChange } from '@jetstream/ui-core';
+import { useEffect, useRef, useState } from 'react';
+
+interface OrganizationModalProps {
+  organization?: Maybe<JetstreamOrganizationWithOrgs>;
+  onSubmit: (organization: JetstreamOrganizationCreateUpdatePayload) => Promise<void>;
+  onClose: () => void;
+}
+
+export function OrganizationModal({ organization, onSubmit, onClose }: OrganizationModalProps) {
+  const isMounted = useRef(true);
+  const rollbar = useRollbar();
+  const [loading, setLoading] = useState(false);
+  const [updatedOrg, setUpdatedOrg] = useState(() => ({
+    name: organization?.name || '',
+    description: organization?.description || '',
+  }));
+  const isCreate = !organization;
+
+  useEffect(() => {
+    isMounted.current = true;
+    return () => {
+      isMounted.current = false;
+    };
+  }, []);
+
+  async function handleSubmit() {
+    try {
+      await onSubmit(updatedOrg);
+      onClose();
+    } catch (ex) {
+      fireToast({ message: `There was an error creating the organization. ${getErrorMessage(ex)}`, type: 'error' });
+      rollbar.error('OrganizationModal: Error creating organization', getErrorMessageAndStackObj(ex));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <Modal
+      header={isCreate ? 'Create Organization' : 'Edit Organization'}
+      closeDisabled={loading}
+      closeOnBackdropClick={false}
+      closeOnEsc={false}
+      footer={
+        <Grid align="spread">
+          <div>
+            <button type="button" className="slds-button slds-button_neutral" disabled={loading} onClick={onClose}>
+              Close
+            </button>
+            <button type="submit" form="organization-form" className="slds-button slds-button_brand" disabled={loading}>
+              Save
+            </button>
+          </div>
+        </Grid>
+      }
+      size="sm"
+      onClose={onClose}
+    >
+      <div className="slds-is-relative">
+        <ConfirmPageChange actionInProgress={loading} />
+        <form
+          id="organization-form"
+          onSubmit={(ev) => {
+            ev.preventDefault();
+            handleSubmit();
+          }}
+        >
+          <Input label="Name" isRequired hasError={false} errorMessageId="Error" errorMessage="This is not valid">
+            <input
+              id="organization-name"
+              className="slds-input"
+              value={updatedOrg.name}
+              required
+              minLength={1}
+              maxLength={60}
+              onChange={(event) => setUpdatedOrg((prevValue) => ({ ...prevValue, name: event.target.value }))}
+              disabled={loading}
+            />
+          </Input>
+          <Textarea id="org-description" label="Description">
+            <textarea
+              id="organization-description"
+              className="slds-input"
+              value={updatedOrg.description}
+              rows={2}
+              maxLength={255}
+              onChange={(event) => setUpdatedOrg((prevValue) => ({ ...prevValue, description: event.target.value }))}
+              disabled={loading}
+            />
+          </Textarea>
+        </form>
+      </div>
+    </Modal>
+  );
+}

--- a/libs/features/organizations/src/lib/OrganizationPage.tsx
+++ b/libs/features/organizations/src/lib/OrganizationPage.tsx
@@ -1,0 +1,249 @@
+import { logger } from '@jetstream/shared/client-logger';
+import { ANALYTICS_KEYS, TITLES } from '@jetstream/shared/constants';
+import {
+  addSfdcOrgToOrganization,
+  createJetstreamOrganization,
+  deleteJetstreamOrganization,
+  getJetstreamOrganizations,
+  updateJetstreamOrganization,
+} from '@jetstream/shared/data';
+import { useRollbar, useTitle } from '@jetstream/shared/ui-utils';
+import { getErrorMessageAndStackObj } from '@jetstream/shared/utils';
+import { JetstreamOrganization, JetstreamOrganizationCreateUpdatePayload, JetstreamOrganizationWithOrgs, Maybe } from '@jetstream/types';
+import {
+  AutoFullHeightContainer,
+  ConfirmationModalPromise,
+  fireToast,
+  Grid,
+  Icon,
+  Page,
+  PageHeader,
+  PageHeaderActions,
+  PageHeaderRow,
+  PageHeaderTitle,
+} from '@jetstream/ui';
+import { AddOrg, fromAppState, useAmplitude, useUpdateOrgs } from '@jetstream/ui-core';
+import { useCallback, useState } from 'react';
+import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
+import OrganizationCard from './OrganizationCard';
+import { OrganizationCardNoOrganization } from './OrganizationCardNoOrganization';
+import { OrganizationModal } from './OrganizationModal';
+
+export function Organizations() {
+  useTitle(TITLES.ORGANIZATIONS);
+  const rollbar = useRollbar();
+  const { trackEvent } = useAmplitude();
+  const selectedOrg = useRecoilValue(fromAppState.selectedOrgStateWithoutPlaceholder);
+  const setSelectedOrgId = useSetRecoilState(fromAppState.selectedOrgIdState);
+  const [allOrgs, setOrgs] = useRecoilState(fromAppState.salesforceOrgsState);
+  const orgsWithoutOrganization = useRecoilValue(fromAppState.salesforceOrgsWithoutOrganizationSelector);
+  const [activeOrganizationId, setActiveOrganizationId] = useRecoilState(fromAppState.jetstreamActiveOrganizationState);
+  const setOrganizationsFromDb = useSetRecoilState(fromAppState.jetstreamOrganizationsState);
+  const [organizations, setOrganizations] = useRecoilState(fromAppState.jetstreamOrganizationsWithOrgsSelector);
+  const setSelectedOrganization = useSetRecoilState(fromAppState.jetstreamActiveOrganizationState);
+  const selectedOrganization = useRecoilValue(fromAppState.jetstreamActiveOrganizationSelector);
+  const [isModalOpen, setIsModalOption] = useState(false);
+
+  const { handleAddOrg } = useUpdateOrgs();
+
+  const handleMoveSfdcOrgToOrganization = useCallback(
+    async ({
+      jetstreamOrganizationId,
+      sfdcOrgUniqueId,
+      action,
+    }: {
+      jetstreamOrganizationId?: Maybe<string>;
+      sfdcOrgUniqueId: string;
+      action: 'add' | 'remove';
+    }) => {
+      const allOrgsBackup = [...allOrgs];
+      const organizationsBackup = [...organizations];
+      const orgToUpdate = allOrgs.find((org) => org.uniqueId === sfdcOrgUniqueId);
+      if (!orgToUpdate) {
+        return;
+      }
+      try {
+        // Optimistic update UI - update all state prior to DB actions and revert if error
+        setOrgs((orgs) =>
+          orgs.map((org) => {
+            if (org.uniqueId !== sfdcOrgUniqueId) {
+              return org;
+            }
+            return {
+              ...org,
+              jetstreamOrganizationId: action === 'add' ? jetstreamOrganizationId : null,
+            };
+          })
+        );
+        setOrganizations((prevOrganizations) => {
+          return prevOrganizations.map((org) => {
+            if (org.id === jetstreamOrganizationId) {
+              if (action === 'add') {
+                return {
+                  ...org,
+                  orgs: [...org.orgs, orgToUpdate],
+                };
+              }
+              return {
+                ...org,
+                orgs: org.orgs.filter(({ uniqueId }) => uniqueId !== sfdcOrgUniqueId),
+              };
+            }
+            return org;
+          });
+        });
+        if (sfdcOrgUniqueId === selectedOrg?.uniqueId) {
+          setSelectedOrgId(null);
+        }
+        await addSfdcOrgToOrganization({
+          jetstreamOrganizationId: action === 'add' ? jetstreamOrganizationId : null,
+          sfdcOrgUniqueId,
+        });
+        // re-fetch just to make sure our state is accurate without blocking the UI
+        getJetstreamOrganizations().then(setOrganizationsFromDb);
+        trackEvent(ANALYTICS_KEYS.organizations_moved, { action });
+      } catch (ex) {
+        // revert org update
+        setOrgs(allOrgsBackup);
+        setOrganizations(organizationsBackup);
+        fireToast({
+          message: `Oops! There was a problem moving the Salesforce Org to the Organization. Please try again.`,
+          type: 'error',
+        });
+        rollbar.error('Organizations: Error moving org to organization', getErrorMessageAndStackObj(ex));
+        logger.error('Organizations: Error moving org to organization', ex);
+      }
+    },
+    [
+      allOrgs,
+      organizations,
+      rollbar,
+      selectedOrg?.uniqueId,
+      setOrganizations,
+      setOrganizationsFromDb,
+      setOrgs,
+      setSelectedOrgId,
+      trackEvent,
+    ]
+  );
+
+  const handleCreateOrUpdate = async (organization: JetstreamOrganizationCreateUpdatePayload) => {
+    let createdOrg: JetstreamOrganization;
+    if (selectedOrganization) {
+      trackEvent(ANALYTICS_KEYS.organizations_created, { priorCount: organizations.length });
+      createdOrg = await updateJetstreamOrganization(selectedOrganization.id, organization);
+    } else {
+      trackEvent(ANALYTICS_KEYS.organizations_updated, { count: organizations.length });
+      createdOrg = await createJetstreamOrganization(organization);
+    }
+    setOrganizationsFromDb((prevOrganizations) => {
+      const orgIndex = prevOrganizations.findIndex((org) => org.id === createdOrg.id);
+      if (orgIndex === -1) {
+        return [...prevOrganizations, createdOrg];
+      }
+      return prevOrganizations.map((org, index) => (index === orgIndex ? createdOrg : org));
+    });
+  };
+
+  const handleDelete = async (organization: JetstreamOrganizationWithOrgs) => {
+    if (
+      await ConfirmationModalPromise({
+        header: 'Delete Organization',
+        content: 'Any Salesforce Orgs will be removed from this organization but will not be deleted.',
+      })
+    ) {
+      await deleteJetstreamOrganization(organization.id);
+      setOrganizationsFromDb(await getJetstreamOrganizations());
+      setOrgs((orgs) =>
+        orgs.map((org) => {
+          if (org.jetstreamOrganizationId !== organization.id) {
+            return org;
+          }
+          return { ...org, jetstreamOrganizationId: null };
+        })
+      );
+      handleCloseOrganizationModal();
+      trackEvent(ANALYTICS_KEYS.organizations_deleted, { priorCount: organizations.length });
+    }
+  };
+
+  const handleOrganizationChange = useCallback(
+    (organization?: Maybe<JetstreamOrganizationWithOrgs>) => {
+      setActiveOrganizationId(organization?.id);
+      if (organization && (!selectedOrg || !organization.orgs.find(({ uniqueId }) => uniqueId === selectedOrg.uniqueId))) {
+        setSelectedOrgId(organization.orgs[0].uniqueId);
+      } else if (!organization && (!selectedOrg || selectedOrg.jetstreamOrganizationId != null)) {
+        const orgsWithNoOrganization = allOrgs.filter(({ jetstreamOrganizationId }) => !jetstreamOrganizationId);
+        setSelectedOrgId(orgsWithNoOrganization[0].uniqueId);
+      }
+    },
+    [allOrgs, selectedOrg, setActiveOrganizationId, setSelectedOrgId]
+  );
+
+  const handleOpenCreateOrganizationModal = async () => {
+    trackEvent(ANALYTICS_KEYS.organizations_create_modal_open, { priorCount: organizations.length });
+    setIsModalOption(true);
+  };
+
+  const handleCloseOrganizationModal = async () => {
+    setIsModalOption(false);
+    setSelectedOrganization(null);
+  };
+
+  return (
+    <Page testId="organization-page">
+      <PageHeader>
+        <PageHeaderRow>
+          <PageHeaderTitle icon={{ type: 'standard', icon: 'employee_organization' }} label="Organizations" docsPath="/organizations" />
+          <PageHeaderActions colType="actions" buttonType="separate">
+            <AddOrg className="slds-button slds-button_neutral" label="Add Salesforce Org" onAddOrg={handleAddOrg} />
+            <button className="slds-button slds-button_brand" onClick={() => handleOpenCreateOrganizationModal()}>
+              <Icon type="utility" icon="add" className="slds-button__icon slds-button__icon_left" />
+              Create New Organization
+            </button>
+          </PageHeaderActions>
+        </PageHeaderRow>
+        <PageHeaderRow>
+          <div>
+            <p>Organizations let you group your Salesforce Orgs so that you can keep your connections separated.</p>
+            <p>When you select an organization to work with, only those orgs show up in the org dropdown.</p>
+          </div>
+        </PageHeaderRow>
+      </PageHeader>
+      {isModalOpen && (
+        <OrganizationModal organization={selectedOrganization} onSubmit={handleCreateOrUpdate} onClose={handleCloseOrganizationModal} />
+      )}
+      <AutoFullHeightContainer bottomBuffer={5} className="slds-p-around_medium">
+        <p>Drag and drop to move salesforce orgs between organizations.</p>
+        <Grid vertical>
+          {organizations.map((organization) => (
+            <div key={organization.id} className="slds-m-top_x-small">
+              <OrganizationCard
+                isActive={activeOrganizationId === organization.id}
+                organization={organization}
+                activeSalesforceOrgId={selectedOrg?.uniqueId}
+                onMoveOrg={handleMoveSfdcOrgToOrganization}
+                onSelected={() => handleOrganizationChange(organization)}
+                onEditOrg={() => {
+                  setIsModalOption(true);
+                  setSelectedOrganization(organization.id);
+                }}
+                onDeleteOrg={() => handleDelete(organization)}
+              />
+            </div>
+          ))}
+        </Grid>
+        <hr className="slds-m-vertical_small" />
+        <OrganizationCardNoOrganization
+          isActive={!activeOrganizationId}
+          orgs={orgsWithoutOrganization}
+          activeSalesforceOrgId={selectedOrg?.uniqueId}
+          onSelected={() => handleOrganizationChange(null)}
+          onMoveOrg={handleMoveSfdcOrgToOrganization}
+        />
+      </AutoFullHeightContainer>
+    </Page>
+  );
+}
+
+export default Organizations;

--- a/libs/features/organizations/src/lib/SalesforceOrgCardDraggable.tsx
+++ b/libs/features/organizations/src/lib/SalesforceOrgCardDraggable.tsx
@@ -1,0 +1,104 @@
+import { css } from '@emotion/react';
+import { SalesforceOrgUi } from '@jetstream/types';
+import { Grid, Icon } from '@jetstream/ui';
+import { OrgInfoPopover, useUpdateOrgs } from '@jetstream/ui-core';
+import { useDrag } from 'react-dnd';
+import { DraggableSfdcCard } from './organization.types';
+
+interface SalesforceOrgCardDraggableProps {
+  org: SalesforceOrgUi;
+  isActive: boolean;
+}
+
+export function SalesforceOrgCardDraggable({ org, isActive }: SalesforceOrgCardDraggableProps) {
+  const { actionInProgress, orgLoading, handleAddOrg, handleRemoveOrg, handleUpdateOrg } = useUpdateOrgs();
+
+  const [{ opacity }, dragRef] = useDrag<DraggableSfdcCard, any, any>(
+    () => ({
+      type: 'SalesforceOrg',
+      item: { uniqueId: org.uniqueId, organizationId: org.jetstreamOrganizationId ?? null },
+      collect: (monitor) => ({
+        opacity: monitor.isDragging() ? 0.5 : 1,
+      }),
+    }),
+    [org.jetstreamOrganizationId]
+  );
+
+  return (
+    <div
+      ref={dragRef}
+      style={{ opacity }}
+      css={css`
+        width: 24rem;
+        position: relative;
+      `}
+    >
+      <div
+        css={css`
+          height: 113px;
+          cursor: grabbing;
+          ${isActive
+            ? `::after {
+            content: '';
+            position: absolute;
+            top: 0;
+            right: 0;
+            border-radius: 0 0.25rem 0 0;
+            border-left: 1rem solid transparent;
+            border-bottom: 1rem solid transparent;
+            border-right: 1rem solid transparent;
+            border-right-color: var(--slds-g-color-brand-base-60, #1b96ff);
+            border-top: 1rem solid transparent;
+            border-top-color: var(--slds-g-color-brand-base-60, #1b96ff);
+          }`
+            : ''}
+        `}
+        className="slds-box slds-box_link slds-box_x-small slds-media"
+      >
+        <div
+          className="slds-media__body slds-p-around_xx-small"
+          css={css`
+            cursor: grabbing;
+          `}
+        >
+          <Grid align="spread" className="slds-m-right_medium">
+            <h2 className="slds-truncate slds-text-heading_small">{org.label}</h2>
+            <Grid>
+              {org.color && (
+                <div
+                  className="slds-swatch slds-m-right_x-small"
+                  css={css`
+                    background: ${org.color};
+                  `}
+                />
+              )}
+              <OrgInfoPopover
+                org={org}
+                loading={orgLoading}
+                disableOrgActions={actionInProgress}
+                iconButtonClassName="slds-button slds-button_icon slds-button_icon-border-filled slds-button_icon-x-small"
+                onAddOrg={handleAddOrg}
+                onRemoveOrg={handleRemoveOrg}
+                onUpdateOrg={handleUpdateOrg}
+              />
+            </Grid>
+          </Grid>
+          <p className="slds-m-top_small">{org.organizationId}</p>
+          <p className="slds-truncate" title={org.instanceUrl}>
+            {org.instanceUrl}
+          </p>
+        </div>
+      </div>
+      {isActive && (
+        <Icon
+          type="utility"
+          icon="check"
+          className="slds-icon slds-icon-text-check slds-icon_x-small"
+          containerClassname="slds-icon_container slds-visual-picker__text-check"
+        />
+      )}
+    </div>
+  );
+}
+
+export default SalesforceOrgCardDraggable;

--- a/libs/features/organizations/src/lib/organization.types.ts
+++ b/libs/features/organizations/src/lib/organization.types.ts
@@ -1,0 +1,4 @@
+export interface DraggableSfdcCard {
+  uniqueId: string;
+  organizationId: string | null;
+}

--- a/libs/features/organizations/tsconfig.json
+++ b/libs/features/organizations/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "jsxImportSource": "@emotion/react",
+    "allowJs": false,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "strict": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/libs/features/organizations/tsconfig.lib.json
+++ b/libs/features/organizations/tsconfig.lib.json
@@ -1,0 +1,24 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "types": ["node"]
+  },
+  "exclude": [
+    "jest.config.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.test.ts",
+    "src/**/*.spec.tsx",
+    "src/**/*.test.tsx",
+    "src/**/*.spec.js",
+    "src/**/*.test.js",
+    "src/**/*.spec.jsx",
+    "src/**/*.test.jsx"
+  ],
+  "include": ["src/**/*.js", "src/**/*.jsx", "src/**/*.ts", "src/**/*.tsx"],
+  "files": [
+    "../../../node_modules/@nx/react/typings/cssmodule.d.ts",
+    "../../../node_modules/@nx/react/typings/image.d.ts",
+    "../../../custom-typings/index.d.ts"
+  ]
+}

--- a/libs/features/organizations/tsconfig.spec.json
+++ b/libs/features/organizations/tsconfig.spec.json
@@ -1,0 +1,23 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "module": "commonjs",
+    "noImplicitAny": false,
+    "strictNullChecks": false,
+    "strict": false,
+    "types": ["jest", "node"]
+  },
+  "include": [
+    "jest.config.ts",
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.test.tsx",
+    "src/**/*.spec.tsx",
+    "src/**/*.test.js",
+    "src/**/*.spec.js",
+    "src/**/*.test.jsx",
+    "src/**/*.spec.jsx",
+    "src/**/*.d.ts"
+  ]
+}

--- a/libs/icon-factory/src/lib/icon-factory.tsx
+++ b/libs/icon-factory/src/lib/icon-factory.tsx
@@ -23,6 +23,7 @@ import StandardIcon_Apex from './icons/standard/Apex';
 import StandardIcon_AssetRelationship from './icons/standard/AssetRelationship';
 import StandardIcon_BundleConfig from './icons/standard/BundleConfig';
 import StandardIcon_DataStreams from './icons/standard/DataStreams';
+import StandardIcon_EmployeeOrganization from './icons/standard/EmployeeOrganization';
 import StandardIcon_Entity from './icons/standard/Entity';
 import StandardIcon_Events from './icons/standard/Events';
 import StandardIcon_Feed from './icons/standard/Feed';
@@ -177,6 +178,7 @@ const standardIcons = {
   asset_relationship: StandardIcon_AssetRelationship,
   bundle_config: StandardIcon_BundleConfig,
   data_streams: StandardIcon_DataStreams,
+  employee_organization: StandardIcon_EmployeeOrganization,
   entity: StandardIcon_Entity,
   events: StandardIcon_Events,
   feed: StandardIcon_Feed,

--- a/libs/shared/constants/src/lib/shared-constants.ts
+++ b/libs/shared/constants/src/lib/shared-constants.ts
@@ -9,7 +9,7 @@ import {
 
 export const ORG_VERSION_PLACEHOLDER = '_DEFAULT_VERSION_';
 
-export const SESSION_EXP_DAYS = 5;
+export const SESSION_EXP_DAYS = 2;
 export const SFDC_BULK_API_NULL_VALUE = '#N/A';
 export const SFDC_BLANK_PICKLIST_VALUE = '--None--';
 
@@ -267,6 +267,16 @@ export const ANALYTICS_KEYS = {
   settings_resend_email_verification: 'settings_resend_email_verification',
   settings_delete_account: 'settings_delete_account',
 
+  /** ORGANIZATIONS */
+  organizations_create_modal_open: 'organizations_create_modal_open',
+  organizations_created: 'organizations_created',
+  organizations_deleted: 'organizations_deleted',
+  organizations_updated: 'organizations_updated',
+  organizations_moved: 'organizations_moved',
+
+  /** SFDC ORGS */
+  sfdc_org_add_org: 'sfdc_org_add_org',
+
   /** FEEDBACK */
   donate_popover_open: 'donate_popover_open',
   donate_popover_cta_click: 'donate_popover_cta_click',
@@ -290,6 +300,7 @@ export const TITLES = {
   PLATFORM_EVENTS: 'Platform Events | Jetstream',
   FEEDBACK: 'Support & Feedback | Jetstream',
   SETTINGS: 'Account Settings | Jetstream',
+  ORGANIZATIONS: 'Manage Organizations | Jetstream',
 };
 
 export const SOCKET_EVENTS = {

--- a/libs/shared/data/src/lib/client-data.ts
+++ b/libs/shared/data/src/lib/client-data.ts
@@ -21,11 +21,13 @@ import {
   GenericRequestPayload,
   GoogleFileApiResponse,
   InputReadFileContent,
+  JetstreamOrganization,
   ListMetadataQuery,
   ListMetadataResult,
   ListMetadataResultRaw,
   ManualRequestPayload,
   ManualRequestResponse,
+  Maybe,
   OperationReturnType,
   QueryResults,
   RetrieveResult,
@@ -111,6 +113,54 @@ export async function deleteOrg(org: SalesforceOrgUi): Promise<void> {
 
 export async function checkOrgHealth(org: SalesforceOrgUi): Promise<void> {
   return handleRequest({ method: 'POST', url: `/api/orgs/health-check` }, { org }).then(unwrapResponseIgnoreCache);
+}
+
+export async function addSfdcOrgToOrganization({
+  sfdcOrgUniqueId,
+  jetstreamOrganizationId,
+}: {
+  jetstreamOrganizationId?: Maybe<string>;
+  sfdcOrgUniqueId: string;
+}): Promise<SalesforceOrgUi> {
+  return handleRequest({ method: 'PUT', url: `/api/orgs/${sfdcOrgUniqueId}/move`, data: { jetstreamOrganizationId } }).then(
+    unwrapResponseIgnoreCache
+  );
+}
+
+export async function getJetstreamOrganizations(): Promise<JetstreamOrganization[]> {
+  return handleRequest({
+    method: 'GET',
+    url: `/api/jetstream-organizations`,
+  }).then(unwrapResponseIgnoreCache);
+}
+
+export async function createJetstreamOrganization(data: { name: string; description?: Maybe<string> }): Promise<JetstreamOrganization> {
+  return handleRequest({
+    method: 'POST',
+    url: `/api/jetstream-organizations`,
+    data,
+  }).then(unwrapResponseIgnoreCache);
+}
+
+export async function updateJetstreamOrganization(
+  id: string,
+  data: {
+    name: string;
+    description?: Maybe<string>;
+  }
+): Promise<JetstreamOrganization> {
+  return handleRequest({
+    method: 'PUT',
+    url: `/api/jetstream-organizations/${id}`,
+    data,
+  }).then(unwrapResponseIgnoreCache);
+}
+
+export async function deleteJetstreamOrganization(id: string): Promise<void> {
+  return handleRequest({
+    method: 'DELETE',
+    url: `/api/jetstream-organizations/${id}`,
+  }).then(unwrapResponseIgnoreCache);
 }
 
 /**

--- a/libs/shared/ui-core/src/app/AppHome.tsx
+++ b/libs/shared/ui-core/src/app/AppHome.tsx
@@ -65,6 +65,55 @@ export const AppHome = () => {
           justify-content: center;
         `}
       >
+        <div
+          className="slds-box slds-box_x-small"
+          css={css`
+            background-color: white;
+            grid-column: span 3;
+          `}
+        >
+          <article className="slds-tile slds-media">
+            <div className="slds-media__figure">
+              <Icon
+                type="standard"
+                icon="employee_organization"
+                containerClassname="slds-icon_container"
+                className={classNames('slds-icon slds-icon_small', `slds-icon-standard-employee-organization`)}
+              />
+            </div>
+            <div className="slds-media__body">
+              <h3
+                className="slds-text-title_caps"
+                css={css`
+                  line-height: 1.5rem;
+                  font-size: 0.85rem;
+                  font-weight: 600;
+                `}
+              >
+                {APP_ROUTES.ORGANIZATIONS.TITLE}
+                {APP_ROUTES.ORGANIZATIONS.NEW_UNTIL && APP_ROUTES.ORGANIZATIONS.NEW_UNTIL >= CURRENT_TIME && (
+                  <Badge type="success" className="slds-m-left_xx-small">
+                    NEW
+                  </Badge>
+                )}
+              </h3>
+              <Link to={APP_ROUTES.ORGANIZATIONS.ROUTE} className="slds-text-heading_x-small">
+                Manage Organizations
+              </Link>
+              <p>Group your Salesforce Orgs within an Organization so that you can isolate which orgs you are working with.</p>
+
+              <a href={APP_ROUTES.ORGANIZATIONS.DOCS} target="_blank" className="slds-text-body_small" rel="noreferrer">
+                Documentation
+                <Icon
+                  type="utility"
+                  icon="help_doc_ext"
+                  className="slds-icon slds-icon_xx-small slds-icon-text-default slds-m-left_xx-small"
+                  omitContainer
+                />
+              </a>
+            </div>
+          </article>
+        </div>
         {HOME_ITEMS.map((card) => (
           <div
             key={card.title}

--- a/libs/shared/ui-core/src/app/app-routes.ts
+++ b/libs/shared/ui-core/src/app/app-routes.ts
@@ -1,5 +1,6 @@
 type RouteKey =
   | 'HOME'
+  | 'ORGANIZATIONS'
   | 'QUERY'
   | 'LOAD'
   | 'LOAD_MULTIPLE'
@@ -32,6 +33,13 @@ export const APP_ROUTES: RouteMap = {
     ROUTE: '/home',
     TITLE: 'Home',
     DESCRIPTION: 'Welcome to Jetstream',
+  },
+  ORGANIZATIONS: {
+    ROUTE: '/organizations',
+    DOCS: 'https://docs.getjetstream.app/organizations',
+    TITLE: 'Organizations',
+    DESCRIPTION: 'Setup organizations to group Salesforce Orgs',
+    NEW_UNTIL: new Date(2024, 11, 31, 23, 59, 59).getTime(), // October 31, 2024
   },
   QUERY: {
     ROUTE: '/query',

--- a/libs/shared/ui-core/src/index.ts
+++ b/libs/shared/ui-core/src/index.ts
@@ -60,6 +60,7 @@ export * from './orgs/OrgsDropdown';
 export * from './orgs/OrgSelectionRequired';
 export * from './orgs/OrgWelcomeInstructions';
 export * from './orgs/useOrgPermissions';
+export * from './orgs/useUpdateOrgs';
 export * from './record/RecordSearchPopover';
 export * from './record/ViewChildRecords';
 export * from './record/ViewEditCloneRecord';

--- a/libs/shared/ui-core/src/orgs/OrgInfoPopover.tsx
+++ b/libs/shared/ui-core/src/orgs/OrgInfoPopover.tsx
@@ -9,6 +9,7 @@ import {
   Grid,
   GridCol,
   Icon,
+  IconProps,
   Input,
   Popover,
   SalesforceLogin,
@@ -45,6 +46,8 @@ export interface OrgInfoPopoverProps {
   loading?: boolean;
   disableOrgActions?: boolean;
   isReadOnly?: boolean;
+  dropdownIconProps?: Partial<IconProps>;
+  iconButtonClassName?: string;
   onAddOrg?: (org: SalesforceOrgUi, switchActiveOrg: boolean) => void;
   onRemoveOrg?: (org: SalesforceOrgUi) => void;
   onUpdateOrg?: (org: SalesforceOrgUi, updatedOrg: Partial<SalesforceOrgUi>) => void;
@@ -100,6 +103,8 @@ export const OrgInfoPopover: FunctionComponent<OrgInfoPopoverProps> = ({
   loading,
   disableOrgActions,
   isReadOnly = false,
+  dropdownIconProps,
+  iconButtonClassName,
   onAddOrg,
   onRemoveOrg,
   onUpdateOrg,
@@ -347,10 +352,10 @@ export const OrgInfoPopover: FunctionComponent<OrgInfoPopoverProps> = ({
         </div>
       }
       buttonProps={{
-        className: 'slds-button slds-button_icon',
+        className: iconButtonClassName || 'slds-button slds-button_icon',
       }}
     >
-      <Icon type="utility" icon="settings" className="slds-button__icon slds-button__icon_left slds-current-color" omitContainer />
+      <Icon type="utility" icon="settings" className="slds-button__icon slds-current-color" omitContainer {...dropdownIconProps} />
     </Popover>
   );
 };

--- a/libs/shared/ui-core/src/orgs/OrganizationSelector.tsx
+++ b/libs/shared/ui-core/src/orgs/OrganizationSelector.tsx
@@ -1,0 +1,142 @@
+import { css } from '@emotion/react';
+import { formatNumber } from '@jetstream/shared/ui-utils';
+import { pluralizeFromNumber } from '@jetstream/shared/utils';
+import { JetstreamOrganization, Maybe } from '@jetstream/types';
+import { Badge, Grid, Popover, PopoverRef } from '@jetstream/ui';
+import { ReactNode, useRef } from 'react';
+import { Link } from 'react-router-dom';
+
+interface OrganizationSelectorProps {
+  organizations: JetstreamOrganization[];
+  selectedOrganization?: Maybe<JetstreamOrganization>;
+  salesforceOrgsWithoutOrganization: number;
+  size?: 'small' | 'medium';
+  onSelection: (organization?: Maybe<JetstreamOrganization>) => void;
+}
+
+interface OrganizationPopoverProps {
+  selectedOrganization?: Maybe<JetstreamOrganization>;
+  organizations: JetstreamOrganization[];
+  salesforceOrgsWithoutOrganization: number;
+  children: ReactNode;
+  onSelection: (organization?: Maybe<JetstreamOrganization>) => void;
+}
+
+export function OrganizationSelector({
+  organizations,
+  selectedOrganization,
+  salesforceOrgsWithoutOrganization,
+  size,
+  onSelection,
+}: OrganizationSelectorProps) {
+  if (!selectedOrganization) {
+    return (
+      <div className="slds-align_absolute-center">
+        <OrganizationPopover
+          organizations={organizations}
+          salesforceOrgsWithoutOrganization={salesforceOrgsWithoutOrganization}
+          onSelection={onSelection}
+        >
+          Choose Organization
+        </OrganizationPopover>
+      </div>
+    );
+  }
+
+  return (
+    <Grid className="slds-align_absolute-center" verticalAlign="center">
+      <p
+        css={css`
+          font-size: ${size === 'small' ? '10px;' : '14px'}
+          margin-bottom: -2px;
+        `}
+      >
+        {selectedOrganization?.name}
+      </p>
+      <OrganizationPopover
+        selectedOrganization={selectedOrganization}
+        organizations={organizations}
+        salesforceOrgsWithoutOrganization={salesforceOrgsWithoutOrganization}
+        onSelection={onSelection}
+      >
+        Switch
+      </OrganizationPopover>
+    </Grid>
+  );
+}
+
+const OrganizationPopover = ({
+  selectedOrganization,
+  organizations,
+  salesforceOrgsWithoutOrganization,
+  children,
+  onSelection,
+}: OrganizationPopoverProps) => {
+  const popoverRef = useRef<PopoverRef>(null);
+
+  function handleSelection(organization?: Maybe<JetstreamOrganization>) {
+    onSelection(organization);
+    popoverRef?.current?.close();
+  }
+  return (
+    <Popover
+      ref={popoverRef}
+      header={
+        <header className="slds-popover__header">
+          <h2 className="slds-text-heading_small" title="Refresh Metadata">
+            Select Organization
+          </h2>
+        </header>
+      }
+      footer={
+        <footer className="slds-popover__footer">
+          <Link to="/organizations" onClick={() => popoverRef?.current?.close()}>
+            Manage Organizations
+          </Link>
+        </footer>
+      }
+      content={
+        <div
+          css={css`
+            max-height: 50vh;
+          `}
+        >
+          <p>When you choose an organization, only Salesforce Orgs within that organization will be available for selection.</p>
+          <ul className="slds-has-dividers_top-space slds-dropdown_length-5">
+            {organizations
+              .filter((organization) => !selectedOrganization || organization.id !== selectedOrganization.id)
+              .map((organization) => (
+                <li key={organization.id} className="slds-item" onClick={() => handleSelection(organization)}>
+                  <Grid className="slds-truncate" align="spread" verticalAlign="center">
+                    <button className="slds-button">{organization.name}</button>
+                    <Badge type="light" className="slds-m-left_xx-small">
+                      {formatNumber(organization.orgs.length)} {pluralizeFromNumber('Org', organization.orgs.length)}
+                    </Badge>
+                  </Grid>
+                </li>
+              ))}
+            {!!selectedOrganization && (
+              <li className="slds-item" onClick={() => handleSelection(null)}>
+                <Grid className="slds-truncate" align="spread" verticalAlign="center">
+                  <button className="slds-button">-No Organization-</button>
+                  <Badge type="light" className="slds-m-left_xx-small">
+                    {formatNumber(salesforceOrgsWithoutOrganization)} {pluralizeFromNumber('Org', salesforceOrgsWithoutOrganization)}
+                  </Badge>
+                </Grid>
+              </li>
+            )}
+          </ul>
+        </div>
+      }
+      buttonProps={{
+        className: 'slds-button slds-m-left_xx-small',
+      }}
+      buttonStyle={{
+        fontSize: '10px',
+        lineHeight: 'unset',
+      }}
+    >
+      {children}
+    </Popover>
+  );
+};

--- a/libs/shared/ui-core/src/orgs/useUpdateOrgs.ts
+++ b/libs/shared/ui-core/src/orgs/useUpdateOrgs.ts
@@ -1,0 +1,103 @@
+import { logger } from '@jetstream/shared/client-logger';
+import {
+  clearCacheForOrg,
+  clearQueryHistoryForOrg,
+  deleteOrg,
+  getJetstreamOrganizations,
+  getOrgs,
+  updateOrg,
+} from '@jetstream/shared/data';
+import { useObservable } from '@jetstream/shared/ui-utils';
+import { JetstreamEventAddOrgPayload, SalesforceOrgUi } from '@jetstream/types';
+import orderBy from 'lodash/orderBy';
+import uniqBy from 'lodash/uniqBy';
+import { useCallback, useEffect, useState } from 'react';
+import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
+import { Observable } from 'rxjs';
+import { fromAppState, fromJetstreamEvents } from '..';
+
+export function useUpdateOrgs() {
+  const [orgs, setOrgs] = useRecoilState(fromAppState.salesforceOrgsState);
+  const setSelectedOrgId = useSetRecoilState(fromAppState.selectedOrgIdState);
+  const actionInProgress = useRecoilValue(fromAppState.actionInProgressState);
+  const setJetstreamOrganizations = useSetRecoilState(fromAppState.jetstreamOrganizationsState);
+  const [orgLoading, setOrgLoading] = useState(false);
+
+  // subscribe to org changes from other places in the application
+  const onAddOrgFromExternalSource = useObservable(fromJetstreamEvents.getObservable('addOrg') as Observable<JetstreamEventAddOrgPayload>);
+
+  useEffect(() => {
+    if (onAddOrgFromExternalSource && onAddOrgFromExternalSource.org) {
+      handleAddOrg(onAddOrgFromExternalSource.org, onAddOrgFromExternalSource.switchActiveOrg);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [onAddOrgFromExternalSource]);
+
+  const handleRefetchOrgs = useCallback(async () => {
+    try {
+      setOrgs(await getOrgs());
+    } catch (ex) {
+      logger.warn('Error refreshing orgs', ex);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const handleRefetchOrganizations = useCallback(async () => {
+    try {
+      setJetstreamOrganizations(await getJetstreamOrganizations());
+    } catch (ex) {
+      logger.warn('Error refreshing orgs', ex);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  /**
+   * This is not in a useCallback because it caused an infinite loop since orgs changes a lot and is a dependency
+   */
+  const handleAddOrg = useCallback((org: SalesforceOrgUi, switchActiveOrg: boolean) => {
+    setOrgs((prevOrgs) => uniqBy(orderBy([org, ...prevOrgs], 'username'), 'uniqueId'));
+    if (switchActiveOrg) {
+      setSelectedOrgId(org.uniqueId);
+    }
+    handleRefetchOrgs();
+    handleRefetchOrganizations();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const handleRemoveOrg = useCallback(async (org: SalesforceOrgUi) => {
+    try {
+      await deleteOrg(org);
+      handleRefetchOrgs();
+      handleRefetchOrganizations();
+      setSelectedOrgId(null);
+      // async, but results are ignored as this will not throw
+      clearCacheForOrg(org);
+      clearQueryHistoryForOrg(org);
+    } catch (ex) {
+      logger.warn('Error removing org', ex);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const handleUpdateOrg = useCallback(async (org: SalesforceOrgUi, updatedOrg: Partial<SalesforceOrgUi>) => {
+    try {
+      setOrgLoading(true);
+      await updateOrg(org, updatedOrg);
+      setOrgs(await getOrgs());
+    } catch (ex) {
+      logger.warn('Error updating org', ex);
+    } finally {
+      setOrgLoading(false);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return {
+    orgs,
+    actionInProgress,
+    orgLoading,
+    handleAddOrg,
+    handleRemoveOrg,
+    handleUpdateOrg,
+  };
+}

--- a/libs/shared/ui-utils/src/lib/shared-ui-utils.ts
+++ b/libs/shared/ui-utils/src/lib/shared-ui-utils.ts
@@ -931,8 +931,11 @@ function handleWindowEvent(event: MessageEvent) {
   }
 }
 
-export function addOrg(options: { serverUrl: string; loginUrl: string; addLoginTrue?: boolean }, callback: (org: SalesforceOrgUi) => void) {
-  const { serverUrl, loginUrl, addLoginTrue } = options;
+export function addOrg(
+  options: { serverUrl: string; loginUrl: string; addLoginTrue?: boolean; jetstreamOrganizationId?: Maybe<string> },
+  callback: (org: SalesforceOrgUi) => void
+) {
+  const { serverUrl, loginUrl, addLoginTrue, jetstreamOrganizationId } = options;
   addOrgCallbackFn = callback;
   window.removeEventListener('message', handleWindowEvent);
   const strWindowFeatures = 'toolbar=no, menubar=no, width=1025, height=700';
@@ -941,6 +944,9 @@ export function addOrg(options: { serverUrl: string; loginUrl: string; addLoginT
   url.searchParams.set('clientUrl', document.location.origin);
   if (addLoginTrue) {
     url.searchParams.set('addLoginParam', 'true');
+  }
+  if (jetstreamOrganizationId) {
+    url.searchParams.set('jetstreamOrganizationId', jetstreamOrganizationId);
   }
   windowRef = window.open(url, 'Add Salesforce Org', strWindowFeatures);
   window.addEventListener('message', handleWindowEvent, false);

--- a/libs/types/src/index.ts
+++ b/libs/types/src/index.ts
@@ -12,5 +12,6 @@ export * from './lib/types';
 export * from './lib/ui/deploy-types';
 export * from './lib/ui/load-records-results-types';
 export * from './lib/ui/load-records-types';
+export * from './lib/ui/organization.types';
 export * from './lib/ui/permission-manager-types';
 export * from './lib/ui/types';

--- a/libs/types/src/lib/types.ts
+++ b/libs/types/src/lib/types.ts
@@ -286,6 +286,7 @@ export interface CloudinaryUploadResponse {
 }
 
 export interface SalesforceOrgUi {
+  jetstreamOrganizationId?: Maybe<string>;
   id?: number;
   uniqueId: string;
   label: string;

--- a/libs/types/src/lib/ui/organization.types.ts
+++ b/libs/types/src/lib/ui/organization.types.ts
@@ -1,0 +1,12 @@
+import type { JetstreamOrganization as JetstreamOrg } from '@prisma/client';
+import { SalesforceOrgUi } from '../types';
+
+export type JetstreamOrganization = Pick<JetstreamOrg, 'id' | 'name' | 'description' | 'createdAt' | 'updatedAt'> & {
+  orgs: { uniqueId: string }[];
+};
+
+export type JetstreamOrganizationWithOrgs = Pick<JetstreamOrg, 'id' | 'name' | 'description' | 'createdAt' | 'updatedAt'> & {
+  orgs: SalesforceOrgUi[];
+};
+
+export type JetstreamOrganizationCreateUpdatePayload = Pick<JetstreamOrganization, 'name' | 'description'>;

--- a/libs/ui/src/lib/layout/Header.tsx
+++ b/libs/ui/src/lib/layout/Header.tsx
@@ -1,3 +1,4 @@
+import { css } from '@emotion/react';
 import { DropDownItem, Maybe, UserProfileUi } from '@jetstream/types';
 import Avatar from '@salesforce-ux/design-system/assets/images/profile_avatar_96.png';
 import { Fragment, FunctionComponent, ReactNode, Suspense, useState } from 'react';
@@ -57,17 +58,40 @@ const HeaderContent: FunctionComponent<Omit<HeaderProps, 'children'>> = ({
   return (
     <Fragment>
       {/* LOGO */}
-      <div className="slds-global-header__item draggable">
-        <div className="slds-global-header__logo draggable" style={{ backgroundImage: `url(${logo})` }}></div>
+      <div
+        className="slds-global-header__item non-draggable"
+        css={css`
+          padding: 0 0.25rem;
+        `}
+      >
+        <div
+          css={css`
+            width: 10.7rem;
+          `}
+          className="slds-global-header__logo non-draggable"
+          style={{ backgroundImage: `url(${logo})` }}
+        ></div>
       </div>
       {/* ORGS */}
       {orgs && (
         <Suspense fallback={<div>Loading...</div>}>
-          <div className="slds-global-header__item non-draggable">{orgs}</div>
+          <div
+            className="slds-global-header__item non-draggable"
+            css={css`
+              padding: 0 0.25rem;
+            `}
+          >
+            {orgs}
+          </div>
         </Suspense>
       )}
       {/* RIGHT HAND AREA */}
-      <div className="slds-global-header__item draggable">
+      <div
+        className="slds-global-header__item non-draggable"
+        css={css`
+          padding: 0 0.25rem;
+        `}
+      >
         <ul className="slds-global-actions non-draggable">
           {rightHandMenuItems && Array.isArray(rightHandMenuItems) ? (
             rightHandMenuItems.map((item, i) => (
@@ -79,7 +103,12 @@ const HeaderContent: FunctionComponent<Omit<HeaderProps, 'children'>> = ({
             <li className="slds-global-actions__item non-draggable">{rightHandMenuItems}</li>
           )}
           {!isChromeExtension && (
-            <li className="slds-global-actions__item non-draggable">
+            <li
+              className="slds-global-actions__item non-draggable"
+              css={css`
+                padding: 0 0.25rem;
+              `}
+            >
               <div className="slds-dropdown-trigger slds-dropdown-trigger_click">
                 <DropDown
                   buttonClassName="slds-button slds-global-actions__avatar slds-global-actions__item-action"

--- a/prisma/migrations/20240905235920_add_organizations/migration.sql
+++ b/prisma/migrations/20240905235920_add_organizations/migration.sql
@@ -1,0 +1,20 @@
+-- AlterTable
+ALTER TABLE "salesforce_org" ADD COLUMN     "jetstreamOrganizationId" UUID;
+
+-- CreateTable
+CREATE TABLE "jetstream_organization" (
+    "id" UUID NOT NULL DEFAULT uuid_generate_v4(),
+    "userId" UUID NOT NULL,
+    "name" VARCHAR(60) NOT NULL,
+    "description" VARCHAR(255),
+    "createdAt" TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "jetstream_organization_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "jetstream_organization" ADD CONSTRAINT "jetstream_organization_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "salesforce_org" ADD CONSTRAINT "salesforce_org_jetstreamOrganizationId_fkey" FOREIGN KEY ("jetstreamOrganizationId") REFERENCES "jetstream_organization"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -8,17 +8,18 @@ datasource db {
 }
 
 model User {
-  id          String          @id @default(dbgenerated("uuid_generate_v4()")) @db.Uuid
-  userId      String          @unique @db.VarChar
-  email       String          @db.VarChar
-  name        String?         @db.VarChar
-  nickname    String?         @db.VarChar
-  picture     String?         @db.VarChar
-  appMetadata Json?           @db.Json
-  preferences UserPreference?
-  deletedAt   DateTime?
-  createdAt   DateTime        @default(now()) @db.Timestamp(6)
-  updatedAt   DateTime        @updatedAt
+  id            String                  @id @default(dbgenerated("uuid_generate_v4()")) @db.Uuid
+  userId        String                  @unique @db.VarChar
+  email         String                  @db.VarChar
+  name          String?                 @db.VarChar
+  nickname      String?                 @db.VarChar
+  picture       String?                 @db.VarChar
+  appMetadata   Json?                   @db.Json
+  preferences   UserPreference?
+  organizations JetstreamOrganization[]
+  deletedAt     DateTime?
+  createdAt     DateTime                @default(now()) @db.Timestamp(6)
+  updatedAt     DateTime                @updatedAt
 }
 
 model UserPreference {
@@ -28,6 +29,19 @@ model UserPreference {
   skipFrontdoorLogin Boolean  @default(false)
   createdAt          DateTime @default(now()) @db.Timestamp(6)
   updatedAt          DateTime @updatedAt
+}
+
+model JetstreamOrganization {
+  id          String          @id @default(dbgenerated("uuid_generate_v4()")) @db.Uuid
+  user        User            @relation(fields: [userId], references: [id])
+  userId      String          @db.Uuid
+  orgs        SalesforceOrg[]
+  name        String          @db.VarChar(60)
+  description String?         @db.VarChar(255)
+  createdAt   DateTime        @default(now()) @db.Timestamp(6)
+  updatedAt   DateTime        @updatedAt
+
+  @@map("jetstream_organization")
 }
 
 model SalesforceApi {
@@ -47,34 +61,36 @@ model SalesforceApi {
 }
 
 model SalesforceOrg {
-  id                     Int       @id @default(autoincrement())
-  jetstreamUserId        String    @db.VarChar
-  uniqueId               String    @db.VarChar
-  filterText             String    @db.VarChar
-  accessToken            String    @db.VarChar
-  instanceUrl            String    @db.VarChar
-  loginUrl               String    @db.VarChar
-  userId                 String    @db.VarChar(18)
-  email                  String    @db.VarChar
-  organizationId         String    @db.VarChar(18)
-  username               String    @db.VarChar
-  displayName            String    @db.VarChar
-  thumbnail              String?   @db.VarChar
-  apiVersion             String?   @db.VarChar
-  orgName                String?   @db.VarChar
-  orgCountry             String?   @db.VarChar
-  orgInstanceName        String?   @db.VarChar
-  orgIsSandbox           Boolean?
-  orgLanguageLocaleKey   String?   @db.VarChar
-  orgNamespacePrefix     String?   @db.VarChar
-  orgTrialExpirationDate DateTime? @db.Date
-  createdAt              DateTime  @default(now()) @db.Timestamp(6)
-  updatedAt              DateTime  @updatedAt
-  connectionError        String?   @db.VarChar
-  jetstreamUrl           String?   @db.VarChar
-  label                  String?   @db.VarChar(100)
-  orgOrganizationType    String?   @db.VarChar
-  color                  String?   @db.VarChar(10)
+  id                      Int                    @id @default(autoincrement())
+  jetstreamUserId         String                 @db.VarChar
+  jetstreamOrganization   JetstreamOrganization? @relation(fields: [jetstreamOrganizationId], references: [id])
+  jetstreamOrganizationId String?                @db.Uuid
+  uniqueId                String                 @db.VarChar
+  filterText              String                 @db.VarChar
+  accessToken             String                 @db.VarChar
+  instanceUrl             String                 @db.VarChar
+  loginUrl                String                 @db.VarChar
+  userId                  String                 @db.VarChar(18)
+  email                   String                 @db.VarChar
+  organizationId          String                 @db.VarChar(18)
+  username                String                 @db.VarChar
+  displayName             String                 @db.VarChar
+  thumbnail               String?                @db.VarChar
+  apiVersion              String?                @db.VarChar
+  orgName                 String?                @db.VarChar
+  orgCountry              String?                @db.VarChar
+  orgInstanceName         String?                @db.VarChar
+  orgIsSandbox            Boolean?
+  orgLanguageLocaleKey    String?                @db.VarChar
+  orgNamespacePrefix      String?                @db.VarChar
+  orgTrialExpirationDate  DateTime?              @db.Date
+  createdAt               DateTime               @default(now()) @db.Timestamp(6)
+  updatedAt               DateTime               @updatedAt
+  connectionError         String?                @db.VarChar
+  jetstreamUrl            String?                @db.VarChar
+  label                   String?                @db.VarChar(100)
+  orgOrganizationType     String?                @db.VarChar
+  color                   String?                @db.VarChar(10)
 
   @@unique([jetstreamUserId, jetstreamUrl, uniqueId], name: "uniqueOrg", map: "uniqueOrg")
   @@map("salesforce_org")

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -28,6 +28,7 @@
       "@jetstream/feature/load-records": ["libs/features/load-records/src/index.ts"],
       "@jetstream/feature/load-records-multi-object": ["libs/features/load-records-multi-object/src/index.ts"],
       "@jetstream/feature/manage-permissions": ["libs/features/manage-permissions/src/index.ts"],
+      "@jetstream/feature/organizations": ["libs/features/organizations/src/index.ts"],
       "@jetstream/feature/platform-event-monitor": ["libs/features/platform-event-monitor/src/index.ts"],
       "@jetstream/feature/query": ["libs/features/query/src/index.ts"],
       "@jetstream/feature/salesforce-api": ["libs/features/salesforce-api/src/index.ts"],


### PR DESCRIPTION
Organizations allow users to group SFDC orgs so that they can work on groups of orgs at one time in isolation.

This feature is most useful for consultants working across many separate groups of orgs, but is also useful to separate out production from other sandboxes etc..

With our new authentication provider, it appears like we may not be able to support multiple accounts with the same email address which was the catalyst for this feature.

resolves #1018