### PR TITLE
Ensure web scope is included in OAuth Connections

### DIFF
--- a/apps/api/src/app/services/oauth.service.ts
+++ b/apps/api/src/app/services/oauth.service.ts
@@ -48,7 +48,7 @@ export function salesforceOauthInit(
     login_hint: loginHint,
     nonce,
     prompt: 'login',
-    scope: 'api refresh_token',
+    scope: 'api web refresh_token',
     state,
   };
 


### PR DESCRIPTION
When the `web` scope is omitted, frontdoor login does not work

resolves #1090