### PR TITLE
Include SecondGen-Installed-Editable in automation control

### DIFF
--- a/libs/features/automation-control/src/automation-control-data-utils.tsx
+++ b/libs/features/automation-control/src/automation-control-data-utils.tsx
@@ -331,7 +331,7 @@ export async function getFlowsMetadata(selectedOrg: SalesforceOrgUi, sobjects: s
     )
   )
     .flatMap(({ queryResults }) => queryResults.records)
-    .filter((record) => record.ManageableState === 'unmanaged' || record.IsTemplate);
+    .filter((record) => record.ManageableState === 'unmanaged' || record.ManageableState === 'installedEditable' || record.IsTemplate);
   return flowMetadataRecords;
 }
 

--- a/libs/features/automation-control/src/automation-control-soql-utils.tsx
+++ b/libs/features/automation-control/src/automation-control-soql-utils.tsx
@@ -242,7 +242,7 @@ export function getFlowsQuery(sobjects: string[]) {
         left: {
           field: 'ManageableState',
           operator: 'IN',
-          value: ['unmanaged', 'installed'],
+          value: ['unmanaged', 'installedEditable', 'installed'],
           literalType: 'STRING',
         },
         operator: 'AND',


### PR DESCRIPTION
These flows are editable and should be included in the visible flows

resolves #1042