### PR TITLE
Add env var for default email mfa for new users

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,8 @@ NX_SFDC_API_VERSION='62.0'
 # trace, debug (default), info, warn, error, fatal, silent
 LOG_LEVEL='trace'
 
+# Default value for email two-factor authentication for new users
+JETSTREAM_AUTH_2FA_EMAIL_DEFAULT_VALUE='false'
 # Session signing secret - minimum of 32 characters
 # Generate using: `openssl rand -base64 32`
 JETSTREAM_SESSION_SECRET=''

--- a/libs/api-config/src/lib/env-config.ts
+++ b/libs/api-config/src/lib/env-config.ts
@@ -110,6 +110,7 @@ const envSchema = z.object({
   AUTH0_DOMAIN: z.string().nullish(),
 
   // JETSTREAM
+  JETSTREAM_AUTH_2FA_EMAIL_DEFAULT_VALUE: z.union([z.string(), z.boolean()]).optional().default(true).transform(ensureBoolean),
   JETSTREAM_AUTH_SECRET: z.string().describe('Used to sign authentication cookies.'),
   // Must be 32 characters
   JETSTREAM_AUTH_OTP_SECRET: z.string(),

--- a/libs/auth/server/src/lib/auth.db.service.ts
+++ b/libs/auth/server/src/lib/auth.db.service.ts
@@ -627,7 +627,7 @@ async function createUserFromProvider(providerUser: ProviderUser, provider: Oaut
       authFactors: {
         create: {
           type: '2fa-email',
-          enabled: true,
+          enabled: ENV.JETSTREAM_AUTH_2FA_EMAIL_DEFAULT_VALUE,
         },
       },
     },
@@ -740,7 +740,7 @@ async function createUserFromUserInfo(email: string, name: string, password: str
         authFactors: {
           create: {
             type: '2fa-email',
-            enabled: true,
+            enabled: ENV.JETSTREAM_AUTH_2FA_EMAIL_DEFAULT_VALUE,
           },
         },
       },


### PR DESCRIPTION
When running locally, it is more convenient to have email 2fa disabled