### PR TITLE
Fox copy cell to clipboard

### DIFF
--- a/libs/ui/src/lib/data-table/DataTable.tsx
+++ b/libs/ui/src/lib/data-table/DataTable.tsx
@@ -140,7 +140,7 @@ export const DataTable = forwardRef<any, DataTableProps<any>>(
                   row: filteredRows[contextMenuProps.rowIdx] as T,
                   rowIdx: contextMenuProps.rowIdx,
                   rows: filteredRows as T[],
-                  column: columns[contextMenuProps.rowIdx],
+                  column: contextMenuProps.column,
                   columns,
                 });
                 handleCloseContextMenu();

--- a/libs/ui/src/lib/data-table/DataTree.tsx
+++ b/libs/ui/src/lib/data-table/DataTree.tsx
@@ -134,7 +134,7 @@ export const DataTree = forwardRef<any, DataTreeProps<any>>(
                   row: filteredRows[contextMenuProps.rowIdx] as T,
                   rowIdx: contextMenuProps.rowIdx,
                   rows: filteredRows as T[],
-                  column: columns[contextMenuProps.rowIdx],
+                  column: contextMenuProps.column,
                   columns,
                 });
                 handleCloseContextMenu();


### PR DESCRIPTION
When refactoring the context menu, the column was not set correctly causing the incorrect cell value to be copied