### PR TITLE
Fix query restore date function detection

### DIFF
--- a/libs/features/query/src/QueryOptions/accordion-titles/QueryGroupByTitleSummary.tsx
+++ b/libs/features/query/src/QueryOptions/accordion-titles/QueryGroupByTitleSummary.tsx
@@ -23,7 +23,7 @@ export const QueryGroupByTitleSummary: FunctionComponent<QueryGroupByTitleSummar
             <Badge key={groupBy.field} className="slds-m-left_x-small slds-truncate" title={groupBy.fieldLabel || undefined}>
               {groupBy.function ? (
                 <>
-                  {groupBy.field}({groupBy.function})
+                  {groupBy.function}({groupBy.field})
                 </>
               ) : (
                 groupBy.field

--- a/libs/features/query/src/utils/query-filter.utils.ts
+++ b/libs/features/query/src/utils/query-filter.utils.ts
@@ -6,7 +6,6 @@ import {
   getFlattenedListItemsById,
   getPicklistListItems,
 } from '@jetstream/shared/ui-utils';
-import { REGEX } from '@jetstream/shared/utils';
 import {
   ExpressionConditionHelpText,
   ExpressionConditionRowSelectedItems,
@@ -18,6 +17,8 @@ import {
   Maybe,
   QueryFilterOperator,
 } from '@jetstream/types';
+import { isValid } from 'date-fns/isValid';
+import { parseISO } from 'date-fns/parseISO';
 
 // Used for GROUP BY and HAVING clause
 export const QUERY_FIELD_DATE_FUNCTIONS: ListItem<string, QueryFilterOperator>[] = [
@@ -217,7 +218,8 @@ export function getTypeFromMetadata(type: FieldType, operator: Maybe<QueryFilter
       // default to SELECT if value is a date literal (query restore would have a value)
       if (Array.isArray(value) || DATE_LITERALS_SET.has(value || '')) {
         return isListOperator(operator) ? 'SELECT-MULTI' : 'SELECT';
-      } else if (value && REGEX.NUMERIC.test(value)) {
+        // Set to manual value if text is not a valid date
+      } else if (value && !isValid(parseISO(value))) {
         return 'TEXT';
       }
       return 'DATE';
@@ -226,7 +228,8 @@ export function getTypeFromMetadata(type: FieldType, operator: Maybe<QueryFilter
       // default to SELECT (Relative Value) if no value or value is a date literal (query restore would have a value)
       if (!value || Array.isArray(value) || DATE_LITERALS_SET.has(value)) {
         return isListOperator(operator) ? 'SELECT-MULTI' : 'SELECT';
-      } else if (value && REGEX.NUMERIC.test(value)) {
+        // Set to manual value if text is not a valid date
+      } else if (value && !isValid(parseISO(value))) {
         return 'TEXT';
       }
       return 'DATETIME';

--- a/libs/features/query/src/utils/query-soql-utils.ts
+++ b/libs/features/query/src/utils/query-soql-utils.ts
@@ -9,6 +9,7 @@ import {
   WhereClause,
   isOrderByField,
   isValueCondition,
+  isValueFunctionCondition,
   isWhereOrHavingClauseWithRightCondition,
 } from '@jetstreamapp/soql-parser-js';
 import isString from 'lodash/isString';
@@ -205,6 +206,9 @@ function getParsableFieldsFromFilter(where: Maybe<WhereClause>, fields: string[]
   }
   if (isValueCondition(where.left)) {
     fields.push(where.left.field?.toLowerCase());
+  }
+  if (isValueFunctionCondition(where.left) && Array.isArray(where.left.fn.parameters) && isString(where.left.fn.parameters[0])) {
+    fields.push(where.left.fn.parameters[0].toLowerCase());
   }
   if (isWhereOrHavingClauseWithRightCondition(where)) {
     getParsableFieldsFromFilter(where.right, fields);


### PR DESCRIPTION
When restoring query, fallback to "Manual Value" if the provided value is not a valid date. This handles date literals with variables since we do not yet support those in the UI.

resolves #1110