### PR TITLE
Inline editing issues

### DIFF
--- a/libs/ui/src/lib/data-table/DataTable.tsx
+++ b/libs/ui/src/lib/data-table/DataTable.tsx
@@ -83,6 +83,7 @@ export const DataTable = forwardRef<any, DataTableProps<any>>(
       handleCellKeydown,
       handleCellContextMenu,
       handleCloseContextMenu,
+      handleRowChange,
     } = useDataTable({
       data,
       columns: _columns,
@@ -130,6 +131,12 @@ export const DataTable = forwardRef<any, DataTableProps<any>>(
             // @ts-expect-error Types are incorrect, but they are generic and difficult to get correct
             onCellContextMenu={handleCellContextMenu}
             {...rest}
+            onRowsChange={(rows, data) => {
+              if (rest.onRowsChange) {
+                handleRowChange(rows, data);
+                rest.onRowsChange(rows as any, data as any);
+              }
+            }}
           />
           {contextMenuProps && contextMenuItems && contextMenuAction && (
             <ContextMenu

--- a/libs/ui/src/lib/data-table/SalesforceRecordDataTable.tsx
+++ b/libs/ui/src/lib/data-table/SalesforceRecordDataTable.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/react';
 import { logger } from '@jetstream/shared/client-logger';
 import { queryRemaining } from '@jetstream/shared/data';
 import { formatNumber, useRollbar } from '@jetstream/shared/ui-utils';
-import { flattenRecord, getIdFromRecordUrl, nullifyEmptyStrings } from '@jetstream/shared/utils';
+import { flattenRecord, getIdFromRecordUrl, groupByFlat, nullifyEmptyStrings } from '@jetstream/shared/utils';
 import { CloneEditView, ContextMenuItem, Field, Maybe, QueryResults, SalesforceOrgUi, SobjectCollectionResponse } from '@jetstream/types';
 import uniqueId from 'lodash/uniqueId';
 import { Fragment, FunctionComponent, ReactNode, memo, useCallback, useEffect, useRef, useState } from 'react';
@@ -294,12 +294,23 @@ export const SalesforceRecordDataTable: FunctionComponent<SalesforceRecordDataTa
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
-    const handleRowsChange = useCallback((rows: RowSalesforceRecordWithKey[], data: RowsChangeData<RowSalesforceRecordWithKey[]>) => {
-      setRows(rows);
-      setDirtyRows(
-        rows.filter((row) => row._touchedColumns.size > 0 && Array.from(row._touchedColumns).some((col) => row[col] !== row._record[col]))
-      );
-    }, []);
+    const handleRowsChange = useCallback(
+      (
+        allRows: RowSalesforceRecordWithKey[],
+        filteredRows: RowSalesforceRecordWithKey[],
+        data: RowsChangeData<RowSalesforceRecordWithKey>
+      ) => {
+        const rowsByKey = groupByFlat(filteredRows, '_key');
+        const newRows = allRows.map((row) => rowsByKey[row._key] || row);
+        setRows(newRows);
+        setDirtyRows(
+          newRows.filter(
+            (row) => row._touchedColumns.size > 0 && Array.from(row._touchedColumns).some((col) => row[col] !== row._record[col])
+          )
+        );
+      },
+      []
+    );
 
     const handleCancelEditMode = () => {
       setRecords((records) => (records ? [...records] : records));
@@ -435,8 +446,7 @@ export const SalesforceRecordDataTable: FunctionComponent<SalesforceRecordDataTa
               onClick={handleSaveRecords}
               disabled={isSavingRecords}
             >
-              Save
-              {isSavingRecords && <Spinner size="small" />}
+              Save ({formatNumber(dirtyRows.length)}){isSavingRecords && <Spinner size="small" />}
             </button>
           </Grid>
         )}
@@ -469,7 +479,7 @@ export const SalesforceRecordDataTable: FunctionComponent<SalesforceRecordDataTa
               onReorderColumns={handleColumnReorder}
               onSelectedRowsChange={handleSelectedRowsChange}
               onSortedAndFilteredRowsChange={handleSortedAndFilteredRowsChange}
-              onRowsChange={handleRowsChange}
+              onRowsChange={(changedRows, data) => handleRowsChange(rows || [], changedRows, data)}
               context={{
                 org,
                 defaultApiVersion,


### PR DESCRIPTION
Inline editing while filters were applied would cause edited values to be removed from the table and would remain hidden even after resetting all filters.

This was caused because the SET filter did not update to include the new value, so the record would be filtered out from the table - and even after resetting, the filter values were not re-calculated.

In addition the onRecordChanged emits the filtered values, not all values, so the parent component was saving just the filtered records thinking that was the universe - this also caused some (most?) records to not be available to be saved when submitting to Salesforce.

To solve, the data table component intercepts the change and ensures that the table set filters are updated to include the new value in the list and select the new record column value.

Unfortunately this only solves the set filter and does not solve any other filters (text, date, etc..) - that would require a complete refactor of how state is managed for the table, which is high-risk and a lot of work - so we will deal with it for now. To help this, a number has been added to the submit button to show the number of changed records.

resolves #1113