### PR TITLE
Change app background color to avoid sharp contrast

### DIFF
--- a/apps/jetstream-web-extension/src/main.scss
+++ b/apps/jetstream-web-extension/src/main.scss
@@ -1,7 +1,7 @@
 @import '@salesforce-ux/design-system/scss/_design-tokens';
 
 html {
-  background-color: rgb(17, 24, 39);
+  background: var(--lwc-brandBackgroundPrimary, rgba(176, 196, 223, 1));
 }
 
 .app {

--- a/apps/jetstream/src/main.scss
+++ b/apps/jetstream/src/main.scss
@@ -10,7 +10,7 @@
 }
 
 html {
-  background-color: rgb(17, 24, 39);
+  background: var(--lwc-brandBackgroundPrimary, rgba(176, 196, 223, 1));
 }
 
 .app {

--- a/libs/ui/.storybook/main.scss
+++ b/libs/ui/.storybook/main.scss
@@ -1,7 +1,7 @@
 @import '~@salesforce-ux/design-system/scss/_design-tokens';
 
 html {
-  background-color: rgb(17, 24, 39);
+  background: var(--lwc-brandBackgroundPrimary, rgba(176, 196, 223, 1));
 }
 
 .app {


### PR DESCRIPTION
Matched salesforce brand color of light blue - this applies mostly to the app home page, but also applies to the background between components

work towards #1109

<img width="1246" alt="image" src="https://github.com/user-attachments/assets/f40c08d9-9ffd-47f7-8e3f-d05ea28effbf" />
