### PR TITLE
Fix inline editor date picker

### DIFF
--- a/libs/ui/src/lib/data-table/DataTableEditors.tsx
+++ b/libs/ui/src/lib/data-table/DataTableEditors.tsx
@@ -253,6 +253,7 @@ export function DataTableEditorDate<TRow extends { _idx: number }, TSummaryRow>(
         initialSelectedDate={currDate}
         openOnInit
         inputProps={{ autoFocus: true }}
+        trigger="onBlur"
         onChange={(value) => {
           /** setTimeout is used to avoid a React error about flushSync being called during a render */
           setTimeout(() => {


### PR DESCRIPTION
The date picker would close when the user entered a valid date, prior to entering the entire date. This was resolved by not emitting the change until the element is blurred and the date was modified and is valid

resolves #1117