### PR TITLE
[WIP] Fix Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -13,7 +13,7 @@
 
 # Include specific files
 !/yarn.lock
-!/.eslintrc.json
+!/eslint.config.js
 !/.gitignore
 !/babel.config.json
 !/Dockerfile


### PR DESCRIPTION
eslint file names were changes with the migration to the flat config but this was not updated in docker-ignore to include that file

resolves #1140