### PR TITLE
Fix record sync bug with too long of key length

### DIFF
--- a/apps/api/src/app/controllers/data-sync.controller.ts
+++ b/apps/api/src/app/controllers/data-sync.controller.ts
@@ -27,7 +27,7 @@ export const SyncRecordOperationSchemaFillHashedKey = z
             (record as any).data = record.hashedKey;
           }
           if (!(record as any).data?.hashedKey) {
-            (record as any).data = record.hashedKey;
+            (record as any).data.hashedKey = record.hashedKey;
           }
           return record;
         })

--- a/apps/api/src/app/controllers/data-sync.controller.ts
+++ b/apps/api/src/app/controllers/data-sync.controller.ts
@@ -24,7 +24,6 @@ export const SyncRecordOperationSchemaFillHashedKey = z
         records.map((record) => {
           if (!record.hashedKey) {
             record.hashedKey = userSyncDbService.hashRecordSyncKey(record.key);
-            (record as any).data = record.hashedKey;
           }
           if (!(record as any).data?.hashedKey) {
             (record as any).data.hashedKey = record.hashedKey;

--- a/apps/api/src/app/controllers/data-sync.controller.ts
+++ b/apps/api/src/app/controllers/data-sync.controller.ts
@@ -8,6 +8,32 @@ import { emitRecordSyncEventsToOtherClients, SyncEvent } from '../services/data-
 import { sendJson } from '../utils/response.handlers';
 import { createRoute } from '../utils/route.utils';
 
+// FIXME: TEMPORARY UNTIL ALL CLIENTS HAVE BEEN BACKFILLED
+export const SyncRecordOperationSchemaFillHashedKey = z
+  .object({
+    key: z.string(),
+    hashedKey: z.string().optional(),
+    data: z.record(z.unknown()),
+  })
+  .passthrough()
+  .array()
+  .transform((records) => {
+    return SyncRecordOperationSchema.array()
+      .max(userSyncDbService.MAX_SYNC)
+      .parse(
+        records.map((record) => {
+          if (!record.hashedKey) {
+            record.hashedKey = userSyncDbService.hashRecordSyncKey(record.key);
+            (record as any).data = record.hashedKey;
+          }
+          if (!(record as any).data?.hashedKey) {
+            (record as any).data = record.hashedKey;
+          }
+          return record;
+        })
+      );
+  });
+
 export const routeDefinition = {
   pull: {
     controllerFn: () => pull,
@@ -48,7 +74,9 @@ export const routeDefinition = {
           .default(false)
           .transform(ensureBoolean),
       }),
-      body: SyncRecordOperationSchema.array().max(userSyncDbService.MAX_SYNC),
+      body: SyncRecordOperationSchemaFillHashedKey,
+      // Original code:
+      // body: SyncRecordOperationSchema.array().max(userSyncDbService.MAX_SYNC),
       hasSourceOrg: false,
     },
   },
@@ -81,7 +109,7 @@ const push = createRoute(routeDefinition.push.validators, async ({ user, body: r
 
   const syncEvent: SyncEvent = {
     clientId: query.clientId,
-    data: { keys: response.records.map(({ key }) => key) },
+    data: { hashedKeys: response.records.map(({ hashedKey }) => hashedKey) },
     userId: user.id,
   };
 

--- a/apps/api/src/app/controllers/web-extension.controller.ts
+++ b/apps/api/src/app/controllers/web-extension.controller.ts
@@ -178,7 +178,7 @@ const dataSyncPush = createRoute(routeDefinition.dataSyncPush.validators, async 
 
   const syncEvent: SyncEvent = {
     clientId: query.clientId,
-    data: { keys: response.records.map(({ key }) => key) },
+    data: { hashedKeys: response.records.map(({ hashedKey }) => hashedKey) },
     userId: user.id,
   };
 

--- a/apps/api/src/app/services/data-sync-broadcast.service.ts
+++ b/apps/api/src/app/services/data-sync-broadcast.service.ts
@@ -8,7 +8,7 @@ const SyncEventSchema = z.object({
   userId: z.string(),
   clientId: z.string(),
   data: z.object({
-    keys: z.array(z.string()),
+    hashedKeys: z.array(z.string()),
   }),
 });
 export type SyncEvent = z.infer<typeof SyncEventSchema>;
@@ -17,7 +17,7 @@ export const emitRecordSyncEventsToOtherClients = async (sessionOrDeviceId: stri
   try {
     const { data, userId } = SyncEventSchema.parse(event);
 
-    const eventResponse = await userSyncDbService.findByKeys({ userId, keys: data.keys });
+    const eventResponse = await userSyncDbService.findByKeys({ userId, hashedKeys: data.hashedKeys });
 
     emitSocketEvent({
       event: 'RECORD_SYNC',

--- a/apps/cron-tasks/src/__tests__/clean-up-user-sync-history.spec.ts
+++ b/apps/cron-tasks/src/__tests__/clean-up-user-sync-history.spec.ts
@@ -37,14 +37,16 @@ export function generateSyncRecords({
   const createdAt = addDays(new Date(), -30);
   return new Array(count).fill(0).map(() => {
     const key = `qh_${orgId}:SELECTIdFROMAccount${uuid()}`;
+    const hashedKey = `${entity}_${key}`;
     return {
       id: uuid(),
       userId: userId,
       orgId: orgId,
-      key: key,
+      key,
+      hashedKey,
       entity: entity,
       data: {
-        key: key,
+        key,
         isFavorite: isFavorite,
       },
       createdAt: createdAt,

--- a/apps/cron-tasks/src/__tests__/clean-up-user-sync-history.spec.ts
+++ b/apps/cron-tasks/src/__tests__/clean-up-user-sync-history.spec.ts
@@ -1,6 +1,7 @@
 import { PrismaClient } from '@prisma/client';
 import { addDays } from 'date-fns';
 import * as dotenv from 'dotenv';
+import { createHash } from 'node:crypto';
 import { v4 as uuid } from 'uuid';
 import {
   cleanUpUserSyncHistory,
@@ -12,6 +13,9 @@ import {
 
 dotenv.config();
 
+const hashRecordSyncKey = (key: string): string => {
+  return createHash('SHA1').update(key).digest('hex');
+};
 // Ensure this runs against a test database
 export const prisma = new PrismaClient({
   datasourceUrl: process.env.PRISMA_TEST_DB_URI || 'postgres://postgres:postgres@postgres:5432/testdb',
@@ -37,7 +41,7 @@ export function generateSyncRecords({
   const createdAt = addDays(new Date(), -30);
   return new Array(count).fill(0).map(() => {
     const key = `qh_${orgId}:SELECTIdFROMAccount${uuid()}`;
-    const hashedKey = `${entity}_${key}`;
+    const hashedKey = hashRecordSyncKey(key);
     return {
       id: uuid(),
       userId: userId,

--- a/libs/features/load-records/src/components/load-mapping-storage/SaveMappingPopover.tsx
+++ b/libs/features/load-records/src/components/load-mapping-storage/SaveMappingPopover.tsx
@@ -3,13 +3,14 @@ import { formatNumber } from '@jetstream/shared/ui-utils';
 import { pluralizeIfMultiple } from '@jetstream/shared/utils';
 import { FieldMapping, LoadSavedMappingItem } from '@jetstream/types';
 import { Grid, Icon, Input, Popover, PopoverRef, ScopedNotification, Tooltip } from '@jetstream/ui';
-import { dexieDb } from '@jetstream/ui/db';
+import { dexieDb, hashRecordKey } from '@jetstream/ui/db';
 import { formatISO } from 'date-fns/formatISO';
 import omit from 'lodash/omit';
 import { FunctionComponent, useEffect, useMemo, useRef, useState } from 'react';
 
 const getDefaultItem = (sobject: string): LoadSavedMappingItem => ({
   key: 'lsm_',
+  hashedKey: '',
   name: '',
   sobject,
   csvFields: [],
@@ -53,10 +54,11 @@ export const SaveMappingPopover: FunctionComponent<SaveMappingPopoverProps> = ({
     );
   }, [fieldMapping, sobject]);
 
-  function handleSave() {
+  async function handleSave() {
     const newMapping: LoadSavedMappingItem = { ...currentSavedMapping, name: mappingName };
     newMapping.createdAt = new Date();
     newMapping.key = `lsm_${sobject}:${newMapping.csvFields.length}:${formatISO(newMapping.createdAt).toLowerCase()}`;
+    newMapping.hashedKey = await hashRecordKey(newMapping.key);
     dexieDb.load_saved_mapping.put(newMapping);
     saveSetMappingName('');
     setCurrentSavedMapping(getDefaultItem(sobject));

--- a/libs/shared/ui-core/src/data-sync/client-data-sync.db.ts
+++ b/libs/shared/ui-core/src/data-sync/client-data-sync.db.ts
@@ -11,7 +11,7 @@ import {
   SyncRecordOperation,
   SyncType,
 } from '@jetstream/types';
-import { dexieDb, SyncableEntities, SyncableTables } from '@jetstream/ui/db';
+import { dexieDb, hashRecordKey, SyncableEntities, SyncableTables } from '@jetstream/ui/db';
 import { parseISO } from 'date-fns';
 import Dexie from 'dexie';
 import type { ICreateChange, IDatabaseChange, IDeleteChange, IUpdateChange } from 'dexie-observable/api';
@@ -39,6 +39,7 @@ interface DeleteEvent {
   type: 'delete';
   entity: SyncType;
   key: string;
+  hashedKey: string;
   deletedAt: Date;
 }
 
@@ -68,14 +69,15 @@ function filterInvalidKeyPrefixes(key: string): boolean {
 
 function transformEntityToSyncRecord(data: CreateOrUpdateEvent | DeleteEvent): SyncRecordOperation {
   if (data.type === 'delete') {
-    const { type, entity, key, deletedAt } = data;
-    return { key, type, entity, deletedAt };
+    const { type, entity, key, hashedKey, deletedAt } = data;
+    return { key, hashedKey, type, entity, deletedAt };
   }
   const { type, keyPrefix, fullRecord } = data;
   switch (keyPrefix) {
     case 'qh': {
       return {
         key: fullRecord.key,
+        hashedKey: fullRecord.hashedKey,
         type,
         entity: 'query_history',
         orgId: fullRecord.org,
@@ -87,6 +89,7 @@ function transformEntityToSyncRecord(data: CreateOrUpdateEvent | DeleteEvent): S
     case 'lsm': {
       return {
         key: fullRecord.key,
+        hashedKey: fullRecord.hashedKey,
         type,
         entity: 'load_saved_mapping',
         data: fullRecord as any,
@@ -214,6 +217,14 @@ async function sendChangesToServer(changes: IDatabaseChange[], syncedRevision: M
     changes.filter(({ table, type }) => SyncableEntities.has(table as keyof typeof SyncableTables)).map((change) => change.key)
   );
 
+  // FIXME: this is temporary just to smooth out the data sync - remove after backfill is complete
+  // Backfill hashed key as needed
+  for (const obj of Object.values(existingRecordsById)) {
+    if (obj.key && !obj.hashedKey) {
+      obj.hashedKey = await hashRecordKey(obj.key);
+    }
+  }
+
   const changesByType = changes
     .filter((record) => SyncableEntities.has(record.table as keyof typeof SyncableTables))
     .reduce(
@@ -246,7 +257,7 @@ async function sendChangesToServer(changes: IDatabaseChange[], syncedRevision: M
         .filter((obj) => filterInvalidKeyPrefixes(obj.key))
         .map(({ obj }) => transformEntityToSyncRecord({ keyPrefix: getKeyPrefix(obj.key), type: 'create', fullRecord: obj })),
       ...changesByType.updates
-        .filter((obj) => filterInvalidKeyPrefixes(obj.key))
+        .filter((obj) => filterInvalidKeyPrefixes(obj.key) && existingRecordsById[obj.key])
         .map(({ mods, key }) =>
           transformEntityToSyncRecord({
             keyPrefix: getKeyPrefix(key),
@@ -254,11 +265,12 @@ async function sendChangesToServer(changes: IDatabaseChange[], syncedRevision: M
             fullRecord: existingRecordsById[key],
           })
         ),
-      ...changesByType.deletes.map(({ key }) =>
+      ...changesByType.deletes.map(({ key, oldObj }) =>
         transformEntityToSyncRecord({
           entity: 'query_history',
           type: 'delete',
           key,
+          hashedKey: oldObj.hashedKey,
           deletedAt,
         })
       ),
@@ -274,7 +286,8 @@ async function sendChangesToServer(changes: IDatabaseChange[], syncedRevision: M
 async function handleServerSyncResponse({ records, updatedAt }: PullResponse, applyRemoteChanges: ApplyRemoteChangesFunction) {
   try {
     const existingRecordsById = await getAllSyncableRecordsById(records.map(({ key }) => key));
-    const serverChanges = records.map(({ entity, data, key, deletedAt }) => {
+    const serverChanges = records.map(({ entity, data, key, hashedKey, deletedAt }) => {
+      data.hashedKey = data.hashedKey ?? hashedKey;
       enrichDataTypes(entity, data);
 
       if (deletedAt) {
@@ -282,7 +295,7 @@ async function handleServerSyncResponse({ records, updatedAt }: PullResponse, ap
         return { type: 3, table: entity, key, oldObj: null } as IDeleteChange;
       } else if (existingRecordsById[key]) {
         // UPDATE
-        const mods = getObjectDiffForDexie(data, existingRecordsById[key]);
+        const mods = getObjectDiffForDexie(existingRecordsById[key], data);
         return { type: 2, table: entity, key, obj: data, mods, oldObj: existingRecordsById[key] } as IUpdateChange;
       } else {
         // CREATE

--- a/libs/shared/ui-core/src/data-sync/query-history-object.db.ts
+++ b/libs/shared/ui-core/src/data-sync/query-history-object.db.ts
@@ -22,15 +22,6 @@ dexieDb.query_history.hook('creating', function (primaryKey, obj, transaction) {
   };
 });
 
-/**
- * Boolean fields cannot be indexes, so we store a string version of the same field
- */
-dexieDb.query_history.hook('updating', function (mods, primaryKey, obj, transaction) {
-  if ('isFavorite' in mods) {
-    return { ...mods, isFavoriteIdx: mods.isFavorite ? 'true' : 'false' };
-  }
-});
-
 function generateKey(orgUniqueId: string, sObject: string, isTooling: boolean): string {
   return `qho_${orgUniqueId}:${sObject}:${isTooling}`.toLowerCase();
 }

--- a/libs/shared/ui-db/src/lib/ui-db.ts
+++ b/libs/shared/ui-db/src/lib/ui-db.ts
@@ -36,6 +36,15 @@ const isChromeExtension = () => {
   }
 };
 
+export async function hashRecordKey(key: string) {
+  const encoder = new TextEncoder();
+  const data = encoder.encode(key);
+  const hashBuffer = await crypto.subtle.digest('SHA-1', data);
+  const hashArray = Array.from(new Uint8Array(hashBuffer));
+  const hashHex = hashArray.map((b) => b.toString(16).padStart(2, '0')).join('');
+  return hashHex;
+}
+
 export const DEXIE_DB_NAME = isChromeExtension() ? 'jetstream-web-extension' : 'jetstream';
 export const DEXIE_DB_SYNC_NAME = isChromeExtension() ? 'jetstream-web-extension' : 'jetstream';
 export const DEXIE_DB_SYNC_PATH = '/';

--- a/libs/types/src/lib/sync/sync.types.ts
+++ b/libs/types/src/lib/sync/sync.types.ts
@@ -18,6 +18,7 @@ export type EntitySyncStatus = z.infer<typeof EntitySyncStatusSchema>;
 
 export const SyncRecordOperationBaseSchema = z.object({
   key: z.string(),
+  hashedKey: z.string(),
   entity: SyncTypeSchema,
 });
 
@@ -46,6 +47,7 @@ export type SyncRecordOperation = z.infer<typeof SyncRecordOperationSchema>;
 // TODO: have a browser and server version - createdAt is a server managed prop
 export const SyncRecordSchema = z.object({
   key: z.string(),
+  hashedKey: z.string(),
   entity: SyncTypeSchema,
   orgId: z.string().nullish(),
   data: z.record(z.unknown()),
@@ -54,16 +56,6 @@ export const SyncRecordSchema = z.object({
   deletedAt: DateTimeSchema.nullish(),
 });
 export type SyncRecord = z.infer<typeof SyncRecordSchema>;
-
-export const SyncRecordRequestSchema = z.object({
-  key: z.string(),
-  entity: SyncTypeSchema,
-  data: z.record(z.unknown()),
-  createdAt: DateTimeSchema,
-  updatedAt: DateTimeSchema,
-  deletedAt: DateTimeSchema.nullish(),
-});
-export type SyncRecordRequest = z.infer<typeof SyncRecordRequestSchema>;
 
 export const PullResponseSchema = z.object({
   records: SyncRecordSchema.array(),
@@ -75,6 +67,7 @@ export type PullResponse = z.infer<typeof PullResponseSchema>;
 
 export interface QueryHistoryItem {
   key: `qh_${string}`; // org:object:(lowercase/removespaces(soql))
+  hashedKey: string;
   org: string;
   sObject: string;
   label: string;
@@ -100,6 +93,7 @@ export interface QueryHistoryObject {
 
 export interface LoadSavedMappingItem {
   key: `lsm_${string}`; // object:csvFieldLength:createdAt
+  hashedKey: string;
   name: string;
   sobject: string;
   csvFields: string[];

--- a/prisma/migrations/20250208000003_record_sync_hashed_key/migration.sql
+++ b/prisma/migrations/20250208000003_record_sync_hashed_key/migration.sql
@@ -1,0 +1,24 @@
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+-- DropIndex
+DROP INDEX "user_key_org";
+
+-- AlterTable - add hashedKey column
+ALTER TABLE "user_sync_data"
+  ADD COLUMN "hashedKey" CHAR(40);
+
+-- AlterTable - hash existing key
+UPDATE "user_sync_data"
+SET "hashedKey" = encode(digest(key, 'sha1'), 'hex');
+
+-- AlterTable - Add hash key to data object
+UPDATE "user_sync_data"
+SET data = jsonb_set(data, '{hashedKey}', to_jsonb("hashedKey")::jsonb)
+WHERE data->>'hashedKey' IS NULL;
+
+-- Ensure hashedKey is not null
+ALTER TABLE "user_sync_data"
+  ALTER COLUMN "hashedKey" SET NOT NULL;
+
+-- Re-CreateIndex
+CREATE UNIQUE INDEX "user_hashed_key_org" ON "user_sync_data"("userId", "hashedKey", "orgId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -297,6 +297,7 @@ model UserSyncData {
   userId    String    @db.Uuid
   orgId     String?
   key       String
+  hashedKey String    @db.Char(40)
   entity    String
   data      Json
   createdAt DateTime  @default(now()) @db.Timestamp(6)
@@ -305,7 +306,7 @@ model UserSyncData {
 
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 
-  @@unique([userId, key, orgId], name: "userKeyOrg", map: "user_key_org")
+  @@unique([userId, hashedKey, orgId], name: "userHashedKeyOrg", map: "user_hashed_key_org")
   @@index([userId, entity, updatedAt])
   @@index([deletedAt])
   @@map("user_sync_data")


### PR DESCRIPTION
Since we use the SOQL query as the key, this was causing save issues because it was too large to be indexed, which cause the record sync to fail for some users with long SOQL queries

To resolve, we now hash the query 40 character SHA1 hash so that we have a pre-determined field length which we know we can index on

This required a data backfill which is non-trivial since the browser needs to use an async hashing function, so we could not cover in a normal DB upgrade.

For the immediate term we are running a browser migration and also populating just-in-time on the server to handle any cases where the records might get synced prior to the browser migration being executed