### PR TITLE
Ensure requests get routed to same worker cluster

### DIFF
--- a/apps/api/src/app/controllers/socket.controller.ts
+++ b/apps/api/src/app/controllers/socket.controller.ts
@@ -4,6 +4,7 @@ import { UserProfileSession } from '@jetstream/auth/types';
 import { HTTP } from '@jetstream/shared/constants';
 import { SocketEvent } from '@jetstream/types';
 import { createAdapter } from '@socket.io/cluster-adapter';
+import { setupWorker } from '@socket.io/sticky';
 import * as express from 'express';
 import { IncomingMessage, createServer } from 'http';
 import { nanoid } from 'nanoid';
@@ -119,6 +120,7 @@ export function initSocketServer(
 
   if (cluster.isWorker) {
     io.adapter(createAdapter());
+    setupWorker(io);
   }
 
   io.engine.use((req: Request, res: Response, next: express.NextFunction) => {

--- a/apps/api/src/app/db/data-sync.db.ts
+++ b/apps/api/src/app/db/data-sync.db.ts
@@ -31,6 +31,7 @@ const SELECT = Prisma.validator<Prisma.UserSyncDataSelect>()({
 });
 
 export const findByKeys = async ({ hashedKeys, userId }: { userId: string; hashedKeys: string[] }) => {
+  hashedKeys = hashedKeys.filter(Boolean);
   return await prisma.userSyncData
     .findMany({
       select: SELECT,
@@ -169,7 +170,7 @@ export const syncRecordChanges = async ({
     throw new Error(`Cannot sync more than ${MAX_SYNC} records at a time`);
   }
 
-  const recordsByHashedKey = Object.keys(groupByFlat(records, 'hashedKey'));
+  const recordsByHashedKey = Object.keys(groupByFlat(records, 'hashedKey')).filter(Boolean);
 
   const existingRecordsById = groupByFlat(
     await prisma.userSyncData.findMany({

--- a/libs/shared/data/src/lib/client-socket-data.ts
+++ b/libs/shared/data/src/lib/client-socket-data.ts
@@ -5,6 +5,11 @@ import { io, Socket } from 'socket.io-client';
 
 let socket: Socket<DefaultEventsMap, DefaultEventsMap> | null = null;
 
+// websocket could introduce a 10 second delay in the connection if it fails, but that is fine for our use-case
+// websocket first does not rely on sticky sessions - so this is more reliable for most users
+// but some corporate users may not have the ability to perform websocket connections
+const transports = ['websocket', 'polling'];
+
 export function initSocket(serverUrl?: string, additionalHeaders?: Record<string, string>) {
   if (socket) {
     return;
@@ -14,11 +19,13 @@ export function initSocket(serverUrl?: string, additionalHeaders?: Record<string
       rememberUpgrade: true,
       withCredentials: true,
       extraHeaders: additionalHeaders,
+      transports,
     });
   } else {
     socket = io({
       rememberUpgrade: true,
       withCredentials: true,
+      transports,
     });
   }
 

--- a/package.json
+++ b/package.json
@@ -278,6 +278,7 @@
     "@react-email/components": "^0.0.25",
     "@react-email/render": "1.0.1",
     "@socket.io/cluster-adapter": "^0.2.2",
+    "@socket.io/sticky": "^1.0.4",
     "@storybook/addon-interactions": "8.5.0",
     "@swc/helpers": "0.5.11",
     "@tanstack/react-virtual": "^3.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8006,6 +8006,11 @@
   resolved "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.0.tgz"
   integrity sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg==
 
+"@socket.io/sticky@^1.0.4":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@socket.io/sticky/-/sticky-1.0.4.tgz#5f6d3ae62881b17e0fb756c6074f18ddb7b2014f"
+  integrity sha512-VuauT5CJLvzYtKIgouFSQ8rUaygseR+zRutnwh6ZA2QYcXx+8g52EoJ8V2SLxfo+Tfs3ELUDy08oEXxlWNrxaw==
+
 "@storybook/addon-actions@8.5.0":
   version "8.5.0"
   resolved "https://registry.yarnpkg.com/@storybook/addon-actions/-/addon-actions-8.5.0.tgz#b2dfb6430637762de302174e650c8cec4109a232"


### PR DESCRIPTION
1. Long-polling socket connections would not get routed to same worker, causing connection issues
2. websocket was made to be the default transport, with a fallback to long-polling only if required
3. ensure data-sync hashedKeys are defined when doing query - not sure how this could happen, but it was observed and need additional investigation - but should smooth over after backfill is completed in all browser instances