### PR TITLE
Add new flag specific for pretty-logging

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,9 @@ NX_SFDC_API_VERSION='62.0'
 # trace, debug (default), info, warn, error, fatal, silent
 LOG_LEVEL='trace'
 
+# If true, will print out logs in a more human readable format instead of JSON (only in dev mode)
+PRETTY_LOGS='true'
+
 # Default value for email two-factor authentication for new users
 JETSTREAM_AUTH_2FA_EMAIL_DEFAULT_VALUE='false'
 # Session signing secret - minimum of 32 characters

--- a/libs/api-config/src/lib/api-logger.ts
+++ b/libs/api-config/src/lib/api-logger.ts
@@ -7,7 +7,7 @@ import { ENV } from './env-config';
 export const logger = pino({
   level: ENV.LOG_LEVEL,
   transport:
-    ENV.ENVIRONMENT === 'development' && !ENV.IS_LOCAL_DOCKER && !ENV.CI
+    ENV.ENVIRONMENT === 'development' && ENV.PRETTY_LOGS && !ENV.IS_LOCAL_DOCKER
       ? {
           target: 'pino-pretty',
         }

--- a/libs/api-config/src/lib/env-config.ts
+++ b/libs/api-config/src/lib/env-config.ts
@@ -75,6 +75,7 @@ const envSchema = z.object({
     .enum(['trace', 'debug', 'info', 'warn', 'error', 'fatal', 'silent'])
     .optional()
     .transform((value) => value ?? 'debug'),
+  PRETTY_LOGS: booleanSchema,
   CI: booleanSchema,
   // LOCAL OVERRIDE
   // EXAMPLE_USER: z.record(z.any()).optional(),


### PR DESCRIPTION
Previously we were relying on the IS_CI flag which has other consequences in some cases (like releasing a new version) - so introduce a new flag to control this more easily.