### PR TITLE
Fix query results record count for big objects

### DIFF
--- a/libs/features/load-records/src/components/LoadRecordsDataPreview.tsx
+++ b/libs/features/load-records/src/components/LoadRecordsDataPreview.tsx
@@ -110,9 +110,10 @@ export const LoadRecordsDataPreview: FunctionComponent<LoadRecordsDataPreviewPro
             return;
           }
           setTotalRecordCount(results.queryResults.totalSize);
-          setOmitTotalRecordCount(false);
+          setOmitTotalRecordCount(results.queryResults.totalSize < 0);
         } catch (ex) {
           logger.warn('[ERROR] Unable to get total record count', ex);
+          setOmitTotalRecordCount(true);
         } finally {
           if (!isMounted.current || selectedSObject?.name !== sobjectName) {
             // eslint-disable-next-line no-unsafe-finally

--- a/libs/ui/src/lib/data-table/SalesforceRecordDataTable.tsx
+++ b/libs/ui/src/lib/data-table/SalesforceRecordDataTable.tsx
@@ -45,6 +45,16 @@ function getRowClass(row: RowSalesforceRecordWithKey): string | undefined {
   return row._saveError ? 'save-error' : undefined;
 }
 
+function getTotalCountText(queryResults: QueryResults['queryResults']) {
+  // Big objects report -1 as totalSize
+  if (queryResults.totalSize < 0 && !queryResults.done) {
+    return `more than ${formatNumber(queryResults.records.length)}`;
+  } else if (queryResults.totalSize < 0 && queryResults.done) {
+    return formatNumber(queryResults.records.length);
+  }
+  return formatNumber(queryResults.totalSize || 0);
+}
+
 export interface SalesforceRecordDataTableProps {
   org: SalesforceOrgUi;
   isTooling: boolean;
@@ -117,7 +127,7 @@ export const SalesforceRecordDataTable = memo<SalesforceRecordDataTableProps>(
     const [dirtyRows, setDirtyRows] = useState<RowSalesforceRecordWithKey[]>([]);
     const [saveErrors, setSaveErrors] = useState<string[]>([]);
 
-    const [totalRecordCount, setTotalRecordCount] = useState<number>();
+    const [totalRecordCountText, setTotalRecordCountText] = useState<string>();
     const [isLoadingMore, setIsLoadingMore] = useState(false);
     const [loadMoreErrorMessage, setLoadMoreErrorMessage] = useState<string | null>(null);
     const [hasMoreRecords, setHasMoreRecords] = useState(false);
@@ -148,7 +158,7 @@ export const SalesforceRecordDataTable = memo<SalesforceRecordDataTableProps>(
         setSubqueryColumnsMap(subqueryColumns);
         setRecords(queryResults.queryResults.records);
         onFilteredRowsChanged(queryResults.queryResults.records);
-        setTotalRecordCount(queryResults.queryResults.totalSize);
+        setTotalRecordCountText(getTotalCountText(queryResults.queryResults));
         if (!queryResults.queryResults.done && queryResults.queryResults.nextRecordsUrl) {
           setHasMoreRecords(true);
           setNextRecordsUrl(queryResults.queryResults.nextRecordsUrl);
@@ -264,7 +274,9 @@ export const SalesforceRecordDataTable = memo<SalesforceRecordDataTableProps>(
         if (results.queryResults.done) {
           setHasMoreRecords(false);
         }
-        setRecords((records || []).concat(results.queryResults.records));
+        const newRecords = (records || []).concat(results.queryResults.records);
+        setRecords(newRecords);
+        setTotalRecordCountText(getTotalCountText({ ...results.queryResults, records: newRecords }));
         setIsLoadingMore(false);
         if (onLoadMoreRecords) {
           onLoadMoreRecords(results);
@@ -408,7 +420,7 @@ export const SalesforceRecordDataTable = memo<SalesforceRecordDataTableProps>(
         <Grid className="slds-p-around_xx-small" align="spread">
           <div className="slds-grid">
             <div className="slds-p-around_x-small">
-              Showing {formatNumber(visibleRecordCount)} of {formatNumber(totalRecordCount || 0)} records
+              Showing {formatNumber(visibleRecordCount)} of {totalRecordCountText} records
             </div>
             {hasMoreRecords && (
               <div>

--- a/libs/ui/src/lib/file-download-modal/RecordDownloadModal.tsx
+++ b/libs/ui/src/lib/file-download-modal/RecordDownloadModal.tsx
@@ -137,6 +137,12 @@ export const RecordDownloadModal: FunctionComponent<RecordDownloadModalProps> = 
 
   const hasSubqueryFields = subqueryFields && !!Object.keys(subqueryFields).length && (fileFormat === 'xlsx' || fileFormat === 'gdrive');
 
+  // Big objects report -1 as totalSize
+  const totalRecordCountText =
+    (totalRecordCount || records.length) < 0
+      ? `more than ${formatNumber(records.length)}`
+      : formatNumber(totalRecordCount || records.length);
+
   const allowBulkApi =
     (totalRecordCount || 0) >= ALLOW_BULK_API_COUNT &&
     !Object.keys(subqueryFields).length &&
@@ -199,7 +205,7 @@ export const RecordDownloadModal: FunctionComponent<RecordDownloadModalProps> = 
   }, [fileName]);
 
   useEffect(() => {
-    const hasMoreRecordsTemp = !!totalRecordCount && !!records && totalRecordCount > records.length;
+    const hasMoreRecordsTemp = !!totalRecordCount && !!records && (totalRecordCount < 0 || totalRecordCount > records.length);
     setHasMoreRecords(hasMoreRecordsTemp);
     setDownloadRecordsValue(hasMoreRecordsTemp ? RADIO_ALL_SERVER : RADIO_ALL_BROWSER);
   }, [totalRecordCount, records]);
@@ -359,7 +365,7 @@ export const RecordDownloadModal: FunctionComponent<RecordDownloadModalProps> = 
                 <Fragment>
                   <Radio
                     name="radio-download"
-                    label={`All records (${formatNumber(totalRecordCount || records.length)})`}
+                    label={`All records (${totalRecordCountText})`}
                     value={RADIO_ALL_SERVER}
                     checked={downloadRecordsValue === RADIO_ALL_SERVER}
                     onChange={setDownloadRecordsValue}


### PR DESCRIPTION
Salesforce returns -1 for the total record count for bug objects, which caused the UI to lok broken and not behave correctly when the download modal was open if there were more records

The solution is not perfect in all cases, but an attempt was made to fill in the correct number of we know it (when all records are downloaded) and otherwise say "more than x records"

resolves #1135