### PR TITLE
Allow blank picklist values in query editor

### DIFF
--- a/libs/ui/src/lib/data-table/DataTableEditors.tsx
+++ b/libs/ui/src/lib/data-table/DataTableEditors.tsx
@@ -155,7 +155,7 @@ export function dataTableEditorDropdownWrapper<TRow extends { _idx: number }, TS
   isMultiSelect: boolean;
 }) {
   return ({ row, column, onRowChange, onClose }: RenderEditCellProps<TRow, TSummaryRow>) => {
-    const allValues = useRef(new Set([BLANK_LIST_ITEM, ..._values.map((v) => v.value)]));
+    const allValues = useRef(new Set([BLANK_LIST_ITEM.value, ..._values.map((v) => v.value)]));
     const [values, setValues] = useState<ListItem[]>(() => [BLANK_LIST_ITEM, ..._values]);
 
     const selectedItemId = row[column.key as keyof TRow] as unknown as string;

--- a/libs/ui/src/lib/data-table/DataTableEditors.tsx
+++ b/libs/ui/src/lib/data-table/DataTableEditors.tsx
@@ -145,6 +145,8 @@ export function DataTableEditorBoolean<TRow extends { _idx: number }, TSummaryRo
   );
 }
 
+const BLANK_LIST_ITEM: ListItem = { id: '_BLANK_', label: '--None--', value: '' };
+
 export function dataTableEditorDropdownWrapper<TRow extends { _idx: number }, TSummaryRow>({
   values: _values,
   isMultiSelect,
@@ -153,8 +155,8 @@ export function dataTableEditorDropdownWrapper<TRow extends { _idx: number }, TS
   isMultiSelect: boolean;
 }) {
   return ({ row, column, onRowChange, onClose }: RenderEditCellProps<TRow, TSummaryRow>) => {
-    const allValues = useRef(new Set(_values.map((v) => v.value)));
-    const [values, setValues] = useState<ListItem[]>(_values);
+    const allValues = useRef(new Set([BLANK_LIST_ITEM, ..._values.map((v) => v.value)]));
+    const [values, setValues] = useState<ListItem[]>(() => [BLANK_LIST_ITEM, ..._values]);
 
     const selectedItemId = row[column.key as keyof TRow] as unknown as string;
     // only used if multi-select is enabled
@@ -200,7 +202,17 @@ export function dataTableEditorDropdownWrapper<TRow extends { _idx: number }, TS
             onChange={(items) => {
               const _touchedColumns = new Set((row as any)._touchedColumns || []);
               _touchedColumns.add(column.key);
-              onRowChange({ ...row, [column.key]: (items || []).map((item) => item.value).join(';'), _touchedColumns }, false);
+              onRowChange(
+                {
+                  ...row,
+                  [column.key]: (items || [])
+                    .map((item) => item.value)
+                    .filter(Boolean)
+                    .join(';'),
+                  _touchedColumns,
+                },
+                false
+              );
             }}
           />
         </DataTableEditorPopover>
@@ -223,7 +235,7 @@ export function dataTableEditorDropdownWrapper<TRow extends { _idx: number }, TS
           onSelected={(item) => {
             const _touchedColumns = new Set((row as any)._touchedColumns || []);
             _touchedColumns.add(column.key);
-            onRowChange({ ...row, [column.key]: item.value, _touchedColumns }, true);
+            onRowChange({ ...row, [column.key]: item.value === '' ? null : item.value, _touchedColumns }, true);
           }}
         />
       </DataTableEditorPopover>

--- a/libs/ui/src/lib/data-table/SalesforceRecordDataTable.tsx
+++ b/libs/ui/src/lib/data-table/SalesforceRecordDataTable.tsx
@@ -372,7 +372,9 @@ export const SalesforceRecordDataTable = memo<SalesforceRecordDataTableProps>(
             if (failedResultsById[id]) {
               return { ...row, _saveError: failedResultsById[id].errors[0].message };
             } else {
-              return { ...row, _touchedColumns: new Set(), _saveError: null };
+              const tempRow: RowSalesforceRecordWithKey = { ...row, _touchedColumns: new Set(), _saveError: null };
+              Array.from(row._touchedColumns).forEach((col) => (tempRow._record[col] = row[col]));
+              return tempRow;
             }
           }
           if (row._saveError) {


### PR DESCRIPTION
Blank value was added as an option

There was a bug where after saving an edit, the record had the new and the old value so editing and changing back to the original value would not be shown as a dirty field.

resolves #1138