### PR TITLE
Allow bulk updating record without changing field data

### DIFF
--- a/apps/docs/docs/load/update-records.mdx
+++ b/apps/docs/docs/load/update-records.mdx
@@ -38,6 +38,7 @@ After selecting an object, you need to configure the fields that you would like 
 - **New Value** Allows you to choose how you want to update the field.
   - **Value from a different field** allows you to copy the value from a field into the field to update, for example, copying the record id to an external id field.
   - **Provided value** allows you to provide any value that you want to update the field with. For example, you could update a picklist field to a new value on all existing records.
+  - **Update record without changes** Will trigger a record update without changing any data. This is useful if you want automation to be executed, e.g. you want a flow you just activated to run against all records.
   - **Clear field value** allows you to remove the existing value in the field across many records.
 - **Criteria** determines which records will be modified.
   - **All records**

--- a/libs/shared/ui-core/src/mass-update-records/MassUpdateRecordTransformationText.tsx
+++ b/libs/shared/ui-core/src/mass-update-records/MassUpdateRecordTransformationText.tsx
@@ -42,6 +42,10 @@ export const MassUpdateRecordTransformationText: FunctionComponent<MassUpdateRec
         </span>
       );
       break;
+    case 'update':
+      title += `Update without changing data`;
+      objectAndField = <span>Update without changing data</span>;
+      break;
     case 'null':
       title += `"${selectedField}" will be set to ${isBoolean ? 'false' : 'null'}`;
       objectAndField = (

--- a/libs/shared/ui-core/src/mass-update-records/mass-update-records.types.tsx
+++ b/libs/shared/ui-core/src/mass-update-records/mass-update-records.types.tsx
@@ -47,5 +47,5 @@ export interface TransformationOptions {
   whereClause: string;
 }
 
-export type TransformationOption = 'staticValue' | 'anotherField' | 'null';
+export type TransformationOption = 'staticValue' | 'anotherField' | 'update' | 'null';
 export type TransformationCriteria = 'all' | 'onlyIfBlank' | 'onlyIfNotBlank' | 'custom';

--- a/libs/shared/ui-core/src/mass-update-records/mass-update-records.utils.tsx
+++ b/libs/shared/ui-core/src/mass-update-records/mass-update-records.utils.tsx
@@ -35,6 +35,7 @@ export const transformationOptionListItems: ListItem[] = [
   { id: 'staticValue', value: 'staticValue', label: 'Provided value' },
   { id: 'anotherField', value: 'anotherField', label: 'Value from different field' },
   { id: 'null', value: 'null', label: 'Clear field value' },
+  { id: 'update', value: 'update', label: 'Update record without changes' },
 ];
 
 export const transformationCriteriaListItems: ListItem[] = [
@@ -258,7 +259,7 @@ export function prepareRecords(
           newRecord[selectedField] = lodashGet(newRecord, transformationOptions.alternateField, emptyFieldValue);
         } else if (transformationOptions.option === 'staticValue') {
           newRecord[selectedField] = transformationOptions.staticValue;
-        } else {
+        } else if (transformationOptions.option === 'null') {
           newRecord[selectedField] = emptyFieldValue;
         }
       }


### PR DESCRIPTION
There are times when a record updates needs to be triggered for automation to run and there is no desire to change a field value at the same time.

resolves #1151