### PR TITLE
Ensure record type metadata is initialized correctly

### DIFF
--- a/libs/connected/connected-ui/src/lib/useListMetadata.tsx
+++ b/libs/connected/connected-ui/src/lib/useListMetadata.tsx
@@ -96,6 +96,7 @@ async function fetchListMetadata(
         });
       }
     } catch (ex) {
+      // IsPersonType is only available in orgs where this feature is enabled - so if it fails we don't need to monkey-patch
       logger.error('Error monkey-patching PersonAccount record types', ex);
     }
   }

--- a/libs/types/src/lib/salesforce/record.types.ts
+++ b/libs/types/src/lib/salesforce/record.types.ts
@@ -439,7 +439,6 @@ export interface RecordTypeRecord {
   Description: string | null;
   DeveloperName: string;
   IsActive: boolean;
-  IsPersonType: boolean;
   NamespacePrefix: string | null;
   SobjectType: string;
 }
@@ -449,7 +448,6 @@ export interface RecordTypeMetadataRecord {
   Id: string;
   Name: string;
   FullName: string;
-  IsPersonType: boolean;
   Metadata: RecordTypeMetadataTooling;
   SobjectType: string;
 }


### PR DESCRIPTION
Since this comes from XML conversion, some items with only one entry are not initialized as arrays

In some other cases, PicklistValues was completely missing which caused things to blow up