### PR TITLE
Remove ip address from remember me check

### DIFF
--- a/apps/landing/components/auth/VerifyEmailOr2fa.tsx
+++ b/apps/landing/components/auth/VerifyEmailOr2fa.tsx
@@ -67,7 +67,7 @@ export function VerifyEmailOr2fa({ csrfToken, email, pendingVerifications }: Ver
       csrfToken,
       captchaToken: '',
       type: activeFactor,
-      rememberDevice: false,
+      rememberDevice: true,
     },
   });
 

--- a/libs/auth/server/src/lib/auth.utils.ts
+++ b/libs/auth/server/src/lib/auth.utils.ts
@@ -4,8 +4,10 @@ import { UserProfileUi } from '@jetstream/types';
 import * as bcrypt from 'bcrypt';
 import * as Bowser from 'bowser';
 
+export const REMEMBER_DEVICE_DAYS = 30;
+
 const TIME_15_MIN = 60 * 15;
-const TIME_30_DAYS = 30 * 24 * 60 * 60;
+const REMEMBER_DEVICE_MAX_AGE = REMEMBER_DEVICE_DAYS * 24 * 60 * 60;
 
 export function getCookieConfig(useSecureCookies: boolean): CookieConfig {
   const cookiePrefix = useSecureCookies ? '__Secure-' : '';
@@ -96,7 +98,7 @@ export function getCookieConfig(useSecureCookies: boolean): CookieConfig {
         sameSite: 'lax',
         path: '/',
         secure: useSecureCookies,
-        maxAge: TIME_30_DAYS,
+        maxAge: REMEMBER_DEVICE_MAX_AGE,
       },
     },
     redirectUrl: {

--- a/libs/test/e2e-utils/src/lib/pageObjectModels/AuthenticationPage.model.ts
+++ b/libs/test/e2e-utils/src/lib/pageObjectModels/AuthenticationPage.model.ts
@@ -189,7 +189,7 @@ export class AuthenticationPage {
 
     await expect(this.page.getByText('Enter your verification code from your authenticator app')).toBeVisible();
 
-    await this.verifyTotp(email, password, secret, rememberMe);
+    await this.verifyTotp(email, secret, rememberMe);
   }
 
   async verifyEmail(email: string, rememberMe = false) {
@@ -213,7 +213,7 @@ export class AuthenticationPage {
     await this.page.waitForURL(`**/app`);
   }
 
-  async verifyTotp(email: string, password: string, secret: string, rememberMe = false) {
+  async verifyTotp(email: string, secret: string, rememberMe = false) {
     const { decodeBase32IgnorePadding } = await import('@oslojs/encoding');
     const { generateTOTP } = await import('@oslojs/otp');
 
@@ -230,9 +230,13 @@ export class AuthenticationPage {
     }
 
     await this.verificationCodeInput.fill(code);
+
     if (rememberMe) {
       await this.rememberDeviceInput.check();
+    } else {
+      await this.rememberDeviceInput.uncheck();
     }
+
     await this.continueButton.click();
 
     await this.page.waitForURL(`**/app`);


### PR DESCRIPTION
Most people have a dynamic ip address that changes on occasion, which would render the "remember me" feature useless

In addition, browser version updates would also cause remember me to fail

we now make sure that the user agent is is similar and has an equal or newer browser version instead of an exact match.

The cookie and DB are also extended when used within the expiration period to make it more convenient for users

resolves #1209