### PR TITLE
Allow deleting reports from query results #1202

### DIFF
--- a/apps/api/src/app/controllers/sf-misc.controller.ts
+++ b/apps/api/src/app/controllers/sf-misc.controller.ts
@@ -78,9 +78,10 @@ const salesforceRequest = createRoute(routeDefinition.salesforceRequest.validato
   }
 });
 
-// TODO: combine with salesforceRequest and rename
-// The request payload and response are slightly different, but the logic is the same
-// The only difference is the caller is expected to pass in the full url to call (AFAIK)
+/**
+ * Similar to salesforceRequest, but the results are not processed as JSON.
+ * This is useful for raw text responses, such as when downloading files.
+ */
 const salesforceRequestManual = createRoute(
   routeDefinition.salesforceRequestManual.validators,
   async ({ body, jetstreamConn }, req, res, next) => {

--- a/libs/api-types/src/lib/api-misc.types.ts
+++ b/libs/api-types/src/lib/api-misc.types.ts
@@ -8,7 +8,7 @@ export const SalesforceApiRequestSchema = z.object({
   headers: z.record(z.string()).nullish(),
   options: z
     .object({
-      responseType: z.enum(['json', 'text']).nullish(),
+      responseType: z.enum(['json', 'text']).nullish().default('json'),
       noContentResponse: z.any().nullish(),
     })
     .nullish(),

--- a/libs/shared/ui-core/src/jobs/Jobs.tsx
+++ b/libs/shared/ui-core/src/jobs/Jobs.tsx
@@ -43,7 +43,7 @@ export const Jobs: FunctionComponent = () => {
   const popoverRef = useRef<PopoverRef>(null);
   const buttonRef = useRef<HTMLButtonElement>(null);
   const isOpen = useRef<boolean>(false);
-  const [{ serverUrl }] = useRecoilState(applicationCookieState);
+  const [{ serverUrl, defaultApiVersion }] = useRecoilState(applicationCookieState);
   const rollbar = useRollbar();
   const setJobs = useSetRecoilState(jobsState);
   const [jobsUnread, setJobsUnread] = useRecoilState(jobsUnreadState);
@@ -72,6 +72,7 @@ export const Jobs: FunctionComponent = () => {
           data: {
             job: { ...job },
             org: job.org,
+            apiVersion: defaultApiVersion,
           },
         });
       });
@@ -499,6 +500,7 @@ export const Jobs: FunctionComponent = () => {
         data: {
           job: { ...job, meta: null, results: null },
           org: job.org,
+          apiVersion: defaultApiVersion,
         },
       });
       setJobs((prevJobs) => ({

--- a/libs/types/src/lib/ui/types.ts
+++ b/libs/types/src/lib/ui/types.ts
@@ -431,6 +431,7 @@ export interface AsyncJob<T = unknown, R = unknown> {
 export interface AsyncJobWorkerMessagePayload<T = unknown> {
   job: AsyncJob<T>;
   org: SalesforceOrgUi;
+  apiVersion: string;
 }
 
 export interface AsyncJobWorkerMessageResponse<T = unknown, R = unknown> {


### PR DESCRIPTION
Deleting reports is now supported by calling a dedicated Salesforce API instead of the normal delete sobject API

resolves #1202