### PR TITLE
feat: allow deploying metadata from comparison modal

### DIFF
--- a/apps/docs/docs/deploy/deploy-metadata.mdx
+++ b/apps/docs/docs/deploy/deploy-metadata.mdx
@@ -174,6 +174,12 @@ To compare all the selected metadata components with another org, choose the org
 
 This will show a line-by-line diff of the content. You can click the swap <Refresh className="icon inline" /> icon to change which is on the left and which is on the right.
 
+:::tip
+
+After comparing the metadata, you can deploy the modified metadata to the other org by clicking the **Deploy Changes** button on the comparison modal.
+
+:::
+
 <img src={require('./view-or-compare-metadata.png').default} alt="View and compare metadata" />
 
 ## Deleting metadata

--- a/libs/features/deploy/src/deploy-to-different-org/DeployMetadataToOrgConfigModal.tsx
+++ b/libs/features/deploy/src/deploy-to-different-org/DeployMetadataToOrgConfigModal.tsx
@@ -15,6 +15,7 @@ export interface DeployMetadataToOrgConfigModalProps {
   initialOptions?: Maybe<DeployOptions>;
   initialSelectedDestinationOrg?: SalesforceOrgUi;
   selectedMetadata: Record<string, ListMetadataResult[]>;
+  lockDestinationOrg?: boolean;
   onSelection?: (deployOptions: DeployOptions) => void;
   onClose: () => void;
   onDeploy: (destinationOrg: SalesforceOrgUi, deployOptions: DeployOptions) => void;
@@ -25,6 +26,7 @@ export const DeployMetadataToOrgConfigModal: FunctionComponent<DeployMetadataToO
   initialOptions,
   initialSelectedDestinationOrg,
   selectedMetadata,
+  lockDestinationOrg = false,
   onSelection,
   onClose,
   onDeploy,
@@ -111,6 +113,7 @@ export const DeployMetadataToOrgConfigModal: FunctionComponent<DeployMetadataToO
                 label="Deploy components to"
                 hideLabel={false}
                 placeholder="Select an org"
+                disabled={lockDestinationOrg}
                 orgs={orgs}
                 selectedOrg={destinationOrg}
                 onSelected={setDestinationOrg}

--- a/libs/features/deploy/src/utils/DeployMetadataStatusModal.tsx
+++ b/libs/features/deploy/src/utils/DeployMetadataStatusModal.tsx
@@ -155,7 +155,7 @@ export const DeployMetadataStatusModal: FunctionComponent<DeployMetadataStatusMo
               </button>
             )}
           </div>
-          <div>
+          <Grid>
             {onGoBack && (
               <button className="slds-button slds-button_neutral" onClick={() => handleGoBack()} disabled={loading}>
                 <Icon type="utility" icon="back" className="slds-button__icon slds-button__icon_left" omitContainer />
@@ -165,7 +165,7 @@ export const DeployMetadataStatusModal: FunctionComponent<DeployMetadataStatusMo
             <button className="slds-button slds-button_brand" onClick={() => onClose()} disabled={loading}>
               Close
             </button>
-          </div>
+          </Grid>
         </Grid>
       }
       size="lg"

--- a/libs/features/deploy/src/view-or-compare-metadata/DeployComparedMetadataModal.tsx
+++ b/libs/features/deploy/src/view-or-compare-metadata/DeployComparedMetadataModal.tsx
@@ -1,0 +1,182 @@
+import { ANALYTICS_KEYS } from '@jetstream/shared/constants';
+import { DeployOptions, DeployResult, ListMetadataResult, SalesforceOrgUi } from '@jetstream/types';
+import { Checkbox, FileDownloadModal, Grid, Icon, Modal } from '@jetstream/ui';
+import { fromJetstreamEvents, useAmplitude } from '@jetstream/ui-core';
+import { applicationCookieState, googleDriveAccessState } from '@jetstream/ui/app-state';
+import classNames from 'classnames';
+import { Fragment, useState } from 'react';
+import { useRecoilValue } from 'recoil';
+import DeployMetadataToOrgConfigModal from '../deploy-to-different-org/DeployMetadataToOrgConfigModal';
+import DeployMetadataToOrgStatusModal from '../deploy-to-different-org/DeployMetadataToOrgStatusModal';
+import { getDeployResultsExcelData } from '../utils/deploy-metadata.utils';
+import { DeployFromCompareMetadataItem } from './viewOrCompareMetadataTypes';
+
+export interface DeployComparedMetadataModalProps {
+  sourceOrg: SalesforceOrgUi;
+  targetOrg: SalesforceOrgUi;
+  items: DeployFromCompareMetadataItem[];
+  onClose: (closeAll?: boolean) => void;
+}
+
+export const DeployComparedMetadataModal = ({ sourceOrg, targetOrg, items, onClose }: DeployComparedMetadataModalProps) => {
+  const { trackEvent } = useAmplitude();
+  const { google_apiKey, google_appId, google_clientId } = useRecoilValue(applicationCookieState);
+  const { hasGoogleDriveAccess, googleShowUpgradeToPro } = useRecoilValue(googleDriveAccessState);
+  const [mode, setMode] = useState<'SELECTION' | 'DEPLOY_CONFIG' | 'DEPLOY'>('SELECTION');
+  const [selectedItems, setSelectedFiles] = useState<Set<string>>(
+    () => new Set(items.flatMap((parent) => parent.items.filter((item) => !item.sourceAndTargetMatch).map((item) => item.filename)))
+  );
+  const [metadataToDeploy, setMetadataToDeploy] = useState<Record<string, ListMetadataResult[]>>();
+  const [downloadResultsModalOpen, setDownloadResultsModalOpen] = useState<boolean>(false);
+  const [deployMetadataOptions, setDeployMetadataOptions] = useState<DeployOptions | null>(null);
+  const [deployResultsData, setDeployResultsData] = useState<Record<string, any[]>>();
+
+  function handleChange(key: string, value: boolean) {
+    const selected = new Set(selectedItems);
+    if (value) {
+      selected.add(key);
+    } else {
+      selected.delete(key);
+    }
+    setSelectedFiles(selected);
+  }
+
+  function handleDeployResultsDownload(deployResults: DeployResult, deploymentUrl: string) {
+    setDeployResultsData(getDeployResultsExcelData(deployResults, deploymentUrl));
+    setDownloadResultsModalOpen(true);
+  }
+
+  function handleDeployMetadata(destinationOrg: SalesforceOrgUi, deployOptions: DeployOptions) {
+    setDeployMetadataOptions(deployOptions);
+    setMode('DEPLOY');
+    trackEvent(ANALYTICS_KEYS.deploy_deployMetadata, { type: 'org-to-org-from-comparison', deployOptions });
+  }
+
+  function handleContinue() {
+    setMode('DEPLOY_CONFIG');
+    setMetadataToDeploy(
+      items
+        .flatMap((item) => item.items)
+        .filter((item) => selectedItems.has(item.filename))
+        .map((item) => item.source)
+        .reduce((acc: Record<string, ListMetadataResult[]>, item) => {
+          acc[item.type] = acc[item.type] || [];
+          acc[item.type].push({
+            createdById: item.createdById,
+            createdByName: item.createdByName,
+            createdDate: null,
+            fileName: item.fileName,
+            fullName: item.fullName,
+            id: item.id,
+            lastModifiedById: item.lastModifiedById,
+            lastModifiedByName: item.lastModifiedByName,
+            lastModifiedDate: null,
+            namespacePrefix: item.namespacePrefix,
+            type: item.type,
+          });
+          return acc;
+        }, {})
+    );
+  }
+
+  if (mode === 'DEPLOY_CONFIG' && metadataToDeploy) {
+    return (
+      <DeployMetadataToOrgConfigModal
+        sourceOrg={sourceOrg}
+        initialSelectedDestinationOrg={targetOrg}
+        initialOptions={deployMetadataOptions}
+        selectedMetadata={metadataToDeploy}
+        lockDestinationOrg
+        onClose={() => setMode('SELECTION')}
+        onDeploy={handleDeployMetadata}
+      />
+    );
+  }
+
+  if (mode === 'DEPLOY' && metadataToDeploy) {
+    return (
+      <>
+        <DeployMetadataToOrgStatusModal
+          hideModal={downloadResultsModalOpen}
+          sourceOrg={sourceOrg}
+          destinationOrg={targetOrg}
+          selectedMetadata={metadataToDeploy}
+          deployOptions={deployMetadataOptions || {}}
+          onGoBack={() => setMode('DEPLOY_CONFIG')}
+          onClose={() => onClose(true)}
+          onDownload={handleDeployResultsDownload}
+        />
+        {downloadResultsModalOpen && deployResultsData && (
+          <FileDownloadModal
+            modalHeader="Download Deploy Results"
+            org={targetOrg}
+            googleIntegrationEnabled={hasGoogleDriveAccess}
+            googleShowUpgradeToPro={googleShowUpgradeToPro}
+            google_apiKey={google_apiKey}
+            google_appId={google_appId}
+            google_clientId={google_clientId}
+            fileNameParts={['deploy-results']}
+            allowedTypes={['xlsx']}
+            data={deployResultsData}
+            onModalClose={() => setDownloadResultsModalOpen(false)}
+            emitUploadToGoogleEvent={fromJetstreamEvents.emit}
+            source="deploy_metadata_to_org_from_comparison"
+            trackEvent={trackEvent}
+          />
+        )}
+      </>
+    );
+  }
+
+  return (
+    <Modal
+      header="Deploy Metadata"
+      closeOnBackdropClick={false}
+      closeOnEsc={false}
+      footer={
+        <Grid align="end">
+          <button className="slds-button slds-button_neutral" onClick={() => onClose()}>
+            <Icon type="utility" icon="back" className="slds-button__icon slds-button__icon_left" omitContainer />
+            Go Back
+          </button>
+          <button className="slds-button slds-button_neutral" onClick={() => onClose(true)}>
+            Cancel
+          </button>
+          <button className="slds-button slds-button_brand" form="create-object-form" type="submit" onClick={handleContinue}>
+            Continue
+          </button>
+        </Grid>
+      }
+      onClose={() => onClose(false)}
+    >
+      <div>
+        {items.map((metadata) => (
+          <Fragment key={metadata.type}>
+            <h3>{metadata.type}</h3>
+            <div className="slds-m-left_x-small">
+              {metadata.items.map((item) => (
+                <div key={item.filename}>
+                  <Checkbox
+                    id={`deploy-checkbox-${metadata.type}-${item.filename}`}
+                    label={
+                      <span
+                        className={classNames({
+                          'slds-text-color_success': item.sourceAndTargetMatch,
+                          'slds-text-color_destructive': !item.sourceAndTargetMatch,
+                        })}
+                      >
+                        {item.source.fullName} {!item.sourceAndTargetMatch && `(Different)`}
+                      </span>
+                    }
+                    checked={selectedItems.has(item.filename)}
+                    onChange={(value) => handleChange(item.filename, value)}
+                  />
+                </div>
+              ))}
+            </div>
+          </Fragment>
+        ))}
+      </div>
+    </Modal>
+  );
+};

--- a/libs/features/deploy/src/view-or-compare-metadata/ViewOrCompareMetadataModalFooter.tsx
+++ b/libs/features/deploy/src/view-or-compare-metadata/ViewOrCompareMetadataModalFooter.tsx
@@ -1,4 +1,4 @@
-import { Grid, Icon } from '@jetstream/ui';
+import { Grid, Icon, Tooltip } from '@jetstream/ui';
 import { FunctionComponent } from 'react';
 import { OrgType } from './viewOrCompareMetadataTypes';
 
@@ -14,6 +14,7 @@ export interface ViewOrCompareMetadataModalFooterProps {
   reloadMetadata?: () => void;
   onDownloadPackage: (which: OrgType) => void;
   onExportSummary: () => void;
+  onDeployToTarget: () => void;
   onClose: () => void;
 }
 
@@ -29,6 +30,7 @@ export const ViewOrCompareMetadataModalFooter: FunctionComponent<ViewOrCompareMe
   reloadMetadata,
   onDownloadPackage,
   onExportSummary,
+  onDeployToTarget,
   onClose,
 }) => {
   const hasBoth = hasSourceMetadata && hasTargetMetadata;
@@ -51,14 +53,30 @@ export const ViewOrCompareMetadataModalFooter: FunctionComponent<ViewOrCompareMe
           </div>
         )}
       </div>
-      <div>
+      <Grid>
+        <Tooltip
+          content={
+            hasTargetMetadata
+              ? 'Deploy changes to the target org, confirm which metadata components to deploy on the next screen'
+              : 'Select a target org to deploy changes'
+          }
+        >
+          <button
+            className="slds-button slds-button_brand slds-m-right_x-small"
+            onClick={() => onDeployToTarget()}
+            disabled={!hasTargetMetadata}
+          >
+            <Icon type="utility" icon="share" className="slds-button__icon slds-button__icon_left" omitContainer />
+            Deploy Changes
+          </button>
+        </Tooltip>
         <button
           className="slds-button slds-button_neutral"
           onClick={() => onDownloadPackage('SOURCE')}
           disabled={!hasSourceMetadata || sourceLoading}
         >
           <Icon type="utility" icon="download" className="slds-button__icon slds-button__icon_left" omitContainer />
-          Download Source Package
+          Source Package
         </button>
 
         {!isChromeExtension && (
@@ -69,7 +87,7 @@ export const ViewOrCompareMetadataModalFooter: FunctionComponent<ViewOrCompareMe
               disabled={!hasTargetMetadata || targetLoading || !hasTargetMetadataContent}
             >
               <Icon type="utility" icon="download" className="slds-button__icon slds-button__icon_left" omitContainer />
-              Download Target Package
+              Target Package
             </button>
 
             <button className="slds-button slds-button_neutral" onClick={() => onExportSummary()} disabled={!hasBoth}>
@@ -82,7 +100,7 @@ export const ViewOrCompareMetadataModalFooter: FunctionComponent<ViewOrCompareMe
         <button className="slds-button slds-button_neutral" onClick={() => onClose()}>
           Close
         </button>
-      </div>
+      </Grid>
     </Grid>
   );
 };

--- a/libs/features/deploy/src/view-or-compare-metadata/viewOrCompareMetadataTypes.ts
+++ b/libs/features/deploy/src/view-or-compare-metadata/viewOrCompareMetadataTypes.ts
@@ -17,3 +17,8 @@ export interface FileItemMetadata {
   targetHasLoaded: boolean;
   sourceAndTargetMatch: boolean;
 }
+
+export interface DeployFromCompareMetadataItem {
+  type: string;
+  items: FileItemMetadata[];
+}

--- a/libs/features/deploy/src/view-or-compare-metadata/viewOrCompareMetadataUtils.tsx
+++ b/libs/features/deploy/src/view-or-compare-metadata/viewOrCompareMetadataUtils.tsx
@@ -3,7 +3,7 @@ import { groupByFlat, orderObjectsBy } from '@jetstream/shared/utils';
 import { Tooltip, TreeItems } from '@jetstream/ui';
 import classNames from 'classnames';
 import JSZip from 'jszip';
-import { FileItemMetadata, FilePropertiesWithContent } from './viewOrCompareMetadataTypes';
+import { DeployFromCompareMetadataItem, FileItemMetadata, FilePropertiesWithContent } from './viewOrCompareMetadataTypes';
 
 export function getEditorLanguage({ fileName, type }: FilePropertiesWithContent) {
   if (type === 'ApexClass' || type === 'ApexTrigger') {
@@ -79,7 +79,7 @@ export function buildTree(
             // set different id for folders
             id = `FOLDER|${id}|${i}|${name}`;
           }
-          output.result.push({ id, label: getTreeLabel(id, name, meta), meta, treeItems: output[name].result });
+          output.result.push({ id, label: getTreeLabel(id, name, meta), title: name, meta, treeItems: output[name].result });
         }
         return output[name];
       }, level);
@@ -127,6 +127,15 @@ export function compare(sourceFile: FilePropertiesWithContent, targetFiles: Reco
     }
   }
   return match;
+}
+
+export function getDeployMetadataFromComparisonTree(files: TreeItems<FileItemMetadata | null>[]): DeployFromCompareMetadataItem[] {
+  return files
+    .map((metadata) => ({
+      type: metadata.treeItems?.[0]?.meta?.type as string,
+      items: metadata.treeItems?.map((item) => item.meta) || [],
+    }))
+    .filter((item) => item.type);
 }
 
 export function generateExport(sourceResultFiles: FilePropertiesWithContent[], targetResultFiles: FilePropertiesWithContent[]) {

--- a/libs/ui/src/lib/form/checkbox/Checkbox.tsx
+++ b/libs/ui/src/lib/form/checkbox/Checkbox.tsx
@@ -1,5 +1,5 @@
 import classNames from 'classnames';
-import React, { Fragment, FunctionComponent, RefObject, SyntheticEvent, useEffect, useRef } from 'react';
+import React, { Fragment, FunctionComponent, ReactNode, RefObject, SyntheticEvent, useEffect, useRef } from 'react';
 import HelpText from '../../widgets/HelpText';
 
 export interface CheckboxProps {
@@ -9,7 +9,7 @@ export interface CheckboxProps {
   checkboxClassName?: string;
   checked: boolean;
   indeterminate?: boolean;
-  label: string;
+  label: ReactNode;
   hideLabel?: boolean;
   labelHelp?: string | JSX.Element | null;
   helpText?: React.ReactNode | string;


### PR DESCRIPTION
After comparison, allow deploying metadata to a target org to make it easier to only deploy modified metadata instead having to track it separately from the main page

resolves #1150