### PR TITLE
Web extension - SFDC link and deployment fixes

### DIFF
--- a/apps/jetstream-web-extension/src/controllers/route.utils.ts
+++ b/apps/jetstream-web-extension/src/controllers/route.utils.ts
@@ -68,6 +68,8 @@ export function createRoute<TParamsSchema extends z.ZodTypeAny, TBodySchema exte
         } catch (ex) {
           // headers may not have been correct, just ignore and continue
         }
+      } else if (req.request.headers.get('content-type') === 'application/zip') {
+        parsedBody = await req.request.arrayBuffer();
       } else {
         parsedBody = await req.request.text();
       }

--- a/apps/jetstream-web-extension/src/extension-scripts/service-worker.ts
+++ b/apps/jetstream-web-extension/src/extension-scripts/service-worker.ts
@@ -36,8 +36,6 @@ import {
 import '../utils/serviceWorker.zip-handler';
 import { getRecordPageRecordId } from '../utils/web-extension.utils';
 
-const ctx: ServiceWorkerGlobalScope = self as any;
-
 if (!environment.production) {
   enableLogger(true);
 }

--- a/apps/jetstream-web-extension/src/utils/extension-axios-adapter.ts
+++ b/apps/jetstream-web-extension/src/utils/extension-axios-adapter.ts
@@ -26,10 +26,14 @@ export async function browserExtensionAxiosAdapter(config: InternalAxiosRequestC
 
   try {
     const url = getUrl(config);
+    let body = data;
+    if (data && typeof data !== 'string' && headers.get('content-type') === 'application/json') {
+      body = JSON.stringify(data);
+    }
     const request = new Request(url, {
       method: method?.toUpperCase() ?? 'GET',
       headers: headers.normalize(false).toJSON() as HeadersInit,
-      body: data && typeof data !== 'string' ? JSON.stringify(data) : data,
+      body,
     });
 
     const route = extensionRoutes.match(request.method as Method, config.url || '/');

--- a/libs/shared/ui-app-state/src/lib/ui-app-state.ts
+++ b/libs/shared/ui-app-state/src/lib/ui-app-state.ts
@@ -339,6 +339,9 @@ export const salesforceOrgsOmitSelectedState = selector({
 export const selectSkipFrontdoorAuth = selector({
   key: 'selectSkipFrontdoorAuth',
   get: ({ get }) => {
+    if (isBrowserExtension()) {
+      return true;
+    }
     const userProfile = get(userProfileState);
     return userProfile?.preferences?.skipFrontdoorLogin || false;
   },


### PR DESCRIPTION
ZIP upload did not work which caused all metadata deployment features to fail

Skip frontdoor auth was enabled in the web extension, which caused SFDC links to be broken since it was attempting to use localhost.

resolves #1229
resolves #1195