### PR TITLE
Remove default web extension keyboard shortcuts

### DIFF
--- a/apps/jetstream-web-extension/src/manifest.json
+++ b/apps/jetstream-web-extension/src/manifest.json
@@ -50,17 +50,9 @@
   },
   "commands": {
     "open-jetstream-home-page": {
-      "suggested_key": {
-        "default": "Alt+J",
-        "mac": "Command+J"
-      },
       "description": "Open Jetstream in a new tab for the current Salesforce page."
     },
     "open-view-record-modal": {
-      "suggested_key": {
-        "default": "Ctrl+Shift+V",
-        "mac": "Command+Shift+V"
-      },
       "description": "View the current Salesforce record in Jetstream."
     }
   },


### PR DESCRIPTION
these were conflicting with other native shortcuts and there wasn't a logical default, so the defaults are removed.

Most likely no one was using these anyway

resolves #1237