### PR TITLE
Fix logic for to determine which fields can be edited #1248

### DIFF
--- a/libs/features/manage-permissions/src/utils/permission-manager-table-utils.tsx
+++ b/libs/features/manage-permissions/src/utils/permission-manager-table-utils.tsx
@@ -689,7 +689,7 @@ export function getFieldRows(
         tableLabel: `${fieldPermission.label} (${fieldPermission.apiName})`,
         type: fieldPermission.metadata.DataType,
         // formula fields and auto-number fields do not allow editing
-        allowEditPermission: fieldPermission.metadata.IsCompound || fieldPermission.metadata.IsCreatable,
+        allowEditPermission: !fieldPermission.metadata.IsCompound && fieldPermission.metadata.IsUpdatable,
         permissions: {},
       };
 

--- a/libs/features/manage-permissions/src/utils/permission-manager-utils.ts
+++ b/libs/features/manage-permissions/src/utils/permission-manager-utils.ts
@@ -608,6 +608,7 @@ export function getQueryForAllPermissionableFields(allSobjects: string[]): strin
         getField('NamespacePrefix'),
         getField('IsCompound'),
         getField('isCreatable'),
+        getField('IsUpdatable'),
         getField('IsPermissionable'),
       ],
       sObject: 'EntityParticle',

--- a/libs/types/src/lib/salesforce/record.types.ts
+++ b/libs/types/src/lib/salesforce/record.types.ts
@@ -155,6 +155,7 @@ export interface EntityParticlePermissionsRecord {
   NamespacePrefix: string;
   IsCompound: boolean;
   IsCreatable: boolean;
+  IsUpdatable: boolean;
   IsPermissionable: boolean;
 }
 


### PR DESCRIPTION
We had bad logic when determining which fields could have "edit" enabled in permission manager.

resolves #1248