### PR TITLE
Ensure saving a query to favorites works prior to running query #1249

### DIFF
--- a/libs/features/query/src/QueryOptions/SaveFavoriteSoql.tsx
+++ b/libs/features/query/src/QueryOptions/SaveFavoriteSoql.tsx
@@ -73,17 +73,19 @@ export const SaveFavoriteSoql: FunctionComponent<SaveFavoriteSoqlProps> = ({
   }
 
   async function handleSave() {
-    if (!queryHistoryItem) {
+    if (!queryHistoryItem || !sObject || !sObjectLabel) {
       return;
     }
     const newQueryHistoryItem: QueryHistoryItem = { ...queryHistoryItem, customLabel: name.trim(), isFavorite: true };
     setQueryHistoryItem(newQueryHistoryItem);
     try {
-      await queryHistoryDb.setAsFavorite(
-        newQueryHistoryItem.key,
-        newQueryHistoryItem.isFavorite,
-        newQueryHistoryItem.customLabel ?? newQueryHistoryItem.label
-      );
+      await queryHistoryDb.saveQueryHistoryItem(selectedOrg, soql, sObject, {
+        sObjectLabel,
+        isTooling,
+        incrementRunCount: false,
+        isFavorite: true,
+        customLabel: name.trim(),
+      });
     } catch (ex) {
       logger.warn('Unable to save favorite', ex);
     }

--- a/libs/features/query/src/QueryOptions/SaveFavoriteSoql.tsx
+++ b/libs/features/query/src/QueryOptions/SaveFavoriteSoql.tsx
@@ -79,13 +79,16 @@ export const SaveFavoriteSoql: FunctionComponent<SaveFavoriteSoqlProps> = ({
     const newQueryHistoryItem: QueryHistoryItem = { ...queryHistoryItem, customLabel: name.trim(), isFavorite: true };
     setQueryHistoryItem(newQueryHistoryItem);
     try {
-      await queryHistoryDb.saveQueryHistoryItem(selectedOrg, soql, sObject, {
+      const savedItem = await queryHistoryDb.saveQueryHistoryItem(selectedOrg, soql, sObject, {
         sObjectLabel,
         isTooling,
         incrementRunCount: false,
         isFavorite: true,
         customLabel: name.trim(),
       });
+      if (savedItem) {
+        setQueryHistoryItem(savedItem);
+      }
     } catch (ex) {
       logger.warn('Unable to save favorite', ex);
     }

--- a/libs/shared/ui-db/src/lib/query-history.db.ts
+++ b/libs/shared/ui-db/src/lib/query-history.db.ts
@@ -33,7 +33,11 @@ async function getAllQueryHistory(): Promise<QueryHistoryItem[]> {
   return await dexieDb.query_history.toArray();
 }
 
-async function setAsFavorite(key: QueryHistoryItem['key'], isFavorite: boolean, customLabel?: string): Promise<QueryHistoryItem> {
+async function setAsFavorite(
+  key: QueryHistoryItem['key'],
+  isFavorite: boolean,
+  customLabel?: string
+): Promise<QueryHistoryItem | undefined> {
   const updates: Partial<QueryHistoryItem> = { isFavorite };
   // update custom label if provided
   if (customLabel) {
@@ -42,8 +46,7 @@ async function setAsFavorite(key: QueryHistoryItem['key'], isFavorite: boolean, 
     updates.customLabel = null;
   }
   await dexieDb.query_history.update(key, updates);
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-  return (await dexieDb.query_history.get(key))!;
+  return await dexieDb.query_history.get(key);
 }
 
 async function getOrInitQueryHistoryItem(


### PR DESCRIPTION
Saving to favorite from query builder screen would not work if query had never been executed.

resolves #1249