### PR TITLE
Allow editing query name in query history #1255

### DIFF
--- a/libs/features/query/src/QueryHistory/QueryHistory.tsx
+++ b/libs/features/query/src/QueryHistory/QueryHistory.tsx
@@ -254,9 +254,22 @@ export const QueryHistory = forwardRef<any, QueryHistoryProps>(({ className, sel
     try {
       await queryHistoryDb.setAsFavorite(item.key, isFavorite);
     } catch (ex) {
-      logger.warn('[ERROR] Could not updated query history', ex);
+      logger.warn('[ERROR] Could not update query history', ex);
     }
     trackEvent(ANALYTICS_KEYS.query_HistorySaveQueryToggled, { location: 'modal', isFavorite });
+  }
+
+  async function handleEdit(item: QueryHistoryItem, customLabel: string | null) {
+    try {
+      await queryHistoryDb.updateCustomLabel(item.key, customLabel);
+    } catch (ex) {
+      logger.warn('[ERROR] Could not update query history', ex);
+    }
+    trackEvent(ANALYTICS_KEYS.query_HistoryUpdateLabel, {
+      location: 'modal',
+      hadPriorCustomLabel: !!item.customLabel,
+      isReset: !customLabel,
+    });
   }
 
   function handleSetWhichType(type: fromQueryHistoryState.QueryHistoryType) {
@@ -384,6 +397,7 @@ export const QueryHistory = forwardRef<any, QueryHistoryProps>(({ className, sel
                     isOnSavedQueries={whichType === 'SAVED'}
                     item={item}
                     onExecute={handleExecute}
+                    onUpdate={handleEdit}
                     onSave={handleSaveFavorite}
                     startRestore={handleStartRestore}
                     endRestore={(fatalError, errors) => handleEndRestore(item, fatalError, errors)}

--- a/libs/features/query/src/QueryHistory/QueryHistoryEditNamePopover.tsx
+++ b/libs/features/query/src/QueryHistory/QueryHistoryEditNamePopover.tsx
@@ -1,0 +1,88 @@
+import { css } from '@emotion/react';
+import { QueryHistoryItem } from '@jetstream/types';
+import { Grid, Icon, Input, Popover, PopoverRef } from '@jetstream/ui';
+import { useRef, useState } from 'react';
+
+export interface QueryHistoryEditNamePopoverProps {
+  item: QueryHistoryItem;
+  onOpenStateChange: (isOpen: boolean) => void;
+  onSave: (name: string | null) => Promise<void>;
+}
+
+export const QueryHistoryEditNamePopover = ({ item, onOpenStateChange, onSave }: QueryHistoryEditNamePopoverProps) => {
+  const itemName = item.customLabel || item.label;
+  const [name, setName] = useState(item.customLabel || item.label);
+  const [saving, setSaving] = useState(false);
+
+  const isDirty = itemName !== name;
+  const canReset = !!item.customLabel;
+
+  const popoverRef = useRef<PopoverRef>(null);
+
+  async function handleOpenStateChange(isOpen: boolean) {
+    if (isOpen) {
+      setName(item.customLabel || item.label);
+    }
+    onOpenStateChange(isOpen);
+  }
+
+  async function handleSave() {
+    setSaving(true);
+    onSave(name.trim())
+      .then(() => popoverRef.current?.close())
+      .finally(() => setSaving(false));
+  }
+
+  async function handleReset() {
+    setSaving(true);
+    onSave(null)
+      .then(() => popoverRef.current?.close())
+      .finally(() => setSaving(false));
+  }
+
+  return (
+    <Popover
+      ref={popoverRef}
+      omitPortal
+      onChange={handleOpenStateChange}
+      content={
+        <div
+          css={css`
+            max-height: 80vh;
+            font-size: 13px;
+            font-weight: 400;
+          `}
+        >
+          <form onSubmit={(event) => event.preventDefault()}>
+            <Input label="Query Name">
+              <input
+                className="slds-input"
+                autoComplete="off"
+                value={name}
+                minLength={1}
+                maxLength={254}
+                onChange={(event) => setName(event.target.value)}
+              />
+            </Input>
+            <Grid className="slds-m-top_small" align="end">
+              <button
+                className="slds-button slds-button_neutral"
+                onClick={() => handleReset()}
+                disabled={saving || !canReset}
+                type="button"
+              >
+                Reset
+              </button>
+              <button type="submit" className="slds-button slds-button_brand" disabled={!isDirty || saving} onClick={() => handleSave()}>
+                Save
+              </button>
+            </Grid>
+          </form>
+        </div>
+      }
+      buttonProps={{ className: 'slds-button slds-button_icon slds-m-left_xx-small', 'aria-label': 'Edit query name' }}
+    >
+      <Icon type="utility" icon="edit" className="slds-button__icon" omitContainer />
+    </Popover>
+  );
+};

--- a/libs/features/query/src/QueryHistory/QueryHistoryItemCard.tsx
+++ b/libs/features/query/src/QueryHistory/QueryHistoryItemCard.tsx
@@ -1,6 +1,7 @@
 import { IconObj } from '@jetstream/icon-factory';
 import { DATE_FORMATS } from '@jetstream/shared/constants';
 import { APP_ROUTES } from '@jetstream/shared/ui-router';
+import { useHover } from '@jetstream/shared/ui-utils';
 import { pluralizeFromNumber } from '@jetstream/shared/utils';
 import { QueryHistoryItem } from '@jetstream/types';
 import { ButtonGroupContainer, Card, CopyToClipboard, Grid, GridCol, Icon, Textarea } from '@jetstream/ui';
@@ -10,6 +11,7 @@ import clamp from 'lodash/clamp';
 import { FunctionComponent, useEffect, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
 import RestoreQuery from '../QueryBuilder/RestoreQuery';
+import { QueryHistoryEditNamePopover } from './QueryHistoryEditNamePopover';
 
 const SOBJECT_QUERY_ICON: IconObj = { type: 'standard', icon: 'record_lookup', description: 'Object Query' };
 const METADATA_QUERY_ICON: IconObj = { type: 'standard', icon: 'settings', description: 'Metadata Query' };
@@ -21,6 +23,7 @@ export interface QueryHistoryItemCardProps {
   item: QueryHistoryItem;
   onExecute: (item: QueryHistoryItem) => void;
   onSave: (item: QueryHistoryItem, value: boolean) => void;
+  onUpdate: (item: QueryHistoryItem, customLabel: string | null) => Promise<void>;
   startRestore: () => void;
   endRestore: (isTooling: boolean, fatalError: boolean, errors?: any) => void;
 }
@@ -30,6 +33,7 @@ export const QueryHistoryItemCard: FunctionComponent<QueryHistoryItemCardProps> 
   item,
   onExecute,
   onSave,
+  onUpdate,
   startRestore,
   endRestore,
 }) => {
@@ -39,6 +43,8 @@ export const QueryHistoryItemCard: FunctionComponent<QueryHistoryItemCardProps> 
   const [lineCount, setLineCount] = useState(Math.max(soql.split('\n').length, 2));
 
   const [isRemoving, setIsRemoving] = useState(false);
+  const [cardRef, isHovered] = useHover();
+  const [isEditPopoverOpen, setIsEditPopoverOpen] = useState(false);
 
   useEffect(() => {
     isMounted.current = true;
@@ -72,6 +78,7 @@ export const QueryHistoryItemCard: FunctionComponent<QueryHistoryItemCardProps> 
 
   return (
     <Card
+      ref={cardRef as any}
       className="modal-card-override"
       icon={isTooling ? METADATA_QUERY_ICON : SOBJECT_QUERY_ICON}
       testId={`query-history-${soql}`}
@@ -79,6 +86,9 @@ export const QueryHistoryItemCard: FunctionComponent<QueryHistoryItemCardProps> 
         <Grid wrap>
           <GridCol size={12}>
             <span>{customLabel ?? label}</span>
+            {(isHovered || isEditPopoverOpen) && (
+              <QueryHistoryEditNamePopover item={item} onOpenStateChange={setIsEditPopoverOpen} onSave={(value) => onUpdate(item, value)} />
+            )}
           </GridCol>
           <GridCol className="slds-text-body_small slds-text-color_weak">{sObject}</GridCol>
         </Grid>

--- a/libs/shared/constants/src/lib/shared-constants.ts
+++ b/libs/shared/constants/src/lib/shared-constants.ts
@@ -196,6 +196,7 @@ export const ANALYTICS_KEYS = {
   query_HistoryModalOpened: 'query_HistoryModalOpened',
   query_HistoryRestore: 'query_HistoryRestore',
   query_HistorySaveQueryToggled: 'query_HistorySaveQueryToggled',
+  query_HistoryUpdateLabel: 'query_HistoryUpdateLabel',
   query_HistoryShowMore: 'query_HistoryShowMore',
   query_HistoryTypeChanged: 'query_HistoryTypeChanged',
   query_LoadMore: 'query_LoadMore',

--- a/libs/shared/ui-db/src/lib/query-history.db.ts
+++ b/libs/shared/ui-db/src/lib/query-history.db.ts
@@ -9,6 +9,7 @@ export const queryHistoryDb = {
   getOrInitQueryHistoryItem,
   saveQueryHistoryItem,
   setAsFavorite,
+  updateCustomLabel,
   deleteAllQueryHistoryForOrgExceptFavorites,
   TEMP_deleteItem,
 };
@@ -42,9 +43,13 @@ async function setAsFavorite(
   // update custom label if provided
   if (customLabel) {
     updates.customLabel = customLabel;
-  } else if (!isFavorite) {
-    updates.customLabel = null;
   }
+  await dexieDb.query_history.update(key, updates);
+  return await dexieDb.query_history.get(key);
+}
+
+async function updateCustomLabel(key: QueryHistoryItem['key'], customLabel: string | null): Promise<QueryHistoryItem | undefined> {
+  const updates: Partial<QueryHistoryItem> = { customLabel: customLabel || null };
   await dexieDb.query_history.update(key, updates);
   return await dexieDb.query_history.get(key);
 }


### PR DESCRIPTION
This feature adds support for editing query history name and saved query names from the query history modal

resolves #1255