### PR TITLE
Ensure compound fields allow edit modification in permission manager

### DIFF
--- a/libs/features/manage-permissions/src/utils/permission-manager-table-utils.tsx
+++ b/libs/features/manage-permissions/src/utils/permission-manager-table-utils.tsx
@@ -688,8 +688,8 @@ export function getFieldRows(
         label: fieldPermission.label,
         tableLabel: `${fieldPermission.label} (${fieldPermission.apiName})`,
         type: fieldPermission.metadata.DataType,
-        // formula fields and auto-number fields do not allow editing
-        allowEditPermission: !fieldPermission.metadata.IsCompound && fieldPermission.metadata.IsUpdatable,
+        // Compound fields (e.x. BillingAddress) show up as non-editable, but they are editable
+        allowEditPermission: fieldPermission.metadata.IsCompound || fieldPermission.metadata.IsUpdatable,
         permissions: {},
       };
 


### PR DESCRIPTION
e.g. Account.BillingAddress shows up as if it is not updateable, but in reality permission "edit" permission can be modified

Bug from #1248