### PR TITLE
Expose recent auth activity to users

### DIFF
--- a/apps/api/src/app/controllers/desktop-app.controller.ts
+++ b/apps/api/src/app/controllers/desktop-app.controller.ts
@@ -103,6 +103,7 @@ const initSession = createRoute(routeDefinition.initSession.validators, async ({
     accessToken = await externalAuthService.issueAccessToken(userProfile, externalAuthService.AUDIENCE_DESKTOP);
     storedRefreshToken = await webExtDb.create(user.id, {
       type: 'AUTH_TOKEN',
+      source: webExtDb.TOKEN_SOURCE_DESKTOP,
       token: accessToken,
       deviceId,
       ipAddress: res.locals.ipAddress || getApiAddressFromReq(req),

--- a/apps/api/src/app/controllers/web-extension.controller.ts
+++ b/apps/api/src/app/controllers/web-extension.controller.ts
@@ -98,6 +98,7 @@ const initSession = createRoute(routeDefinition.initSession.validators, async ({
     accessToken = await externalAuthService.issueAccessToken(userProfile, externalAuthService.AUDIENCE_WEB_EXT);
     storedRefreshToken = await webExtDb.create(user.id, {
       type: 'AUTH_TOKEN',
+      source: webExtDb.TOKEN_SOURCE_BROWSER_EXTENSION,
       token: accessToken,
       deviceId,
       ipAddress: res.locals.ipAddress || getApiAddressFromReq(req),

--- a/apps/api/src/app/db/web-extension.db.ts
+++ b/apps/api/src/app/db/web-extension.db.ts
@@ -1,10 +1,14 @@
 import { prisma } from '@jetstream/api-config';
+import { TokenSource, TokenSourceBrowserExtensions, TokenSourceDesktop } from '@jetstream/auth/types';
 import { Prisma } from '@jetstream/prisma';
 
 export type TokenTypeAuthToken = 'AUTH_TOKEN';
 export type TokenType = TokenTypeAuthToken;
 
 export const TOKEN_TYPE_AUTH: TokenTypeAuthToken = 'AUTH_TOKEN';
+
+export const TOKEN_SOURCE_BROWSER_EXTENSION: TokenSourceBrowserExtensions = 'BROWSER_EXTENSION';
+export const TOKEN_SOURCE_DESKTOP: TokenSourceDesktop = 'DESKTOP';
 
 const SELECT = Prisma.validator<Prisma.WebExtensionTokenSelect>()({
   id: true,
@@ -15,6 +19,7 @@ const SELECT = Prisma.validator<Prisma.WebExtensionTokenSelect>()({
     },
   },
   type: true,
+  source: true,
   token: true,
   deviceId: true,
   ipAddress: true,
@@ -48,6 +53,7 @@ export const create = async (
   userId: string,
   payload: {
     type: TokenType;
+    source: TokenSource;
     token: string;
     deviceId: string;
     ipAddress: string;

--- a/apps/jetstream/src/app/components/profile/ProfileIdentityCard.tsx
+++ b/apps/jetstream/src/app/components/profile/ProfileIdentityCard.tsx
@@ -90,7 +90,7 @@ export const ProfileIdentityCard: FunctionComponent<ProfileIdentityCardProps> = 
             <div
               css={css`
                 position: absolute;
-                bottom: 0.25rem;
+                top: -1.25rem;
                 right: 0.25rem;
               `}
             >

--- a/apps/jetstream/src/app/components/profile/ProfileLinkedAccounts.tsx
+++ b/apps/jetstream/src/app/components/profile/ProfileLinkedAccounts.tsx
@@ -39,7 +39,7 @@ export const ProfileLinkedAccounts: FunctionComponent<ProfileLinkedAccountsProps
   }
 
   return (
-    <Grid className="slds-m-top_small slds-m-bottom_large" vertical>
+    <Grid className="slds-m-top_small" vertical>
       <h2 className="slds-text-heading_small">Linked Accounts</h2>
       <p>You can login to Jetstream using any of these accounts</p>
       <ul className="slds-has-dividers_around-space">

--- a/apps/jetstream/src/app/components/profile/ProfileUserPassword.tsx
+++ b/apps/jetstream/src/app/components/profile/ProfileUserPassword.tsx
@@ -90,10 +90,10 @@ export const ProfileUserPassword: FunctionComponent<ProfileUserPasswordProps> = 
     );
   }
 
-  return <SetPassword onSetPassword={onSetPassword} />;
+  return <SetPassword username={fullUserProfile.email} onSetPassword={onSetPassword} />;
 };
 
-function SetPassword({ onSetPassword }: { onSetPassword: (password: string) => Promise<void> }) {
+function SetPassword({ username, onSetPassword }: { username: string; onSetPassword: (password: string) => Promise<void> }) {
   const [changePasswordActive, setChangePasswordActive] = useState(false);
   const [loading, setLoading] = useState(false);
 
@@ -130,6 +130,8 @@ function SetPassword({ onSetPassword }: { onSetPassword: (password: string) => P
     return (
       <form className="slds-is-relative slds-m-top_small" onSubmit={handleSubmit(handleSetPassword)}>
         {loading && <Spinner />}
+
+        <input hidden readOnly name="username" value={username} autoComplete="username" />
 
         <FormRowItem>
           <Input

--- a/apps/jetstream/src/app/components/profile/ProfileUserProfile.tsx
+++ b/apps/jetstream/src/app/components/profile/ProfileUserProfile.tsx
@@ -1,8 +1,8 @@
 import { css } from '@emotion/react';
 import type { UserProfileUiWithIdentities } from '@jetstream/auth/types';
-import { Form, FormRow, FormRowItem, Grid, Input, ReadOnlyFormItem } from '@jetstream/ui';
+import { Form, FormRow, FormRowItem, Input, ReadOnlyFormItem } from '@jetstream/ui';
 import Avatar from '@salesforce-ux/design-system/assets/images/profile_avatar_96.png';
-import { Fragment, FunctionComponent, useMemo, useState } from 'react';
+import { FunctionComponent, useMemo, useState } from 'react';
 import { ProfileUserPassword } from './ProfileUserPassword';
 
 export interface ProfileUserProfileProps {
@@ -40,71 +40,60 @@ export const ProfileUserProfile: FunctionComponent<ProfileUserProfileProps> = ({
   const [avatarSrc, setAvatarSrc] = useState(fullUserProfile?.picture || Avatar);
 
   return (
-    <Fragment>
-      <Grid className="slds-m-top_large" verticalAlign="center">
-        <div className="slds-avatar slds-avatar_circle slds-avatar_large">
-          <img loading="lazy" alt="Avatar" src={avatarSrc} onError={(err) => setAvatarSrc(Avatar)} />
-        </div>
-        {/* TODO: implement this sometime */}
-        {/* <div>
-          <button className="slds-button slds-button_neutral slds-m-left_small">Change picture</button>
-        </div> */}
-      </Grid>
-      <div
-        className="slds-m-top_small slds-m-bottom_large"
-        css={css`
-          max-width: 33rem;
-        `}
-      >
-        <Form>
-          <FormRow>
-            <FormRowItem>
-              {!editMode && (
-                <ReadOnlyFormItem label="Name" horizontal omitEdit={blockNameEdit} onEditMore={() => onEditMode(true)}>
-                  {fullUserProfile.name}
-                </ReadOnlyFormItem>
-              )}
-              {editMode && (
-                <Input
-                  className="slds-form-element_horizontal slds-is-editing"
-                  label="Name"
-                  hasError={invalidName}
-                  errorMessage="Your name must be between 1 and 255 characters"
-                >
-                  <input
-                    className="slds-input"
-                    value={name}
-                    minLength={1}
-                    maxLength={254}
-                    onChange={(event) => onChange({ name: event.target.value })}
-                  />
-                </Input>
-              )}
-            </FormRowItem>
-            <FormRowItem>
-              <ReadOnlyFormItem label="Email" horizontal omitEdit labelHelp="File a support ticket to change your email.">
-                {fullUserProfile.email}
+    <div
+      className="slds-m-top_small slds-m-bottom_large"
+      css={css`
+        max-width: 33rem;
+      `}
+    >
+      <Form>
+        <FormRow>
+          <FormRowItem>
+            {!editMode && (
+              <ReadOnlyFormItem label="Name" horizontal omitEdit={blockNameEdit} onEditMore={() => onEditMode(true)}>
+                {fullUserProfile.name}
               </ReadOnlyFormItem>
-            </FormRowItem>
-            <ProfileUserPassword
-              fullUserProfile={fullUserProfile}
-              onResetPassword={onResetPassword}
-              onSetPassword={onSetPassword}
-              onRemovePassword={onRemovePassword}
-            />
+            )}
+            {editMode && (
+              <Input
+                className="slds-form-element_horizontal slds-is-editing"
+                label="Name"
+                hasError={invalidName}
+                errorMessage="Your name must be between 1 and 255 characters"
+              >
+                <input
+                  className="slds-input"
+                  value={name}
+                  minLength={1}
+                  maxLength={254}
+                  onChange={(event) => onChange({ name: event.target.value })}
+                />
+              </Input>
+            )}
+          </FormRowItem>
+          <FormRowItem>
+            <ReadOnlyFormItem label="Email" horizontal omitEdit labelHelp="File a support ticket to change your email.">
+              {fullUserProfile.email}
+            </ReadOnlyFormItem>
+          </FormRowItem>
+          <ProfileUserPassword
+            fullUserProfile={fullUserProfile}
+            onResetPassword={onResetPassword}
+            onSetPassword={onSetPassword}
+            onRemovePassword={onRemovePassword}
+          />
+        </FormRow>
+        {editMode && (
+          <FormRow className="slds-align_absolute-center slds-m-top_medium">
+            <button className="slds-button slds-button_brand" disabled={invalidName} onClick={onSave}>
+              Save
+            </button>
+            <button className="slds-button slds-button_neutral" onClick={onCancel}>
+              Cancel
+            </button>
           </FormRow>
-          {editMode && (
-            <FormRow className="slds-align_absolute-center slds-m-top_medium">
-              <button className="slds-button slds-button_brand" disabled={invalidName} onClick={onSave}>
-                Save
-              </button>
-              <button className="slds-button slds-button_neutral" onClick={onCancel}>
-                Cancel
-              </button>
-            </FormRow>
-          )}
-        </Form>
-      </div>
-    </Fragment>
+        )}
+      </Form>
+    </div>
   );
 };

--- a/apps/jetstream/src/app/components/profile/session/ProfileLoginActivity.tsx
+++ b/apps/jetstream/src/app/components/profile/session/ProfileLoginActivity.tsx
@@ -1,0 +1,41 @@
+import { css } from '@emotion/react';
+import { Card, Grid, ScopedNotification, Spinner } from '@jetstream/ui';
+import { useSessionData } from '../useSessionData';
+import { ProfileLoginActivityItem } from './ProfileLoginActivityItem';
+
+export const ProfileLoginActivity = ({ sessionData }: { sessionData: ReturnType<typeof useSessionData> }) => {
+  const { errorMessage, isLoading } = sessionData;
+  const { currentSessionId, loginActivity } = sessionData.sessions;
+
+  return (
+    <Card
+      className="slds-is-relative"
+      bodyClassName={null}
+      title={
+        <Grid verticalAlign="center">
+          Recent Session Activity{' '}
+          {isLoading && !!currentSessionId && (
+            <Spinner
+              className="slds-m-left_x-small slds-m-top_x-small slds-spinner slds-spinner_brand slds-spinner_x-small slds-spinner_inline"
+              hasContainer={false}
+            />
+          )}
+        </Grid>
+      }
+      icon={{
+        type: 'standard',
+        icon: 'events',
+      }}
+      nestedBorder
+      css={css`
+        max-width: 33rem;
+      `}
+    >
+      {errorMessage && <ScopedNotification theme="error">{errorMessage}</ScopedNotification>}
+      {isLoading && !currentSessionId && <Spinner />}
+      {loginActivity.map((loginActivity) => (
+        <ProfileLoginActivityItem key={`${loginActivity.createdAt}${loginActivity.action}`} loginActivity={loginActivity} />
+      ))}
+    </Card>
+  );
+};

--- a/apps/jetstream/src/app/components/profile/session/ProfileLoginActivityItem.tsx
+++ b/apps/jetstream/src/app/components/profile/session/ProfileLoginActivityItem.tsx
@@ -1,0 +1,43 @@
+import { LoginActivityUserFacing } from '@jetstream/auth/types';
+import { Card } from '@jetstream/ui';
+import { parseISO } from 'date-fns/parseISO';
+import { FunctionComponent, useMemo } from 'react';
+import { getBrowserInfo } from './browser-session.utils';
+import { ProfileSessionLocation } from './ProfileSessionLocation';
+
+export interface ProfileLoginActivityItemProps {
+  loginActivity: LoginActivityUserFacing;
+}
+
+export const ProfileLoginActivityItem: FunctionComponent<ProfileLoginActivityItemProps> = ({ loginActivity }) => {
+  const { action, createdAt, ipAddress, success, userAgent, location } = loginActivity;
+  const { browserName, browserVersion, osName } = useMemo(
+    () =>
+      userAgent
+        ? getBrowserInfo(userAgent)
+        : {
+            browserName: '',
+            browserVersion: '',
+            osName: '',
+          },
+    [userAgent]
+  );
+
+  return (
+    <Card>
+      <p className="text-bold">{action}</p>
+      {browserName && (
+        <p className="slds-text-color_weak">
+          {osName} - {browserName} {browserVersion}
+        </p>
+      )}
+      <p className="slds-text-color_weak">
+        {ipAddress} {location && <ProfileSessionLocation location={location} />}
+      </p>
+      <p className="slds-text-color_weak" title={createdAt}>
+        {parseISO(createdAt).toLocaleString()}
+      </p>
+      {success ? <p className="slds-text-color_success">Successful</p> : <p className="slds-text-color_error">Failed</p>}
+    </Card>
+  );
+};

--- a/apps/jetstream/src/app/components/profile/session/ProfileSessionLocation.tsx
+++ b/apps/jetstream/src/app/components/profile/session/ProfileSessionLocation.tsx
@@ -1,0 +1,24 @@
+import { SessionIpData } from '@jetstream/auth/types';
+
+export function ProfileSessionLocation({ location }: { location: SessionIpData }) {
+  if (location.status !== 'success') {
+    return null;
+  }
+  const { city, region, countryCode, lat, lon } = location;
+
+  const estimatedLocation = [city, region, countryCode].filter(Boolean).join(', ');
+
+  if (lat && lon) {
+    return (
+      <span>
+        (Est. location:{' '}
+        <a href={`https://www.google.com/maps?q=${lat},${lon}`} target="_blank" rel="noopener noreferrer">
+          {estimatedLocation}
+        </a>
+        )
+      </span>
+    );
+  }
+
+  return <span>(Est. location: {estimatedLocation})</span>;
+}

--- a/apps/jetstream/src/app/components/profile/session/browser-session.utils.ts
+++ b/apps/jetstream/src/app/components/profile/session/browser-session.utils.ts
@@ -1,0 +1,26 @@
+import Bowser from 'bowser';
+
+const browserMap = new Map<
+  string,
+  {
+    browserName: string;
+    browserVersion: string;
+    osName: string;
+  }
+>();
+
+export function getBrowserInfo(userAgent: string) {
+  if (browserMap.has(userAgent)) {
+    return browserMap.get(userAgent)!;
+  }
+
+  const browser = Bowser.getParser(userAgent);
+  const browserInfo = {
+    browserName: browser.getBrowserName(),
+    browserVersion: browser.getBrowserVersion(),
+    osName: browser.getOSName(),
+  };
+
+  browserMap.set(userAgent, browserInfo);
+  return browserInfo;
+}

--- a/apps/jetstream/src/app/components/profile/useSessionData.ts
+++ b/apps/jetstream/src/app/components/profile/useSessionData.ts
@@ -1,0 +1,81 @@
+import { UserSessionAndExtTokensAndActivityWithLocation } from '@jetstream/auth/types';
+import { logger } from '@jetstream/shared/client-logger';
+import { getUserSessions, revokeAllUserSessions, revokeUserSession } from '@jetstream/shared/data';
+import { ConfirmationModalPromise, fireToast } from '@jetstream/ui';
+import { useCallback, useEffect, useState } from 'react';
+
+export function useSessionData() {
+  const [isLoading, setIsLoading] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>();
+  const [sessions, setSessions] = useState<UserSessionAndExtTokensAndActivityWithLocation>({
+    currentSessionId: '',
+    sessions: [],
+    webTokenSessions: [],
+    loginActivity: [],
+  });
+
+  const getSessions = useCallback(async () => {
+    try {
+      setIsLoading(true);
+      setErrorMessage(null);
+      const response = await getUserSessions();
+      setSessions(response);
+    } catch (ex) {
+      logger.error('Failed to get sessions', ex);
+      setErrorMessage('Failed to get sessions, please try again later.');
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  async function revokeSession(sessionId: string, type: 'SESSION' | 'EXTERNAL_SESSION') {
+    try {
+      if (
+        await ConfirmationModalPromise({
+          content: 'Are you sure you want to revoke this session?',
+        })
+      ) {
+        setIsLoading(true);
+        const response = await revokeUserSession(sessionId, type);
+        setSessions(response);
+      }
+    } catch (ex) {
+      logger.error('Failed to revoke session', ex);
+      fireToast({ message: 'There was an error revoking your sessions, try again later.', type: 'error' });
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  async function revokeAllSessions() {
+    try {
+      if (
+        await ConfirmationModalPromise({
+          content: 'Are you sure you want to revoke all other sessions?',
+        })
+      ) {
+        setIsLoading(true);
+        const response = await revokeAllUserSessions(sessions.currentSessionId);
+        setSessions(response);
+      }
+    } catch (ex) {
+      logger.error('Failed to revoke session', ex);
+      fireToast({ message: 'There was an error revoking your sessions, try again later.', type: 'error' });
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    getSessions();
+  }, [getSessions]);
+
+  return {
+    isLoading,
+    errorMessage,
+    sessions,
+    getSessions,
+    revokeSession,
+    revokeAllSessions,
+  };
+}

--- a/apps/landing/components/auth/PasswordResetVerify.tsx
+++ b/apps/landing/components/auth/PasswordResetVerify.tsx
@@ -106,7 +106,7 @@ export function PasswordResetVerify({ csrfToken, email, token }: PasswordResetVe
           <form onSubmit={handleSubmit(onSubmit)} method="POST" noValidate className="space-y-6">
             <input type="hidden" {...register('csrfToken')} />
             <input type="hidden" {...register('captchaToken')} />
-            <input type="hidden" {...register('email')} />
+            <input hidden readOnly {...register('email')} autoComplete="username" />
             <input type="hidden" {...register('token')} />
 
             <Input

--- a/libs/auth/server/src/lib/auth-logging.db.service.ts
+++ b/libs/auth/server/src/lib/auth-logging.db.service.ts
@@ -1,10 +1,12 @@
 import { logger, prisma } from '@jetstream/api-config';
+import { Maybe } from '@jetstream/types';
 import type { Request, Response } from 'express';
 import { AuthError } from './auth.errors';
 
 export type Action =
   | 'LOGIN'
   | 'PASSWORD_SET'
+  | 'PASSWORD_REMOVE'
   | 'PASSWORD_RESET_REQUEST'
   | 'PASSWORD_RESET_COMPLETION'
   | 'OAUTH_INIT'
@@ -21,16 +23,43 @@ export type Action =
   | 'REVOKE_SESSION'
   | 'DELETE_ACCOUNT';
 
+export const actionDisplayName: Record<Action, string> = {
+  LOGIN: 'Login Attempt',
+  PASSWORD_SET: 'Password Set',
+  PASSWORD_REMOVE: 'Password Removed',
+  PASSWORD_RESET_REQUEST: 'Password Reset Request',
+  PASSWORD_RESET_COMPLETION: 'Password Reset Completion',
+  OAUTH_INIT: 'OAuth Login Initialization',
+  LINK_IDENTITY_INIT: 'Link Identity Initialization',
+  LINK_IDENTITY: 'Link Identity Completion',
+  UNLINK_IDENTITY: 'Unlink Identity',
+  EMAIL_VERIFICATION: 'Email Verification',
+  '2FA_VERIFICATION': '2FA Verification',
+  '2FA_RESEND_VERIFICATION': '2FA Resend Verification',
+  '2FA_SETUP': '2FA Setup',
+  '2FA_REMOVAL': '2FA Removal',
+  '2FA_ACTIVATE': '2FA Activate',
+  '2FA_DEACTIVATE': '2FA Deactivate',
+  REVOKE_SESSION: 'Revoke Session',
+  DELETE_ACCOUNT: 'Delete Account',
+};
+
+export const methodDisplayName: Record<string, string> = {
+  CREDENTIALS: 'Username/Password',
+  GOOGLE: 'Google',
+  SALESFORCE: 'Salesforce',
+};
+
 interface LoginActivity {
   action: Action;
-  method?: string;
+  method?: Maybe<string>;
   success: boolean;
-  email?: string;
-  userId?: string;
-  ipAddress?: string;
-  userAgent?: string;
-  errorMessage?: string;
-  requestId?: string;
+  email?: Maybe<string>;
+  userId?: Maybe<string>;
+  ipAddress?: Maybe<string>;
+  userAgent?: Maybe<string>;
+  errorMessage?: Maybe<string>;
+  requestId?: Maybe<string>;
 }
 
 export async function createUserActivityFromReq(
@@ -64,6 +93,7 @@ export async function createUserActivityFromReqWithError(
     data.success = false;
     if (ex instanceof AuthError) {
       data.errorMessage = `${ex.type}: ${ex.message}`;
+      data.userId = data.userId || ex.userId;
     } else if (ex instanceof Error) {
       data.errorMessage = ex.message;
     }

--- a/libs/auth/server/src/lib/auth.db.service.ts
+++ b/libs/auth/server/src/lib/auth.db.service.ts
@@ -432,7 +432,7 @@ export async function getUserActivity(userId: string) {
     const activityWithIpAddress = recentActivity.filter((item) => item.ipAddress);
     await lookupGeoLocationFromIpAddresses(activityWithIpAddress.map(({ ipAddress }) => ipAddress) as string[]).then((locationInfo) => {
       activityWithIpAddress.forEach((activityWithIpAddress, i) => {
-        activityWithIpAddress.location = locationInfo[0].location;
+        activityWithIpAddress.location = locationInfo[i].location;
       });
     });
   } catch (ex) {

--- a/libs/auth/server/src/lib/auth.db.service.ts
+++ b/libs/auth/server/src/lib/auth.db.service.ts
@@ -1,14 +1,17 @@
 import { ENV, logger, prisma } from '@jetstream/api-config';
 import {
   AuthenticatedUser,
+  ExternalTokenSessionWithLocation,
+  LoginActivityUserFacing,
   OauthProviderType,
   ProviderTypeCredentials,
   ProviderTypeOauth,
   ProviderUser,
   SessionData,
-  SessionIpData,
+  TokenSource,
   TwoFactorTypeWithoutEmail,
   UserSession,
+  UserSessionAndExtTokensAndActivityWithLocation,
   UserSessionWithLocation,
 } from '@jetstream/auth/types';
 import { Prisma } from '@jetstream/prisma';
@@ -17,6 +20,7 @@ import { getErrorMessageAndStackObj } from '@jetstream/shared/utils';
 import { Maybe } from '@jetstream/types';
 import { addDays, startOfDay } from 'date-fns';
 import { addMinutes } from 'date-fns/addMinutes';
+import { actionDisplayName, methodDisplayName } from './auth-logging.db.service';
 import { DELETE_ACTIVITY_DAYS, DELETE_TOKEN_DAYS, PASSWORD_RESET_DURATION_MINUTES } from './auth.constants';
 import {
   InvalidAction,
@@ -26,7 +30,7 @@ import {
   InvalidRegistration,
   LoginWithExistingIdentity,
 } from './auth.errors';
-import { ensureAuthError, verifyAuth0CredentialsOrThrow_MIGRATION_TEMPORARY } from './auth.service';
+import { ensureAuthError, lookupGeoLocationFromIpAddresses } from './auth.service';
 import { checkUserAgentSimilarity, hashPassword, REMEMBER_DEVICE_DAYS, verifyPassword } from './auth.utils';
 
 const userSelect = Prisma.validator<Prisma.UserSelect>()({
@@ -273,14 +277,36 @@ export async function toggleEnableDisableAuthFactor(userId: string, type: TwoFac
 }
 
 export async function deleteAuthFactor(userId: string, type: TwoFactorTypeWithoutEmail) {
+  if (!userId) {
+    throw new Error('Invalid userId');
+  }
   await prisma.authFactors.delete({
     where: { userId_type: { type, userId } },
   });
   return getAuthFactors(userId);
 }
 
+export async function getAllSessions(userId: string, currentSessionId: string) {
+  if (!userId) {
+    throw new Error('Invalid userId');
+  }
+  const sessions = await getUserSessions(userId);
+  const webTokenSessions = await getUserWebExtensionSessions(userId);
+  const loginActivity = await getUserActivity(userId);
+  const output: UserSessionAndExtTokensAndActivityWithLocation = {
+    currentSessionId,
+    sessions,
+    webTokenSessions,
+    loginActivity,
+  };
+  return output;
+}
+
 export async function getUserSessions(userId: string, omitLocationData?: boolean): Promise<UserSessionWithLocation[]> {
-  const sessions = await prisma.sessions
+  if (!userId) {
+    throw new Error('Invalid userId');
+  }
+  const sessions: UserSessionWithLocation[] = await prisma.sessions
     .findMany({
       select: {
         sid: true,
@@ -301,11 +327,10 @@ export async function getUserSessions(userId: string, omitLocationData?: boolean
         return {
           sessionId: sid,
           expires: expire.toISOString(),
-          userAgent: userAgent,
-          ipAddress: ipAddress,
+          userAgent,
+          ipAddress,
           loginTime: new Date(loginTime).toISOString(),
-          provider: provider,
-          // TODO: last activity?
+          provider,
         };
       })
     );
@@ -313,57 +338,108 @@ export async function getUserSessions(userId: string, omitLocationData?: boolean
   // Fetch location data and add to each session
   if (!omitLocationData && sessions.length > 0) {
     try {
-      let response: Awaited<ReturnType<typeof fetch>> | null = null;
-      const ipAddresses = sessions.map((session) => session.ipAddress);
-      if (ENV.IP_API_SERVICE === 'LOCAL' && ENV.GEO_IP_API_USERNAME && ENV.GEO_IP_API_PASSWORD && ENV.GEO_IP_API_HOSTNAME) {
-        response = await fetch(`${ENV.GEO_IP_API_HOSTNAME}/api/lookup`, {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-            Authorization: `Basic ${Buffer.from(`${ENV.GEO_IP_API_USERNAME}:${ENV.GEO_IP_API_PASSWORD}`, 'utf-8').toString('base64')}`,
-          },
-          body: JSON.stringify({ ips: ipAddresses }),
-        });
-        if (response?.ok) {
-          const locations = (await response.json()) as
-            | { success: true; results: SessionIpData[] }
-            | { success: false; message: string; details?: string };
-
-          if (locations.success) {
-            return sessions.map(
-              (session, i): UserSessionWithLocation => ({
-                ...session,
-                location: locations.results[i],
-              })
-            );
-          }
-        }
-      } else if (ENV.IP_API_KEY) {
-        const params = new URLSearchParams({
-          fields: 'status,country,countryCode,region,regionName,city,isp,lat,lon,query',
-          key: ENV.IP_API_KEY,
-        });
-
-        response = await fetch(`https://pro.ip-api.com/batch?${params.toString()}`, {
-          method: 'POST',
-          body: JSON.stringify(ipAddresses),
-        });
-        if (response?.ok) {
-          const locations = (await response.json()) as SessionIpData[];
-          return sessions.map(
-            (session, i): UserSessionWithLocation => ({
-              ...session,
-              location: locations[i],
-            })
-          );
-        }
-      }
+      return await lookupGeoLocationFromIpAddresses(sessions.map(({ ipAddress }) => ipAddress)).then((locationInfo) =>
+        locationInfo.map(
+          ({ location }, i): UserSessionWithLocation => ({
+            ...sessions[i],
+            location,
+          })
+        )
+      );
     } catch (ex) {
       logger.warn({ ...getErrorMessageAndStackObj(ex) }, 'Error fetching location data for sessions');
     }
   }
 
   return sessions;
+}
+
+export async function getUserWebExtensionSessions(userId: string, omitLocationData?: boolean): Promise<ExternalTokenSessionWithLocation[]> {
+  if (!userId) {
+    throw new Error('Invalid userId');
+  }
+  const webTokenSessions = await prisma.webExtensionToken
+    .findMany({
+      select: {
+        id: true,
+        source: true,
+        createdAt: true,
+        expiresAt: true,
+        ipAddress: true,
+        userAgent: true,
+      },
+      where: { userId, type: 'AUTH_TOKEN' },
+    })
+    .then((token) => {
+      return token.map((token) => ({
+        id: token.id,
+        source: token.source as TokenSource,
+        createdAt: token.createdAt.toISOString(),
+        expiresAt: token.expiresAt.toISOString(),
+        ipAddress: token.ipAddress,
+        userAgent: token.userAgent,
+      }));
+    });
+
+  if (!omitLocationData && webTokenSessions.length > 0) {
+    try {
+      return await lookupGeoLocationFromIpAddresses(webTokenSessions.map(({ ipAddress }) => ipAddress)).then((locationInfo) =>
+        locationInfo.map(
+          ({ location }, i): ExternalTokenSessionWithLocation => ({
+            ...webTokenSessions[i],
+            location,
+          })
+        )
+      );
+    } catch (ex) {
+      logger.warn({ ...getErrorMessageAndStackObj(ex) }, 'Error fetching location data for webTokens');
+    }
+  }
+
+  return webTokenSessions;
+}
+
+export async function getUserActivity(userId: string) {
+  if (!userId) {
+    throw new Error('Invalid userId');
+  }
+  const recentActivity: LoginActivityUserFacing[] = await prisma.loginActivity
+    .findMany({
+      select: {
+        action: true,
+        createdAt: true,
+        errorMessage: true,
+        ipAddress: true,
+        method: true,
+        success: true,
+        userAgent: true,
+      },
+      where: { userId, method: { notIn: ['OAUTH_INIT', 'DELETE_ACCOUNT'] } },
+      take: 25,
+      orderBy: { createdAt: 'desc' },
+    })
+    .then((records) =>
+      records.map((record) => ({
+        ...record,
+        action: actionDisplayName[record.action] || record.action,
+        method: (record.method ? methodDisplayName[record.method] : record.method) || record.method,
+        createdAt: record.createdAt.toISOString(),
+      }))
+    );
+
+  try {
+    // mutate records to add location property if there is an associated ip address
+    const activityWithIpAddress = recentActivity.filter((item) => item.ipAddress);
+    await lookupGeoLocationFromIpAddresses(activityWithIpAddress.map(({ ipAddress }) => ipAddress) as string[]).then((locationInfo) => {
+      activityWithIpAddress.forEach((activityWithIpAddress, i) => {
+        activityWithIpAddress.location = locationInfo[0].location;
+      });
+    });
+  } catch (ex) {
+    logger.warn({ ...getErrorMessageAndStackObj(ex) }, 'Error fetching location data for recent activity');
+  }
+
+  return recentActivity;
 }
 
 export async function revokeUserSession(userId: string, sessionId: string) {
@@ -379,7 +455,15 @@ export async function revokeUserSession(userId: string, sessionId: string) {
       sid: sessionId,
     },
   });
-  return getUserSessions(userId);
+}
+
+export async function revokeExternalSession(userId: string, sessionId: string) {
+  if (!userId || !sessionId) {
+    throw new Error('Invalid parameters');
+  }
+  await prisma.webExtensionToken.delete({
+    where: { id: sessionId },
+  });
 }
 
 export async function revokeAllUserSessions(userId: string, exceptId?: Maybe<string>) {
@@ -389,20 +473,14 @@ export async function revokeAllUserSessions(userId: string, exceptId?: Maybe<str
   await prisma.sessions.deleteMany({
     where: exceptId
       ? {
-          sess: {
-            path: ['user', 'id'],
-            equals: userId,
-          },
+          sess: { path: ['user', 'id'], equals: userId },
           NOT: { sid: exceptId },
         }
-      : {
-          sess: {
-            path: ['user', 'id'],
-            equals: userId,
-          },
-        },
+      : { sess: { path: ['user', 'id'], equals: userId } },
   });
-  return getUserSessions(userId);
+  await prisma.webExtensionToken.deleteMany({
+    where: exceptId ? { userId, NOT: { id: exceptId } } : { userId },
+  });
 }
 
 export async function setPasswordForUser(id: string, password: string) {
@@ -477,7 +555,7 @@ export const generatePasswordResetToken = async (email: string) => {
 
 export const resetUserPassword = async (email: string, token: string, password: string) => {
   email = email.toLowerCase();
-  // if there is an existing token, delete it
+
   const restToken = await prisma.passwordResetToken.findUnique({
     where: { email_token: { email, token } },
   });
@@ -508,6 +586,8 @@ export const resetUserPassword = async (email: string, token: string, password: 
   });
 
   await revokeAllUserSessions(restToken.userId);
+
+  return restToken.userId;
 };
 
 export const removePasswordFromUser = async (id: string) => {
@@ -539,24 +619,10 @@ async function getUserAndVerifyPassword(email: string, password: string) {
     where: { email, password: { not: null } },
   });
 
-  // There is not a user with the email address that has a password set
   if (!UNSAFE_userWithPassword) {
-    // FIXME: TEMPORARY This is temporary just to handle the users that signed up after we exported data
-    try {
-      const updatedUser = await migratePasswordFromAuth0(email, password);
-      return {
-        error: null,
-        user: updatedUser,
-      };
-    } catch (ex) {
-      return { error: new InvalidCredentials('Could not migrate from Auth0') };
-    }
-
-    // Use this after code above is removed
-    // if (!UNSAFE_userWithPassword) {
-    //   return { error: new InvalidCredentials() };
-    // }
+    return { error: new InvalidCredentials('Incorrect email or password') };
   }
+
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   if (await verifyPassword(password, UNSAFE_userWithPassword.password!)) {
     return {
@@ -567,30 +633,7 @@ async function getUserAndVerifyPassword(email: string, password: string) {
       }),
     };
   }
-  return { error: new InvalidCredentials('Incorrect email or password') };
-}
-
-async function migratePasswordFromAuth0(email: string, password: string) {
-  email = email.toLowerCase();
-  // If the user has a linked social identity, we have no way to confirm 100% that this is the correct account
-  // since we allowed same email on multiple accounts with Auth0
-  const userWithoutSocialIdentities = await prisma.user.findFirst({
-    select: { id: true, identities: true },
-    where: { email, password: null, identities: { none: {} } },
-  });
-
-  if (!userWithoutSocialIdentities || userWithoutSocialIdentities.identities.length > 0) {
-    logger.warn({ email }, 'Cannot migrate password on the fly from Auth0, user has linked social identity');
-    throw new InvalidCredentials('Could not migrate from Auth0');
-  }
-
-  await verifyAuth0CredentialsOrThrow_MIGRATION_TEMPORARY({ email, password });
-
-  return await prisma.user.update({
-    select: userSelect,
-    data: { password: await hashPassword(password), passwordUpdatedAt: new Date() },
-    where: { id: userWithoutSocialIdentities.id },
-  });
+  return { error: new InvalidCredentials('Incorrect email or password', { userId: UNSAFE_userWithPassword.id }) };
 }
 
 async function addIdentityToUser(userId: string, providerUser: ProviderUser, provider: OauthProviderType) {

--- a/libs/auth/server/src/lib/auth.errors.ts
+++ b/libs/auth/server/src/lib/auth.errors.ts
@@ -21,6 +21,7 @@ type ErrorOptions = Error | Record<string, unknown>;
 export class AuthError extends Error {
   type: ErrorType;
   kind?: 'signIn' | 'error';
+  userId?: string;
 
   constructor(message?: string | Error, errorOptions?: ErrorOptions) {
     if (message instanceof Error) {
@@ -42,6 +43,10 @@ export class AuthError extends Error {
 
     // @ts-expect-error https://github.com/microsoft/TypeScript/issues/3841
     this.kind = this.constructor.kind ?? 'error';
+
+    if (errorOptions && 'userId' in errorOptions && typeof errorOptions.userId === 'string') {
+      this.userId = errorOptions.userId;
+    }
 
     Error.captureStackTrace?.(this, this.constructor);
   }

--- a/libs/auth/server/src/lib/auth.service.ts
+++ b/libs/auth/server/src/lib/auth.service.ts
@@ -1,11 +1,11 @@
 import { ENV, getExceptionLog, logger } from '@jetstream/api-config';
-import { OauthProviderType, Providers, ResponseLocalsCookies } from '@jetstream/auth/types';
+import { OauthProviderType, Providers, ResponseLocalsCookies, SessionIpData } from '@jetstream/auth/types';
 import { parse as parseCookie } from 'cookie';
 import * as crypto from 'crypto';
 import type { Response } from 'express';
 import * as QRCode from 'qrcode';
 import { OauthClientProvider, OauthClients } from './OauthClients';
-import { AuthError, InvalidCredentials, InvalidCsrfToken, InvalidVerificationToken } from './auth.errors';
+import { AuthError, InvalidCsrfToken, InvalidVerificationToken } from './auth.errors';
 import { getCookieConfig, validateCSRFToken } from './auth.utils';
 
 const oauthPromise = import('oauth4webapi');
@@ -270,41 +270,45 @@ async function getUserInfo({ authorizationServer, client }: OauthClientProvider,
   return userInfo;
 }
 
-/**
- * Log user into Auth0 using Username+Password
- *
- * This is used to verify a user's password if we do not have the password hash stored in Jetstream database.
- *
- * Once the user migration is complete, this function should be removed.
- */
-export async function verifyAuth0CredentialsOrThrow_MIGRATION_TEMPORARY({ email, password }: { email: string; password: string }) {
-  if (!ENV.AUTH0_DOMAIN || !ENV.AUTH0_CLIENT_ID || !ENV.AUTH0_CLIENT_SECRET) {
-    logger.error('Auth0 credentials are not set, unable to check for password migration');
-    throw new InvalidCredentials();
+export async function lookupGeoLocationFromIpAddresses(ipAddresses: string[]) {
+  if (!ipAddresses || ipAddresses.length === 0) {
+    return [];
   }
+  let response: Awaited<ReturnType<typeof fetch>> | null = null;
+  if (ENV.IP_API_SERVICE === 'LOCAL' && ENV.GEO_IP_API_USERNAME && ENV.GEO_IP_API_PASSWORD && ENV.GEO_IP_API_HOSTNAME) {
+    response = await fetch(`${ENV.GEO_IP_API_HOSTNAME}/api/lookup`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Basic ${Buffer.from(`${ENV.GEO_IP_API_USERNAME}:${ENV.GEO_IP_API_PASSWORD}`, 'utf-8').toString('base64')}`,
+      },
+      body: JSON.stringify({ ips: ipAddresses }),
+    });
+  } else if (ENV.IP_API_KEY) {
+    const params = new URLSearchParams({
+      fields: 'status,country,countryCode,region,regionName,city,isp,lat,lon,query',
+      key: ENV.IP_API_KEY,
+    });
 
-  const response = await fetch(`https://${ENV.AUTH0_DOMAIN}/oauth/token`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/x-www-form-urlencoded',
-    },
-    body: new URLSearchParams({
-      grant_type: 'password',
-      username: email,
-      password,
-      scope: 'email',
-      client_id: ENV.AUTH0_CLIENT_ID,
-      client_secret: ENV.AUTH0_CLIENT_SECRET,
-    }),
-  });
-
-  if (!response.ok) {
-    throw new InvalidCredentials();
+    response = await fetch(`https://pro.ip-api.com/batch?${params.toString()}`, {
+      method: 'POST',
+      body: JSON.stringify(ipAddresses),
+    });
   }
+  if (response?.ok) {
+    const locations = (await response.json()) as
+      | { success: true; results: SessionIpData[] }
+      | { success: false; message: string; details?: string };
 
-  const data = (await response.json()) as { access_token: string; scope: string; expires_in: number; token_type: 'Bearer' };
-
-  if (!data.access_token) {
-    throw new InvalidCredentials();
+    if (locations.success) {
+      return ipAddresses.map((ipAddress, i) => ({
+        ipAddress,
+        location: locations.results[i],
+      }));
+    }
   }
+  return ipAddresses.map((ipAddress) => ({
+    ipAddress,
+    location: null,
+  }));
 }

--- a/libs/auth/types/src/lib/auth-types.ts
+++ b/libs/auth/types/src/lib/auth-types.ts
@@ -66,7 +66,39 @@ export interface UserSession {
 }
 
 export interface UserSessionWithLocation extends UserSession {
-  location?: SessionIpData;
+  location?: Maybe<SessionIpData>;
+}
+
+export type TokenSourceBrowserExtensions = 'BROWSER_EXTENSION';
+export type TokenSourceDesktop = 'DESKTOP';
+export type TokenSource = TokenSourceBrowserExtensions | TokenSourceDesktop;
+
+export interface ExternalTokenSessionWithLocation {
+  id: string;
+  source: TokenSource;
+  createdAt: string;
+  expiresAt: string;
+  ipAddress: string;
+  userAgent: string;
+  location?: Maybe<SessionIpData>;
+}
+
+export interface LoginActivityUserFacing {
+  action: string;
+  createdAt: string;
+  errorMessage: Maybe<string>;
+  ipAddress: Maybe<string>;
+  method: Maybe<string>;
+  success: boolean;
+  userAgent: Maybe<string>;
+  location?: Maybe<SessionIpData>;
+}
+
+export interface UserSessionAndExtTokensAndActivityWithLocation {
+  currentSessionId: string;
+  sessions: UserSessionWithLocation[];
+  webTokenSessions: ExternalTokenSessionWithLocation[];
+  loginActivity: LoginActivityUserFacing[];
 }
 
 export type TwoFactorTypeEmail = 'email';

--- a/libs/shared/data/src/lib/client-data.ts
+++ b/libs/shared/data/src/lib/client-data.ts
@@ -4,7 +4,7 @@ import type {
   TwoFactorTypeWithoutEmail,
   UserProfileAuthFactor,
   UserProfileUiWithIdentities,
-  UserSessionWithLocation,
+  UserSessionAndExtTokensAndActivityWithLocation,
 } from '@jetstream/auth/types';
 import { logger } from '@jetstream/shared/client-logger';
 import { HTTP, MIME_TYPES } from '@jetstream/shared/constants';
@@ -128,7 +128,7 @@ export async function updateUserProfile<T = UserProfileUiWithIdentities>(userPro
   return handleRequest({ method: 'POST', url: '/api/me/profile', data: userProfile }).then(unwrapResponseIgnoreCache);
 }
 
-export async function getUserSessions(): Promise<{ currentSessionId: string; sessions: UserSessionWithLocation[] }> {
+export async function getUserSessions(): Promise<UserSessionAndExtTokensAndActivityWithLocation> {
   return handleRequest({ method: 'GET', url: '/api/me/profile/sessions' }).then(unwrapResponseIgnoreCache);
 }
 
@@ -140,11 +140,16 @@ export async function getCsrfToken(): Promise<{ csrfToken: string }> {
   return handleRequest({ method: 'GET', url: '/api/auth/csrf' }).then(unwrapResponseIgnoreCache);
 }
 
-export async function revokeUserSession(sessionId: string): Promise<{ currentSessionId: string; sessions: UserSessionWithLocation[] }> {
-  return handleRequest({ method: 'DELETE', url: `/api/me/profile/sessions/${sessionId}` }).then(unwrapResponseIgnoreCache);
+export async function revokeUserSession(
+  sessionId: string,
+  type: 'SESSION' | 'EXTERNAL_SESSION'
+): Promise<UserSessionAndExtTokensAndActivityWithLocation> {
+  return handleRequest({ method: 'DELETE', url: `/api/me/profile/sessions/${sessionId}`, params: { type } }).then(
+    unwrapResponseIgnoreCache
+  );
 }
 
-export async function revokeAllUserSessions(exceptId?: string): Promise<{ currentSessionId: string; sessions: UserSessionWithLocation[] }> {
+export async function revokeAllUserSessions(exceptId?: string): Promise<UserSessionAndExtTokensAndActivityWithLocation> {
   return handleRequest({ method: 'DELETE', url: '/api/me/profile/sessions/', data: { exceptId } }).then(unwrapResponseIgnoreCache);
 }
 

--- a/prisma/migrations/20250608161800_add_source_to_web_extension/migration.sql
+++ b/prisma/migrations/20250608161800_add_source_to_web_extension/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "web_extension_token" ADD COLUMN     "source" TEXT NOT NULL DEFAULT 'BROWSER_EXTENSION';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -85,6 +85,7 @@ model WebExtensionToken {
   id        String   @id @default(dbgenerated("uuid_generate_v4()")) @db.Uuid
   userId    String   @db.Uuid
   type      String
+  source    String   @default("BROWSER_EXTENSION")
   token     String
   deviceId  String   @unique
   ipAddress String


### PR DESCRIPTION
On the user session page, show recent auth activity for the user

Additionally, there were a few activity events that were not tracked which are now tracked (e.g. set password)

Activity events are more often attributed to users (e.g. failed login attempts)