### PR TITLE
Tooling API queries are not added to history #1281

### DIFF
--- a/apps/jetstream-e2e/src/tests/query/query-results.spec.ts
+++ b/apps/jetstream-e2e/src/tests/query/query-results.spec.ts
@@ -46,6 +46,16 @@ test.describe('QUERY RESULTS', () => {
     await queryPage.waitForQueryResults(query3);
   });
 
+  test('Query history should work for tooling queries', async ({ queryPage, page }) => {
+    const query = 'SELECT Id, Name, CreatedById, CreatedDate FROM ApexDebuggerSession';
+    await queryPage.gotoResults(query, true);
+    expect(page.url()).toContain('/query/results');
+    await queryPage.waitForQueryResults(query);
+
+    await queryPage.performQueryHistoryAction(query, 'EXECUTE');
+    expect(page.url()).toContain('/query/results');
+  });
+
   test('restore should work from changes made on results page', async ({ queryPage, page }) => {
     // const query1 = `SELECT Id, BillingAddress, CreatedBy.Id, CreatedBy.Name, CreatedBy.IsActive, Type FROM Account`;
     // await queryPage.gotoResults(query1);

--- a/libs/shared/ui-db/src/lib/query-history.db.ts
+++ b/libs/shared/ui-db/src/lib/query-history.db.ts
@@ -112,7 +112,7 @@ async function saveQueryHistoryItem(
     incrementRunCount?: boolean;
   } = {}
 ): Promise<QueryHistoryItem> {
-  const queryHistoryItem = await getOrInitQueryHistoryItem(org, soql, sObject);
+  const queryHistoryItem = await getOrInitQueryHistoryItem(org, soql, sObject, sObjectLabel, customLabel, isTooling);
 
   if (incrementRunCount) {
     queryHistoryItem.runCount++;

--- a/libs/test/e2e-utils/src/lib/pageObjectModels/QueryPage.model.ts
+++ b/libs/test/e2e-utils/src/lib/pageObjectModels/QueryPage.model.ts
@@ -27,16 +27,20 @@ export class QueryPage {
     await this.page.waitForURL('**/query');
   }
 
-  async gotoResults(query: string) {
-    await this.setManualQuery(query, 'EXECUTE');
+  async gotoResults(query: string, isTooling = false) {
+    await this.setManualQuery(query, 'EXECUTE', isTooling);
   }
 
-  async setManualQuery(query: string, action?: 'EXECUTE' | 'RESTORE') {
+  async setManualQuery(query: string, action?: 'EXECUTE' | 'RESTORE', isTooling = false) {
     await this.page.getByRole('menuitem', { name: 'Query Records' }).click();
     await this.page.waitForURL('**/query');
     await this.page.getByRole('button', { name: 'Manually enter query Manual Query' }).first().click();
     const manualQueryPopover = this.page.getByTestId('manual-query');
     await manualQueryPopover.getByRole('textbox', { name: 'Editor content' }).fill(query);
+
+    if (isTooling) {
+      await manualQueryPopover.locator('#is-tooling-user-soql span').first().click();
+    }
 
     if (action === 'EXECUTE') {
       await Promise.all([


### PR DESCRIPTION
Fetching object metadata was not properly passing the isTooling flag which was causing the history not to be saved since that call failed

resolves #1281