### PR TITLE
Ensure automation control works if user has non-english language #1280

### DIFF
--- a/libs/features/automation-control/src/automation-control-soql-utils.tsx
+++ b/libs/features/automation-control/src/automation-control-soql-utils.tsx
@@ -249,8 +249,8 @@ export function getFlowsQuery(sobjects: string[]) {
         right: {
           left: {
             field: 'TriggerType',
-            operator: 'LIKE',
-            value: 'Record%',
+            operator: 'IN',
+            value: ['RecordBeforeSave', 'RecordBeforeDelete', 'RecordAfterSave'],
             literalType: 'STRING',
           },
         },


### PR DESCRIPTION
There was a query using the LIKE operator which apparently is matched against picklist labels, not values - and the labels are translated which means that the matching doesn't work as expected.

We are now hard-coding the TriggerType values instead of using LIKE in the query to ensure results are not language dependent.

resolves #1280