### PR TITLE
Allow datetime fields to be used in group-by

### DIFF
--- a/libs/features/query/src/QueryBuilder/QueryBuilder.tsx
+++ b/libs/features/query/src/QueryBuilder/QueryBuilder.tsx
@@ -205,7 +205,10 @@ export const QueryBuilder: FunctionComponent<QueryBuilderProps> = () => {
         let allFilterItems = getFlattenedListItemsById(prevItems);
         allFilterItems = {
           ...allFilterItems,
-          [item.id]: { ...allFilterItems[item.id], childItems: childFields.filter((field) => field.meta?.groupable) },
+          [item.id]: {
+            ...allFilterItems[item.id],
+            childItems: childFields.filter((field) => field.meta?.groupable || field.meta?.type === 'datetime'),
+          },
         };
         return unFlattenedListItemsById(allFilterItems);
       });

--- a/libs/features/query/src/QueryBuilder/QueryFields.tsx
+++ b/libs/features/query/src/QueryBuilder/QueryFields.tsx
@@ -80,7 +80,9 @@ export const QueryFieldsComponent: FunctionComponent<QueryFieldsProps> = ({ sele
           const fields = Object.values(tempQueryFieldsMap[BASE_KEY].fields).map((item) => item.metadata);
           setFilterFields(getListItemsFromFieldWithRelatedItems(sortQueryFields(fields.filter((field) => field.filterable))));
           setOrderByFields(getListItemsFromFieldWithRelatedItems(sortQueryFields(fields.filter((field) => field.sortable))));
-          setGroupByFields(getListItemsFromFieldWithRelatedItems(sortQueryFields(fields.filter((field) => field.groupable))));
+          setGroupByFields(
+            getListItemsFromFieldWithRelatedItems(sortQueryFields(fields.filter((field) => field.groupable || field.type === 'datetime')))
+          );
 
           tempQueryFieldsMap[BASE_KEY] = { ...tempQueryFieldsMap[BASE_KEY], loading: false };
           setChildRelationships(tempQueryFieldsMap[BASE_KEY].childRelationships || []);

--- a/libs/features/query/src/QueryOptions/QueryGroupByRow.tsx
+++ b/libs/features/query/src/QueryOptions/QueryGroupByRow.tsx
@@ -68,6 +68,9 @@ export const QueryGroupByRow: FunctionComponent<QueryOrderByProps> = ({
               itemLength: 10,
               showSelectionAsButton: true,
               onClear: () => onChange({ ...groupBy, function: null }),
+              errorMessage: 'This field requires a grouping function.',
+              // Datetime fields show up as non-groupable, but they can be groupable with a function
+              hasError: !groupBy.function && !selectedField?.meta.groupable,
             }}
             items={QUERY_FIELD_DATE_FUNCTIONS}
             selectedItemId={groupBy.function}

--- a/libs/features/query/src/utils/query-restore-utils.ts
+++ b/libs/features/query/src/utils/query-restore-utils.ts
@@ -170,7 +170,7 @@ async function queryRestoreBuildState(org: SalesforceOrgUi, query: Query, data: 
   );
   outputStateItems.groupByQueryFieldsState = unFlattenedListItemsById(
     groupByFlat(
-      allListItems.filter((item) => item.meta.groupable),
+      allListItems.filter((item) => item.meta?.groupable || item.meta?.type === 'datetime'),
       'id'
     )
   );


### PR DESCRIPTION
Datetime fields are groupable as long as a group-by function is used. we are now including them in the list and show a soft error to the user if a function is not selected.

resolves #1289