### PR TITLE
Bug-bash/7.6.25

### DIFF
--- a/apps/jetstream-web-extension/webpack.config.js
+++ b/apps/jetstream-web-extension/webpack.config.js
@@ -38,7 +38,6 @@ module.exports = composePlugins(withNx(), withReact(), (config, { configuration 
         new TerserPlugin({
           parallel: true,
           minify: TerserPlugin.esbuildMinify,
-          // @ts-expect-error this is correct, not sure why it is complaining
         }).apply(compiler);
       },
     ],

--- a/libs/features/create-object-and-fields/src/useFieldValues.ts
+++ b/libs/features/create-object-and-fields/src/useFieldValues.ts
@@ -79,7 +79,7 @@ function reducer(state: State, action: Action): State {
         };
 
         if (newRow.label.value) {
-          newRow.label = { ...newRow.label, value: `${newRow.label.value} copy` };
+          newRow.label = { ...newRow.label, value: `Copy ${newRow.label.value}` };
           newRow.fullName = { ...newRow.fullName, value: generateApiNameFromLabel(newRow.label.value as string) };
         }
 

--- a/libs/shared/ui-core/src/jobs/JobWorker.ts
+++ b/libs/shared/ui-core/src/jobs/JobWorker.ts
@@ -198,7 +198,7 @@ export class JobWorker {
             }
 
             /**
-             * In the browser extension, we cannot stream the file, so we download the results it directly
+             * In the browser extension, we cannot stream the file, so we download the results directly
              */
             if (isBrowserExtension()) {
               downloadedRecords = await bulkApiGetRecords(org, jobId, batchResult.id, 'result', true);


### PR DESCRIPTION
When cloning rows, add "Copy" at the beginning instead of the end so that it is more visible to the user

resolves #1295

In the browser extension, ensure bulk download jobs always download the results instead of including a file link to the jetstream server - which is unavailable in this context.

resolves #1296