### PR TITLE
Fix checking for cell renderer function for table tab navigation

### DIFF
--- a/libs/ui/src/lib/data-table/DataTableRenderers.tsx
+++ b/libs/ui/src/lib/data-table/DataTableRenderers.tsx
@@ -571,6 +571,9 @@ export const IdLinkRenderer = ({ column, row }: RenderCellProps<RowWithKey, unkn
     />
   );
 };
+IdLinkRenderer.prototype = {
+  displayName: 'IdLinkRenderer',
+};
 
 export function TextOrIdLinkRenderer(RenderCellProps: RenderCellProps<RowWithKey>): ReactNode {
   const { column, row } = RenderCellProps;
@@ -638,6 +641,9 @@ export const ActionRenderer = ({ row }: { row: any }): ReactNode => {
       </Tooltip>
     </Fragment>
   );
+};
+ActionRenderer.prototype = {
+  displayName: 'ActionRenderer',
 };
 
 export const BooleanRenderer = ({ column, row }: RenderCellProps<any, unknown>): ReactNode => {

--- a/libs/ui/src/lib/data-table/DataTableRenderers.tsx
+++ b/libs/ui/src/lib/data-table/DataTableRenderers.tsx
@@ -54,6 +54,13 @@ export function configIdLinkRenderer(serverUrl: string, org: SalesforceOrgUi, sk
   _skipFrontdoorLogin = skipFrontdoorLogin ?? _skipFrontdoorLogin;
 }
 
+/**
+ * Map of function identities in order to identify the function in callback functions
+ * This is generally used to have dedicated functionality for keyboard navigation based on the cell renderer type
+ */
+// eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
+export const dataTableRenderFnMap = new Map<Function, string>();
+
 // HEADER RENDERERS
 
 export function SelectHeaderGroupRenderer<T>(props: RenderGroupCellProps<T>) {
@@ -76,6 +83,7 @@ export function SelectHeaderGroupRenderer<T>(props: RenderGroupCellProps<T>) {
     </DataTableSelectedContext.Consumer>
   );
 }
+dataTableRenderFnMap.set(SelectHeaderGroupRenderer, 'SelectHeaderGroupRenderer');
 
 export function FilterRenderer<R, SR, T extends HTMLOrSVGElement>({
   sortDirection,
@@ -110,6 +118,7 @@ export function FilterRenderer<R, SR, T extends HTMLOrSVGElement>({
     </div>
   );
 }
+dataTableRenderFnMap.set(FilterRenderer, 'FilterRenderer');
 
 /**
  * Filter renderer that can be used for any field that does not need sort
@@ -124,6 +133,7 @@ export function SummaryFilterRenderer({ columnKey, label }: { columnKey: string;
     </div>
   );
 }
+dataTableRenderFnMap.set(SummaryFilterRenderer, 'SummaryFilterRenderer');
 
 interface HeaderFilterProps {
   columnKey: string;
@@ -222,6 +232,7 @@ export const HeaderFilter = memo(({ columnKey, filters, filterSetValues, updateF
     </div>
   );
 });
+dataTableRenderFnMap.set(HeaderFilter, 'HeaderFilter');
 
 interface DataTableTextFilterProps {
   columnKey: string;
@@ -246,6 +257,7 @@ export const HeaderTextFilter = memo(({ columnKey, filter, autoFocus = false, up
     </Input>
   );
 });
+dataTableRenderFnMap.set(HeaderTextFilter, 'HeaderTextFilter');
 
 interface HeaderSetFilterProps {
   columnKey: string;
@@ -361,6 +373,7 @@ export const HeaderSetFilter = memo(({ columnKey, filter, values, updateFilter }
     </div>
   );
 });
+dataTableRenderFnMap.set(HeaderSetFilter, 'HeaderSetFilter');
 
 interface DataTableDateFilterProps {
   columnKey: string;
@@ -409,6 +422,7 @@ export const HeaderDateFilter = memo(({ columnKey, filter, updateFilter }: DataT
     </div>
   );
 });
+dataTableRenderFnMap.set(HeaderDateFilter, 'HeaderDateFilter');
 
 interface HeaderTimeFilterProps {
   columnKey: string;
@@ -458,6 +472,7 @@ export const HeaderTimeFilter = memo(({ columnKey, filter, updateFilter }: Heade
     </div>
   );
 });
+dataTableRenderFnMap.set(HeaderTimeFilter, 'HeaderTimeFilter');
 
 // CELL RENDERERS
 /** Generic cell renderer when the type of data is unknown */
@@ -480,6 +495,7 @@ export function GenericRenderer(RenderCellProps: RenderCellProps<RowWithKey>): R
 
   return <div className="slds-truncate">{value}</div>;
 }
+dataTableRenderFnMap.set(GenericRenderer, 'GenericRenderer');
 
 export function SelectFormatter<T>(props: RenderCellProps<T>): ReactNode {
   const { column, row } = props;
@@ -496,6 +512,7 @@ export function SelectFormatter<T>(props: RenderCellProps<T>): ReactNode {
     />
   );
 }
+dataTableRenderFnMap.set(SelectFormatter, 'SelectFormatter');
 
 export function ValueOrLoadingRenderer<T extends { loading: boolean }>({ column, row }: RenderCellProps<T>): ReactNode {
   if (!row) {
@@ -508,6 +525,7 @@ export function ValueOrLoadingRenderer<T extends { loading: boolean }>({ column,
   }
   return <div>{value}</div>;
 }
+dataTableRenderFnMap.set(ValueOrLoadingRenderer, 'ValueOrLoadingRenderer');
 
 export const ComplexDataRenderer = ({ column, row }: RenderCellProps<RowWithKey, unknown>): ReactNode => {
   const value = row[column.key];
@@ -552,6 +570,7 @@ export const ComplexDataRenderer = ({ column, row }: RenderCellProps<RowWithKey,
     </div>
   );
 };
+dataTableRenderFnMap.set(ComplexDataRenderer, 'ComplexDataRenderer');
 
 export const IdLinkRenderer = ({ column, row }: RenderCellProps<RowWithKey, unknown>): ReactNode => {
   const { onRecordAction } = useContext(DataTableGenericContext) as {
@@ -571,9 +590,7 @@ export const IdLinkRenderer = ({ column, row }: RenderCellProps<RowWithKey, unkn
     />
   );
 };
-IdLinkRenderer.prototype = {
-  displayName: 'IdLinkRenderer',
-};
+dataTableRenderFnMap.set(IdLinkRenderer, 'IdLinkRenderer');
 
 export function TextOrIdLinkRenderer(RenderCellProps: RenderCellProps<RowWithKey>): ReactNode {
   const { column, row } = RenderCellProps;
@@ -642,9 +659,7 @@ export const ActionRenderer = ({ row }: { row: any }): ReactNode => {
     </Fragment>
   );
 };
-ActionRenderer.prototype = {
-  displayName: 'ActionRenderer',
-};
+dataTableRenderFnMap.set(ActionRenderer, 'ActionRenderer');
 
 export const BooleanRenderer = ({ column, row }: RenderCellProps<any, unknown>): ReactNode => {
   const value = row[column.key];
@@ -659,6 +674,7 @@ export const BooleanRenderer = ({ column, row }: RenderCellProps<any, unknown>):
     />
   );
 };
+dataTableRenderFnMap.set(BooleanRenderer, 'BooleanRenderer');
 
 export const ErrorMessageRenderer = ({ row }: { row: any }): ReactNode => {
   if (!row?._saveError) {
@@ -702,3 +718,4 @@ export const ErrorMessageRenderer = ({ row }: { row: any }): ReactNode => {
     </Popover>
   );
 };
+dataTableRenderFnMap.set(ErrorMessageRenderer, 'ErrorMessageRenderer');

--- a/libs/ui/src/lib/data-table/useDataTable.tsx
+++ b/libs/ui/src/lib/data-table/useDataTable.tsx
@@ -22,7 +22,7 @@ import {
 } from 'react-data-grid';
 import 'react-data-grid/lib/styles.css';
 import Icon from '../widgets/Icon';
-import { configIdLinkRenderer } from './DataTableRenderers';
+import { configIdLinkRenderer, dataTableRenderFnMap } from './DataTableRenderers';
 import './data-table-styles.scss';
 import { ColumnWithFilter, ContextMenuActionData, DataTableFilter, DataTableRef, FILTER_SET_TYPES, RowWithKey } from './data-table-types';
 import { EMPTY_FIELD, NON_DATA_COLUMN_KEYS, filterRecord, getSearchTextByRow, isFilterActive, resetFilter } from './data-table-utils';
@@ -301,11 +301,11 @@ export function useDataTable<T = RowWithKey>({
   function handleCellKeydown(args: CellKeyDownArgs<T, unknown>, event: CellKeyboardEvent) {
     try {
       // Handle renderer-specific keyboard interactions
-      if (args.column.renderCell?.prototype?.displayName === 'IdLinkRenderer' && handleIdLinkRendererKeydown(event)) {
+      if (dataTableRenderFnMap.get(args.column.renderCell) === 'IdLinkRenderer' && handleIdLinkRendererKeydown(event)) {
         return;
       }
 
-      if (args.column.renderCell?.prototype?.displayName === 'ActionRenderer' && handleActionRendererTabNavigation(event)) {
+      if (dataTableRenderFnMap.get(args.column.renderCell) === 'ActionRenderer' && handleActionRendererTabNavigation(event)) {
         return;
       }
 

--- a/libs/ui/src/lib/data-table/useDataTable.tsx
+++ b/libs/ui/src/lib/data-table/useDataTable.tsx
@@ -301,11 +301,11 @@ export function useDataTable<T = RowWithKey>({
   function handleCellKeydown(args: CellKeyDownArgs<T, unknown>, event: CellKeyboardEvent) {
     try {
       // Handle renderer-specific keyboard interactions
-      if (args.column.renderCell?.name === 'IdLinkRenderer' && handleIdLinkRendererKeydown(event)) {
+      if (args.column.renderCell?.prototype?.displayName === 'IdLinkRenderer' && handleIdLinkRendererKeydown(event)) {
         return;
       }
 
-      if (args.column.renderCell?.name === 'ActionRenderer' && handleActionRendererTabNavigation(event)) {
+      if (args.column.renderCell?.prototype?.displayName === 'ActionRenderer' && handleActionRendererTabNavigation(event)) {
         return;
       }
 


### PR DESCRIPTION
Teh actions column and a column with an Id have special behavior and when built the function name changes, so we attached the name to the prototype to gain access to the original name to detect when to have special behavior