### PR TITLE
View bulk results does not work when bulk editing records from query …

### DIFF
--- a/libs/features/query/src/QueryResults/BulkUpdateFromQuery/BulkUpdateFromQueryModal.tsx
+++ b/libs/features/query/src/QueryResults/BulkUpdateFromQuery/BulkUpdateFromQueryModal.tsx
@@ -97,7 +97,6 @@ export const BulkUpdateFromQueryModal: FunctionComponent<BulkUpdateFromQueryModa
   const [batchSize, setBatchSize] = useState<Maybe<number>>(10000);
   const [batchSizeError, setBatchSizeError] = useState<string | null>(null);
   const [serialMode, setSerialMode] = useState(false);
-  const [isSecondModalOpen, setIsSecondModalOpen] = useState(false);
   const [deployResults, setDeployResults] = useAtom(deployResultsState);
   const [didDeploy, setDidDeploy] = useState(false);
   const resetDeployResults = useResetAtom(deployResultsState);
@@ -256,13 +255,13 @@ export const BulkUpdateFromQueryModal: FunctionComponent<BulkUpdateFromQueryModa
 
   return (
     <Modal
+      testId="bulk-update-query-results-modal"
       header="Update Records"
       tagline="Update a field from your query results to a new value."
       size="lg"
       closeOnBackdropClick={false}
       closeOnEsc={false}
       closeDisabled={deployInProgress}
-      hide={isSecondModalOpen}
       footer={
         <Grid align="spread">
           <NotSeeingRecentMetadataPopover
@@ -387,7 +386,6 @@ export const BulkUpdateFromQueryModal: FunctionComponent<BulkUpdateFromQueryModa
             hasExternalWhereClause={!!parsedQuery.where}
             batchSize={batchSize ?? 10000}
             omitTransformationText
-            onModalOpenChange={setIsSecondModalOpen}
           />
         )}
       </div>

--- a/libs/shared/ui-core/src/load/LoadRecordsResultsModal.tsx
+++ b/libs/shared/ui-core/src/load/LoadRecordsResultsModal.tsx
@@ -105,6 +105,7 @@ export const LoadRecordsResultsModal: FunctionComponent<LoadRecordsResultsModalP
   return (
     <div>
       <Modal
+        testId="load-records-results-modal"
         size="lg"
         header="Load Results"
         closeOnBackdropClick

--- a/libs/shared/ui-core/src/mass-update-records/MassUpdateRecordsDeploymentRow.tsx
+++ b/libs/shared/ui-core/src/mass-update-records/MassUpdateRecordsDeploymentRow.tsx
@@ -99,7 +99,7 @@ export const MassUpdateRecordsDeploymentRow = ({
       const header = ['_id', '_success', '_errors'].concat(['Id', ...configuration.map(({ selectedField }) => selectedField!)]);
 
       if (action === 'view') {
-        setResultsModalData({ ...downloadModalData, open: true, header, data: combinedResults, type });
+        setResultsModalData({ ...resultsModalData, open: true, header, data: combinedResults, type });
         trackEvent(ANALYTICS_KEYS.mass_update_DownloadRecords, {
           type,
           numRows: data.length,

--- a/libs/ui/src/lib/file-download-modal/FileDownloadModal.tsx
+++ b/libs/ui/src/lib/file-download-modal/FileDownloadModal.tsx
@@ -281,6 +281,7 @@ export const FileDownloadModal: FunctionComponent<FileDownloadModalProps> = ({
 
   return (
     <Modal
+      testId="record-download-modal"
       header={modalHeader}
       tagline={modalTagline}
       overrideZIndex={1001}
@@ -299,7 +300,6 @@ export const FileDownloadModal: FunctionComponent<FileDownloadModalProps> = ({
           {alternateDownloadButton}
         </Fragment>
       }
-      hide={isGooglePickerVisible}
       onClose={() => onModalClose(true)}
     >
       <div>

--- a/libs/ui/src/lib/file-download-modal/FileFauxDownloadModal.tsx
+++ b/libs/ui/src/lib/file-download-modal/FileFauxDownloadModal.tsx
@@ -174,6 +174,7 @@ export const FileFauxDownloadModal: FunctionComponent<FileFauxDownloadModalProps
 
   return (
     <Modal
+      testId="record-download-modal"
       header={modalHeader}
       tagline={modalTagline}
       overrideZIndex={1001}
@@ -190,7 +191,6 @@ export const FileFauxDownloadModal: FunctionComponent<FileFauxDownloadModalProps
           {alternateDownloadButton}
         </Fragment>
       }
-      hide={isGooglePickerVisible}
       onClose={() => onCancel()}
     >
       <div>

--- a/libs/ui/src/lib/file-download-modal/RecordDownloadModal.tsx
+++ b/libs/ui/src/lib/file-download-modal/RecordDownloadModal.tsx
@@ -334,6 +334,7 @@ export const RecordDownloadModal: FunctionComponent<RecordDownloadModalProps> = 
     <Fragment>
       {downloadModalOpen && (
         <Modal
+          testId="record-download-modal"
           header="Download Records"
           footer={
             <Fragment>
@@ -352,7 +353,6 @@ export const RecordDownloadModal: FunctionComponent<RecordDownloadModalProps> = 
           }
           overrideZIndex={1001}
           onClose={() => handleModalClose(true)}
-          hide={isGooglePickerVisible}
         >
           <div>
             {requireBulkApi && (

--- a/libs/ui/src/lib/modal/Modal.tsx
+++ b/libs/ui/src/lib/modal/Modal.tsx
@@ -17,9 +17,15 @@ import Icon from '../widgets/Icon';
 import { PortalProvider } from './PortalContext';
 
 export interface ModalProps {
+  testId?: string;
   className?: string;
   classStyles?: SerializedStyles;
-  hide?: boolean; // used to hide the modal without destroying contents
+  /**
+   * Used to hide the modal without destroying modal state.
+   * Generally used to open a second modal (e.g. file download)
+   * Since nothing is rendered, ensure the secondary modals are rendered in a different tree.
+   */
+  hide?: boolean;
   header?: Maybe<string | React.ReactNode>;
   tagline?: Maybe<string | React.ReactNode>;
   footer?: React.ReactNode;
@@ -49,6 +55,7 @@ function getSizeClass(size?: SizeSmMdLg) {
 }
 
 export const Modal = ({
+  testId,
   className,
   classStyles,
   hide,
@@ -145,7 +152,7 @@ export const Modal = ({
                 ${overrideZIndex ? `z-index: ${overrideZIndex}` : ''}
               `}
             >
-              <div className={classNames('slds-modal__container', containerClassName)}>
+              <div data-testid={testId} className={classNames('slds-modal__container', containerClassName)}>
                 <header className={classNames('slds-modal__header', { 'slds-modal__header_empty': !header })}>
                   <button
                     className="slds-button slds-button_icon slds-modal__close"


### PR DESCRIPTION
…results #1328

Remove nested modals for query download to ensure that view/download modal are rendered in the dom.

The parent modal was hidden and nothing in the dom was rendered, thus making the nested modals which were children to not be rendered.

Also ensured that the google file picker does not hide the parent modal just to ensure that there are no weird state issues with keeping track of the currently opened modal.

resolves #1328