### PR TITLE
Collapse unchanged regions diff on swap

### DIFF
--- a/apps/api/src/app/utils/route.utils.ts
+++ b/apps/api/src/app/utils/route.utils.ts
@@ -1,4 +1,4 @@
-import { getExceptionLog, logger, rollbarServer } from '@jetstream/api-config';
+import { getExceptionLog, logger } from '@jetstream/api-config';
 import { CookieOptions, UserProfileSession } from '@jetstream/auth/types';
 import { ApiConnection } from '@jetstream/salesforce-api';
 import { NextFunction } from 'express';
@@ -98,20 +98,6 @@ export function createRoute<TParamsSchema extends z.ZodTypeAny, TBodySchema exte
         next(new UserFacingError(ex));
       }
     } catch (ex) {
-      rollbarServer.error('Route Validation Error', req, {
-        context: `route#createRoute`,
-        custom: {
-          ...getExceptionLog(ex, true),
-          message: ex.message,
-          stack: ex.stack,
-          url: req.url,
-          params: req.params,
-          query: req.query,
-          body: req.body,
-          userId: req.session.user?.id,
-          requestId: res.locals.requestId,
-        },
-      });
       req.log.error(getExceptionLog(ex), '[ROUTE][VALIDATION ERROR]');
       next(new UserFacingError(ex));
     }

--- a/apps/geo-ip-api/src/route.utils.ts
+++ b/apps/geo-ip-api/src/route.utils.ts
@@ -1,4 +1,4 @@
-import { getExceptionLog, rollbarServer } from '@jetstream/api-config';
+import { getExceptionLog } from '@jetstream/api-config';
 import type { Request as ExpressRequest, Response as ExpressResponse } from 'express';
 import { NextFunction } from 'express';
 import type pino from 'pino';
@@ -48,18 +48,6 @@ export function createRoute<TParamsSchema extends z.ZodTypeAny, TBodySchema exte
         next(ex);
       }
     } catch (ex) {
-      rollbarServer.error('Route Validation Error', req, {
-        context: `route#createRoute`,
-        custom: {
-          ...getExceptionLog(ex, true),
-          message: ex.message,
-          stack: ex.stack,
-          url: req.url,
-          params: req.params,
-          query: req.query,
-          body: req.body,
-        },
-      });
       req.log.error(getExceptionLog(ex), '[ROUTE][VALIDATION ERROR]');
       res.status(400);
       next(ex);

--- a/libs/features/deploy/src/view-or-compare-metadata/ViewOrCompareMetadataModal.tsx
+++ b/libs/features/deploy/src/view-or-compare-metadata/ViewOrCompareMetadataModal.tsx
@@ -351,7 +351,6 @@ export const ViewOrCompareMetadataModal = ({ sourceOrg, selectedMetadata, onClos
                                 toggleHideUnchangedRegions(diffEditorRef.current);
                               }
                             }}
-                            disabled={editorType !== 'DIFF'}
                             className="slds-m-bottom_x-small"
                           />
                         </div>
@@ -396,11 +395,12 @@ export const ViewOrCompareMetadataModal = ({ sourceOrg, selectedMetadata, onClos
 
                     {editorType === 'DIFF' && (
                       <DiffEditor
+                        key={swapped ? 'swapped' : 'original'}
                         height="100%"
                         theme="vs-dark"
                         language={activeFileType}
-                        keepCurrentModifiedModel={true}
-                        keepCurrentOriginalModel={true}
+                        keepCurrentModifiedModel
+                        keepCurrentOriginalModel
                         options={{
                           readOnly: true,
                           contextmenu: false,


### PR DESCRIPTION
Ensure editor re-renders on swap to ensure that collapsing changing regions is applied

remove rollbar logs for route validation errors

resolves #1315