### PR TITLE
Improve org encryption strategy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,21 +39,23 @@ NX_PUBLIC_CLIENT_URL='http://localhost:4200/app'
 NX_PUBLIC_SERVER_URL='http://localhost:3333'
 
 # OAUTH FOR LOGGING IN TO THE APP
-# You can provide your own keys by creating a connected app in your dev or production org.
+# You must provide your own keys by creating a connected app in your dev or production org.
 # Salesforce - Scopes: email, profile, openid
-AUTH_SFDC_CLIENT_ID='3MVG9riCAn8HHkYWGpu4WgDxYOW_9snDbMX1MD9hZ5Hd9NZ4yIKUhecgKe.bLizoOuSZGUwL.214Oyhcfd..1'
-AUTH_SFDC_CLIENT_SECRET='3DC73F32C7385596DF9625F914D96A2CADC68F074010D658C122A774A9EC6AA3'
+AUTH_SFDC_CLIENT_ID=''
+AUTH_SFDC_CLIENT_SECRET=''
 
 # Google - Scopes: email, profile, openid
 AUTH_GOOGLE_CLIENT_ID=''
 AUTH_GOOGLE_CLIENT_SECRET=''
 
 # SALESFORCE CONFIGURATION
-# You can provide your own keys by creating a connected app in your dev or production org.
+# You must provide your own keys by creating a connected app in your dev or production org.
 # Scopes: api, web, refresh_token
 SFDC_CALLBACK_URL='http://localhost:3333/oauth/sfdc/callback'
-SFDC_CONSUMER_KEY='3MVG9riCAn8HHkYWGpu4WgDxYOW_9snDbMX1MD9hZ5Hd9NZ4yIKUhecgKe.bLizoOuSZGUwL.214Oyhcfd..1'
-SFDC_CONSUMER_SECRET='3DC73F32C7385596DF9625F914D96A2CADC68F074010D658C122A774A9EC6AA3'
+SFDC_CONSUMER_KEY=''
+# Generate using `openssl rand -base64 32`
+SFDC_ENCRYPTION_KEY=''
+
 
 ###### OPTIONAL ######
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,6 +128,7 @@ jobs:
       SFDC_CALLBACK_URL: http://localhost:3333/oauth/sfdc/callback
       SFDC_CONSUMER_KEY: ${{ secrets.SFDC_CONSUMER_KEY }}
       SFDC_CONSUMER_SECRET: ${{ secrets.SFDC_CONSUMER_SECRET }}
+      SFDC_ENCRYPTION_KEY: ${{ secrets.SFDC_ENCRYPTION_KEY }}
 
     services:
       postgres:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ env:
   NX_PUBLIC_ROLLBAR_KEY: ${{ secrets.NX_PUBLIC_ROLLBAR_KEY }}
   NX_PUBLIC_CLIENT_URL: 'http://localhost:3333/app'
   NX_PUBLIC_SERVER_URL: 'http://localhost:3333'
+  SFDC_ENCRYPTION_KEY: ${{ secrets.SFDC_ENCRYPTION_KEY }}
 
 jobs:
   # Build application
@@ -128,7 +129,6 @@ jobs:
       SFDC_CALLBACK_URL: http://localhost:3333/oauth/sfdc/callback
       SFDC_CONSUMER_KEY: ${{ secrets.SFDC_CONSUMER_KEY }}
       SFDC_CONSUMER_SECRET: ${{ secrets.SFDC_CONSUMER_SECRET }}
-      SFDC_ENCRYPTION_KEY: ${{ secrets.SFDC_ENCRYPTION_KEY }}
 
     services:
       postgres:

--- a/apps/api/src/app/services/__tests__/salesforce-org-encryption.service.spec.ts
+++ b/apps/api/src/app/services/__tests__/salesforce-org-encryption.service.spec.ts
@@ -1,0 +1,110 @@
+import { decryptString, encryptString } from '@jetstream/shared/node-utils';
+import { decryptAccessToken, encryptAccessToken } from '../salesforce-org-encryption.service';
+
+jest.mock('@jetstream/shared/node-utils', () => ({
+  encryptString: jest.fn(),
+  decryptString: jest.fn(),
+  hexToBase64: jest.fn((v) => v),
+}));
+
+jest.mock('@jetstream/api-config', () => ({
+  ENV: {
+    SFDC_ENCRYPTION_KEY: 'test-master-key',
+    SFDC_ENCRYPTION_CACHE_MAX_ENTRIES: 10000,
+    SFDC_ENCRYPTION_CACHE_TTL_MS: 3600000,
+    SFDC_ENCRYPTION_ITERATIONS: 10000,
+    SFDC_CONSUMER_SECRET: 'legacy-secret',
+  },
+  logger: { error: jest.fn() },
+  rollbarServer: { error: jest.fn() },
+  getExceptionLog: jest.fn((err) => ({ message: err.message })),
+}));
+
+describe('salesforce-org-encryption.service', () => {
+  const userId = 'user123';
+  const accessToken = 'access-token';
+  const refreshToken = 'refresh-token';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('encryptAccessToken', () => {
+    it('should encrypt tokens and return v2 format', async () => {
+      // Mock encryptString to return a predictable value
+      (encryptString as jest.Mock).mockReturnValue('encrypted-data');
+
+      const result = await encryptAccessToken({ accessToken, refreshToken, userId });
+
+      // Should match v2:salt:encryptedData format
+      const parts = result.split(':');
+      expect(parts[0]).toBe('v2');
+      expect(parts[2]).toBe('encrypted-data');
+      expect(parts[1]).toBeDefined();
+      expect(result.startsWith('v2:')).toBe(true);
+
+      // Should call encryptString with correct data
+      expect(encryptString).toHaveBeenCalledWith(`${accessToken} ${refreshToken}`, expect.any(String));
+    });
+  });
+
+  describe('decryptAccessToken', () => {
+    it('should decrypt v2 tokens and return access/refresh tokens', async () => {
+      // Prepare a v2 token
+      const salt = 'test-salt';
+      const encryptedData = 'encrypted-data';
+      const encryptedAccessToken = `v2:${salt}:${encryptedData}`;
+
+      // Mock decryptString to return the original tokens
+      (decryptString as jest.Mock).mockReturnValue(`${accessToken} ${refreshToken}`);
+
+      const result = await decryptAccessToken({ encryptedAccessToken, userId });
+
+      expect(result).toEqual([accessToken, refreshToken]);
+      expect(decryptString).toHaveBeenCalledWith(encryptedData, expect.any(String));
+    });
+
+    it('should decrypt legacy tokens and return access/refresh tokens', async () => {
+      const legacyEncrypted = 'legacy-encrypted-token';
+      // Mock decryptString for legacy
+      (decryptString as jest.Mock).mockReturnValueOnce(`${accessToken} ${refreshToken}`);
+
+      const result = await decryptAccessToken({ encryptedAccessToken: legacyEncrypted, userId });
+
+      expect(result).toEqual([accessToken, refreshToken]);
+      expect(decryptString).toHaveBeenCalledWith(legacyEncrypted, 'legacy-secret');
+    });
+
+    it('should return ["invalid", "invalid"] if decryption fails', async () => {
+      // v2 format but decryptString throws
+      (decryptString as jest.Mock).mockImplementation(() => {
+        throw new Error('decryption failed');
+      });
+
+      const encryptedAccessToken = `v2:test-salt:encrypted-data`;
+      const result = await decryptAccessToken({ encryptedAccessToken, userId });
+
+      expect(result).toEqual(['invalid', 'invalid']);
+    });
+
+    it('should return ["invalid", "invalid"] if legacy decryption fails', async () => {
+      // legacy format, decryptString throws
+      (decryptString as jest.Mock).mockImplementation(() => {
+        throw new Error('legacy decryption failed');
+      });
+
+      const legacyEncrypted = 'legacy-encrypted-token';
+      const result = await decryptAccessToken({ encryptedAccessToken: legacyEncrypted, userId });
+
+      expect(result).toEqual(['invalid', 'invalid']);
+    });
+
+    it('should throw error for invalid v2 format', async () => {
+      const encryptedAccessToken = `v2:missingparts`;
+
+      const result = await decryptAccessToken({ encryptedAccessToken, userId });
+
+      expect(result).toEqual(['invalid', 'invalid']);
+    });
+  });
+});

--- a/apps/api/src/app/services/salesforce-org-encryption.service.ts
+++ b/apps/api/src/app/services/salesforce-org-encryption.service.ts
@@ -1,0 +1,150 @@
+import { ENV, getExceptionLog, logger } from '@jetstream/api-config';
+import { decryptString, encryptString, hexToBase64 } from '@jetstream/shared/node-utils';
+import { createHash, pbkdf2, randomBytes } from 'crypto';
+import { LRUCache } from 'lru-cache';
+import { promisify } from 'util';
+
+const pbkdf2Async = promisify(pbkdf2);
+
+/**
+ * Cache for derived encryption keys to avoid expensive PBKDF2 operations
+ * Cache keys for 1 hour with max 10,000 entries (configurable via env vars)
+ */
+const keyCache = new LRUCache<string, string>({
+  max: ENV.SFDC_ENCRYPTION_CACHE_MAX_ENTRIES,
+  ttl: ENV.SFDC_ENCRYPTION_CACHE_TTL_MS,
+});
+
+/**
+ * Encryption versions
+ * - v1: Legacy encryption using SFDC_CONSUMER_SECRET
+ * - v2: Per-user encryption with derived keys
+ */
+export const EncryptionVersion = {
+  V2_PER_USER: 'v2',
+};
+
+/**
+ * Get configurable iteration count for PBKDF2
+ * Allows different values for dev/test/prod environments
+ */
+function getIterationCount(): number {
+  const iterations = ENV.SFDC_ENCRYPTION_ITERATIONS;
+  // Minimum 10k iterations for security
+  return Math.max(iterations, 10000);
+}
+
+/**
+ * Derive a unique encryption key for a specific user
+ * Uses PBKDF2 to derive a key from the master key and user ID with caching
+ */
+async function deriveUserKey({ userId, salt }: { userId: string; salt?: string }): Promise<{ key: string; salt: string }> {
+  const masterKey = ENV.SFDC_ENCRYPTION_KEY;
+  const keySalt = salt || randomBytes(32).toString('base64');
+
+  // Create cache key
+  const cacheKey = `${userId}:${keySalt}`;
+
+  // Use cached value if available
+  const cachedKey = keyCache.get(cacheKey);
+  if (cachedKey) {
+    return { key: cachedKey, salt: keySalt };
+  }
+
+  const derivedKey = await pbkdf2Async(
+    masterKey,
+    cacheKey,
+    getIterationCount(),
+    32, // key length in bytes
+    'sha256'
+  );
+
+  const keyString = derivedKey.toString('base64');
+  keyCache.set(cacheKey, keyString);
+
+  return {
+    key: keyString,
+    salt: keySalt,
+  };
+}
+
+/**
+ * Encrypt Salesforce tokens with versioning support
+ * Returns format: "version:salt:encryptedData" for v2
+ */
+export async function encryptAccessToken({
+  accessToken,
+  refreshToken,
+  userId,
+}: {
+  accessToken: string;
+  refreshToken: string;
+  userId: string;
+}): Promise<string> {
+  const tokenData = `${accessToken} ${refreshToken}`;
+
+  // Per-user encryption key
+  const { key, salt } = await deriveUserKey({ userId });
+  const encryptedData = encryptString(tokenData, key);
+
+  // Store version, salt, and encrypted data
+  // Format: "v2:salt:encryptedData"
+  return `${EncryptionVersion.V2_PER_USER}:${salt}:${encryptedData}`;
+}
+
+/**
+ * Decrypt Salesforce tokens with automatic version detection (ASYNC VERSION - RECOMMENDED)
+ * Handles both legacy (v1) and new (v2) encryption formats
+ */
+export async function decryptAccessToken({
+  encryptedAccessToken,
+  userId,
+}: {
+  encryptedAccessToken: string;
+  userId: string;
+}): Promise<[string, string]> {
+  try {
+    // Check if this is the new format (version:salt:data)
+    if (encryptedAccessToken.startsWith('v2:')) {
+      const [version, salt, encryptedData] = encryptedAccessToken.split(':');
+
+      if (version !== EncryptionVersion.V2_PER_USER || !salt || !encryptedData) {
+        throw new Error('Invalid encrypted token format');
+      }
+
+      // Derive the same key using the stored salt
+      const { key } = await deriveUserKey({ userId, salt });
+      const decrypted = decryptString(encryptedData, key);
+      return decrypted.split(' ') as [string, string];
+    }
+
+    // Legacy format - decrypt with old method
+    try {
+      const decrypted = decryptString(encryptedAccessToken, hexToBase64(ENV.SFDC_CONSUMER_SECRET));
+      return decrypted.split(' ') as [string, string];
+    } catch (error) {
+      logger.error('Failed to decrypt token, it may be corrupted', error);
+      throw new Error('Unable to decrypt access token');
+    }
+  } catch (error) {
+    logger.error({ userId, ...getExceptionLog(error) }, 'Failed to decrypt token, it may be corrupted');
+    // return invalid data to allow the org to gt marked as having invalid credentials once we attempt use them for Salesforce connection
+    return ['invalid', 'invalid'];
+  }
+}
+
+/**
+ * Check if a token is using legacy encryption
+ */
+export function isLegacyEncryption(encryptedAccessToken: string): boolean {
+  return !encryptedAccessToken.startsWith('v2:');
+}
+
+/**
+ * Generate a fingerprint of the encryption key (for monitoring/debugging)
+ * We never want to log the real keys, but can use this as a proxy
+ */
+export async function getKeyFingerprint(userId: string): Promise<string> {
+  const { key } = await deriveUserKey({ userId });
+  return createHash('sha256').update(key).digest('hex').substring(0, 8);
+}

--- a/libs/api-config/src/lib/env-config.ts
+++ b/libs/api-config/src/lib/env-config.ts
@@ -192,6 +192,21 @@ const envSchema = z.object({
   SFDC_CONSUMER_SECRET: z.string().min(1),
   SFDC_CONSUMER_KEY: z.string().min(1),
   SFDC_CALLBACK_URL: z.string().url(),
+  // Should be a base64-encoded 32-byte key (generate with: openssl rand -base64 32)
+  SFDC_ENCRYPTION_KEY: z.string(),
+  // Encryption performance tuning
+  SFDC_ENCRYPTION_ITERATIONS: z
+    .string()
+    .optional()
+    .transform((val) => (val ? parseInt(val) : 100_000)),
+  SFDC_ENCRYPTION_CACHE_MAX_ENTRIES: z
+    .string()
+    .optional()
+    .transform((val) => (val ? parseInt(val) : 10_000)),
+  SFDC_ENCRYPTION_CACHE_TTL_MS: z
+    .string()
+    .optional()
+    .transform((val) => (val ? parseInt(val) : 3_600_000)),
   /**
    * Google OAuth2
    * Allows google drive configuration

--- a/libs/api-config/src/lib/env-config.ts
+++ b/libs/api-config/src/lib/env-config.ts
@@ -33,11 +33,11 @@ function ensureBoolean(value: Maybe<string | boolean>): boolean {
  * This user cannot be used outside of localhost regardless of the environment variables.
  */
 const EXAMPLE_USER: UserProfileSession = {
-  id: 'AAAAAAAA-0000-0000-0000-AAAAAAAAAAAA',
+  id: 'aaaaaaaa-0000-0000-0000-aaaaaaaaaaaa',
   name: 'Test User',
   email: 'test@example.com',
   emailVerified: true,
-  userId: 'test|AAAAAAAA-0000-0000-0000-AAAAAAAAAAAA',
+  userId: 'test|aaaaaaaa-0000-0000-0000-aaaaaaaaaaaa',
   authFactors: [],
 };
 
@@ -52,7 +52,7 @@ const EXAMPLE_USER_FULL_PROFILE: UserProfileUiWithIdentities = {
   preferences: {
     skipFrontdoorLogin: false,
     recordSyncEnabled: false,
-    id: 'AAAAAAAA-0000-0000-0000-AAAAAAAAAAAA',
+    id: 'aaaaaaaa-0000-0000-0000-aaaaaaaaaaaa',
     userId: 'test|TEST_USER_ID',
     createdAt: new Date(),
     updatedAt: new Date(),

--- a/libs/shared/node-utils/src/lib/shared-node-utils.ts
+++ b/libs/shared/node-utils/src/lib/shared-node-utils.ts
@@ -1,4 +1,4 @@
-import { Cipher, createCipheriv, createDecipheriv, Decipher, randomBytes } from 'crypto';
+import { createCipheriv, createDecipheriv, randomBytes } from 'crypto';
 
 export function generateKey(): string {
   // Generates 32 byte cryptographically strong pseudo-random data as a base64 encoded string
@@ -25,16 +25,16 @@ export function encryptString(plainText: string, secret: string): string {
     throw new Error('you must pass a secret');
   }
 
-  const keyBytes: Buffer = Buffer.from(secret, 'base64');
+  const keyBytes = Buffer.from(secret, 'base64');
 
   // Generates 16 byte cryptographically strong pseudo-random data as IV
   // https://nodejs.org/api/crypto.html#crypto_crypto_randombytes_size_callback
-  const ivBytes: Buffer = randomBytes(16);
-  const ivText: string = ivBytes.toString('base64');
+  const ivBytes = randomBytes(16);
+  const ivText = ivBytes.toString('base64');
 
   // encrypt using aes256 iv + key + plainText = encryptedText
-  const cipher: Cipher = createCipheriv('aes256', keyBytes, ivBytes);
-  let encryptedValue: string = cipher.update(plainText, 'utf8', 'base64');
+  const cipher = createCipheriv('aes-256-cbc', new Uint8Array(keyBytes), new Uint8Array(ivBytes));
+  let encryptedValue = cipher.update(plainText, 'utf8', 'base64');
   encryptedValue += cipher.final('base64');
 
   // store base64(ivBytes)!base64(encryptedValue)
@@ -62,8 +62,8 @@ export function decryptString(encryptedValue: string, secret: string): string {
     throw new Error('The encrypted value is not a valid format');
   }
 
-  const ivBytes: Buffer = Buffer.from(ivText, 'base64');
-  const keyBytes: Buffer = Buffer.from(secret, 'base64');
+  const ivBytes = Buffer.from(ivText, 'base64');
+  const keyBytes = Buffer.from(secret, 'base64');
 
   if (ivBytes.length !== 16) {
     throw new Error('The encrypted value is not a valid format');
@@ -74,8 +74,8 @@ export function decryptString(encryptedValue: string, secret: string): string {
   }
 
   // decrypt using aes256 iv + key + encryptedText = decryptedText
-  const decipher: Decipher = createDecipheriv('aes-256-cbc', keyBytes, ivBytes);
-  let value: string = decipher.update(encryptedText, 'base64', 'utf8');
+  const decipher = createDecipheriv('aes-256-cbc', new Uint8Array(keyBytes), new Uint8Array(ivBytes));
+  let value = decipher.update(encryptedText, 'base64', 'utf8');
   value += decipher.final('utf8');
 
   return value;

--- a/libs/test/e2e-utils/src/lib/pageObjectModels/ProfilePage.model.ts
+++ b/libs/test/e2e-utils/src/lib/pageObjectModels/ProfilePage.model.ts
@@ -6,7 +6,7 @@ import { PlaywrightPage } from './PlaywrightPage.model';
 export function getDefaultProfile() {
   const defaultProfile: UserProfileUiWithIdentities = {
     id: 'aaaaaaaa-0000-0000-0000-aaaaaaaaaaaa',
-    userId: 'test|AAAAAAAA-0000-0000-0000-AAAAAAAAAAAA',
+    userId: 'test|aaaaaaaa-0000-0000-0000-aaaaaaaaaaaa',
     name: 'Test User',
     email: 'test@example.com',
     emailVerified: true,

--- a/scripts/generate.env.mjs
+++ b/scripts/generate.env.mjs
@@ -44,6 +44,7 @@ const replacements = [
   ['JETSTREAM_AUTH_SECRET=', `JETSTREAM_AUTH_SECRET='${generateRandomBase64(32)}'`],
   ['JETSTREAM_AUTH_OTP_SECRET=', `JETSTREAM_AUTH_OTP_SECRET='${generateRandomBase64(32)}'`],
   ['EXAMPLE_USER_OVERRIDE=', `EXAMPLE_USER_OVERRIDE='${enableExampleUser}'`],
+  ['SFDC_ENCRYPTION_KEY=', `SFDC_ENCRYPTION_KEY='${generateRandomBase64(32)}'`],
 ];
 
 // for each line in file, see if line starts with a replacement string


### PR DESCRIPTION
Move to a more secure encryption approach for storing org credentials, where each use has a unique encryption key instead of one global key.

Removed example client id/secret from example env file. These were never used in any production systems, but better not to include them in the codebase for security scanning false positives.