### PR TITLE
Remove the order by from soql record count

### DIFF
--- a/apps/api/src/app/services/salesforce-org-encryption.service.ts
+++ b/apps/api/src/app/services/salesforce-org-encryption.service.ts
@@ -83,6 +83,10 @@ export async function encryptAccessToken({
 }): Promise<string> {
   const tokenData = `${accessToken} ${refreshToken}`;
 
+  if (!userId) {
+    throw new Error('User ID is required for encryption');
+  }
+
   // Per-user encryption key
   const { key, salt } = await deriveUserKey({ userId });
   const encryptedData = encryptString(tokenData, key);

--- a/libs/api-config/src/lib/env-config.ts
+++ b/libs/api-config/src/lib/env-config.ts
@@ -193,7 +193,9 @@ const envSchema = z.object({
   SFDC_CONSUMER_KEY: z.string().min(1),
   SFDC_CALLBACK_URL: z.string().url(),
   // Should be a base64-encoded 32-byte key (generate with: openssl rand -base64 32)
-  SFDC_ENCRYPTION_KEY: z.string(),
+  SFDC_ENCRYPTION_KEY: z.string().min(44, {
+    message: 'SFDC_ENCRYPTION_KEY must be a base64-encoded 32-byte key',
+  }),
   // Encryption performance tuning
   SFDC_ENCRYPTION_ITERATIONS: z
     .string()

--- a/libs/features/query/src/QueryBuilder/QueryBuilderSoqlUpdater.tsx
+++ b/libs/features/query/src/QueryBuilder/QueryBuilderSoqlUpdater.tsx
@@ -33,9 +33,19 @@ export const QueryBuilderSoqlUpdater: FunctionComponent = () => {
         limit: queryLimit,
         offset: queryLimitSkip,
       };
-      const queryCount: Query = { ...query, fields: [{ type: 'FieldFunctionExpression', functionName: 'COUNT', parameters: [] }] };
       setSoql(composeSoqlQuery(query, filters, hasGroupBy ? havingClauses : undefined));
-      setSoqlCount(composeSoqlQuery(queryCount, filters, hasGroupBy ? havingClauses : undefined));
+
+      const queryCount: Query = {
+        ...query,
+        fields: [{ type: 'FieldFunctionExpression', functionName: 'COUNT', parameters: [] }],
+        orderBy: undefined,
+      };
+
+      if (query.groupBy || query.having) {
+        setSoqlCount('');
+      } else {
+        setSoqlCount(composeSoqlQuery(queryCount, filters));
+      }
     } else if (soql !== '') {
       setSoql('');
       setSoqlCount('');


### PR DESCRIPTION
when we show the user a preview of the number of records a query will product, an order by would fail 100% of the time as it is incompatible with count(), so that was removed from the query.