### PR TITLE
Google Picker, Date Picker, Record Modal, Add to Changeset

### DIFF
--- a/apps/jetstream-desktop-client/src/app/app.tsx
+++ b/apps/jetstream-desktop-client/src/app/app.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/react';
 import { Announcement } from '@jetstream/types';
 import { AppToast, ConfirmationServiceProvider } from '@jetstream/ui';
-import { AppLoading, DownloadFileStream, ErrorBoundaryFallback, HeaderNavbar } from '@jetstream/ui-core';
+import { AppLoading, DownloadFileStream, ErrorBoundaryFallback, HeaderNavbar, ViewEditCloneRecordWrapper } from '@jetstream/ui-core';
 import { Suspense, useState } from 'react';
 import { DndProvider } from 'react-dnd';
 import { HTML5Backend } from 'react-dnd-html5-backend';
@@ -33,6 +33,7 @@ export const App = () => {
                 <LogInitializer />
                 <NotificationsRequestModal loadDelay={10000} />
                 <DownloadFileStream />
+                <ViewEditCloneRecordWrapper />
                 <div>
                   <div
                     css={css`

--- a/apps/jetstream-web-extension/src/core/AppWrapper.tsx
+++ b/apps/jetstream-web-extension/src/core/AppWrapper.tsx
@@ -1,7 +1,7 @@
 import { enableLogger } from '@jetstream/shared/client-logger';
 import { AxiosAdapterConfig } from '@jetstream/shared/data';
 import { AppToast, ConfirmationServiceProvider } from '@jetstream/ui';
-import { AppLoading } from '@jetstream/ui-core';
+import { AppLoading, ViewEditCloneRecordWrapper } from '@jetstream/ui-core';
 import '@salesforce-ux/design-system/assets/styles/salesforce-lightning-design-system.css';
 import { useAtomValue } from 'jotai';
 import { ReactNode, Suspense } from 'react';
@@ -35,6 +35,7 @@ export function AppWrapper({ allowWithoutSalesforceOrg, children }: { allowWitho
             <DndProvider backend={HTML5Backend}>
               <ModalContainer />
               <AppToast />
+              <ViewEditCloneRecordWrapper />
               {children}
             </DndProvider>
           </AppInitializer>

--- a/apps/jetstream/src/app/app.tsx
+++ b/apps/jetstream/src/app/app.tsx
@@ -1,6 +1,6 @@
 import { Announcement } from '@jetstream/types';
 import { AppToast, ConfirmationServiceProvider } from '@jetstream/ui';
-import { AppLoading, DownloadFileStream, ErrorBoundaryFallback, HeaderNavbar } from '@jetstream/ui-core';
+import { AppLoading, DownloadFileStream, ErrorBoundaryFallback, HeaderNavbar, ViewEditCloneRecordWrapper } from '@jetstream/ui-core';
 import { Suspense, useState } from 'react';
 import { DndProvider } from 'react-dnd';
 import { HTML5Backend } from 'react-dnd-html5-backend';
@@ -30,6 +30,7 @@ export const App = () => {
               <LogInitializer />
               <NotificationsRequestModal loadDelay={10000} />
               <DownloadFileStream />
+              <ViewEditCloneRecordWrapper />
               <div>
                 <div data-testid="header">
                   <HeaderNavbar isBillingEnabled={environment.BILLING_ENABLED} />

--- a/libs/features/deploy/src/add-to-changeset/AddToChangeset.tsx
+++ b/libs/features/deploy/src/add-to-changeset/AddToChangeset.tsx
@@ -1,5 +1,13 @@
 import { ANALYTICS_KEYS } from '@jetstream/shared/constants';
-import { ChangeSet, DeployMetadataTableRow, DeployResult, ListMetadataResult, Maybe, SalesforceOrgUi } from '@jetstream/types';
+import {
+  ChangeSet,
+  DeployMetadataTableRow,
+  DeployOptions,
+  DeployResult,
+  ListMetadataResult,
+  Maybe,
+  SalesforceOrgUi,
+} from '@jetstream/types';
 import { FileDownloadModal, Icon } from '@jetstream/ui';
 import { fromDeployMetadataState, fromJetstreamEvents, useAmplitude } from '@jetstream/ui-core';
 import { applicationCookieState, googleDriveAccessState } from '@jetstream/ui/app-state';
@@ -7,8 +15,8 @@ import classNames from 'classnames';
 import { useAtom, useAtomValue } from 'jotai';
 import { Fragment, useState } from 'react';
 import { convertRowsToMapOfListMetadataResults, getDeployResultsExcelData } from '../utils/deploy-metadata.utils';
-import AddToChangesetConfigModal from './AddToChangesetConfigModal';
-import AddToChangesetStatusModal from './AddToChangesetStatusModal';
+import { AddToChangesetConfigModal } from './AddToChangesetConfigModal';
+import { AddToChangesetStatusModal } from './AddToChangesetStatusModal';
 
 export interface AddToChangesetProps {
   className?: string;
@@ -28,6 +36,7 @@ export const AddToChangeset = ({ className, selectedOrg, loading, selectedRows }
 
   const [changesetPackageName, setChangesetPackageName] = useState<string | null>(null);
   const [changesetPackageDescription, setChangesetPackageDescription] = useState<string | null>(null);
+  const [deployOptions, setDeployOptions] = useState<DeployOptions | null>(null);
   const [selectedChangeset, setSelectedChangeset] = useState<ChangeSet | null | undefined>(null);
 
   const [changesetPackage, setChangesetPackage] = useAtom(fromDeployMetadataState.changesetPackage);
@@ -40,9 +49,15 @@ export const AddToChangeset = ({ className, selectedOrg, loading, selectedRows }
     setSelectedMetadata(convertRowsToMapOfListMetadataResults(Array.from(selectedRows)));
   }
 
-  function handleDeployToChangeset(packageName: string, changesetDescription: string, changeset?: Maybe<ChangeSet>) {
+  function handleDeployToChangeset(
+    packageName: string,
+    changesetDescription: string,
+    deployOptions: DeployOptions,
+    changeset?: Maybe<ChangeSet>
+  ) {
     setChangesetPackageName(packageName);
     setChangesetPackageDescription(changesetDescription);
+    setDeployOptions(deployOptions);
     setSelectedChangeset(changeset);
     setConfigModalOpen(false);
     setDeployStatusModalOpen(true);
@@ -94,6 +109,7 @@ export const AddToChangeset = ({ className, selectedOrg, loading, selectedRows }
           changesetName={changesetPackageName}
           changesetDescription={changesetPackageDescription || ''}
           changeset={selectedChangeset}
+          deployOptions={deployOptions}
           selectedMetadata={selectedMetadata}
           onGoBack={handleGoBackFromDeploy}
           onClose={() => setDeployStatusModalOpen(false)}

--- a/libs/features/deploy/src/add-to-changeset/AddToChangesetStatusModal.tsx
+++ b/libs/features/deploy/src/add-to-changeset/AddToChangesetStatusModal.tsx
@@ -1,5 +1,5 @@
 import { useNonInitialEffect } from '@jetstream/shared/ui-utils';
-import { ChangeSet, DeployResult, ListMetadataResult, SalesforceOrgUi } from '@jetstream/types';
+import { ChangeSet, DeployOptions, DeployResult, ListMetadataResult, SalesforceOrgUi } from '@jetstream/types';
 import { SalesforceLogin } from '@jetstream/ui';
 import { applicationCookieState, selectSkipFrontdoorAuth } from '@jetstream/ui/app-state';
 import { useAtomValue } from 'jotai';
@@ -14,6 +14,7 @@ export interface AddToChangesetStatusModalProps {
   changesetName: string;
   changesetDescription: string;
   changeset?: ChangeSet | null;
+  deployOptions: DeployOptions | null;
   // used to hide while download window is open
   hideModal: boolean;
   onGoBack: () => void;
@@ -26,6 +27,7 @@ export const AddToChangesetStatusModal: FunctionComponent<AddToChangesetStatusMo
   changesetName,
   changesetDescription,
   changeset,
+  deployOptions,
   selectedMetadata,
   hideModal,
   onGoBack,
@@ -38,6 +40,7 @@ export const AddToChangesetStatusModal: FunctionComponent<AddToChangesetStatusMo
   const { deployMetadata, results, deployId, loading, status, lastChecked, hasError, errorMessage } = useAddItemsToChangeset(selectedOrg, {
     changesetName,
     changesetDescription,
+    deployOptions,
     selectedMetadata,
   });
 
@@ -108,5 +111,3 @@ export const AddToChangesetStatusModal: FunctionComponent<AddToChangesetStatusMo
     />
   );
 };
-
-export default AddToChangesetStatusModal;

--- a/libs/features/deploy/src/utils/useAddItemsToChangeset.tsx
+++ b/libs/features/deploy/src/utils/useAddItemsToChangeset.tsx
@@ -2,7 +2,7 @@ import { logger } from '@jetstream/shared/client-logger';
 import { getPackageXml, retrieveMetadataFromListMetadata } from '@jetstream/shared/data';
 import { pollAndDeployMetadataResultsWhenReady, pollMetadataResultsUntilDone, useBrowserNotifications } from '@jetstream/shared/ui-utils';
 import { getErrorMessage } from '@jetstream/shared/utils';
-import { DeployMetadataStatus, DeployOptions, DeployResult, ListMetadataResult, SalesforceOrgUi } from '@jetstream/types';
+import { DeployMetadataStatus, DeployOptions, DeployResult, ListMetadataResult, Maybe, SalesforceOrgUi } from '@jetstream/types';
 import { applicationCookieState } from '@jetstream/ui/app-state';
 import { useAtom } from 'jotai';
 import { useCallback, useEffect, useReducer, useRef, useState } from 'react';
@@ -76,8 +76,14 @@ export function useAddItemsToChangeset(
   {
     changesetName,
     changesetDescription,
+    deployOptions: providedDeployOptions,
     selectedMetadata,
-  }: { changesetName: string; changesetDescription: string; selectedMetadata: Record<string, ListMetadataResult[]> }
+  }: {
+    changesetName: string;
+    changesetDescription: string;
+    deployOptions?: Maybe<DeployOptions>;
+    selectedMetadata: Record<string, ListMetadataResult[]>;
+  }
 ) {
   const isMounted = useRef(true);
 
@@ -118,6 +124,8 @@ export function useAddItemsToChangeset(
           runAllTests: false,
           singlePackage: false,
           testLevel: 'NoTestRun',
+          rollbackOnError: !!selectedOrg.orgIsSandbox,
+          ...providedDeployOptions,
         };
         const { results: deployResults, zipFile } = await pollAndDeployMetadataResultsWhenReady(selectedOrg, selectedOrg, id, {
           deployOptions,

--- a/libs/features/formula-evaluator/src/FormulaEvaluator.tsx
+++ b/libs/features/formula-evaluator/src/FormulaEvaluator.tsx
@@ -9,6 +9,7 @@ import { DescribeGlobalSObjectResult } from '@jetstream/types';
 import {
   Alert,
   AutoFullHeightContainer,
+  ButtonGroupContainer,
   Card,
   EmptyState,
   GoneFishingIllustration,
@@ -40,7 +41,7 @@ import * as formulon from 'formulon';
 import { useAtom, useAtomValue } from 'jotai';
 import type { editor } from 'monaco-editor';
 import { FunctionComponent, useCallback, useEffect, useRef, useState } from 'react';
-import FormulaEvaluatorDeployModal from './deploy/FormulaEvaluatorDeployModal';
+import { FormulaEvaluatorDeployModal } from './deploy/FormulaEvaluatorDeployModal';
 
 // Lazy import
 const prettier = import('prettier/standalone');
@@ -418,7 +419,7 @@ export const FormulaEvaluator: FunctionComponent<FormulaEvaluatorProps> = () => 
               icon={{ type: 'standard', icon: 'outcome' }}
               title={<div>Results</div>}
               actions={
-                <>
+                <ButtonGroupContainer>
                   <button
                     className="slds-button slds-button_neutral"
                     disabled={deployFormulaDisabled}
@@ -433,7 +434,7 @@ export const FormulaEvaluator: FunctionComponent<FormulaEvaluatorProps> = () => 
                   >
                     Test
                   </button>
-                </>
+                </ButtonGroupContainer>
               }
             >
               {loading && <Spinner />}

--- a/libs/features/formula-evaluator/src/deploy/FormulaEvaluatorDeployModal.tsx
+++ b/libs/features/formula-evaluator/src/deploy/FormulaEvaluatorDeployModal.tsx
@@ -374,5 +374,3 @@ export const FormulaEvaluatorDeployModal = ({
     </>
   );
 };
-
-export default FormulaEvaluatorDeployModal;

--- a/libs/features/load-records/src/LoadRecords.tsx
+++ b/libs/features/load-records/src/LoadRecords.tsx
@@ -4,7 +4,7 @@ import { ANALYTICS_KEYS, TITLES } from '@jetstream/shared/constants';
 import { clearCacheForOrg } from '@jetstream/shared/data';
 import { APP_ROUTES } from '@jetstream/shared/ui-router';
 import { formatNumber, useTitle } from '@jetstream/shared/ui-utils';
-import { FieldWithRelatedEntities, LocalOrGoogle, Step } from '@jetstream/types';
+import { FieldWithRelatedEntities, LocalOrGoogle, Maybe, Step } from '@jetstream/types';
 import {
   AutoFullHeightContainer,
   Grid,
@@ -79,6 +79,7 @@ export const LoadRecords = () => {
   const [inputFileHeader, setInputFileHeader] = useAtom(fromLoadRecordsState.inputFileHeaderState);
   const [inputFilename, setInputFilename] = useAtom(fromLoadRecordsState.inputFilenameState);
   const [inputFilenameType, setInputFilenameType] = useAtom(fromLoadRecordsState.inputFilenameTypeState);
+  const [inputGoogleFile, setInputGoogleFile] = useAtom(fromLoadRecordsState.inputGoogleFileState);
 
   const [inputZipFileData, setInputZipFileData] = useAtom(fromLoadRecordsState.inputZipFileDataState);
   const [inputZipFilename, setInputZipFilename] = useAtom(fromLoadRecordsState.inputZipFilenameState);
@@ -110,6 +111,7 @@ export const LoadRecords = () => {
   const resetInputFilenameState = useResetAtom(fromLoadRecordsState.inputFilenameState);
   const resetFieldMappingState = useResetAtom(fromLoadRecordsState.fieldMappingState);
   const resetFieldMappingTypeState = useResetAtom(fromLoadRecordsState.inputFilenameTypeState);
+  const resetInputGoogleFile = useResetAtom(fromLoadRecordsState.inputGoogleFileState);
   const resetInputZipFileData = useResetAtom(fromLoadRecordsState.inputZipFileDataState);
   const resetInputZipFilename = useResetAtom(fromLoadRecordsState.inputZipFilenameState);
 
@@ -167,6 +169,7 @@ export const LoadRecords = () => {
         resetInputFilenameState();
         resetFieldMappingState();
         resetFieldMappingTypeState();
+        resetInputGoogleFile();
         resetInputZipFileData();
         resetInputZipFilename();
         resetApiModeState();
@@ -186,6 +189,7 @@ export const LoadRecords = () => {
     resetLoadTypeState,
     resetSelectedSObjectState,
     resetFieldMappingTypeState,
+    resetInputGoogleFile,
     resetInputZipFileData,
     resetInputZipFilename,
     resetApiModeState,
@@ -348,11 +352,18 @@ export const LoadRecords = () => {
     setLoadSummaryText(text.join(' • '));
   }, [selectedSObject, loadType, fieldMapping, inputFileHeader, externalId]);
 
-  function handleFileChange(data: any[], headers: string[], filename: string, type: LocalOrGoogle) {
+  function handleFileChange(
+    data: any[],
+    headers: string[],
+    filename: string,
+    type: LocalOrGoogle,
+    googleFile?: Maybe<google.picker.DocumentObject>
+  ) {
     setInputFileData(data);
     setInputFileHeader(headers);
     setInputFilename(filename);
     setInputFilenameType(type);
+    setInputGoogleFile(googleFile);
   }
 
   function handleZipFileChange(data: ArrayBuffer, filename: string) {
@@ -471,6 +482,7 @@ export const LoadRecords = () => {
                 externalId={externalId}
                 inputFilename={inputFilename}
                 inputFileType={inputFilenameType}
+                inputGoogleFile={inputGoogleFile}
                 allowBinaryAttachment={!!allowBinaryAttachment}
                 binaryAttachmentBodyField={binaryAttachmentBodyField}
                 inputZipFilename={inputZipFilename}

--- a/libs/features/load-records/src/steps/SelectObjectAndFile.tsx
+++ b/libs/features/load-records/src/steps/SelectObjectAndFile.tsx
@@ -40,13 +40,20 @@ export interface LoadRecordsSelectObjectAndFileProps {
   externalId: string;
   inputFileType: Maybe<LocalOrGoogle>;
   inputFilename: Maybe<string>;
+  inputGoogleFile: Maybe<google.picker.DocumentObject>;
   loadingFields: Maybe<boolean>;
   allowBinaryAttachment: Maybe<boolean>;
   binaryAttachmentBodyField: Maybe<string>;
   inputZipFilename: Maybe<string>;
   onSobjects: (sobjects: DescribeGlobalSObjectResult[] | null) => void;
   onSelectedSobject: (selectedSObject: DescribeGlobalSObjectResult) => void;
-  onFileChange: (data: any[], headers: string[], filename: string, inputFileType: LocalOrGoogle) => void;
+  onFileChange: (
+    data: any[],
+    headers: string[],
+    filename: string,
+    inputFileType: LocalOrGoogle,
+    googleFile?: Maybe<google.picker.DocumentObject>
+  ) => void;
   onZipFileChange: (data: ArrayBuffer, filename: string) => void;
   onLoadTypeChange: (type: InsertUpdateUpsertDelete) => void;
   onExternalIdChange: (externalId: string) => void;
@@ -70,6 +77,7 @@ export const LoadRecordsSelectObjectAndFile = ({
   externalId,
   inputFileType,
   inputFilename,
+  inputGoogleFile,
   loadingFields,
   allowBinaryAttachment,
   binaryAttachmentBodyField,
@@ -118,7 +126,7 @@ export const LoadRecordsSelectObjectAndFile = ({
   async function handleGoogleFile({ workbook, selectedFile }: InputReadGoogleSheet) {
     try {
       const { data, headers } = await parseWorkbook(workbook, { onParsedMultipleWorkbooks });
-      onFileChange(data, headers, selectedFile.name, 'google');
+      onFileChange(data, headers, selectedFile.name, 'google', selectedFile);
     } catch (ex) {
       fireToast({
         message: `There was an error reading your file. ${getErrorMessage(ex)}`,
@@ -195,6 +203,7 @@ export const LoadRecordsSelectObjectAndFile = ({
                     label: 'Google Drive',
                     buttonLabel: 'Choose Google Sheet',
                     filename: inputFileType === 'google' ? inputFilename : undefined,
+                    inputGoogleFile,
                     onReadFile: handleGoogleFile,
                   }}
                   source="load_records_single_object"

--- a/libs/features/load-records/tsconfig.lib.json
+++ b/libs/features/load-records/tsconfig.lib.json
@@ -2,7 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
-    "types": ["node"]
+    "types": ["node", "google.accounts", "google.picker", "gapi.auth2"]
   },
   "exclude": [
     "jest.config.ts",

--- a/libs/features/load-records/tsconfig.spec.json
+++ b/libs/features/load-records/tsconfig.spec.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "outDir": "../../../dist/out-tsc",
     "module": "commonjs",
-    "types": ["jest", "node"]
+    "types": ["jest", "node", "google.accounts", "google.picker", "gapi.auth2"]
   },
   "include": [
     "jest.config.ts",

--- a/libs/shared/ui-core/src/index.ts
+++ b/libs/shared/ui-core/src/index.ts
@@ -68,6 +68,7 @@ export * from './query/ValidQueryText';
 export * from './record/RecordSearchPopover';
 export * from './record/ViewChildRecords';
 export * from './record/ViewEditCloneRecord';
+export * from './record/ViewEditCloneRecordWrapper';
 export * as fromAutomationControlState from './state-management/automation-control.state';
 export * as fromDeployMetadataState from './state-management/deploy-metadata.state';
 export * as fromFormulaState from './state-management/formula-evaluator.state';

--- a/libs/shared/ui-core/src/record/ViewEditCloneRecordWrapper.tsx
+++ b/libs/shared/ui-core/src/record/ViewEditCloneRecordWrapper.tsx
@@ -1,0 +1,147 @@
+import { logger } from '@jetstream/shared/client-logger';
+import { describeGlobal } from '@jetstream/shared/data';
+import {
+  appActionObservable$,
+  appActionRecordEventFilter,
+  convertId15To18,
+  isValidSalesforceRecordId,
+  recordActionModalClosedObservable,
+  useObservable,
+} from '@jetstream/shared/ui-utils';
+import { CloneEditView, Maybe, SalesforceOrgUi } from '@jetstream/types';
+import { applicationCookieState, selectedOrgState } from '@jetstream/ui/app-state';
+import { useAtom, useAtomValue } from 'jotai';
+import { FunctionComponent, useEffect, useState } from 'react';
+import { ViewEditCloneRecord } from './ViewEditCloneRecord';
+
+async function fetchSobjectName(selectedOrg: SalesforceOrgUi, recordId: string) {
+  try {
+    const keyPrefix = recordId.substring(0, 3);
+    const describeGlobalResults = await describeGlobal(selectedOrg);
+    const sobject = describeGlobalResults.data.sobjects.find((sobject) => sobject.keyPrefix === keyPrefix);
+    if (!sobject) {
+      return null;
+    }
+    if (recordId.length === 15) {
+      try {
+        recordId = convertId15To18(recordId);
+      } catch (ex) {
+        logger.warn('[ERROR] Could not convert 15 digit to 18 digit id', ex);
+      }
+    }
+    return { recordId, sobjectName: sobject.name };
+  } catch (ex) {
+    return null;
+  }
+}
+
+/**
+ * Manages the state and behavior of the ViewEditCloneRecord component.
+ * Anywhere in the app, components can emit observable events to trigger this to open.
+ */
+export const ViewEditCloneRecordWrapper: FunctionComponent = () => {
+  const [{ defaultApiVersion }] = useAtom(applicationCookieState);
+  const selectedOrg = useAtomValue(selectedOrgState);
+  const [modalOpen, setModalOpen] = useState<boolean>(false);
+  const [recordId, setRecordId] = useState<string>('');
+  const [sobjectName, setSobjectName] = useState<string | null>(null);
+  const [action, setAction] = useState<CloneEditView>('view');
+
+  const appActionEvents = useObservable(appActionObservable$.pipe(appActionRecordEventFilter));
+
+  useEffect(() => {
+    if (!appActionEvents) {
+      return;
+    }
+    let _modalOpen = false;
+    let _recordId = '';
+    let _sobjectName = appActionEvents.payload.objectName || '';
+
+    switch (appActionEvents.action) {
+      case 'VIEW_RECORD': {
+        if (!isValidSalesforceRecordId(appActionEvents.payload.recordId)) {
+          return;
+        }
+        setAction('view');
+        _modalOpen = true;
+        _recordId = appActionEvents.payload.recordId;
+        break;
+      }
+      case 'EDIT_RECORD': {
+        if (!isValidSalesforceRecordId(appActionEvents.payload.recordId)) {
+          return;
+        }
+        setAction('edit');
+        _modalOpen = true;
+        _recordId = appActionEvents.payload.recordId;
+        break;
+      }
+      case 'CREATE_RECORD': {
+        setAction('create');
+        _modalOpen = true;
+        _sobjectName = appActionEvents.payload.objectName;
+        break;
+      }
+      case 'CLONE_RECORD': {
+        if (!isValidSalesforceRecordId(appActionEvents.payload.recordId)) {
+          return;
+        }
+        setAction('clone');
+        _modalOpen = true;
+        _recordId = appActionEvents.payload.recordId;
+        break;
+      }
+    }
+
+    if (!_modalOpen) {
+      setModalOpen(false);
+      return;
+    }
+
+    // Fetch object name if needed
+    if (!_sobjectName && _recordId) {
+      fetchSobjectName(selectedOrg, _recordId).then((result) => {
+        if (result) {
+          setRecordId(result.recordId);
+          setSobjectName(result.sobjectName);
+          setModalOpen(true);
+        }
+      });
+    } else if (_sobjectName && _recordId) {
+      setRecordId(_recordId);
+      setSobjectName(_sobjectName);
+      setModalOpen(true);
+    }
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [appActionEvents]);
+
+  function onActionChange(action: CloneEditView) {
+    setAction(action);
+  }
+
+  function onModalClose(reloadRecords?: Maybe<boolean>) {
+    const objectName = sobjectName;
+    setAction('view');
+    setModalOpen(false);
+    setSobjectName(null);
+    setRecordId('');
+    recordActionModalClosedObservable.next({ objectName, reloadRecords });
+  }
+
+  if (!selectedOrg || !!selectedOrg.connectionError || !modalOpen || !sobjectName) {
+    return null;
+  }
+
+  return (
+    <ViewEditCloneRecord
+      apiVersion={defaultApiVersion}
+      selectedOrg={selectedOrg}
+      action={action}
+      sobjectName={sobjectName}
+      recordId={recordId}
+      onClose={onModalClose}
+      onChangeAction={onActionChange}
+    />
+  );
+};

--- a/libs/shared/ui-core/src/record/record-utils.ts
+++ b/libs/shared/ui-core/src/record/record-utils.ts
@@ -1,5 +1,85 @@
+import { logger } from '@jetstream/shared/client-logger';
+import { INDEXED_DB } from '@jetstream/shared/constants';
 import { REGEX } from '@jetstream/shared/utils';
 import { composeQuery, getField, WhereClause } from '@jetstreamapp/soql-parser-js';
+import localforage from 'localforage';
+import uniqBy from 'lodash/uniqBy';
+
+type RecentRecordStorageMap = Record<string, RecentRecord[]>;
+export interface RecentRecord {
+  recordId: string;
+  sobject: string;
+  name?: string;
+}
+
+const NUM_HISTORY_ITEMS = 25;
+let recentItemsMapCache: RecentRecordStorageMap | null = null;
+
+export async function getRecentRecordsFromStorage() {
+  try {
+    if (recentItemsMapCache) {
+      return recentItemsMapCache;
+    }
+    recentItemsMapCache = await localforage.getItem<RecentRecordStorageMap>(INDEXED_DB.KEYS.userPreferences);
+    return recentItemsMapCache || {};
+  } catch (ex) {
+    return recentItemsMapCache || {};
+  }
+}
+
+export async function addRecentRecordToStorage(record: RecentRecord, orgUniqueId: string) {
+  if (!record.recordId || !record?.sobject) {
+    return getRecentRecordsFromStorage().then((recentItems) => recentItems[orgUniqueId] || []);
+  }
+  const { recordId, sobject, name } = record;
+
+  const recentItems = await getRecentRecordsFromStorage();
+
+  recentItems[orgUniqueId] = recentItems[orgUniqueId] || [];
+  const existingItem = recentItems[orgUniqueId].find((item) => item.recordId === recordId);
+  recentItems[orgUniqueId].unshift({ recordId, sobject, name: name || existingItem?.name });
+  recentItems[orgUniqueId] = uniqBy(recentItems[orgUniqueId], 'recordId').slice(0, NUM_HISTORY_ITEMS);
+
+  localforage.setItem<RecentRecordStorageMap>(INDEXED_DB.KEYS.userPreferences, recentItems).catch((err) => {
+    logger.warn('[ERROR] Could not save recent record history', err);
+  });
+
+  return recentItems[orgUniqueId];
+}
+
+export async function updateRecentRecordItem(recordId: string, record: Partial<RecentRecord>, orgUniqueId: string) {
+  if (!recordId) {
+    return getRecentRecordsFromStorage().then((recentItems) => recentItems[orgUniqueId] || []);
+  }
+
+  const recentItems = await getRecentRecordsFromStorage();
+
+  recentItems[orgUniqueId] = recentItems[orgUniqueId] || [];
+  recentItems[orgUniqueId] = recentItems[orgUniqueId].map((item) => (item.recordId !== recordId ? item : { ...item, ...record }));
+
+  localforage.setItem<RecentRecordStorageMap>(INDEXED_DB.KEYS.userPreferences, recentItems).catch((err) => {
+    logger.warn('[ERROR] Could not save recent record history', err);
+  });
+
+  return recentItems[orgUniqueId];
+}
+
+export async function removeRecentRecordItem(recordId: string, orgUniqueId: string) {
+  if (!recordId) {
+    return getRecentRecordsFromStorage().then((recentItems) => recentItems[orgUniqueId] || []);
+  }
+
+  const recentItems = await getRecentRecordsFromStorage();
+
+  recentItems[orgUniqueId] = recentItems[orgUniqueId] || [];
+  recentItems[orgUniqueId] = recentItems[orgUniqueId].filter((item) => item.recordId !== recordId);
+
+  localforage.setItem<RecentRecordStorageMap>(INDEXED_DB.KEYS.userPreferences, recentItems).catch((err) => {
+    logger.warn('[ERROR] Could not save recent record history', err);
+  });
+
+  return recentItems[orgUniqueId];
+}
 
 export function getSearchUserSoql(value: string) {
   let whereClause: WhereClause = {

--- a/libs/shared/ui-core/src/state-management/load-records.state.ts
+++ b/libs/shared/ui-core/src/state-management/load-records.state.ts
@@ -35,6 +35,8 @@ export const inputFilenameState = atomWithReset<string | null>(null);
 
 export const inputFilenameTypeState = atomWithReset<LocalOrGoogle | null>(null);
 
+export const inputGoogleFileState = atomWithReset<Maybe<google.picker.DocumentObject>>(null);
+
 export const inputZipFileDataState = atomWithReset<ArrayBuffer | null>(null);
 
 export const inputZipFilenameState = atomWithReset<string | null>(null);

--- a/libs/shared/ui-utils/src/lib/shared-ui-observables.ts
+++ b/libs/shared/ui-utils/src/lib/shared-ui-observables.ts
@@ -1,16 +1,21 @@
+import { Maybe } from '@jetstream/types';
 import { filter, Subject } from 'rxjs';
 
-export type AppAction = AppActionViewRecord | AppActionEditRecord | AppActionCreateRecord;
-export type AppActionTypes = AppActionViewRecord['action'] | AppActionEditRecord['action'] | AppActionCreateRecord['action'];
+export type AppAction = AppActionViewRecord | AppActionEditRecord | AppActionCreateRecord | AppActionCloneRecord;
+export type AppActionTypes =
+  | AppActionViewRecord['action']
+  | AppActionEditRecord['action']
+  | AppActionCreateRecord['action']
+  | AppActionCloneRecord['action'];
 
 export type AppActionViewRecord = {
   action: 'VIEW_RECORD';
-  payload: { recordId: string };
+  payload: { recordId: string; objectName?: Maybe<string> };
 };
 
 export type AppActionEditRecord = {
   action: 'EDIT_RECORD';
-  payload: { recordId: string };
+  payload: { recordId: string; objectName?: Maybe<string> };
 };
 
 export type AppActionCreateRecord = {
@@ -18,10 +23,16 @@ export type AppActionCreateRecord = {
   payload: { objectName: string };
 };
 
+export type AppActionCloneRecord = {
+  action: 'CLONE_RECORD';
+  payload: { recordId: string; objectName?: Maybe<string> };
+};
+
 export const appActionObservable = new Subject<AppAction>();
 export const appActionObservable$ = appActionObservable.asObservable();
 
-export const APP_ACTION_RECORD_EVENTS = new Set<
-  AppActionViewRecord['action'] | AppActionEditRecord['action'] | AppActionCreateRecord['action']
->(['EDIT_RECORD', 'VIEW_RECORD', 'CREATE_RECORD']);
+export const APP_ACTION_RECORD_EVENTS = new Set<AppActionTypes>(['EDIT_RECORD', 'VIEW_RECORD', 'CREATE_RECORD', 'CLONE_RECORD']);
 export const appActionRecordEventFilter = filter<AppAction>((action) => APP_ACTION_RECORD_EVENTS.has(action.action));
+
+export const recordActionModalClosedObservable = new Subject<{ objectName?: Maybe<string>; reloadRecords?: Maybe<boolean> }>();
+export const recordActionModalClosedObservable$ = recordActionModalClosedObservable.asObservable();

--- a/libs/ui/src/lib/data-table/DataTableRenderers.tsx
+++ b/libs/ui/src/lib/data-table/DataTableRenderers.tsx
@@ -602,11 +602,7 @@ export function TextOrIdLinkRenderer(RenderCellProps: RenderCellProps<RowWithKey
   const maybeSalesforceId = row[column.key];
 
   if (_org && isString(maybeSalesforceId) && maybeSalesforceId.length === 18 && isValidSalesforceRecordId(maybeSalesforceId, false)) {
-    return (
-      <a href={`${_org.instanceUrl}/${maybeSalesforceId}`} target="_blank" rel="noopener noreferrer">
-        {maybeSalesforceId}
-      </a>
-    );
+    return <IdLinkRenderer {...RenderCellProps} />;
   }
 
   return GenericRenderer(RenderCellProps);

--- a/libs/ui/src/lib/data-table/DataTableSubqueryRenderer.tsx
+++ b/libs/ui/src/lib/data-table/DataTableSubqueryRenderer.tsx
@@ -1,7 +1,7 @@
 import { queryMore } from '@jetstream/shared/data';
-import { copyRecordsToClipboard, formatNumber } from '@jetstream/shared/ui-utils';
+import { appActionObservable, copyRecordsToClipboard, formatNumber } from '@jetstream/shared/ui-utils';
 import { flattenRecord } from '@jetstream/shared/utils';
-import { ContextMenuItem, Maybe, QueryResult, SalesforceOrgUi } from '@jetstream/types';
+import { CloneEditView, ContextMenuItem, Maybe, QueryResult, SalesforceOrgUi } from '@jetstream/types';
 import { ReactNode, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { RenderCellProps } from 'react-data-grid';
 import RecordDownloadModal from '../file-download-modal/RecordDownloadModal';
@@ -337,6 +337,19 @@ function ModalDataTable({
                 contextMenuItems={TABLE_CONTEXT_MENU_ITEMS}
                 contextMenuAction={handleContextMenuAction}
                 onReorderColumns={handleColumnReorder}
+                context={{
+                  org,
+                  onRecordAction: (action: CloneEditView, recordId: string, objectName: string) => {
+                    switch (action) {
+                      case 'view':
+                        appActionObservable.next({ action: 'VIEW_RECORD', payload: { recordId, objectName } });
+                        break;
+                      case 'edit':
+                        appActionObservable.next({ action: 'EDIT_RECORD', payload: { recordId, objectName } });
+                        break;
+                    }
+                  },
+                }}
               />
             </AutoFullHeightContainer>
           </div>

--- a/libs/ui/src/lib/form/combobox/Combobox.tsx
+++ b/libs/ui/src/lib/form/combobox/Combobox.tsx
@@ -392,16 +392,7 @@ export const Combobox = forwardRef<ComboboxPropsRef, ComboboxProps>(
                   onSelected={onLeadingDropdownChange}
                 />
               )}
-              <div
-                className={classNames('slds-combobox_container', { 'slds-has-selection': showSelectionAsButton && selectedItemLabel })}
-                // additionalParentRef={popoverRef.current}
-                // onOutsideClick={() => {
-                //   // if (isOpen) {
-                //   //   setIsOpen(false);
-                //   //   onClose && onClose();
-                //   // }
-                // }}
-              >
+              <div className={classNames('slds-combobox_container', { 'slds-has-selection': showSelectionAsButton && selectedItemLabel })}>
                 <div
                   ref={entireContainerEl}
                   className={classNames('slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click', { 'slds-is-open': isOpen })}

--- a/libs/ui/src/lib/form/date/DatePickerPopup.tsx
+++ b/libs/ui/src/lib/form/date/DatePickerPopup.tsx
@@ -14,6 +14,7 @@ import DateGrid from './DateGrid';
 import DateGridPrevNextSelector from './DateGridPrevNextSelector';
 
 export interface DatePickerPopupProps {
+  ref?: React.Ref<HTMLDivElement>;
   initialSelectedDate?: Date;
   initialVisibleDate?: Date;
   dropDownPosition?: PositionLeftRight;
@@ -26,6 +27,7 @@ export interface DatePickerPopupProps {
 }
 
 export const DatePickerPopup: FunctionComponent<DatePickerPopupProps> = ({
+  ref,
   initialSelectedDate,
   initialVisibleDate = startOfMonth(new Date()),
   availableYears,
@@ -85,13 +87,7 @@ export const DatePickerPopup: FunctionComponent<DatePickerPopupProps> = ({
   }
 
   return (
-    // <div
-    //   aria-hidden="false"
-    //   aria-label={`Date picker: ${visibleMonth}`}
-    //   className={`slds-datepicker slds-dropdown slds-dropdown_${dropDownPosition}`}
-    //   role="dialog"
-    // >
-    <>
+    <div ref={ref}>
       <DateGridPrevNextSelector
         id="date-picker"
         currMonth={currMonthString}
@@ -131,8 +127,7 @@ export const DatePickerPopup: FunctionComponent<DatePickerPopupProps> = ({
           </button>
         </GridCol>
       </Grid>
-      {/* </div> */}
-    </>
+    </div>
   );
 };
 

--- a/libs/ui/src/lib/form/file-selector/FileOrGoogleSelector.tsx
+++ b/libs/ui/src/lib/form/file-selector/FileOrGoogleSelector.tsx
@@ -1,10 +1,7 @@
-import { lazy } from 'react';
 import Tabs from '../../tabs/Tabs';
 import FileSelector, { FileSelectorProps } from './FileSelector';
-import type { GoogleFileSelectorProps } from './GoogleFileSelector';
+import { GoogleFileSelector, type GoogleFileSelectorProps } from './GoogleFileSelector';
 import { GoogleSelectedProUpgradeButton } from './GoogleSelectedProUpgradeButton';
-
-const GoogleFileSelector = lazy(() => import('./GoogleFileSelector'));
 
 export interface FileOrGoogleSelectorProps {
   fileSelectorProps: FileSelectorProps;

--- a/libs/ui/src/lib/form/file-selector/GoogleFileSelector.tsx
+++ b/libs/ui/src/lib/form/file-selector/GoogleFileSelector.tsx
@@ -20,6 +20,7 @@ export interface GoogleFileSelectorProps {
   id?: string;
   className?: string;
   filename?: Maybe<string>;
+  inputGoogleFile?: Maybe<google.picker.DocumentObject>;
   label?: string;
   buttonLabel?: string;
   helpText?: string;
@@ -38,6 +39,7 @@ export const GoogleFileSelector: FunctionComponent<GoogleFileSelectorProps> = ({
   id = uniqueId('google-file-input'),
   className,
   filename,
+  inputGoogleFile,
   label,
   buttonLabel = 'Choose Google Sheet',
   hideLabel,
@@ -53,7 +55,7 @@ export const GoogleFileSelector: FunctionComponent<GoogleFileSelectorProps> = ({
   const [labelId] = useState(() => `${id}-label`);
   const { data, error: scriptLoadError, loading: googleApiLoading, isVisible, openPicker } = useDrivePicker(apiConfig);
   const [loading, setLoading] = useState(false);
-  const [selectedFile, setSelectedFile] = useState<google.picker.DocumentObject>();
+  const [selectedFile, setSelectedFile] = useState<Maybe<google.picker.DocumentObject>>(inputGoogleFile);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [{ managedFilename, filenameTruncated }, setManagedFilename] = useFilename(filename);
 

--- a/libs/ui/src/lib/widgets/RecordLookupPopover.tsx
+++ b/libs/ui/src/lib/widgets/RecordLookupPopover.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react';
 import { describeGlobal, describeSObject, queryWithCache } from '@jetstream/shared/data';
-import { useNonInitialEffect } from '@jetstream/shared/ui-utils';
+import { appActionObservable, useNonInitialEffect } from '@jetstream/shared/ui-utils';
 import { CloneEditView, RecordWithAuditFields, SalesforceOrgUi } from '@jetstream/types';
 import { FunctionComponent, useEffect, useRef, useState } from 'react';
 import { dataTableDateFormatter } from '../data-table/data-table-formatters';
@@ -98,7 +98,13 @@ export const RecordLookupPopover: FunctionComponent<RecordLookupPopoverProps> = 
         return;
       }
 
-      setRecord(queryResults.data.queryResults.records[0]);
+      const _record = queryResults.data.queryResults.records[0];
+
+      if (!_record) {
+        setErrorMessage(`A record with id "${recordId}" for object "${sobject.name}" was not found.`);
+      }
+
+      setRecord(_record);
     } catch (ex) {
       setErrorMessage(`There was an error getting the record data.`);
     } finally {
@@ -204,25 +210,21 @@ export const RecordLookupPopover: FunctionComponent<RecordLookupPopoverProps> = 
           <footer className="slds-popover__footer">
             <Grid align="spread">
               <div>
-                {onRecordAction && sobjectName && (
-                  <>
-                    <button
-                      autoFocus
-                      className="slds-button slds-button_neutral"
-                      onClick={() => onRecordAction('view', recordId, sobjectName)}
-                    >
-                      <Icon type="utility" icon="preview" className="slds-button__icon slds-button__icon_left" omitContainer />
-                      View Record
-                    </button>
-                    <button
-                      className="slds-button slds-button_neutral slds-p-left_x-small"
-                      onClick={() => onRecordAction('edit', recordId, sobjectName)}
-                    >
-                      <Icon type="utility" icon="edit" className="slds-button__icon slds-button__icon_left" omitContainer />
-                      Edit Record
-                    </button>
-                  </>
-                )}
+                <button
+                  autoFocus
+                  className="slds-button slds-button_neutral"
+                  onClick={() => appActionObservable.next({ action: 'VIEW_RECORD', payload: { recordId } })}
+                >
+                  <Icon type="utility" icon="preview" className="slds-button__icon slds-button__icon_left" omitContainer />
+                  View Record
+                </button>
+                <button
+                  className="slds-button slds-button_neutral slds-p-left_x-small"
+                  onClick={() => appActionObservable.next({ action: 'EDIT_RECORD', payload: { recordId } })}
+                >
+                  <Icon type="utility" icon="edit" className="slds-button__icon slds-button__icon_left" omitContainer />
+                  Edit Record
+                </button>
               </div>
               <button className="slds-button" disabled={loading} onClick={() => fetchRecord(true)}>
                 <Icon type="utility" icon="refresh" className="slds-button__icon slds-button__icon_left" omitContainer />


### PR DESCRIPTION
Allow refreshing from google sheet on load records page even after user goes forward and backwards

Ensure date picker closes on outside click - there is still some slightly buggy behavior in a couple places. Inside a modal, the date picker closes when clicking on the date picker popup if the element is not focusable, and on the data table the date picker closes but not the entire edit input if user clicks outside of the table.

Refactored the ViewEditCreate record modal - this is now managed at the application level instead of managed at the component level - events are emitted from anywhere and the modal "JustWorks(TM)"

Any time a user views a record, the record search history now gets updated as a convenience for users to find their recently interacted with records

When uploading metadata to a changeset, we now allow the user to change some options and we default to rolling back on failure in production orgs (it is rare, but some users create outbound changesets in production orgs)

resolves #1344
resolves #1338
resolves #1340