### PR TITLE
Binary file bugfixes

### DIFF
--- a/libs/features/load-records/src/steps/SelectObjectAndFile.tsx
+++ b/libs/features/load-records/src/steps/SelectObjectAndFile.tsx
@@ -228,7 +228,7 @@ export const LoadRecordsSelectObjectAndFile = ({
               <Grid verticalAlign="center">
                 <GridCol size={6}>
                   <FileSelector
-                    id={'load-record-file'}
+                    id="load-record-file-zip"
                     label="Zip file with attachments"
                     filename={inputZipFilename}
                     accept={[INPUT_ACCEPT_FILETYPES.ZIP]}

--- a/libs/features/load-records/src/utils/load-records-process.ts
+++ b/libs/features/load-records/src/utils/load-records-process.ts
@@ -297,6 +297,12 @@ async function getBatchApiBatches({
         }
         batchRecordMap.get(i)?.push(_record);
       } catch (ex) {
+        logger.error(`Error processing record with binary data: ${getErrorMessage(ex)}`, {
+          binaryBodyField,
+          filePath: _record[binaryBodyField],
+          record: _record,
+        });
+        logger.error(ex);
         failedRecords.push(_record);
       }
 

--- a/libs/features/load-records/src/utils/load-records-process.ts
+++ b/libs/features/load-records/src/utils/load-records-process.ts
@@ -1,7 +1,7 @@
 import { logger } from '@jetstream/shared/client-logger';
 import { bulkApiAddBatchToJob, bulkApiCloseJob, bulkApiCreateJob, bulkApiGetJob, genericRequest } from '@jetstream/shared/data';
 import { generateCsv } from '@jetstream/shared/ui-utils';
-import { getErrorMessage, getHttpMethod, getSizeInMbFromBase64, splitArrayToMaxSize } from '@jetstream/shared/utils';
+import { getErrorMessage, getErrorStack, getHttpMethod, getSizeInMbFromBase64, splitArrayToMaxSize } from '@jetstream/shared/utils';
 import {
   BulkJobBatchInfo,
   BulkJobWithBatches,
@@ -301,8 +301,8 @@ async function getBatchApiBatches({
           binaryBodyField,
           filePath: _record[binaryBodyField],
           record: _record,
+          stackTrace: getErrorStack(ex),
         });
-        logger.error(ex);
         failedRecords.push(_record);
       }
 

--- a/libs/shared/utils/src/lib/utils.ts
+++ b/libs/shared/utils/src/lib/utils.ts
@@ -856,7 +856,7 @@ export function getExcelSafeSheetName(name: string, existingNames: string[] = []
 
 // https://stackoverflow.com/questions/53228948/how-to-get-image-file-size-from-base-64-string-in-javascript
 export function getSizeInMbFromBase64(data: string) {
-  if (!data) {
+  if (!data || !isString(data) || !data.length) {
     return 0;
   }
   const padding = data.endsWith('==') ? 2 : 1;


### PR DESCRIPTION
Ensure clicking on the "Zip with attachments" input does not click the normal file input

Added logging when processing a binary attachment fails