### PR TITLE
Improve binary upload process

### DIFF
--- a/apps/api/src/app/controllers/sf-record.controller.ts
+++ b/apps/api/src/app/controllers/sf-record.controller.ts
@@ -1,4 +1,6 @@
-import { BooleanQueryParamSchema, RecordOperationRequestSchema } from '@jetstream/api-types';
+import { BooleanQueryParamSchema, RecordOperationRequestSchema, SalesforceApiRequestSchema } from '@jetstream/api-types';
+import { HTTP } from '@jetstream/shared/constants';
+import { StripBlobFilename } from '@jetstream/shared/node-utils';
 import { toBoolean } from '@jetstream/shared/utils';
 import { z } from 'zod';
 import { UserFacingError } from '../utils/error-handler';
@@ -6,6 +8,17 @@ import { sendJson } from '../utils/response.handlers';
 import { createRoute } from '../utils/route.utils';
 
 export const routeDefinition = {
+  binaryUpload: {
+    controllerFn: () => binaryUpload,
+    validators: {
+      query: z.object({
+        url: z.string(),
+        method: SalesforceApiRequestSchema.shape.method,
+        isTooling: z.coerce.boolean().optional().default(false),
+        assignmentRuleId: z.string().optional().default('FALSE'),
+      }),
+    },
+  },
   recordOperation: {
     controllerFn: () => recordOperation,
     validators: {
@@ -21,6 +34,41 @@ export const routeDefinition = {
     },
   },
 };
+
+const binaryUpload = createRoute(routeDefinition.binaryUpload.validators, async ({ query, jetstreamConn }, req, res, next) => {
+  try {
+    const { assignmentRuleId, isTooling, method, url } = query;
+
+    const contentType = req.headers['content-type'];
+    if (!contentType?.startsWith('multipart/form-data')) {
+      throw new UserFacingError('Expected multipart/form-data');
+    }
+
+    // Proxy request to Salesforce
+    const results = await jetstreamConn.request.manualRequest(
+      {
+        method,
+        url,
+        body: req.pipe(new StripBlobFilename()),
+        headers: {
+          [HTTP.HEADERS.CONTENT_TYPE]: contentType,
+          // https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/headers_autoassign.htm
+          // default is true
+          'Sforce-Auto-Assign': assignmentRuleId || 'FALSE',
+        },
+        isTooling,
+        rawBody: true,
+        duplex: 'half',
+      },
+      'json',
+      true,
+    );
+
+    sendJson(res, results);
+  } catch (ex) {
+    next(new UserFacingError(ex));
+  }
+});
 
 const recordOperation = createRoute(
   routeDefinition.recordOperation.validators,

--- a/apps/api/src/app/routes/api.routes.ts
+++ b/apps/api/src/app/routes/api.routes.ts
@@ -148,6 +148,8 @@ routes.post('/request-manual', miscController.salesforceRequestManual.controller
  * recordController Routes
  * ************************************
  */
+// handle multipart/form-data for binary uploads
+routes.post('/record/upload', recordController.binaryUpload.controllerFn());
 routes.post('/record/:operation/:sobject', recordController.recordOperation.controllerFn());
 
 /**

--- a/apps/jetstream-desktop-client/src/app/utils/desktop-axios-adapter.ts
+++ b/apps/jetstream-desktop-client/src/app/utils/desktop-axios-adapter.ts
@@ -12,7 +12,68 @@ interface IcpResponse {
   status: number;
   statusText: string;
   headers: Record<string, string>;
-  body?: unknown; // TODO:
+  body?: unknown;
+}
+
+/**
+ * Axios normally handles FormData automatically in the browser, but since we're
+ * using a custom adapter to route requests through Electron's IPC, we need to manually
+ * handle FormData
+ */
+async function formDataToMultipart(formData: FormData, boundary: string): Promise<Uint8Array> {
+  const carriageNewLine = '\r\n';
+  const encoder = new TextEncoder();
+  const parts: Uint8Array[] = [];
+
+  // Helper to escape field names
+  const escapeName = (name: string) => {
+    return name.replace(
+      /[\r\n"]/g,
+      (match) =>
+        ({
+          '\r': '%0D',
+          '\n': '%0A',
+          '"': '%22',
+        })[match] || match,
+    );
+  };
+
+  // Process each form field
+  for (const [name, _value] of formData.entries()) {
+    const boundaryBytes = encoder.encode(`--${boundary}\r\n`);
+    parts.push(boundaryBytes);
+
+    if (_value instanceof File || (_value as any) instanceof Blob) {
+      const value = _value as File | Blob;
+      const fileName = value instanceof File ? value.name : 'blob';
+      const headerStr =
+        `Content-Disposition: form-data; name="${escapeName(name)}"; filename="${escapeName(fileName)}"${carriageNewLine}` +
+        `Content-Type: ${value.type || 'application/octet-stream'}${carriageNewLine}${carriageNewLine}`;
+      parts.push(encoder.encode(headerStr));
+
+      const arrayBuffer = await value.arrayBuffer();
+      parts.push(new Uint8Array(arrayBuffer));
+      parts.push(encoder.encode(carriageNewLine));
+    } else {
+      const headerStr = `Content-Disposition: form-data; name="${escapeName(name)}"${carriageNewLine}${carriageNewLine}`;
+      parts.push(encoder.encode(headerStr));
+      parts.push(encoder.encode(String(_value)));
+      parts.push(encoder.encode(carriageNewLine));
+    }
+  }
+
+  // Add closing boundary
+  parts.push(encoder.encode(`--${boundary}--\r\n`));
+  const totalLength = parts.reduce((sum, part) => sum + part.length, 0);
+  // Combine all parts
+  const combined = new Uint8Array(totalLength);
+  let offset = 0;
+  for (const part of parts) {
+    combined.set(part, offset);
+    offset += part.length;
+  }
+
+  return combined;
 }
 
 export async function desktopExtensionAxiosAdapter(config: InternalAxiosRequestConfig): Promise<AxiosResponse> {
@@ -34,9 +95,20 @@ export async function desktopExtensionAxiosAdapter(config: InternalAxiosRequestC
   try {
     const url = getUrl(config) || '/';
     let body = data;
-    if (data && typeof data !== 'string' && headers.get('content-type') === 'application/json') {
+
+    // Handle FormData
+    if (data instanceof FormData) {
+      const boundary = `----jetstream-${Date.now()}-${Math.random().toString(36).substring(2, 15)}`;
+
+      const multipartData = await formDataToMultipart(data, boundary);
+      body = multipartData.buffer;
+
+      headers.set('Content-Type', `multipart/form-data; boundary=${boundary}`);
+      headers.set('Content-Length', String(multipartData.length));
+    } else if (data && typeof data !== 'string' && headers.get('content-type') === 'application/json') {
       body = JSON.stringify(data);
     }
+
     const request: IcpRequest = {
       url,
       method: method?.toUpperCase() ?? 'GET',

--- a/apps/jetstream-desktop/src/controllers/desktop.routes.ts
+++ b/apps/jetstream-desktop/src/controllers/desktop.routes.ts
@@ -91,6 +91,7 @@ router.post('/api/request-manual', miscController.salesforceRequestManual.contro
  * recordController Routes
  * ************************************
  */
+router.post('/api/record/upload', recordController.binaryUpload.controllerFn());
 router.post('/api/record/:operation/:sobject', recordController.recordOperation.controllerFn());
 
 /**

--- a/apps/jetstream-desktop/src/controllers/sf-record.desktop.controller.ts
+++ b/apps/jetstream-desktop/src/controllers/sf-record.desktop.controller.ts
@@ -1,9 +1,24 @@
-import { BooleanQueryParamSchema, RecordOperationRequestSchema } from '@jetstream/api-types';
+import { BooleanQueryParamSchema, RecordOperationRequestSchema, SalesforceApiRequestSchema } from '@jetstream/api-types';
+import { HTTP } from '@jetstream/shared/constants';
 import { toBoolean } from '@jetstream/shared/utils';
 import { z } from 'zod';
 import { createRoute, handleErrorResponse, handleJsonResponse } from '../utils/route.utils';
 
 export const routeDefinition = {
+  binaryUpload: {
+    controllerFn: () => binaryUpload,
+    validators: {
+      skipBodyParse: true,
+      // ideally we would stream this
+      body: z.string(),
+      query: z.object({
+        url: z.string(),
+        method: SalesforceApiRequestSchema.shape.method,
+        isTooling: z.coerce.boolean().optional().default(false),
+        assignmentRuleId: z.string().optional().default('FALSE'),
+      }),
+    },
+  },
   recordOperation: {
     controllerFn: () => recordOperation,
     validators: {
@@ -19,6 +34,41 @@ export const routeDefinition = {
     },
   },
 };
+
+const binaryUpload = createRoute(routeDefinition.binaryUpload.validators, async ({ query, body, jetstreamConn }, req) => {
+  try {
+    const { assignmentRuleId, isTooling, method, url } = query;
+
+    const contentType = req.request.headers.get('content-type');
+    if (!contentType?.startsWith('multipart/form-data')) {
+      return handleErrorResponse(new Error('Expected multipart/form-data'));
+    }
+
+    // Proxy request to Salesforce
+    const results = await jetstreamConn!.request.manualRequest(
+      {
+        method,
+        url,
+        // Browsers add filename="blob" to json multipart form data parts, but Salesforce chokes on it.
+        body: body.replace(/name="collection"; filename="blob"/, 'name="collection"'),
+        headers: {
+          [HTTP.HEADERS.CONTENT_TYPE]: contentType,
+          // https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/headers_autoassign.htm
+          // default is true
+          'Sforce-Auto-Assign': assignmentRuleId || 'FALSE',
+        },
+        isTooling,
+        rawBody: true,
+      },
+      'json',
+      true,
+    );
+
+    return handleJsonResponse(results);
+  } catch (ex) {
+    return handleErrorResponse(ex);
+  }
+});
 
 const recordOperation = createRoute(routeDefinition.recordOperation.validators, async ({ body, params, query, jetstreamConn }, req) => {
   try {

--- a/libs/salesforce-api/src/lib/api-request.ts
+++ b/libs/salesforce-api/src/lib/api-request.ts
@@ -1,6 +1,6 @@
 import { SalesforceApiRequest } from '@jetstream/api-types';
 import { ApiConnection } from './connection';
-import { ApiRequestOutputType } from './types';
+import { ApiRequestOptions, ApiRequestOutputType } from './types';
 import { SalesforceApi } from './utils';
 
 export class ApiRequest extends SalesforceApi {
@@ -9,7 +9,7 @@ export class ApiRequest extends SalesforceApi {
   }
 
   async manualRequest<T = unknown>(
-    { method, url, body, headers = {}, options }: SalesforceApiRequest,
+    { method, url, body, headers = {}, options, rawBody, duplex }: SalesforceApiRequest & Pick<ApiRequestOptions, 'rawBody' | 'duplex'>,
     outputType: ApiRequestOutputType = 'text',
     ensureRestUrl = false,
   ): Promise<T> {
@@ -28,6 +28,8 @@ export class ApiRequest extends SalesforceApi {
       body: body,
       headers: headers || {},
       outputType,
+      rawBody,
+      duplex,
     });
 
     return data;

--- a/libs/salesforce-api/src/lib/callout-adapter.ts
+++ b/libs/salesforce-api/src/lib/callout-adapter.ts
@@ -38,7 +38,7 @@ export function getApiRequestFactoryFn(fetch: FetchFn) {
     logger: Logger = console,
   ) => {
     const apiRequest = async <Response = unknown>(options: ApiRequestOptions, attemptRefresh = true): Promise<Response> => {
-      let { url, body, outputType } = options;
+      let { url, body, outputType, duplex } = options;
       const { method = 'GET', sessionInfo, headers, rawBody = false } = options;
       const { accessToken, instanceUrl } = sessionInfo;
       url = `${instanceUrl}${url}`;
@@ -52,11 +52,14 @@ export function getApiRequestFactoryFn(fetch: FetchFn) {
       return fetch(url, {
         method,
         body,
+        duplex,
         headers: {
           Authorization: `Bearer ${accessToken}`,
+          // default headers, can be overridden by caller
           [HTTP.HEADERS.CONTENT_TYPE]: 'application/json; charset=UTF-8',
           [HTTP.HEADERS.ACCEPT]: 'application/json; charset=UTF-8',
           [HTTP.HEADERS.X_SFDC_Session]: accessToken,
+          // caller provided headers
           ...headers,
         },
       })

--- a/libs/salesforce-api/src/lib/types.ts
+++ b/libs/salesforce-api/src/lib/types.ts
@@ -48,6 +48,7 @@ export interface FetchOptions {
   method?: FetchMethod;
   body?: BodyInit | null;
   headers?: [string, string][] | Record<string, string> | Headers;
+  duplex?: ApiRequestOptions['duplex'];
 }
 
 export interface FetchResponse<T = unknown> {
@@ -72,7 +73,14 @@ export interface ApiRequestOptions {
   headers?: Record<string, string>;
   sessionInfo: SessionInfo;
   outputType?: ApiRequestOutputType;
+  /**
+   * Indicates that the body is already serialized (e.g. string or stream) and should not be JSON.stringified
+   */
   rawBody?: boolean;
+  /**
+   * Used when streaming requests (e.g. file uploads)
+   */
+  duplex?: 'half';
 }
 
 export type ApiRequestOutputType = 'json' | 'text' | 'xml' | 'soap' | 'arrayBuffer' | 'stream' | 'void' | 'response';

--- a/libs/shared/data/src/lib/client-data.ts
+++ b/libs/shared/data/src/lib/client-data.ts
@@ -31,6 +31,7 @@ import {
   DescribeSObjectResult,
   GenericRequestPayload,
   GoogleFileApiResponse,
+  HttpMethod,
   JetstreamOrganization,
   ListMetadataQuery,
   ListMetadataResult,
@@ -46,6 +47,7 @@ import {
   RetrieveResult,
   SalesforceApiRequest,
   SalesforceOrgUi,
+  SobjectCollectionResponse,
   SobjectOperation,
   StripeUserFacingCustomer,
   SyncRecord,
@@ -694,6 +696,21 @@ export async function queryAllUsingOffset<T = any>(
   return results;
 }
 
+export async function sobjectUploadBinaryUpload(
+  org: SalesforceOrgUi,
+  body: FormData,
+  options: {
+    url: string;
+    method: HttpMethod;
+    isTooling?: Maybe<boolean>;
+    assignmentRuleId?: Maybe<string>;
+  },
+): Promise<SobjectCollectionResponse> {
+  return handleRequest({ method: 'POST', url: `/api/record/upload`, params: { ...options }, data: body }, { org }).then(
+    unwrapResponseIgnoreCache,
+  );
+}
+
 export async function sobjectOperation<O extends SobjectOperation>(
   org: SalesforceOrgUi,
   sobject: string,
@@ -708,9 +725,18 @@ export async function sobjectOperation<O extends SobjectOperation>(
   } = {},
 ): Promise<OperationReturnType<O, any>> {
   // FIXME: add type for R as the first generic type in function
-  return handleRequest({ method: 'POST', url: `/api/record/${operation}/${sobject}`, params: { ...query }, data: body }, { org }).then(
-    unwrapResponseIgnoreCache,
-  );
+  return handleRequest(
+    {
+      method: 'POST',
+      url: `/api/record/${operation}/${sobject}`,
+      params: { ...query },
+      data: body,
+      headers: {
+        'Content-Type': 'multipart/form-data',
+      },
+    },
+    { org },
+  ).then(unwrapResponseIgnoreCache);
 }
 
 export async function describeMetadata(org: SalesforceOrgUi): Promise<ApiResponse<DescribeMetadataResult>> {

--- a/libs/shared/data/src/lib/client-data.ts
+++ b/libs/shared/data/src/lib/client-data.ts
@@ -731,9 +731,6 @@ export async function sobjectOperation<O extends SobjectOperation>(
       url: `/api/record/${operation}/${sobject}`,
       params: { ...query },
       data: body,
-      headers: {
-        'Content-Type': 'multipart/form-data',
-      },
     },
     { org },
   ).then(unwrapResponseIgnoreCache);

--- a/libs/shared/node-utils/src/index.ts
+++ b/libs/shared/node-utils/src/index.ts
@@ -1,2 +1,3 @@
 export * from './lib/AsyncIntervalTimer';
 export * from './lib/shared-node-utils';
+export * from './lib/stream-transformers';

--- a/libs/shared/node-utils/src/lib/__tests__/stream-transformers.spec.ts
+++ b/libs/shared/node-utils/src/lib/__tests__/stream-transformers.spec.ts
@@ -1,0 +1,73 @@
+import { PassThrough } from 'stream';
+import { StripBlobFilename } from '../stream-transformers'; // adjust path
+
+describe('StripBlobFilename', () => {
+  it('removes filename="blob" from the collection part', (done) => {
+    const input = [
+      '------boundary123\r\n',
+      'Content-Disposition: form-data; name="collection"; filename="blob"\r\n',
+      'Content-Type: application/json\r\n',
+      '\r\n',
+      '{"allOrNone":false,"records":[]}\r\n',
+      '------boundary123\r\n',
+      'Content-Disposition: form-data; name="binaryPart1"; filename="file.pdf"\r\n',
+      'Content-Type: application/pdf\r\n',
+      '\r\n',
+      '%PDF-1.4 ...binary...\r\n',
+      '------boundary123--\r\n',
+    ].join('');
+
+    const expected = input.replace('name="collection"; filename="blob"', 'name="collection"');
+
+    const transformer = new StripBlobFilename();
+    const passthrough = new PassThrough();
+
+    let output = '';
+    transformer.on('data', (chunk) => {
+      output += chunk.toString('latin1');
+    });
+
+    transformer.on('end', () => {
+      try {
+        expect(output).toBe(expected);
+        done();
+      } catch (err) {
+        done(err);
+      }
+    });
+
+    passthrough.pipe(transformer);
+    passthrough.end(Buffer.from(input, 'latin1'));
+  });
+
+  it('passes through unchanged when no blob filename present', (done) => {
+    const input = [
+      '------boundary123\r\n',
+      'Content-Disposition: form-data; name="collection"\r\n',
+      'Content-Type: application/json\r\n',
+      '\r\n',
+      '{"allOrNone":false}\r\n',
+      '------boundary123--\r\n',
+    ].join('');
+
+    const transformer = new StripBlobFilename();
+    const passthrough = new PassThrough();
+
+    let output = '';
+    transformer.on('data', (chunk) => {
+      output += chunk.toString('latin1');
+    });
+
+    transformer.on('end', () => {
+      try {
+        expect(output).toBe(input);
+        done();
+      } catch (err) {
+        done(err);
+      }
+    });
+
+    passthrough.pipe(transformer);
+    passthrough.end(Buffer.from(input, 'latin1'));
+  });
+});

--- a/libs/shared/node-utils/src/lib/stream-transformers.ts
+++ b/libs/shared/node-utils/src/lib/stream-transformers.ts
@@ -1,0 +1,44 @@
+import { Transform, TransformCallback } from 'node:stream';
+
+/**
+ * Browsers add filename="blob" to json multipart form data parts, but Salesforce chokes on it.
+ * This transform strips that out of the multipart headers.
+ * only the very first part will have this, so we can stop processing after that.
+ */
+export class StripBlobFilename extends Transform {
+  private _replaced = false;
+  private readonly _replacementText = /name="collection"; filename="blob"/;
+  private readonly _splitString = '\r\n\r\n';
+  private _buffer: Buffer = Buffer.alloc(0);
+
+  _transform(chunk: Buffer, _encoding: BufferEncoding, callback: TransformCallback) {
+    if (this._replaced) {
+      this.push(chunk);
+      return callback();
+    }
+
+    // Append incoming chunk to our buffer
+    this._buffer = Buffer.concat([this._buffer as any, chunk as any]);
+
+    // Search for the header terminator in latin1 encoding
+    const splitIndex = this._buffer.toString('latin1').indexOf(this._splitString);
+
+    if (splitIndex !== -1) {
+      // Split into headers (string) and the rest (Buffer)
+      const headers = this._buffer.subarray(0, splitIndex).toString('latin1');
+      const rest = this._buffer.subarray(splitIndex + this._splitString.length);
+
+      const rewritten = headers.replace(this._replacementText, 'name="collection"');
+
+      // Push back rewritten headers + separator + untouched rest
+      this.push(Buffer.from(rewritten, 'latin1'));
+      this.push(Buffer.from(this._splitString, 'latin1'));
+      this.push(rest);
+
+      this._replaced = true;
+      this._buffer = Buffer.alloc(0); // release memory
+    }
+
+    callback();
+  }
+}

--- a/libs/types/src/lib/salesforce/record.types.ts
+++ b/libs/types/src/lib/salesforce/record.types.ts
@@ -61,7 +61,9 @@ export interface SobjectCollectionRequest {
   records?: SobjectCollectionRequestRecord[];
 }
 
-export type SobjectCollectionRequestRecord<T = { [field: string]: any }> = T & { attributes: { type: string } };
+export type SobjectCollectionRequestRecord<T = { [field: string]: any }> = T & {
+  attributes: { type: string; binaryPartName?: string; binaryPartNameAlias?: string };
+};
 
 export type SobjectCollectionResponse = RecordResult[];
 

--- a/libs/web-extension-utils2/src/index copy.ts
+++ b/libs/web-extension-utils2/src/index copy.ts
@@ -1,3 +1,0 @@
-export * from './lib/extension.types';
-export * from './lib/web-extension-localforage-driver';
-export * from './lib/web-extension-utils';


### PR DESCRIPTION
Move to multi-part file upload instead of base64 upload to support large file uploads

Stream file uploads from browser, via server, to Salesforce for binary uploads

Salesforce is very picky and does not follow spec, so we need to transform the incoming binary stream to remove the filename for the application/json

For desktop, we use a custom axios adapter so we need to manually generate all the boundaries for the body

resolve #1363