### PR TITLE
Grant View All Fields Via Manage Permissions #1372

### DIFF
--- a/libs/features/create-object-and-fields/src/create-new-object/CreateNewObjectPermissions.tsx
+++ b/libs/features/create-object-and-fields/src/create-new-object/CreateNewObjectPermissions.tsx
@@ -15,6 +15,7 @@ function getDefaultPermissions(): CreateObjectPermissions {
     allowRead: true,
     modifyAllRecords: true,
     viewAllRecords: true,
+    viewAllFields: true,
   };
 }
 

--- a/libs/features/create-object-and-fields/src/create-new-object/CreateNewObjectPermissionsCheckboxes.tsx
+++ b/libs/features/create-object-and-fields/src/create-new-object/CreateNewObjectPermissionsCheckboxes.tsx
@@ -16,7 +16,8 @@ export const CreateNewObjectPermissionsCheckboxes = ({ label, objectPermissions,
     objectPermissions.allowEdit &&
     objectPermissions.allowRead &&
     objectPermissions.modifyAllRecords &&
-    objectPermissions.viewAllRecords;
+    objectPermissions.viewAllRecords &&
+    objectPermissions.viewAllFields;
 
   const noneSelected =
     !objectPermissions.allowCreate &&
@@ -24,7 +25,8 @@ export const CreateNewObjectPermissionsCheckboxes = ({ label, objectPermissions,
     !objectPermissions.allowEdit &&
     !objectPermissions.allowRead &&
     !objectPermissions.modifyAllRecords &&
-    !objectPermissions.viewAllRecords;
+    !objectPermissions.viewAllRecords &&
+    !objectPermissions.viewAllFields;
 
   function handleSelectAll(value: boolean) {
     onChange({
@@ -34,6 +36,7 @@ export const CreateNewObjectPermissionsCheckboxes = ({ label, objectPermissions,
       allowRead: value,
       modifyAllRecords: value,
       viewAllRecords: value,
+      viewAllFields: value,
     });
   }
 
@@ -102,6 +105,13 @@ export const CreateNewObjectPermissionsCheckboxes = ({ label, objectPermissions,
         label="View All Records"
         checked={objectPermissions.viewAllRecords}
         onChange={(value) => onChange(setSObjectPermissionDependencies(objectPermissions, 'viewAllRecords', value))}
+        disabled={loading}
+      />
+      <Checkbox
+        id={`${label}-objectPermissions.viewAllFields`}
+        label="View All Fields"
+        checked={objectPermissions.viewAllFields}
+        onChange={(value) => onChange(setSObjectPermissionDependencies(objectPermissions, 'viewAllFields', value))}
         disabled={loading}
       />
     </>

--- a/libs/features/create-object-and-fields/src/create-new-object/create-object-state.ts
+++ b/libs/features/create-object-and-fields/src/create-new-object/create-object-state.ts
@@ -38,6 +38,7 @@ export const objectPermissionsState = atomWithReset<ObjectPermissionState>({
     allowRead: true,
     modifyAllRecords: true,
     viewAllRecords: true,
+    viewAllFields: true,
   },
 });
 
@@ -115,7 +116,8 @@ export const isFormValidSelector = atom<{
         permissions.allowEdit ||
         permissions.allowRead ||
         permissions.modifyAllRecords ||
-        permissions.viewAllRecords,
+        permissions.viewAllRecords ||
+        permissions.viewAllFields,
     );
   }
 

--- a/libs/features/create-object-and-fields/src/create-new-object/create-object-types.ts
+++ b/libs/features/create-object-and-fields/src/create-new-object/create-object-types.ts
@@ -60,4 +60,5 @@ export interface CreateObjectPermissions {
   allowRead: boolean;
   modifyAllRecords: boolean;
   viewAllRecords: boolean;
+  viewAllFields: boolean;
 }

--- a/libs/features/create-object-and-fields/src/create-new-object/create-object-utils.ts
+++ b/libs/features/create-object-and-fields/src/create-new-object/create-object-utils.ts
@@ -41,6 +41,10 @@ export function setSObjectPermissionDependencies(
     output.modifyAllRecords = newValue;
     fieldsToSetIfTrue = ['allowRead', 'allowEdit', 'allowDelete', 'viewAllRecords'];
     fieldsToSetIfFalse = [];
+  } else if (modifiedKey === 'viewAllFields') {
+    output.viewAllFields = newValue;
+    fieldsToSetIfTrue = [];
+    fieldsToSetIfFalse = [];
   }
   if (newValue) {
     fieldsToSetIfTrue.forEach((prop) => (output[prop] = newValue));
@@ -87,6 +91,7 @@ export function getObjectAndTabPermissionRecords(
       PermissionsModifyAllRecords: permissions.modifyAllRecords,
       PermissionsRead: permissions.allowRead,
       PermissionsViewAllRecords: permissions.viewAllRecords,
+      PermissionsViewAllFields: permissions.viewAllFields,
       SobjectType: apiName,
     });
     if (createTab) {
@@ -110,6 +115,7 @@ export function getObjectAndTabPermissionRecords(
       PermissionsModifyAllRecords: permissions.modifyAllRecords,
       PermissionsRead: permissions.allowRead,
       PermissionsViewAllRecords: permissions.viewAllRecords,
+      PermissionsViewAllFields: permissions.viewAllFields,
       SobjectType: apiName,
     });
     if (createTab) {

--- a/libs/features/manage-permissions/src/ManagePermissionsEditor.tsx
+++ b/libs/features/manage-permissions/src/ManagePermissionsEditor.tsx
@@ -248,8 +248,11 @@ export const ManagePermissionsEditor: FunctionComponent<ManagePermissionsEditorP
         const row = rows[rowIndex];
         const rowKey = row.key; // e.x. Obj__c.Field__c
         const dirtyCount = Object.values(row.permissions).reduce(
-          (output, { createIsDirty, readIsDirty, editIsDirty, deleteIsDirty, viewAllIsDirty, modifyAllIsDirty }) => {
-            output += createIsDirty || readIsDirty || editIsDirty || deleteIsDirty || viewAllIsDirty || modifyAllIsDirty ? 1 : 0;
+          (output, { createIsDirty, readIsDirty, editIsDirty, deleteIsDirty, viewAllIsDirty, modifyAllIsDirty, viewAllFieldsIsDirty }) => {
+            output +=
+              createIsDirty || readIsDirty || editIsDirty || deleteIsDirty || viewAllIsDirty || modifyAllIsDirty || viewAllFieldsIsDirty
+                ? 1
+                : 0;
             return output;
           },
           0,

--- a/libs/features/manage-permissions/src/usePermissionRecords.tsx
+++ b/libs/features/manage-permissions/src/usePermissionRecords.tsx
@@ -187,6 +187,7 @@ function getObjectPermissionMap(
           delete: permissionRecord.PermissionsDelete,
           viewAll: permissionRecord.PermissionsViewAllRecords,
           modifyAll: permissionRecord.PermissionsModifyAllRecords,
+          viewAllFields: permissionRecord.PermissionsViewAllFields,
           record: permissionRecord,
         };
       } else {
@@ -197,6 +198,7 @@ function getObjectPermissionMap(
           delete: false,
           viewAll: false,
           modifyAll: false,
+          viewAllFields: false,
           record: null,
         };
       }

--- a/libs/features/manage-permissions/src/utils/permission-manager-export-utils.ts
+++ b/libs/features/manage-permissions/src/utils/permission-manager-export-utils.ts
@@ -50,9 +50,10 @@ function generateObjectWorksheet(columns: ObjectOrFieldOrTabVisibilityColumn[], 
       header1.push('');
       header1.push('');
       header1.push('');
+      header1.push('');
       // merge the added cells
       merges.push({
-        s: { r: 0, c: header1.length - 6 },
+        s: { r: 0, c: header1.length - 7 },
         e: { r: 0, c: header1.length - 1 },
       });
       // header 2
@@ -62,6 +63,7 @@ function generateObjectWorksheet(columns: ObjectOrFieldOrTabVisibilityColumn[], 
       header2.push('Delete');
       header2.push('View All');
       header2.push('Modify All');
+      header2.push('View All Fields');
       // keep track of group order to ensure same across all rows
       permissionKeys.push(col.key.split('-')[0]);
     });
@@ -76,6 +78,7 @@ function generateObjectWorksheet(columns: ObjectOrFieldOrTabVisibilityColumn[], 
       currRow.push(permission.delete ? 'TRUE' : 'FALSE');
       currRow.push(permission.viewAll ? 'TRUE' : 'FALSE');
       currRow.push(permission.modifyAll ? 'TRUE' : 'FALSE');
+      currRow.push(permission.viewAllFields ? 'TRUE' : 'FALSE');
     });
     excelRows.push(currRow);
   });

--- a/libs/features/manage-permissions/src/utils/permission-manager-utils.ts
+++ b/libs/features/manage-permissions/src/utils/permission-manager-utils.ts
@@ -78,6 +78,7 @@ export function prepareObjectPermissionSaveData(dirtyPermissions: PermissionTabl
         PermissionsDelete: perm.delete,
         PermissionsViewAllRecords: perm.viewAll,
         PermissionsModifyAllRecords: perm.modifyAll,
+        PermissionsViewAllFields: perm.viewAllFields,
         ParentId: perm.parentId,
       };
       let recordIdx: number;
@@ -349,6 +350,7 @@ export function getUpdatedObjectPermissions(
         PermissionsDelete: dirtyPermission.delete,
         PermissionsViewAllRecords: dirtyPermission.viewAllIsDirty,
         PermissionsModifyAllRecords: dirtyPermission.modifyAll,
+        PermissionsViewAllFields: dirtyPermission.viewAllFields,
         SobjectType: dirtyPermission.sobject,
         // missing Parent related lookup, as we do not have data for it
       };
@@ -364,6 +366,7 @@ export function getUpdatedObjectPermissions(
               delete: dirtyPermission.delete,
               viewAll: dirtyPermission.viewAll,
               modifyAll: dirtyPermission.modifyAll,
+              viewAllFields: dirtyPermission.viewAllFields,
               record: fieldPermission as ObjectPermissionRecord,
             },
           },
@@ -381,6 +384,7 @@ export function getUpdatedObjectPermissions(
               delete: dirtyPermission.delete,
               viewAll: dirtyPermission.viewAll,
               modifyAll: dirtyPermission.modifyAll,
+              viewAllFields: dirtyPermission.viewAllFields,
               record: isDelete ? null : (fieldPermission as ObjectPermissionRecord),
             },
           },
@@ -678,6 +682,7 @@ export function getQueryObjectPermissions(allSobjects: string[], permSetIds: str
         getField('PermissionsDelete'),
         getField('PermissionsModifyAllRecords'),
         getField('PermissionsViewAllRecords'),
+        getField('PermissionsViewAllFields'),
         getField('ParentId'),
         getField('Parent.Id'),
         getField('Parent.Name'),

--- a/libs/features/manage-permissions/src/utils/permission-manager-utils.ts
+++ b/libs/features/manage-permissions/src/utils/permission-manager-utils.ts
@@ -348,7 +348,7 @@ export function getUpdatedObjectPermissions(
         PermissionsRead: dirtyPermission.read,
         PermissionsEdit: dirtyPermission.edit,
         PermissionsDelete: dirtyPermission.delete,
-        PermissionsViewAllRecords: dirtyPermission.viewAllIsDirty,
+        PermissionsViewAllRecords: dirtyPermission.viewAll,
         PermissionsModifyAllRecords: dirtyPermission.modifyAll,
         PermissionsViewAllFields: dirtyPermission.viewAllFields,
         SobjectType: dirtyPermission.sobject,

--- a/libs/types/src/lib/salesforce/metadata.types.ts
+++ b/libs/types/src/lib/salesforce/metadata.types.ts
@@ -93,6 +93,7 @@ export interface ProfileObjectPermissions {
   modifyAllRecords?: boolean | undefined;
   object: string;
   viewAllRecords?: boolean | undefined;
+  viewAllFields?: boolean | undefined;
 }
 
 export interface RetrieveRequest {

--- a/libs/types/src/lib/salesforce/record.types.ts
+++ b/libs/types/src/lib/salesforce/record.types.ts
@@ -211,6 +211,7 @@ export interface ObjectPermissionRecord {
   PermissionsDelete: boolean;
   PermissionsModifyAllRecords: boolean;
   PermissionsViewAllRecords: boolean;
+  PermissionsViewAllFields: boolean;
   ParentId: string;
   Parent: PermissionPermissionSetRecord;
 }
@@ -412,6 +413,7 @@ export interface ObjectPermission {
   modifyAllRecords: string;
   object: string;
   viewAllRecords: string;
+  viewAllFields: string;
 }
 
 export interface PageAccess {

--- a/libs/types/src/lib/ui/permission-manager-types.ts
+++ b/libs/types/src/lib/ui/permission-manager-types.ts
@@ -9,7 +9,7 @@ import {
 import { Maybe } from '../types';
 
 export type PermissionType = 'object' | 'field' | 'tabVisibility';
-export type ObjectPermissionTypes = 'create' | 'read' | 'edit' | 'delete' | 'viewAll' | 'modifyAll';
+export type ObjectPermissionTypes = 'create' | 'read' | 'edit' | 'delete' | 'viewAll' | 'modifyAll' | 'viewAllFields';
 export type FieldPermissionTypes = 'read' | 'edit';
 export type TabVisibilityPermissionTypes = 'available' | 'visible';
 
@@ -40,6 +40,7 @@ export interface ObjectPermissionItem {
   delete: boolean;
   viewAll: boolean;
   modifyAll: boolean;
+  viewAllFields: boolean;
   record?: Maybe<ObjectPermissionRecord>;
   errorMessage?: string;
 }
@@ -154,12 +155,14 @@ export interface PermissionTableObjectCellPermission extends PermissionTableObje
   delete: boolean;
   viewAll: boolean;
   modifyAll: boolean;
+  viewAllFields: boolean;
   createIsDirty: boolean;
   readIsDirty: boolean;
   editIsDirty: boolean;
   deleteIsDirty: boolean;
   viewAllIsDirty: boolean;
   modifyAllIsDirty: boolean;
+  viewAllFieldsIsDirty: boolean;
 }
 export interface PermissionTableFieldCellPermission extends PermissionTableObjectCellPermissionBase<FieldPermissionItem> {
   field: string;


### PR DESCRIPTION
Add support for `viewAllFields` for object permissions

This feature was newly added to Salesforce https://help.salesforce.com/s/articleView?id=release-notes.rn_permissions_view_all_fields.htm&release=254&type=5

This field has no dependencies and can be enabled/disabled without impacting other permissions

resolves #1372