### PR TITLE
Ensure electron dependency is marked as external

### DIFF
--- a/apps/jetstream-desktop/project.json
+++ b/apps/jetstream-desktop/project.json
@@ -17,6 +17,7 @@
         "main": "apps/jetstream-desktop/src/main.ts",
         "additionalEntryPoints": ["apps/jetstream-desktop/src/preload.ts"],
         "tsConfig": "apps/jetstream-desktop/tsconfig.app.json",
+        "external": ["electron", "electron-log", "electron-updater", "electron-builder"],
         "assets": [
           {
             "input": "apps/jetstream-desktop/src/assets",

--- a/scripts/build-electron.mjs
+++ b/scripts/build-electron.mjs
@@ -184,7 +184,7 @@ async function build() {
   console.log(chalk.green('Ready to build with electron-builder!'));
   console.log(chalk.green('Publish your artifacts by running:'));
   console.log(chalk.blue('cd dist/desktop-build && yarn publish:mac'));
-  console.log(chalk.blue('cd dist/desktop-build && yarn publish:win'));
+  console.log(chalk.blue('cd dist/desktop-build; yarn publish:win'));
 }
 
 async function main() {


### PR DESCRIPTION
For some reason this suddenly started causing the macos build to fail to start