### PR TITLE
Update application state pipeline

### DIFF
--- a/apps/api/src/app/routes/api.routes.ts
+++ b/apps/api/src/app/routes/api.routes.ts
@@ -1,4 +1,6 @@
 import { ENV } from '@jetstream/api-config';
+import { getDefaultAppState } from '@jetstream/shared/utils';
+import { AppInfo } from '@jetstream/types';
 import express, { Router } from 'express';
 import { getAnnouncements } from '../announcements';
 import { routeDefinition as billingController } from '../controllers/billing.controller';
@@ -25,8 +27,20 @@ routes.use(addOrgsToLocal);
 
 // used to make sure the user is authenticated and can communicate with the server
 routes.get('/heartbeat', (req: express.Request, res: express.Response) => {
+  const result: AppInfo = {
+    version: ENV.VERSION || 'unknown',
+    announcements: getAnnouncements(),
+    appInfo: getDefaultAppState({
+      serverUrl: ENV.JETSTREAM_SERVER_URL,
+      environment: ENV.ENVIRONMENT,
+      defaultApiVersion: `v${ENV.SFDC_API_VERSION}`,
+      google_appId: ENV.GOOGLE_APP_ID || 'unset',
+      google_apiKey: ENV.GOOGLE_API_KEY || 'unset',
+      google_clientId: ENV.GOOGLE_CLIENT_ID || 'unset',
+    }),
+  };
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  sendJson(res as any, { version: ENV.VERSION || null, announcements: getAnnouncements() });
+  sendJson(res as any, result);
 });
 
 /**

--- a/apps/api/src/app/routes/route.middleware.ts
+++ b/apps/api/src/app/routes/route.middleware.ts
@@ -12,8 +12,7 @@ import {
 import { UserProfileSession } from '@jetstream/auth/types';
 import { ApiConnection, getApiRequestFactoryFn } from '@jetstream/salesforce-api';
 import { HTTP } from '@jetstream/shared/constants';
-import { ensureBoolean, getErrorMessageAndStackObj } from '@jetstream/shared/utils';
-import { ApplicationCookie } from '@jetstream/types';
+import { ensureBoolean, getDefaultAppState, getErrorMessageAndStackObj } from '@jetstream/shared/utils';
 import { parse as parseCookie } from 'cookie';
 import { getUnixTime } from 'date-fns';
 import * as express from 'express';
@@ -42,7 +41,7 @@ export function addContextMiddleware(req: express.Request, res: express.Response
  * @param next
  */
 export function setApplicationCookieMiddleware(req: express.Request, res: express.Response, next: express.NextFunction) {
-  const appCookie: ApplicationCookie = {
+  const appCookie = getDefaultAppState({
     serverUrl: ENV.JETSTREAM_SERVER_URL,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     environment: ENV.ENVIRONMENT as any,
@@ -53,7 +52,7 @@ export function setApplicationCookieMiddleware(req: express.Request, res: expres
     google_apiKey: ENV.GOOGLE_API_KEY!,
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     google_clientId: ENV.GOOGLE_CLIENT_ID!,
-  };
+  });
   res.cookie(HTTP.COOKIE.JETSTREAM, appCookie, { httpOnly: false, sameSite: 'strict' });
   next();
 }

--- a/apps/jetstream-desktop-client/src/app/components/core/AppInitializer.tsx
+++ b/apps/jetstream-desktop-client/src/app/components/core/AppInitializer.tsx
@@ -41,8 +41,7 @@ export interface AppInitializerProps {
 
 export const AppInitializer: FunctionComponent<AppInitializerProps> = ({ authInfo, onAnnouncements, children }) => {
   const userProfile = useAtomValue(fromAppState.userProfileState);
-  const { version, announcements } = useAtomValue(fromAppState.appVersionState);
-  const [appCookie, setAppCookie] = useAtom(fromAppState.applicationCookieState);
+  const { version, announcements, appInfo } = useAtomValue(fromAppState.appInfoState);
   const [orgs, setOrgs] = useAtom(fromAppState.salesforceOrgsState);
   const invalidOrg = useObservable(orgConnectionError$);
 
@@ -73,22 +72,8 @@ APP VERSION ${version}
   }, [version]);
 
   useEffect(() => {
-    window.electronAPI
-      ?.getAppCookie()
-      .then((appCookie) => {
-        if (appCookie) {
-          setAppCookie(appCookie);
-        }
-      })
-      .catch((err) => {
-        logger.error('Error getting app cookie', err);
-        // TODO: this is fatal, we need to block the app from working
-      });
-  }, [setAppCookie]);
-
-  useEffect(() => {
     if (recordSyncEnabled) {
-      initSocket(appCookie.serverUrl, {
+      initSocket(appInfo.serverUrl, {
         [HTTP.HEADERS.AUTHORIZATION]: `Bearer ${authInfo.accessToken}`,
         [HTTP.HEADERS.X_EXT_DEVICE_ID]: authInfo.deviceId,
       });
@@ -98,7 +83,7 @@ APP VERSION ${version}
     initDexieDb({ recordSyncEnabled }).catch((ex) => {
       logger.error('[DB] Error initializing db', ex);
     });
-  }, [appCookie.serverUrl, recordSyncEnabled]);
+  }, [appInfo.serverUrl, recordSyncEnabled]);
 
   useEffect(() => {
     announcements && onAnnouncements && onAnnouncements(announcements);
@@ -106,7 +91,7 @@ APP VERSION ${version}
 
   useRollbar({
     accessToken: environment.rollbarClientAccessToken,
-    environment: appCookie.environment,
+    environment: appInfo.environment,
     userProfile: userProfile,
     version,
   });

--- a/apps/jetstream-desktop/src/config/auto-updater.ts
+++ b/apps/jetstream-desktop/src/config/auto-updater.ts
@@ -127,6 +127,7 @@ export function checkForUpdates(silent = false) {
       })
       .catch((err) => {
         logger.error('Update check failed:', err);
+        dialog.showErrorBox('Update Error', `Failed to check for updates: ${err.message}`);
       });
   }
 }

--- a/apps/jetstream-desktop/src/config/environment.ts
+++ b/apps/jetstream-desktop/src/config/environment.ts
@@ -1,3 +1,4 @@
+import { getDefaultAppState } from '@jetstream/shared/utils';
 import type { Maybe } from '@jetstream/types';
 import chalk from 'chalk';
 import { app } from 'electron';
@@ -15,11 +16,13 @@ for (const arg of args) {
   }
 }
 
+const { defaultApiVersion } = getDefaultAppState();
+
 const ENV_INTERNAL_DEV = {
   ENVIRONMENT: 'development',
   CLIENT_URL: 'http://localhost:4200',
   SERVER_URL: 'http://localhost:3333',
-  SFDC_API_VERSION: '64.0',
+  SFDC_API_VERSION: defaultApiVersion.replace('v', ''),
   DESKTOP_SFDC_CALLBACK_URL: 'jetstream://addOrg/oauth/sfdc/callback',
   DESKTOP_SFDC_CLIENT_ID: '3MVG94YrNIs0WS4d2PK0lDfKIz_loKEkofpaTrvi7_3g_tLRZSQ9_XNQpSmtNVMs7hnO77x3RqRGaxy86vnK_',
 };

--- a/apps/jetstream-desktop/src/controllers/desktop.routes.ts
+++ b/apps/jetstream-desktop/src/controllers/desktop.routes.ts
@@ -1,4 +1,8 @@
+import { getDefaultAppState } from '@jetstream/shared/utils';
+import { AppInfo } from '@jetstream/types';
+import { app } from 'electron';
 import { Router } from 'tiny-request-router';
+import { ENV } from '../config/environment';
 import { handleJsonResponse, RequestOptions } from '../utils/route.utils';
 import { routeDefinition as dataSyncController } from './jetstream-data-sync.desktop.controller';
 import { routeDefinition as jetstreamOrganizationsController } from './jetstream-orgs.desktop.controller';
@@ -15,7 +19,15 @@ const router = new Router<(req: RequestOptions) => Promise<Response>>();
 export const desktopRoutes = router;
 
 router.get('/api/heartbeat', async (req) => {
-  return handleJsonResponse({ version: 'unknown' });
+  const result: AppInfo = {
+    version: app.getVersion(),
+    announcements: [],
+    appInfo: getDefaultAppState({
+      serverUrl: ENV.SERVER_URL,
+      environment: ENV.ENVIRONMENT,
+    }),
+  };
+  return handleJsonResponse(result);
 });
 router.get('/api/me', userController.getUserProfile.controllerFn());
 router.get('/api/me/profile', userController.getFullUserProfile.controllerFn());

--- a/apps/jetstream-desktop/src/main.ts
+++ b/apps/jetstream-desktop/src/main.ts
@@ -29,10 +29,16 @@ app.on('window-all-closed', () => {
   }
 });
 
-logger.info('Current app version:', app.getVersion());
-logger.info('App name:', app.getName());
-logger.info('App path:', app.getAppPath());
-logger.info('User data path:', app.getPath('userData'));
+logger.info({
+  name: app.getName(),
+  version: app.getVersion(),
+  electron: process.versions.electron,
+  chrome: process.versions.chrome,
+  node: process.versions.node,
+  v8: process.versions.v8,
+  appLocation: app.getAppPath(),
+  userData: app.getPath('userData'),
+});
 
 app.whenReady().then(async () => {
   registerProtocols();

--- a/apps/jetstream-desktop/src/preload.ts
+++ b/apps/jetstream-desktop/src/preload.ts
@@ -12,7 +12,6 @@ const API: ElectronAPI = {
   // Request / Response
   checkAuth: () => ipcRenderer.invoke('checkAuth'),
   addOrg: (payload) => ipcRenderer.invoke('addOrg', payload),
-  getAppCookie: () => ipcRenderer.invoke('getAppCookie'),
   selectFolder: () => ipcRenderer.invoke('selectFolder'),
   getPreferences: () => ipcRenderer.invoke('getPreferences'),
   setPreferences: (payload) => ipcRenderer.invoke('setPreferences', payload),

--- a/apps/jetstream-desktop/src/services/ipc.service.ts
+++ b/apps/jetstream-desktop/src/services/ipc.service.ts
@@ -7,7 +7,7 @@ import {
 } from '@jetstream/desktop/types';
 import { ApiConnection, getApiRequestFactoryFn } from '@jetstream/salesforce-api';
 import { HTTP } from '@jetstream/shared/constants';
-import { ApplicationCookie, UserProfileUi } from '@jetstream/types';
+import { UserProfileUi } from '@jetstream/types';
 import { addDays } from 'date-fns';
 import { app, dialog, ipcMain, shell } from 'electron';
 import logger from 'electron-log';
@@ -42,25 +42,12 @@ export function registerIpc(): void {
   registerHandler('logout', handleLogoutEvent);
   registerHandler('addOrg', handleAddOrgEvent);
   registerHandler('checkAuth', handleCheckAuthEvent);
-  registerHandler('getAppCookie', handleGetAppCookieEvent);
   registerHandler('selectFolder', handleSelectFolderEvent);
   registerHandler('getPreferences', handleGetPreferences);
   registerHandler('setPreferences', handleSetPreferences);
   // Handle API requests to Salesforce
   registerHandler('request', handleRequestEvent);
 }
-
-const handleGetAppCookieEvent: MainIpcHandler<'getAppCookie'> = async (event) => {
-  const appCookie: ApplicationCookie = {
-    serverUrl: ENV.SERVER_URL,
-    environment: ENV.ENVIRONMENT,
-    defaultApiVersion: `v${ENV.SFDC_API_VERSION}`,
-    google_appId: '1071580433137',
-    google_apiKey: 'invalid',
-    google_clientId: '1046118608516-lstbl00607e43hev2abfh9hegbv7iuav.apps.googleusercontent.com',
-  };
-  return appCookie;
-};
 
 const handleSelectFolderEvent: MainIpcHandler<'selectFolder'> = async (event) => {
   const result = await dialog.showOpenDialog({

--- a/apps/jetstream-desktop/src/services/menu.service.ts
+++ b/apps/jetstream-desktop/src/services/menu.service.ts
@@ -9,7 +9,6 @@ export function initAppMenu() {
   let template: MenuItem[] = [];
 
   template = [
-    // { role: 'appMenu' }
     ...((isMac()
       ? [
           {
@@ -32,7 +31,6 @@ export function initAppMenu() {
           } as MenuItem,
         ]
       : []) as any[]),
-    // { role: 'fileMenu' }
     {
       label: 'File',
       submenu: [
@@ -50,57 +48,12 @@ export function initAppMenu() {
               },
             ]) as any[]),
         { type: 'separator' },
-        { role: isMac() ? 'close' : 'quit' },
+        isMac() ? { role: 'close' } : { role: 'quit' },
       ],
     },
-    // { role: 'editMenu' }
-    {
-      label: 'Edit',
-      submenu: [
-        { role: 'undo' },
-        { role: 'redo' },
-        { type: 'separator' },
-        { role: 'cut' },
-        { role: 'copy' },
-        { role: 'paste' },
-        ...(isMac()
-          ? [
-              { role: 'pasteAndMatchStyle' },
-              { role: 'delete' },
-              { role: 'selectAll' },
-              { type: 'separator' },
-              {
-                label: 'Speech',
-                submenu: [{ role: 'startSpeaking' }, { role: 'stopSpeaking' }],
-              },
-            ]
-          : [{ role: 'delete' }, { type: 'separator' }, { role: 'selectAll' }]),
-      ],
-    },
-    // { role: 'viewMenu' }
-    {
-      label: 'View',
-      submenu: [
-        { role: 'reload' },
-        { role: 'forceReload' },
-        { role: 'toggleDevTools' },
-        { type: 'separator' },
-        { role: 'resetZoom' },
-        { role: 'zoomIn' },
-        { role: 'zoomOut' },
-        { type: 'separator' },
-        { role: 'togglefullscreen' },
-      ],
-    },
-    // { role: 'windowMenu' }
-    {
-      label: 'Window',
-      submenu: [
-        { role: 'minimize' },
-        { role: 'zoom' },
-        ...(isMac() ? [{ type: 'separator' }, { role: 'front' }, { type: 'separator' }, { role: 'window' }] : [{ role: 'close' }]),
-      ],
-    },
+    { role: 'editMenu' },
+    { role: 'viewMenu' },
+    { role: 'windowMenu' },
     {
       role: 'help',
       submenu: [
@@ -122,6 +75,7 @@ export function initAppMenu() {
             await shell.openExternal('email:support@getjetstream.app');
           },
         },
+        ...((isMac() ? [] : [{ type: 'separator' }, { role: 'about' }]) as any[]),
       ],
     },
   ];

--- a/apps/jetstream-web-extension/src/controllers/extension.routes.ts
+++ b/apps/jetstream-web-extension/src/controllers/extension.routes.ts
@@ -1,5 +1,8 @@
-import { UserProfileUi } from '@jetstream/types';
+import { getBrowserExtensionVersion } from '@jetstream/shared/ui-utils';
+import { getDefaultAppState } from '@jetstream/shared/utils';
+import { AppInfo, UserProfileUi } from '@jetstream/types';
 import { Router } from 'tiny-request-router';
+import { environment } from '../environments/environment';
 import { routeDefinition as dataSyncController } from './jetstream-data-sync.web-ext.controller';
 import { handleJsonResponse, RequestOptions } from './route.utils';
 import { routeDefinition as bulkApiController } from './sf-bulk-api.web-ext.controller';
@@ -13,7 +16,15 @@ const router = new Router<(req: RequestOptions) => Promise<Response>>();
 export const extensionRoutes = router;
 
 router.get('/api/heartbeat', async (req) => {
-  return handleJsonResponse({ version: 'unknown' });
+  const result: AppInfo = {
+    version: getBrowserExtensionVersion(),
+    announcements: [],
+    appInfo: getDefaultAppState({
+      serverUrl: environment.serverUrl,
+      environment: environment.production ? 'production' : 'development',
+    }),
+  };
+  return handleJsonResponse(result);
 });
 router.get('/api/me', async (req) => {
   return handleJsonResponse({

--- a/apps/jetstream/src/app/components/core/AppInitializer.tsx
+++ b/apps/jetstream/src/app/components/core/AppInitializer.tsx
@@ -38,8 +38,7 @@ export interface AppInitializerProps {
 
 export const AppInitializer: FunctionComponent<AppInitializerProps> = ({ onAnnouncements, children }) => {
   const userProfile = useAtomValue(fromAppState.userProfileState);
-  const { version, announcements } = useAtomValue(fromAppState.appVersionState);
-  const appCookie = useAtomValue(fromAppState.applicationCookieState);
+  const { version, announcements, appInfo } = useAtomValue(fromAppState.appInfoState);
   const [orgs, setOrgs] = useAtom(fromAppState.salesforceOrgsState);
   const invalidOrg = useObservable(orgConnectionError$);
 
@@ -69,14 +68,14 @@ APP VERSION ${version}
 
   useEffect(() => {
     if (recordSyncEnabled) {
-      initSocket(appCookie.serverUrl);
+      initSocket(appInfo.serverUrl);
     } else {
       disconnectSocket();
     }
     initDexieDb({ recordSyncEnabled }).catch((ex) => {
       logger.error('[DB] Error initializing db', ex);
     });
-  }, [appCookie.serverUrl, recordSyncEnabled]);
+  }, [appInfo.serverUrl, recordSyncEnabled]);
 
   useEffect(() => {
     announcements && onAnnouncements && onAnnouncements(announcements);
@@ -84,7 +83,7 @@ APP VERSION ${version}
 
   useRollbar({
     accessToken: environment.rollbarClientAccessToken,
-    environment: appCookie.environment,
+    environment: appInfo.environment,
     userProfile: userProfile,
     version,
   });

--- a/libs/api-config/src/lib/env-config.ts
+++ b/libs/api-config/src/lib/env-config.ts
@@ -99,11 +99,11 @@ const envSchema = z.object({
   IS_LOCAL_DOCKER: booleanSchema,
   // SYSTEM
   NODE_ENV: z
-    .enum(['development', 'test', 'staging', 'production'])
+    .enum(['development', 'production'])
     .optional()
     .transform((value) => value ?? 'production'),
   ENVIRONMENT: z
-    .enum(['development', 'test', 'staging', 'production'])
+    .enum(['development', 'production'])
     .optional()
     .transform((value) => value ?? 'production'),
   PORT: numberSchema.default(3333),

--- a/libs/desktop-types/src/lib/desktop-app.types.ts
+++ b/libs/desktop-types/src/lib/desktop-app.types.ts
@@ -1,4 +1,4 @@
-import { ApplicationCookie, InputReadFileContent, Maybe, SalesforceOrgUi, UserProfileUi } from '@jetstream/types';
+import { InputReadFileContent, Maybe, SalesforceOrgUi, UserProfileUi } from '@jetstream/types';
 import { z } from 'zod';
 
 /**
@@ -18,7 +18,6 @@ export interface ElectronApiRequestResponse {
   logout: () => void;
   addOrg: (payload: { loginUrl: string; addLoginTrue?: boolean; jetstreamOrganizationId?: Maybe<string> }) => void;
   checkAuth: () => Promise<{ userProfile: UserProfileUi; authInfo: DesktopAuthInfo } | undefined>;
-  getAppCookie: () => Promise<ApplicationCookie>;
   selectFolder: () => Promise<Maybe<string>>;
   getPreferences: () => Promise<DesktopUserPreferences>;
   setPreferences: (preferences: DesktopUserPreferences) => Promise<DesktopUserPreferences>;

--- a/libs/shared/data/src/lib/client-data.ts
+++ b/libs/shared/data/src/lib/client-data.ts
@@ -11,10 +11,10 @@ import { logger } from '@jetstream/shared/client-logger';
 import { HTTP, MIME_TYPES } from '@jetstream/shared/constants';
 import { splitArrayToMaxSize } from '@jetstream/shared/utils';
 import {
-  Announcement,
   AnonymousApexResponse,
   ApexCompletionResponse,
   ApiResponse,
+  AppInfo,
   AsyncResult,
   BulkApiCreateJobRequestPayload,
   BulkApiDownloadType,
@@ -84,10 +84,11 @@ function convertDateToLocale(dateOrIsoDateString?: string | Date, options?: Intl
 
 //// APPLICATION ROUTES
 
-export async function checkHeartbeat(): Promise<{ version: string; announcements?: Announcement[] }> {
-  const heartbeat = await handleRequest<{ version: string; announcements?: Announcement[] }>({ method: 'GET', url: '/api/heartbeat' }).then(
-    unwrapResponseIgnoreCache,
-  );
+export async function checkHeartbeat(): Promise<AppInfo> {
+  const heartbeat = await handleRequest<AppInfo>({
+    method: 'GET',
+    url: '/api/heartbeat',
+  }).then(unwrapResponseIgnoreCache);
   try {
     heartbeat?.announcements?.forEach((item) => {
       item?.replacementDates?.forEach(({ key, value }) => {

--- a/libs/shared/ui-core/src/orgs/AddOrg.tsx
+++ b/libs/shared/ui-core/src/orgs/AddOrg.tsx
@@ -5,7 +5,7 @@ import { AddOrgHandlerFn, SalesforceOrgUi } from '@jetstream/types';
 import { Checkbox, CheckboxToggle, Grid, GridCol, Icon, Input, Popover, PopoverRef, Radio, RadioGroup } from '@jetstream/ui';
 import { fromAppState } from '@jetstream/ui/app-state';
 import classNames from 'classnames';
-import { useAtom, useAtomValue } from 'jotai';
+import { useAtomValue } from 'jotai';
 import { FunctionComponent, useEffect, useRef, useState } from 'react';
 import { useAmplitude } from '..';
 
@@ -51,7 +51,7 @@ export const AddOrg: FunctionComponent<AddOrgProps> = ({
   const [advancedOptionsEnabled, setAdvancedOptionsEnabled] = useState(false);
   const [addLoginTrue, setAddLoginTrue] = useState(false);
   const [addToActiveOrganization, setAddToActiveOrganization] = useState(true);
-  const [applicationState] = useAtom(fromAppState.applicationCookieState);
+  const applicationState = useAtomValue(fromAppState.applicationCookieState);
   const jetstreamOrganization = useAtomValue(fromAppState.jetstreamActiveOrganizationSelector);
 
   useEffect(() => {

--- a/libs/shared/utils/src/lib/utils.ts
+++ b/libs/shared/utils/src/lib/utils.ts
@@ -1,5 +1,6 @@
 import { DATE_FORMATS } from '@jetstream/shared/constants';
 import {
+  ApplicationState,
   BulkJob,
   BulkJobBatchInfo,
   BulkJobBatchInfoUntyped,
@@ -33,6 +34,18 @@ import { REGEX } from './regex';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function
 export function NOOP() {}
+
+export function getDefaultAppState(initial?: Maybe<Partial<ApplicationState>>): ApplicationState {
+  return {
+    serverUrl: 'https://getjetstream.app',
+    environment: 'production',
+    defaultApiVersion: 'v64.0',
+    google_appId: 'unset',
+    google_apiKey: 'unset',
+    google_clientId: 'unset',
+    ...initial,
+  };
+}
 
 export function getErrorMessage(error: unknown) {
   if (error instanceof Error) {

--- a/libs/types/src/lib/types.ts
+++ b/libs/types/src/lib/types.ts
@@ -3,6 +3,12 @@ import { SalesforceOrgEdition } from './salesforce/misc.types';
 import { QueryResult } from './salesforce/query.types';
 import { InsertUpdateUpsertDeleteQuery } from './salesforce/record.types';
 
+export interface AppInfo {
+  announcements: Announcement[];
+  appInfo: ApplicationState;
+  version: string;
+}
+
 export interface Announcement {
   id: string;
   title: string;
@@ -78,7 +84,7 @@ export type Environment = Production | Test | Development;
 
 export type HttpMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
 
-export interface ApplicationCookie {
+export interface ApplicationState {
   serverUrl: string;
   environment: Environment;
   defaultApiVersion: string;


### PR DESCRIPTION
The desktop app was defaulting to localhost for the websocket server if history sync was enabled since it was falling back to the default cookie value.

The application cookie has been largely replaced by the heartbeat API, it still exists for web app, but can be removed in the future.

App state has been improved and centralized to be used in all form-factors instead of having a bunch of bespoke/duplicate implementations