### PR TITLE
Route validation for salesforce routes

### DIFF
--- a/apps/api/src/app/controllers/oauth.controller.ts
+++ b/apps/api/src/app/controllers/oauth.controller.ts
@@ -24,7 +24,13 @@ export const routeDefinition = {
     controllerFn: () => salesforceOauthInitAuth,
     validators: {
       query: z.object({
-        loginUrl: z.string().min(1),
+        loginUrl: z.union([
+          z.literal('https://login.salesforce.com'),
+          z.literal('https://test.salesforce.com'),
+          z.literal('https://welcome.salesforce.com'),
+          z.literal('https://prerellogin.pre.salesforce.com'),
+          z.string().regex(/^https:\/\/[a-zA-Z0-9.-]+\.my\.salesforce\.com$/),
+        ]),
         addLoginParam: z
           .enum(['true', 'false'])
           .nullish()

--- a/apps/api/src/app/routes/route.middleware.ts
+++ b/apps/api/src/app/routes/route.middleware.ts
@@ -285,7 +285,7 @@ export async function getOrgForRequest(
   requestId?: string,
 ) {
   const org = await salesforceOrgsDb.findByUniqueId_UNSAFE(user.id, uniqueId);
-  if (!org) {
+  if (!org || org.jetstreamUserId2 !== user.id) {
     throw new NotFoundError('An org with the provided id does not exist');
   }
 

--- a/apps/api/src/app/services/oauth.service.ts
+++ b/apps/api/src/app/services/oauth.service.ts
@@ -3,6 +3,10 @@ import { SalesforceUserInfo } from '@jetstream/types';
 import { AuthorizationParameters, CallbackParamsType, Issuer, generators } from 'openid-client';
 
 function getSalesforceAuthClient(loginUrl: string) {
+  const url = new URL(loginUrl);
+  if (!url.hostname.endsWith('.salesforce.com')) {
+    throw new Error('Invalid Salesforce login URL');
+  }
   const { Client } = new Issuer({
     authorization_endpoint: `${loginUrl}/services/oauth2/authorize`,
     end_session_endpoint: `${loginUrl}/services/oauth2/logout`,

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -179,7 +179,7 @@ if (ENV.NODE_ENV === 'production' && !ENV.CI && cluster.isPrimary) {
           baseUri: ["'self'"],
           blockAllMixedContent: [],
           fontSrc: ["'self'", 'https:', "'unsafe-inline'", 'data:', '*.gstatic.com', 'https://checkout.stripe.com'],
-          frameAncestors: ["'self'", '*.google.com'],
+          frameAncestors: ["'self'"],
           imgSrc: [
             "'self'",
             'data:',
@@ -221,6 +221,14 @@ if (ENV.NODE_ENV === 'production' && !ENV.CI && cluster.isPrimary) {
           upgradeInsecureRequests: ENV.ENVIRONMENT === 'development' ? null : [],
         },
       },
+      hsts:
+        ENV.ENVIRONMENT === 'production'
+          ? {
+              maxAge: 15_552_000, // 180 days in seconds
+              includeSubDomains: true,
+              preload: true,
+            }
+          : false,
     }),
   );
 
@@ -305,13 +313,9 @@ if (ENV.NODE_ENV === 'production' && !ENV.CI && cluster.isPrimary) {
     });
     app.options(
       '/{*splat}',
-      (req: express.Request, res: express.Response, next: express.NextFunction) => {
-        res.setHeader('Access-Control-Allow-Credentials', 'true');
-        res.setHeader('Access-Control-Allow-Origin', '*');
-        next();
-      },
       cors({
         origin: true,
+        credentials: true,
         exposedHeaders: [
           'BAYEUX_BROWSER',
           HTTP.HEADERS.X_LOGOUT,
@@ -382,6 +386,11 @@ if (ENV.NODE_ENV === 'production' && !ENV.CI && cluster.isPrimary) {
       '/app',
       redirectIfPendingVerificationMiddleware,
       redirectIfMfaEnrollmentRequiredMiddleware,
+      // Allow Google to frame /app routes for Google Picker functionality
+      (req: express.Request, res: express.Response, next: express.NextFunction) => {
+        res.setHeader('Content-Security-Policy', "frame-ancestors 'self' *.google.com *.googleusercontent.com accounts.google.com;");
+        next();
+      },
       (req: express.Request, res: express.Response) => {
         res.sendFile(join(__dirname, '../jetstream/index.html'));
       },


### PR DESCRIPTION
Added validation to Salesforce domains when adding an org to avoid potential bad actors. Ensure that redirect is to valid Salesforce controlled domain.

Add additional check that org being accessed belongs to user. This is already checked at the DB level so the check is just an added redundancy.

Added hsts to force https for all domains and sub-domains.