### PR TITLE
Fix cookie consent banner padding

### DIFF
--- a/apps/landing/pages/_app.js
+++ b/apps/landing/pages/_app.js
@@ -10,7 +10,10 @@ export default function MyApp({ Component, pageProps }) {
   return getLayout(
     <>
       <Component {...pageProps} />
-      <CookieConsentBanner />
+      <CookieConsentBanner
+        /* Placeholder to ensure that no page content gets hidden behind the banner */
+        containerStyles={{ minHeight: '80px' }}
+      />
     </>,
   );
 }

--- a/libs/shared/cookie-consent-banner/src/lib/CookieConsentBanner.tsx
+++ b/libs/shared/cookie-consent-banner/src/lib/CookieConsentBanner.tsx
@@ -1,3 +1,4 @@
+import { CSSProperties } from 'react';
 import styles from './cookie-consent-banner.module.css';
 import { CookieOptions } from './cookie-storage';
 import { useCookieConsent } from './useCookieConsent';
@@ -5,10 +6,16 @@ import { useCookieConsent } from './useCookieConsent';
 export interface CookieConsentBannerProps {
   cookieOptions?: CookieOptions;
   privacyPolicyUrl?: string;
+  containerStyles?: CSSProperties;
   onConsentChange?: (analytics: 'accepted' | 'rejected' | null) => void | Promise<void>;
 }
 
-export function CookieConsentBanner({ cookieOptions, privacyPolicyUrl = '/privacy', onConsentChange }: CookieConsentBannerProps) {
+export function CookieConsentBanner({
+  cookieOptions,
+  privacyPolicyUrl = '/privacy',
+  containerStyles,
+  onConsentChange,
+}: CookieConsentBannerProps) {
   const { showBanner, acceptAll, rejectAll } = useCookieConsent({ onConsentChange, cookieOptions });
 
   if (!showBanner) {
@@ -16,7 +23,7 @@ export function CookieConsentBanner({ cookieOptions, privacyPolicyUrl = '/privac
   }
 
   return (
-    <div className={styles['banner-container']}>
+    <div style={containerStyles}>
       <div className={styles.banner}>
         <div className={styles.container}>
           <div className={styles.content}>

--- a/libs/shared/cookie-consent-banner/src/lib/cookie-consent-banner.module.css
+++ b/libs/shared/cookie-consent-banner/src/lib/cookie-consent-banner.module.css
@@ -1,10 +1,5 @@
 /* Cookie consent banner - plain CSS for compatibility with both Tailwind and SLDS */
 
-/* Placeholder to ensure that no page content gets hidden behind the banner */
-.banner-container {
-  min-height: 80px;
-}
-
 .banner {
   position: fixed;
   bottom: 0;


### PR DESCRIPTION
The banner had fixed height to make it so the landing page worked correctly, but this caused an issue in-app where the alignment was off.

resolves #1425