### PR TITLE
Fix password reset for email with +

### DIFF
--- a/apps/landing/pages/auth/password-reset/verify/index.tsx
+++ b/apps/landing/pages/auth/password-reset/verify/index.tsx
@@ -13,7 +13,7 @@ export default function Page() {
 
   const searchParams = useSearchParams();
 
-  const email = (searchParams.get('email') || '').trim().replace(' ', '+').replace('%20', ' ');
+  const email = searchParams.get('email') || '';
   const token = searchParams.get('code') || '';
 
   useEffect(() => {

--- a/libs/email/src/lib/email-templates/auth/PasswordResetEmail.tsx
+++ b/libs/email/src/lib/email-templates/auth/PasswordResetEmail.tsx
@@ -19,7 +19,7 @@ export const PasswordResetEmail = ({
   validationCode,
   expMinutes,
 }: PasswordResetEmailProps) => {
-  const url = `${baseUrl}/auth/password-reset/verify?email=${emailAddress}&code=${validationCode}`;
+  const url = `${baseUrl}/auth/password-reset/verify?email=${encodeURIComponent(emailAddress)}&code=${encodeURIComponent(validationCode)}`;
 
   return (
     <Html>


### PR DESCRIPTION
Email with + was getting converted to a space during the password reset, causing API validation to reject the incoming data