### PR TITLE
Fix org popover width

### DIFF
--- a/libs/shared/ui-core/src/orgs/OrgPersistence.tsx
+++ b/libs/shared/ui-core/src/orgs/OrgPersistence.tsx
@@ -21,5 +21,3 @@ export const OrgPersistence: FunctionComponent = () => {
 
   return null;
 };
-
-export default OrgPersistence;

--- a/libs/shared/ui-core/src/orgs/SelectedOrgReadOnly.tsx
+++ b/libs/shared/ui-core/src/orgs/SelectedOrgReadOnly.tsx
@@ -4,8 +4,8 @@ import classNames from 'classnames';
 import { useAtomValue } from 'jotai';
 import { Fragment } from 'react';
 import { useOrgPermissions } from '..';
-import OrgInfoPopover from './OrgInfoPopover';
-import OrgPersistence from './OrgPersistence';
+import { OrgInfoPopover } from './OrgInfoPopover';
+import { OrgPersistence } from './OrgPersistence';
 
 export const SelectedOrgReadOnly = () => {
   const actionInProgress = useAtomValue(fromAppState.actionInProgressState);


### PR DESCRIPTION
When an org has a trial expiration date defined, the org info popover body expanded beyond the popover content.