### PR TITLE
Fix metadata download issues

### DIFF
--- a/libs/shared/browser-worker-utils/src/lib/browser-worker-utils.ts
+++ b/libs/shared/browser-worker-utils/src/lib/browser-worker-utils.ts
@@ -26,7 +26,7 @@ import * as XLSX from 'xlsx';
  */
 
 export function base64ToArrayBuffer(base64: string) {
-  return Uint8Array.from(atob(base64), ({ charCodeAt }) => charCodeAt(0)).buffer;
+  return Uint8Array.from(atob(base64), (str) => str.charCodeAt(0)).buffer;
 }
 
 function detectDelimiter(): string {


### PR DESCRIPTION
A recent code change to destructure a string primitive caused base64ToArrayBuffer to fail