### PR TITLE
bug: Fix multiple feedback file attachments

### DIFF
--- a/libs/shared/ui-core/src/app/ErrorBoundaryFallback.tsx
+++ b/libs/shared/ui-core/src/app/ErrorBoundaryFallback.tsx
@@ -14,12 +14,10 @@ export const ErrorBoundaryFallback: FunctionComponent<FallbackProps> = ({ error,
     if (error && rollbar) {
       try {
         logger.error(error);
-        // logger.error(componentStack);
         rollbar.error(`[UNCAUGHT] ${error.message}`, error, {
           errorName: error.name,
           message: error.message,
           stack: error.stack,
-          // componentStack,
         });
       } catch (ex) {
         try {
@@ -30,7 +28,7 @@ export const ErrorBoundaryFallback: FunctionComponent<FallbackProps> = ({ error,
         }
       }
     }
-  }, [/** componentStack, */ error, rollbar]);
+  }, [error, rollbar]);
 
   function resetPage() {
     window.location.reload();

--- a/libs/ui/src/lib/user-feedback-widget/UserFeedbackWidget.tsx
+++ b/libs/ui/src/lib/user-feedback-widget/UserFeedbackWidget.tsx
@@ -95,7 +95,13 @@ export const UserFeedbackWidget = () => {
       fireToast({ message: 'You can only upload up to 5 screenshots.', type: 'warning' });
       return;
     }
-    setScreenshots((prev) => [...prev, fileContent]);
+    setScreenshots((prev) => {
+      if (prev.length >= 5) {
+        setTimeout(() => fireToast({ message: 'You can only upload up to 5 screenshots.', type: 'warning' }), 0);
+        return prev;
+      }
+      return [...prev, fileContent];
+    });
   };
 
   const handleRemoveScreenshot = (index: number) => {


### PR DESCRIPTION
Ensure that the feedback form limits the user to 5 attachments and shows a warning toast if too many are added

Ensure that multiple file attachments are supported in email, which requires buffering all the attachments as the email provider does not seem to support multiple file streams at once