### PR TITLE
Add option to "hard delete"

### DIFF
--- a/libs/api-types/src/lib/api-bulk-api.types.ts
+++ b/libs/api-types/src/lib/api-bulk-api.types.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 
 export const CreateJobRequestSchema = z
   .object({
-    type: z.enum(['INSERT', 'UPDATE', 'UPSERT', 'DELETE', 'QUERY', 'QUERY_ALL']),
+    type: z.enum(['INSERT', 'UPDATE', 'UPSERT', 'DELETE', 'HARD_DELETE', 'QUERY', 'QUERY_ALL']),
     sObject: z.string(),
     serialMode: z.boolean().nullish(),
     externalId: z.string().nullish(),

--- a/libs/features/load-records/src/LoadRecords.tsx
+++ b/libs/features/load-records/src/LoadRecords.tsx
@@ -240,7 +240,7 @@ export const LoadRecords = () => {
       let tempFields = fields;
       if (loadType === 'INSERT') {
         tempFields = fields.filter((field) => field.name !== 'Id');
-      } else if (loadType === 'DELETE') {
+      } else if (loadType === 'DELETE' || loadType === 'HARD_DELETE') {
         tempFields = fields.filter((field) => field.name === 'Id');
       }
       setMappableFields(tempFields);

--- a/libs/features/load-records/src/components/LoadRecordsDataPreview.tsx
+++ b/libs/features/load-records/src/components/LoadRecordsDataPreview.tsx
@@ -40,6 +40,9 @@ function getLoadDescription(loadType: InsertUpdateUpsertDelete, totalRecordCount
     case 'UPSERT':
       action = 'update or create';
       break;
+    case 'HARD_DELETE':
+      action = 'hard delete';
+      break;
     case 'DELETE':
     default:
       action = 'delete';

--- a/libs/features/load-records/src/components/LoadRecordsLoadTypeButtons.tsx
+++ b/libs/features/load-records/src/components/LoadRecordsLoadTypeButtons.tsx
@@ -65,62 +65,77 @@ export const LoadRecordsLoadTypeButtons: FunctionComponent<LoadRecordsLoadTypeBu
   }
 
   return (
-    <Grid testId="load-type" verticalAlign="end">
-      <GridCol growNone>
-        <RadioGroup label="Type of Data Load" required isButtonGroup>
-          <RadioButton
-            name="INSERT"
-            label="Insert"
-            value="INSERT"
-            checked={selectedType === 'INSERT'}
-            disabled={isCustomMetadataObject}
-            onChange={(value) => handleChange(value as InsertUpdateUpsertDelete)}
-          />
-          <RadioButton
-            name="UPDATE"
-            label="Update"
-            value="UPDATE"
-            checked={selectedType === 'UPDATE'}
-            disabled={isCustomMetadataObject}
-            onChange={(value) => handleChange(value as InsertUpdateUpsertDelete)}
-          />
-          <RadioButton
-            name="UPSERT"
-            label="Upsert"
-            value="UPSERT"
-            checked={selectedType === 'UPSERT'}
-            disabled={isCustomMetadataObject}
-            onChange={(value) => handleChange(value as InsertUpdateUpsertDelete)}
-          />
-          <RadioButton
-            name="DELETE"
-            label="Delete"
-            value="DELETE"
-            checked={selectedType === 'DELETE'}
-            disabled={isCustomMetadataObject}
-            onChange={(value) => handleChange(value as InsertUpdateUpsertDelete)}
-          />
-        </RadioGroup>
-      </GridCol>
-      {selectedType === 'UPSERT' && !isCustomMetadataObject && (
-        <GridCol>
-          <div className="slds-is-relative">
-            {loadingFields && <Spinner size="small" />}
-            <ComboboxWithItems
-              comboboxProps={{
-                label: 'External Id',
-                noItemsPlaceholder: externalIdNoItemsText,
-                labelHelp:
-                  'Upsert requires an external Id as an alternative to a record id for matching rows in your input data to records in Salesforce. If a match is found, the record will be updated. Otherwise a new record will be created.',
-              }}
-              items={externalIdFieldOptions}
-              selectedItemId={externalId}
-              onSelected={(item) => handleExternalIdChange(item.id)}
+    <>
+      <Grid testId="load-type" verticalAlign="end">
+        <GridCol growNone>
+          <RadioGroup label="Type of Data Load" required isButtonGroup>
+            <RadioButton
+              name="INSERT"
+              label="Insert"
+              value="INSERT"
+              checked={selectedType === 'INSERT'}
+              disabled={isCustomMetadataObject}
+              onChange={(value) => handleChange(value as InsertUpdateUpsertDelete)}
             />
-          </div>
+            <RadioButton
+              name="UPDATE"
+              label="Update"
+              value="UPDATE"
+              checked={selectedType === 'UPDATE'}
+              disabled={isCustomMetadataObject}
+              onChange={(value) => handleChange(value as InsertUpdateUpsertDelete)}
+            />
+            <RadioButton
+              name="UPSERT"
+              label="Upsert"
+              value="UPSERT"
+              checked={selectedType === 'UPSERT'}
+              disabled={isCustomMetadataObject}
+              onChange={(value) => handleChange(value as InsertUpdateUpsertDelete)}
+            />
+            <RadioButton
+              name="DELETE"
+              label="Delete"
+              value="DELETE"
+              checked={selectedType === 'DELETE'}
+              disabled={isCustomMetadataObject}
+              onChange={(value) => handleChange(value as InsertUpdateUpsertDelete)}
+            />
+            <RadioButton
+              name="HARD_DELETE"
+              label="Hard Delete"
+              value="HARD_DELETE"
+              checked={selectedType === 'HARD_DELETE'}
+              disabled={isCustomMetadataObject}
+              onChange={(value) => handleChange(value as InsertUpdateUpsertDelete)}
+            />
+          </RadioGroup>
         </GridCol>
+        {selectedType === 'UPSERT' && !isCustomMetadataObject && (
+          <GridCol>
+            <div className="slds-is-relative">
+              {loadingFields && <Spinner size="small" />}
+              <ComboboxWithItems
+                comboboxProps={{
+                  label: 'External Id',
+                  noItemsPlaceholder: externalIdNoItemsText,
+                  labelHelp:
+                    'Upsert requires an external Id as an alternative to a record id for matching rows in your input data to records in Salesforce. If a match is found, the record will be updated. Otherwise a new record will be created.',
+                }}
+                items={externalIdFieldOptions}
+                selectedItemId={externalId}
+                onSelected={(item) => handleExternalIdChange(item.id)}
+              />
+            </div>
+          </GridCol>
+        )}
+      </Grid>
+      {selectedType === 'HARD_DELETE' && (
+        <p className="slds-p-top_xx-small slds-p-left_small text-color_warning">
+          Hard Delete skips the Recycle Bin and requires the <strong>"Bulk API Hard Delete"</strong> system permission.
+        </p>
       )}
-    </Grid>
+    </>
   );
 };
 

--- a/libs/features/load-records/src/components/load-results/LoadRecordsBatchApiResults.tsx
+++ b/libs/features/load-records/src/components/load-results/LoadRecordsBatchApiResults.tsx
@@ -25,11 +25,11 @@ import {
   ViewModalData,
 } from '@jetstream/types';
 import { FileDownloadModal, Grid, ProgressRing, Spinner, Tooltip } from '@jetstream/ui';
-import { LoadRecordsResultsModal, fromJetstreamEvents, getFieldHeaderFromMapping, useAmplitude } from '@jetstream/ui-core';
+import { fromJetstreamEvents, getFieldHeaderFromMapping, LoadRecordsResultsModal, useAmplitude } from '@jetstream/ui-core';
 import { applicationCookieState, googleDriveAccessState } from '@jetstream/ui/app-state';
 import { useAtomValue } from 'jotai';
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { loadBatchApiData, prepareData } from '../../utils/load-records-process';
+import { loadBatchApiData, LoadTypeDisplayNames, prepareData } from '../../utils/load-records-process';
 import LoadRecordsBatchApiResultsTable from './LoadRecordsBatchApiResultsTable';
 
 type Status = 'Preparing Data' | 'Processing Data' | 'Aborting' | 'Finished' | 'Error';
@@ -151,7 +151,7 @@ export const LoadRecordsBatchApiResults = ({
         setStartTime(dateString);
         setEndTime(dateString);
         onFinish({ success: 0, failure: inputFileData.length });
-        notifyUser(`Your ${loadType.toLowerCase()} data load failed`, {
+        notifyUser(`Your ${LoadTypeDisplayNames[loadType]} data load failed`, {
           body: `❌ Pre-processing records failed.`,
           tag: 'load-records',
         });
@@ -168,7 +168,7 @@ export const LoadRecordsBatchApiResults = ({
       setStatus(STATUSES.ERROR);
       setFatalError(getErrorMessage(ex));
       onFinish({ success: 0, failure: inputFileData.length });
-      notifyUser(`Your ${loadType.toLowerCase()} data load failed`, {
+      notifyUser(`Your ${LoadTypeDisplayNames[loadType]} data load failed`, {
         body: `❌ ${getErrorMessage(ex)}`,
         tag: 'load-records',
       });
@@ -221,7 +221,7 @@ export const LoadRecordsBatchApiResults = ({
       setStatus(STATUSES.ERROR);
       onFinish({ success: 0, failure: inputFileData.length });
       setEndTime(dateString);
-      notifyUser(`Your ${loadType.toLowerCase()} data load failed`, {
+      notifyUser(`Your ${LoadTypeDisplayNames[loadType]} data load failed`, {
         body: `❌ ${getErrorMessage(ex)}`,
         tag: 'load-records',
       });
@@ -250,7 +250,7 @@ export const LoadRecordsBatchApiResults = ({
     if (status === STATUSES.FINISHED && preparedData) {
       const numSuccess = processingStatus.success;
       const numFailure = processingStatus.failure + preparedData.errors.length;
-      notifyUser(`Your ${loadType.toLowerCase()} data load is finished`, {
+      notifyUser(`Your ${LoadTypeDisplayNames[loadType]} data load is finished`, {
         body: `${getSuccessOrFailureChar('success', numSuccess)} ${numSuccess.toLocaleString()} ${pluralizeFromNumber(
           'record',
           numSuccess,

--- a/libs/features/load-records/src/steps/PerformLoad.tsx
+++ b/libs/features/load-records/src/steps/PerformLoad.tsx
@@ -6,7 +6,7 @@ import { Badge, Checkbox, ConfirmationModalPromise, Grid, Input, Radio, RadioBut
 import { ConfirmPageChange, fromLoadRecordsState, getMaxBatchSize, useAmplitude } from '@jetstream/ui-core';
 import { useAtom, useAtomValue } from 'jotai';
 import startCase from 'lodash/startCase';
-import { ChangeEvent, FunctionComponent, useState } from 'react';
+import { ChangeEvent, FunctionComponent, useEffect, useState } from 'react';
 import LoadRecordsAssignmentRules from '../components/LoadRecordsAssignmentRules';
 import LoadRecordsDuplicateWarning from '../components/LoadRecordsDuplicateWarning';
 import LoadRecordsResults from '../components/load-results/LoadRecordsResults';
@@ -84,6 +84,13 @@ export const LoadRecordsPerformLoad: FunctionComponent<LoadRecordsPerformLoadPro
 
   const numRecordsImpactedLabel = formatNumber(inputFileDataToLoad.length);
   const numRecordsImpactedTrialRunLabel = formatNumber(inputFileDataTrialRun.length);
+
+  useEffect(() => {
+    // Hard delete requires the bulk api - the batch api gets disabled in this case but we need to ensure the state is correct
+    if (loadType === 'HARD_DELETE') {
+      setApiMode('BULK');
+    }
+  }, [loadType, setApiMode]);
 
   useNonInitialEffect(() => {
     setBatchSize(getMaxBatchSize(apiMode));
@@ -208,7 +215,7 @@ export const LoadRecordsPerformLoad: FunctionComponent<LoadRecordsPerformLoadPro
             label={bulkApiModeLabel}
             value="BULK"
             checked={apiMode === 'BULK'}
-            disabled={loading || !!inputZipFileData}
+            disabled={loading || !!inputZipFileData || loadType === 'HARD_DELETE'}
             onChange={setApiMode as (value: string) => void}
           />
           <Radio
@@ -218,7 +225,7 @@ export const LoadRecordsPerformLoad: FunctionComponent<LoadRecordsPerformLoadPro
             label={batchApiModeLabel}
             value="BATCH"
             checked={apiMode === 'BATCH'}
-            disabled={loading || !!inputZipFileData}
+            disabled={loading || !!inputZipFileData || loadType === 'HARD_DELETE'}
             onChange={setApiMode as (value: string) => void}
           />
         </RadioGroup>
@@ -250,7 +257,7 @@ export const LoadRecordsPerformLoad: FunctionComponent<LoadRecordsPerformLoadPro
         <Input
           id="batch-size"
           label="Batch Size"
-          isRequired={true}
+          isRequired
           hasError={!!batchSizeError || !!batchApiLimitError}
           errorMessageId="batch-size-error"
           errorMessage={batchSizeError || batchApiLimitError}

--- a/libs/features/load-records/src/utils/load-records-process.ts
+++ b/libs/features/load-records/src/utils/load-records-process.ts
@@ -13,6 +13,7 @@ import {
   BulkJobBatchInfo,
   BulkJobWithBatches,
   HttpMethod,
+  InsertUpdateUpsertDeleteQuery,
   LoadDataBulkApi,
   LoadDataBulkApiStatusPayload,
   LoadDataPayload,
@@ -25,6 +26,16 @@ import {
 import { LoadRecordsBatchError, fetchMappedRelatedRecords, transformData } from '@jetstream/ui-core';
 import JSZip from 'jszip';
 import isString from 'lodash/isString';
+
+export const LoadTypeDisplayNames: Record<InsertUpdateUpsertDeleteQuery, string> = {
+  INSERT: 'Insert',
+  UPDATE: 'Update',
+  UPSERT: 'Upsert',
+  DELETE: 'Delete',
+  HARD_DELETE: 'Hard Delete',
+  QUERY: 'Query',
+  QUERY_ALL: 'Query All',
+};
 
 /**
  * Pre-process all load data to prepare for loading
@@ -162,7 +173,7 @@ export async function loadBatchApiData(
         if (checkIfAborted()) {
           throw new Error('Aborted');
         }
-        if (type === 'DELETE') {
+        if (type === 'DELETE' || type === 'HARD_DELETE') {
           queryParams = `?ids=${batch.records
             ?.map((record) => record.Id)
             .filter(Boolean)

--- a/libs/salesforce-api/src/lib/__tests__/utils.spec.ts
+++ b/libs/salesforce-api/src/lib/__tests__/utils.spec.ts
@@ -1,6 +1,13 @@
-import { vi, Mock } from 'vitest';
+import { vi } from 'vitest';
 import { ApiConnection } from '../connection';
-import { SalesforceApi, correctInvalidXmlResponseTypes, prepareCloseOrAbortJobPayload, toSoapXML } from '../utils';
+import {
+  SalesforceApi,
+  correctInvalidArrayXmlResponseTypes,
+  correctInvalidXmlResponseTypes,
+  prepareBulkApiRequestPayload,
+  prepareCloseOrAbortJobPayload,
+  toSoapXML,
+} from '../utils';
 
 describe('getRestApiUrl', () => {
   const apiConnection = new ApiConnection({
@@ -48,8 +55,6 @@ it('should convert object to SOAP XML', () => {
 
   expect(result).toBe(expectedXML);
 });
-
-import { correctInvalidArrayXmlResponseTypes, prepareBulkApiRequestPayload } from '../utils';
 
 describe('getRestApiUrl', () => {
   const apiConnection = new ApiConnection({
@@ -291,6 +296,29 @@ describe('prepareBulkApiRequestPayload', () => {
     const expectedXML = `<?xml version="1.0" encoding="UTF-8"?>
 <jobInfo xmlns="http://www.force.com/2009/06/asyncapi/dataload">
 <operation>delete</operation>
+<object>Lead</object>
+<concurrencyMode>Parallel</concurrencyMode>
+<contentType>CSV</contentType>
+</jobInfo>`;
+
+    const result = prepareBulkApiRequestPayload(payload);
+
+    expect(result).toBe(expectedXML);
+  });
+
+  it('should generate the correct XML payload for HARD_DELETE operation without assignment rule', () => {
+    const payload: any = {
+      type: 'HARD_DELETE',
+      sObject: 'Lead',
+      assignmentRuleId: '',
+      serialMode: false,
+      externalId: '',
+      hasZipAttachment: false,
+    };
+
+    const expectedXML = `<?xml version="1.0" encoding="UTF-8"?>
+<jobInfo xmlns="http://www.force.com/2009/06/asyncapi/dataload">
+<operation>hardDelete</operation>
 <object>Lead</object>
 <concurrencyMode>Parallel</concurrencyMode>
 <contentType>CSV</contentType>

--- a/libs/salesforce-api/src/lib/utils.ts
+++ b/libs/salesforce-api/src/lib/utils.ts
@@ -288,6 +288,8 @@ export function prepareBulkApiRequestPayload({
   let operation = type.toLowerCase();
   if (operation === 'query_all') {
     operation = 'queryAll';
+  } else if (operation === 'hard_delete') {
+    operation = 'hardDelete';
   }
 
   const xml = [

--- a/libs/shared/ui-core/src/load/load-records-utils.tsx
+++ b/libs/shared/ui-core/src/load/load-records-utils.tsx
@@ -898,9 +898,10 @@ export function checkForDuplicateRecords(
   duplicateRecords: [string, any[]][];
 } | null {
   let mappingItem: FieldMappingItem | undefined;
+
   if (isCustomMetadata) {
     mappingItem = Object.values(fieldMapping).find(({ targetField }) => targetField === 'DeveloperName');
-  } else if (loadType === 'UPDATE' || loadType === 'DELETE') {
+  } else if (loadType === 'UPDATE' || loadType === 'DELETE' || loadType === 'HARD_DELETE') {
     mappingItem = Object.values(fieldMapping).find(({ targetField }) => targetField === 'Id');
   } else if (loadType === 'UPSERT' && externalId) {
     mappingItem = Object.values(fieldMapping).find(({ targetField }) => targetField === externalId);

--- a/libs/shared/ui-core/src/state-management/load-records.state.ts
+++ b/libs/shared/ui-core/src/state-management/load-records.state.ts
@@ -46,7 +46,9 @@ export const fieldMappingState = atomWithReset<FieldMapping>({});
 
 export const selectAllowBinaryAttachment = atom<boolean | null>((get) => {
   const selectedObject = get(selectedSObjectState);
-  return selectedObject && SUPPORTED_ATTACHMENT_OBJECTS.has(selectedObject.name) && get(loadTypeState) !== 'DELETE';
+  const loadType = get(loadTypeState);
+  const isDelete = loadType === 'DELETE' || loadType === 'HARD_DELETE';
+  return selectedObject && SUPPORTED_ATTACHMENT_OBJECTS.has(selectedObject.name) && !isDelete;
 });
 
 export const selectBinaryAttachmentBodyField = atom<string | null>((get) => {
@@ -116,11 +118,17 @@ export const selectTrialRunSizeError = atom<string | null>((get) => {
 
 export const selectBulkApiModeLabel = atom<string | React.ReactNode>((get) => {
   const inputFileDataLength = get(inputFileDataState)?.length || 0;
-  return getLabelWithOptionalRecommended('Bulk API', inputFileDataLength > BATCH_RECOMMENDED_THRESHOLD, false);
+  const loadType = get(loadTypeState);
+  return getLabelWithOptionalRecommended('Bulk API', inputFileDataLength > BATCH_RECOMMENDED_THRESHOLD, loadType === 'HARD_DELETE');
 });
 
 export const selectBatchApiModeLabel = atom<string | React.ReactNode>((get) => {
   const inputFileDataLength = get(inputFileDataState)?.length || 0;
   const hasZipAttachment = !!get(inputZipFileDataState);
-  return getLabelWithOptionalRecommended('Batch API', inputFileDataLength <= BATCH_RECOMMENDED_THRESHOLD, hasZipAttachment);
+  const loadType = get(loadTypeState);
+  return getLabelWithOptionalRecommended(
+    'Batch API',
+    loadType !== 'HARD_DELETE' && inputFileDataLength <= BATCH_RECOMMENDED_THRESHOLD,
+    hasZipAttachment,
+  );
 });

--- a/libs/shared/utils/src/lib/utils.ts
+++ b/libs/shared/utils/src/lib/utils.ts
@@ -550,6 +550,7 @@ export function getHttpMethod(type: InsertUpdateUpsertDelete): HttpMethod {
     case 'UPSERT':
       return 'PATCH';
     case 'DELETE':
+    case 'HARD_DELETE':
       return 'DELETE';
     default:
       return 'POST';

--- a/libs/types/src/lib/salesforce/record.types.ts
+++ b/libs/types/src/lib/salesforce/record.types.ts
@@ -22,11 +22,12 @@ export type Insert = 'INSERT';
 export type Update = 'UPDATE';
 export type Upsert = 'UPSERT';
 export type Delete = 'DELETE';
+export type HardDelete = 'HARD_DELETE';
 export type Query = 'QUERY';
 export type QueryAll = 'QUERY_ALL';
 export type InsertUpdateUpsert = Insert | Update | Upsert;
-export type InsertUpdateUpsertDelete = Insert | Update | Upsert | Delete;
-export type InsertUpdateUpsertDeleteQuery = Insert | Update | Upsert | Delete | Query | QueryAll;
+export type InsertUpdateUpsertDelete = Insert | Update | Upsert | Delete | HardDelete;
+export type InsertUpdateUpsertDeleteQuery = Insert | Update | Upsert | Delete | HardDelete | Query | QueryAll;
 
 export interface ErrorResult {
   errors: {


### PR DESCRIPTION
Introduce a "hard delete" option to the data loader and query results page. This enhancement allows users to perform hard deletes alongside existing operations. The implementation includes updates to the API request payload, type definitions, and UI components to accommodate the new operation.

Fixes #1447