### PR TITLE
Fix error message typo in license assignment notification

### DIFF
--- a/apps/api/src/app/db/team.db.ts
+++ b/apps/api/src/app/db/team.db.ts
@@ -794,7 +794,7 @@ export async function canAddBillableMember({
     if (existingBillableMemberCount + existingBillableInvitationCount >= licenseCountLimit) {
       return {
         canAdd: false,
-        reason: `You don't have any available licensed to assign. Please purchase more licenses or contact support for assistance.`,
+        reason: `You don't have any available licenses to assign. Please purchase more licenses or contact support for assistance.`,
       };
     }
   }


### PR DESCRIPTION
Correct the typo in the error message regarding available licenses for assignment.