### PR TITLE
fix: add team-management page to docs

### DIFF
--- a/apps/docs/sidebars.ts
+++ b/apps/docs/sidebars.ts
@@ -22,6 +22,11 @@ const sidebar = {
     },
     {
       type: 'category',
+      label: 'Team Management',
+      items: ['team-management/team-management'],
+    },
+    {
+      type: 'category',
       label: 'Query',
       items: ['query/query', 'query/query-results', 'query/download-attachments'],
     },


### PR DESCRIPTION
This page existed, but was not added to the sidebar so it was not included in the overall documentation