### PR TITLE
fix: remove email preview

### DIFF
--- a/apps/api/src/app/controllers/auth.controller.ts
+++ b/apps/api/src/app/controllers/auth.controller.ts
@@ -858,7 +858,6 @@ const validatePasswordReset = createRoute(routeDefinition.validatePasswordReset.
     const userId = await resetUserPassword(email, token, password);
 
     await sendAuthenticationChangeConfirmation(email, 'Password change confirmation', {
-      preview: 'Your password has been successfully changed.',
       heading: 'Password changed',
     });
 

--- a/apps/api/src/app/controllers/user.controller.ts
+++ b/apps/api/src/app/controllers/user.controller.ts
@@ -259,7 +259,6 @@ const deletePassword = createRoute(routeDefinition.deletePassword.validators, as
   await removePasswordFromUser(user.id);
 
   await sendAuthenticationChangeConfirmation(user.email, 'Your password has been removed from your account', {
-    preview: 'Your password has been removed from your account.',
     heading: 'You have removed your password as a login method',
   });
 
@@ -367,7 +366,6 @@ const saveOtpAuthFactor = createRoute(routeDefinition.saveOtpAuthFactor.validato
     sendJson(res, authFactors);
 
     await sendAuthenticationChangeConfirmation(user.email, 'A new 2FA method has been added to your account', {
-      preview: 'A new 2FA method has been added to your account.',
       heading: 'Authenticator app added',
     });
 
@@ -400,12 +398,10 @@ const toggleEnableDisableAuthFactorRoute = createRoute(
       const emailAction = action === 'enable' ? 'enabled' : 'disabled';
       if (type === '2fa-email') {
         await sendAuthenticationChangeConfirmation(user.email, `Email 2FA has been ${emailAction}`, {
-          preview: `Email 2FA has been ${emailAction}.`,
           heading: `Email 2FA has been ${emailAction}`,
         });
       } else if (type === '2fa-otp') {
         await sendAuthenticationChangeConfirmation(user.email, `Authenticator app 2FA has been ${emailAction}`, {
-          preview: `Authenticator app 2FA has been ${emailAction}.`,
           heading: `Authenticator app 2FA has been ${emailAction}`,
         });
       }
@@ -436,7 +432,6 @@ const deleteAuthFactorRoute = createRoute(routeDefinition.deleteAuthFactor.valid
     sendJson(res, authFactors);
 
     await sendAuthenticationChangeConfirmation(user.email, 'Two-factor authentication method removed', {
-      preview: 'Two-factor authentication method removed.',
       heading: 'An authentication method has been removed',
     });
 
@@ -468,7 +463,6 @@ const unlinkIdentity = createRoute(routeDefinition.unlinkIdentity.validators, as
     sendJson(res, updatedUser);
 
     await sendAuthenticationChangeConfirmation(user.email, 'An linked identity has been removed from your account', {
-      preview: 'An linked identity has been removed from your account.',
       heading: 'An linked identity has been removed from your account',
       additionalTextSegments: [`The ${provider} identity has been removed from your account.`, 'You can link a new identity at any time.'],
     });
@@ -507,7 +501,6 @@ const linkIdentity = createRoute(routeDefinition.linkIdentity.validators, async 
     redirect(res, authorizationUrl.toString());
 
     await sendAuthenticationChangeConfirmation(user.email, 'A new identity has been linked to your account', {
-      preview: 'A new identity has been linked to your account.',
       heading: 'A new login method has been added to your account',
     });
 

--- a/libs/email/src/lib/email-templates/auth/AuthenticationChangeConfirmationEmail.tsx
+++ b/libs/email/src/lib/email-templates/auth/AuthenticationChangeConfirmationEmail.tsx
@@ -1,4 +1,4 @@
-import { Body, Container, Head, Heading, Html, Preview, Section, Text } from '@react-email/components';
+import { Body, Container, Head, Heading, Html, Section, Text } from '@react-email/components';
 import * as React from 'react';
 import { EmailFooter } from '../../components/EmailFooter';
 import { EmailLogo } from '../../components/EmailLogo';
@@ -6,20 +6,14 @@ import { EMAIL_STYLES } from '../../shared-styles';
 
 void React.createElement;
 export interface AuthenticationChangeConfirmationEmailProps {
-  preview: string;
   heading: string;
   additionalTextSegments?: string[];
 }
 
-export const AuthenticationChangeConfirmationEmail = ({
-  preview,
-  heading,
-  additionalTextSegments,
-}: AuthenticationChangeConfirmationEmailProps) => {
+export const AuthenticationChangeConfirmationEmail = ({ heading, additionalTextSegments }: AuthenticationChangeConfirmationEmailProps) => {
   return (
     <Html>
       <Head />
-      <Preview>{preview}</Preview>
       <Body style={EMAIL_STYLES.main}>
         <Container style={EMAIL_STYLES.container}>
           <EmailLogo />

--- a/libs/email/src/lib/email-templates/auth/GenericEmail.tsx
+++ b/libs/email/src/lib/email-templates/auth/GenericEmail.tsx
@@ -7,7 +7,7 @@ import { EMAIL_STYLES } from '../../shared-styles';
 void React.createElement;
 
 interface GenericEmailProps {
-  preview: string;
+  preview?: string;
   heading: string;
   segments: string[];
 }
@@ -15,7 +15,7 @@ interface GenericEmailProps {
 export const GenericEmail = ({ preview, heading, segments }: GenericEmailProps) => (
   <Html>
     <Head />
-    <Preview>{preview}</Preview>
+    {preview && <Preview>{preview}</Preview>}
     <Body style={EMAIL_STYLES.main}>
       <Container style={EMAIL_STYLES.container}>
         <EmailLogo />

--- a/libs/email/src/lib/email-templates/auth/PasswordResetConfirmationEmail.tsx
+++ b/libs/email/src/lib/email-templates/auth/PasswordResetConfirmationEmail.tsx
@@ -1,4 +1,4 @@
-import { Body, Container, Head, Heading, Html, Preview, Text } from '@react-email/components';
+import { Body, Container, Head, Heading, Html, Text } from '@react-email/components';
 import * as React from 'react';
 import { EmailFooter } from '../../components/EmailFooter';
 import { EmailLogo } from '../../components/EmailLogo';
@@ -10,7 +10,6 @@ export const PasswordResetConfirmationEmail = () => {
   return (
     <Html>
       <Head />
-      <Preview>Your password has been reset</Preview>
       <Body style={EMAIL_STYLES.main}>
         <Container style={EMAIL_STYLES.container}>
           <EmailLogo />

--- a/libs/email/src/lib/email-templates/auth/PasswordResetEmail.tsx
+++ b/libs/email/src/lib/email-templates/auth/PasswordResetEmail.tsx
@@ -1,4 +1,4 @@
-import { Body, Button, Container, Head, Heading, Html, Link, Preview, Section, Text } from '@react-email/components';
+import { Body, Button, Container, Head, Heading, Html, Link, Section, Text } from '@react-email/components';
 import * as React from 'react';
 import { EmailFooter } from '../../components/EmailFooter';
 import { EmailLogo } from '../../components/EmailLogo';
@@ -24,7 +24,6 @@ export const PasswordResetEmail = ({
   return (
     <Html>
       <Head />
-      <Preview>Reset your password with Jetstream</Preview>
       <Body style={EMAIL_STYLES.main}>
         <Container style={EMAIL_STYLES.container}>
           <EmailLogo />

--- a/libs/email/src/lib/email-templates/auth/TeamInvitationEmail.tsx
+++ b/libs/email/src/lib/email-templates/auth/TeamInvitationEmail.tsx
@@ -1,4 +1,4 @@
-import { Body, Button, Container, Head, Heading, Html, Preview, Section, Text } from '@react-email/components';
+import { Body, Button, Container, Head, Heading, Html, Section, Text } from '@react-email/components';
 import * as React from 'react';
 import { EmailFooter } from '../../components/EmailFooter';
 import { EmailLogo } from '../../components/EmailLogo';
@@ -35,7 +35,6 @@ export const TeamInvitation = ({ baseUrl, teamId, teamName, token, email, expire
   return (
     <Html>
       <Head />
-      <Preview>You're invited to join the team "{teamName}" on Jetstream!</Preview>
       <Body style={EMAIL_STYLES.main}>
         <Container style={EMAIL_STYLES.container}>
           <EmailLogo />

--- a/libs/email/src/lib/email-templates/auth/TwoStepVerificationEmail.tsx
+++ b/libs/email/src/lib/email-templates/auth/TwoStepVerificationEmail.tsx
@@ -1,4 +1,4 @@
-import { Body, Container, Head, Heading, Html, Link, Preview, Section, Text } from '@react-email/components';
+import { Body, Container, Head, Heading, Html, Link, Section, Text } from '@react-email/components';
 import * as React from 'react';
 import { EmailFooter } from '../../components/EmailFooter';
 import { EmailLogo } from '../../components/EmailLogo';
@@ -19,7 +19,6 @@ export const TwoStepVerificationEmail = ({
 }: TwoStepVerificationEmailProps) => (
   <Html>
     <Head />
-    <Preview>Verify your identity with Jetstream - {validationCode}</Preview>
     <Body style={EMAIL_STYLES.main}>
       <Container style={EMAIL_STYLES.container}>
         <EmailLogo />

--- a/libs/email/src/lib/email-templates/auth/VerifyEmail.tsx
+++ b/libs/email/src/lib/email-templates/auth/VerifyEmail.tsx
@@ -1,5 +1,5 @@
 import { pluralizeFromNumber } from '@jetstream/shared/utils';
-import { Body, Button, Container, Head, Heading, Html, Preview, Section, Text } from '@react-email/components';
+import { Body, Button, Container, Head, Heading, Html, Section, Text } from '@react-email/components';
 import * as React from 'react';
 import { EmailFooter } from '../../components/EmailFooter';
 import { EmailLogo } from '../../components/EmailLogo';
@@ -16,7 +16,6 @@ interface VerifyEmailProps {
 export const VerifyEmail = ({ baseUrl = 'https://getjetstream.app', validationCode, expHours }: VerifyEmailProps) => (
   <Html>
     <Head />
-    <Preview>Verify your email address with Jetstream - {validationCode}</Preview>
     <Body style={EMAIL_STYLES.main}>
       <Container style={EMAIL_STYLES.container}>
         <EmailLogo />

--- a/libs/email/src/lib/email.tsx
+++ b/libs/email/src/lib/email.tsx
@@ -79,7 +79,6 @@ export async function sendGoodbyeEmail(emailAddress: string, billingPortalLinkTe
   const component = (
     <GenericEmail
       heading="We're sorry to see you go!"
-      preview="We're sorry to see you go!"
       segments={[
         `We hope that you will give us a try in the future.`,
         `If you have any feedback on how we can improve or why Jetstream wasn't the right tool for you, please let us know by replying to this email.`,


### PR DESCRIPTION
Some corporate email filters have some issues with email deliverability Removing preview to keep deliverability to a maximum since this adds a bunch of invisible characters