### PR TITLE
swap XML library

### DIFF
--- a/libs/features/record-type-manager/src/lib/utils/__tests__/record-types.utils.spec.ts
+++ b/libs/features/record-type-manager/src/lib/utils/__tests__/record-types.utils.spec.ts
@@ -5,7 +5,7 @@ const TEST_DATA: { 'Contact.Record_Type_1': ReadMetadataRecordTypeExtended; 'Con
   'Contact.Record_Type_1': {
     sobject: 'Contact',
     recordType: 'Record_Type_1',
-    '@xsi:type': 'RecordType',
+    '@_type': 'RecordType',
     fullName: 'Contact.Record_Type_1',
     active: true,
     description: '123',
@@ -60,7 +60,7 @@ const TEST_DATA: { 'Contact.Record_Type_1': ReadMetadataRecordTypeExtended; 'Con
   'Contact.Record_Type_2': {
     sobject: 'Contact',
     recordType: 'Record_Type_2',
-    '@xsi:type': 'RecordType',
+    '@_type': 'RecordType',
     fullName: 'Contact.Record_Type_2',
     active: true,
     label: 'Record Type 2',

--- a/libs/salesforce-api/src/lib/__tests__/api-bulk.spec.ts
+++ b/libs/salesforce-api/src/lib/__tests__/api-bulk.spec.ts
@@ -1,0 +1,449 @@
+import { describe, it, expect, vi } from 'vitest';
+import { ApiBulk } from '../api-bulk';
+import { ApiConnection } from '../connection';
+import { getApiRequestFactoryFn } from '../callout-adapter';
+import type { BulkApiCreateJobRequestPayload } from '@jetstream/types';
+
+// Real XML responses from Salesforce Bulk API
+const BULK_XML_RESPONSES = {
+  JOB_INFO_OPEN: `<?xml version="1.0" encoding="UTF-8"?><jobInfo
+   xmlns="http://www.force.com/2009/06/asyncapi/dataload">
+ <id>750Kf00000R1wzRIAR</id>
+ <operation>update</operation>
+ <object>Account</object>
+ <createdById>0056g000004tCpaAAE</createdById>
+ <createdDate>2026-02-12T15:43:48.000Z</createdDate>
+ <systemModstamp>2026-02-12T15:43:48.000Z</systemModstamp>
+ <state>Open</state>
+ <concurrencyMode>Parallel</concurrencyMode>
+ <contentType>CSV</contentType>
+ <numberBatchesQueued>0</numberBatchesQueued>
+ <numberBatchesInProgress>0</numberBatchesInProgress>
+ <numberBatchesCompleted>0</numberBatchesCompleted>
+ <numberBatchesFailed>0</numberBatchesFailed>
+ <numberBatchesTotal>0</numberBatchesTotal>
+ <numberRecordsProcessed>0</numberRecordsProcessed>
+ <numberRetries>0</numberRetries>
+ <apiVersion>65.0</apiVersion>
+ <numberRecordsFailed>0</numberRecordsFailed>
+ <totalProcessingTime>0</totalProcessingTime>
+ <apiActiveProcessingTime>0</apiActiveProcessingTime>
+ <apexProcessingTime>0</apexProcessingTime>
+</jobInfo>`,
+
+  JOB_INFO_CLOSED: `<?xml version="1.0" encoding="UTF-8"?><jobInfo
+   xmlns="http://www.force.com/2009/06/asyncapi/dataload">
+ <id>750Kf00000R1wzRIAR</id>
+ <operation>update</operation>
+ <object>Account</object>
+ <createdById>0056g000004tCpaAAE</createdById>
+ <createdDate>2026-02-12T15:43:48.000Z</createdDate>
+ <systemModstamp>2026-02-12T15:44:11.000Z</systemModstamp>
+ <state>Closed</state>
+ <concurrencyMode>Parallel</concurrencyMode>
+ <contentType>CSV</contentType>
+ <numberBatchesQueued>0</numberBatchesQueued>
+ <numberBatchesInProgress>0</numberBatchesInProgress>
+ <numberBatchesCompleted>1</numberBatchesCompleted>
+ <numberBatchesFailed>0</numberBatchesFailed>
+ <numberBatchesTotal>1</numberBatchesTotal>
+ <numberRecordsProcessed>251</numberRecordsProcessed>
+ <numberRetries>0</numberRetries>
+ <apiVersion>65.0</apiVersion>
+ <numberRecordsFailed>251</numberRecordsFailed>
+ <totalProcessingTime>741</totalProcessingTime>
+ <apiActiveProcessingTime>497</apiActiveProcessingTime>
+ <apexProcessingTime>0</apexProcessingTime>
+</jobInfo>`,
+
+  BATCH_INFO_QUEUED: `<?xml version="1.0" encoding="UTF-8"?><batchInfo
+   xmlns="http://www.force.com/2009/06/asyncapi/dataload">
+ <id>751Kf000018uaV7IAI</id>
+ <jobId>750Kf00000R1wzRIAR</jobId>
+ <state>Queued</state>
+ <createdDate>2026-02-12T15:44:04.000Z</createdDate>
+ <systemModstamp>2026-02-12T15:44:04.000Z</systemModstamp>
+ <numberRecordsProcessed>0</numberRecordsProcessed>
+ <numberRecordsFailed>0</numberRecordsFailed>
+ <totalProcessingTime>0</totalProcessingTime>
+ <apiActiveProcessingTime>0</apiActiveProcessingTime>
+ <apexProcessingTime>0</apexProcessingTime>
+</batchInfo>`,
+
+  BATCH_INFO_COMPLETED: `<?xml version="1.0" encoding="UTF-8"?><batchInfo
+   xmlns="http://www.force.com/2009/06/asyncapi/dataload">
+ <id>751Kf000018uaV7IAI</id>
+ <jobId>750Kf00000R1wzRIAR</jobId>
+ <state>Completed</state>
+ <createdDate>2026-02-12T15:44:04.000Z</createdDate>
+ <systemModstamp>2026-02-12T15:44:06.000Z</systemModstamp>
+ <numberRecordsProcessed>251</numberRecordsProcessed>
+ <numberRecordsFailed>251</numberRecordsFailed>
+ <totalProcessingTime>741</totalProcessingTime>
+ <apiActiveProcessingTime>497</apiActiveProcessingTime>
+ <apexProcessingTime>0</apexProcessingTime>
+</batchInfo>`,
+
+  BATCH_INFO_LIST_SINGLE: `<?xml version="1.0" encoding="UTF-8"?><batchInfoList
+   xmlns="http://www.force.com/2009/06/asyncapi/dataload">
+ <batchInfo>
+  <id>751Kf000018uaV7IAI</id>
+  <jobId>750Kf00000R1wzRIAR</jobId>
+  <state>Completed</state>
+  <createdDate>2026-02-12T15:44:04.000Z</createdDate>
+  <systemModstamp>2026-02-12T15:44:06.000Z</systemModstamp>
+  <numberRecordsProcessed>251</numberRecordsProcessed>
+  <numberRecordsFailed>251</numberRecordsFailed>
+  <totalProcessingTime>741</totalProcessingTime>
+  <apiActiveProcessingTime>497</apiActiveProcessingTime>
+  <apexProcessingTime>0</apexProcessingTime>
+ </batchInfo>
+</batchInfoList>`,
+
+  BATCH_INFO_LIST_MULTIPLE: `<?xml version="1.0" encoding="UTF-8"?><batchInfoList
+   xmlns="http://www.force.com/2009/06/asyncapi/dataload">
+ <batchInfo>
+  <id>751Kf000018uaV7IAI</id>
+  <jobId>750Kf00000R1wzRIAR</jobId>
+  <state>Completed</state>
+  <numberRecordsProcessed>100</numberRecordsProcessed>
+  <numberRecordsFailed>50</numberRecordsFailed>
+ </batchInfo>
+ <batchInfo>
+  <id>751Kf000018uaV8IAI</id>
+  <jobId>750Kf00000R1wzRIAR</jobId>
+  <state>Completed</state>
+  <numberRecordsProcessed>151</numberRecordsProcessed>
+  <numberRecordsFailed>201</numberRecordsFailed>
+ </batchInfo>
+</batchInfoList>`,
+
+  BATCH_INFO_LIST_EMPTY: `<?xml version="1.0" encoding="UTF-8"?><batchInfoList
+   xmlns="http://www.force.com/2009/06/asyncapi/dataload">
+</batchInfoList>`,
+
+  RESULT_LIST_SINGLE: `<?xml version="1.0" encoding="UTF-8"?><result-list
+   xmlns="http://www.force.com/2009/06/asyncapi/dataload">
+ <result>752Kf000018uaV9IAI</result>
+</result-list>`,
+
+  RESULT_LIST_MULTIPLE: `<?xml version="1.0" encoding="UTF-8"?><result-list
+   xmlns="http://www.force.com/2009/06/asyncapi/dataload">
+ <result>752Kf000018uaV9IAI</result>
+ <result>752Kf000018uaVAIAI</result>
+ <result>752Kf000018uaVBIAI</result>
+</result-list>`,
+};
+
+// Helper to create a mock fetch that returns XML
+const createMockFetch = (responses: Record<string, string>) => {
+  return vi.fn((url: string | URL) => {
+    const urlStr = typeof url === 'string' ? url : url.toString();
+
+    // Find the most specific matching key (longest match wins to handle nested URLs)
+    const matchedKey = Object.keys(responses)
+      .filter((key) => urlStr.includes(key))
+      .sort((a, b) => b.length - a.length)[0];
+
+    if (!matchedKey) {
+      throw new Error(`No mock response for URL: ${urlStr}`);
+    }
+
+    return Promise.resolve({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      headers: new Headers({ 'content-type': 'text/xml; charset=UTF-8' }),
+      type: 'basic' as ResponseType,
+      url: urlStr,
+      text: () => Promise.resolve(responses[matchedKey]),
+      json: () => Promise.reject(new Error('Not JSON')),
+      clone() {
+        return this;
+      },
+    } as any);
+  });
+};
+
+// Helper to create connection with real XML parsing
+const createConnectionWithXmlParsing = (mockFetch: any) => {
+  const apiRequest = getApiRequestFactoryFn(mockFetch)();
+  return {
+    apiRequest,
+    sessionInfo: {
+      accessToken: 'test-token',
+      instanceUrl: 'https://test.salesforce.com',
+      apiVersion: '65.0',
+      userId: 'test-user-id',
+      organizationId: 'test-org-id',
+    },
+    logger: console,
+  } as unknown as ApiConnection;
+};
+
+describe('ApiBulk XML parsing and type handling', () => {
+  describe('createJob - XML parsing and type conversion', () => {
+    it('should parse XML jobInfo and convert string numbers to actual numbers', async () => {
+      const mockFetch = createMockFetch({
+        '/services/async/65.0/job': BULK_XML_RESPONSES.JOB_INFO_OPEN,
+      });
+
+      const connection = createConnectionWithXmlParsing(mockFetch);
+      const apiBulk = new ApiBulk(connection);
+
+      const payload: BulkApiCreateJobRequestPayload = {
+        type: 'UPDATE',
+        sObject: 'Account',
+      };
+
+      const result = await apiBulk.createJob(payload);
+
+      // Verify the result structure from parsed XML
+      expect(result).toBeDefined();
+      expect(result.id).toBe('750Kf00000R1wzRIAR');
+      expect(result.operation).toBe('update');
+      expect(result.state).toBe('Open');
+
+      // CRITICAL: Verify that bulkApiEnsureTyped converted string numbers to actual numbers
+      expect(typeof result.numberBatchesQueued).toBe('number');
+      expect(typeof result.numberBatchesInProgress).toBe('number');
+      expect(typeof result.numberBatchesCompleted).toBe('number');
+      expect(typeof result.numberBatchesFailed).toBe('number');
+      expect(typeof result.numberBatchesTotal).toBe('number');
+      expect(typeof result.numberRecordsProcessed).toBe('number');
+      expect(typeof result.numberRetries).toBe('number');
+      expect(typeof result.apiVersion).toBe('number');
+      expect(typeof result.numberRecordsFailed).toBe('number');
+      expect(typeof result.totalProcessingTime).toBe('number');
+      expect(typeof result.apiActiveProcessingTime).toBe('number');
+      expect(typeof result.apexProcessingTime).toBe('number');
+
+      // Verify actual values
+      expect(result.numberBatchesTotal).toBe(0);
+      expect(result.numberRecordsProcessed).toBe(0);
+      expect(result.apiVersion).toBe(65);
+    });
+
+    it('should handle closed job state with large numeric values', async () => {
+      const mockFetch = createMockFetch({
+        '/services/async/65.0/job': BULK_XML_RESPONSES.JOB_INFO_CLOSED,
+      });
+
+      const connection = createConnectionWithXmlParsing(mockFetch);
+      const apiBulk = new ApiBulk(connection);
+
+      const payload: BulkApiCreateJobRequestPayload = {
+        type: 'UPDATE',
+        sObject: 'Account',
+      };
+
+      const result = await apiBulk.createJob(payload);
+
+      expect(result.state).toBe('Closed');
+      expect(result.numberBatchesCompleted).toBe(1);
+      expect(result.numberRecordsProcessed).toBe(251);
+      expect(result.numberRecordsFailed).toBe(251);
+      expect(result.totalProcessingTime).toBe(741);
+
+      // All should be numbers, not strings
+      expect(typeof result.numberBatchesCompleted).toBe('number');
+      expect(typeof result.numberRecordsProcessed).toBe('number');
+    });
+  });
+
+  describe('getJob - XML parsing with parallel requests', () => {
+    it('should parse jobInfo and single batchInfo from XML', async () => {
+      const mockFetch = createMockFetch({
+        '/services/async/65.0/job/750Kf00000R1wzRIAR': BULK_XML_RESPONSES.JOB_INFO_CLOSED,
+        '/services/async/65.0/job/750Kf00000R1wzRIAR/batch': BULK_XML_RESPONSES.BATCH_INFO_LIST_SINGLE,
+      });
+
+      const connection = createConnectionWithXmlParsing(mockFetch);
+      const apiBulk = new ApiBulk(connection);
+
+      const result = await apiBulk.getJob('750Kf00000R1wzRIAR');
+
+      // Verify job info parsed and typed correctly
+      expect(result.id).toBe('750Kf00000R1wzRIAR');
+      expect(result.state).toBe('Closed');
+      expect(typeof result.numberBatchesCompleted).toBe('number');
+      expect(result.numberBatchesCompleted).toBe(1);
+
+      // Verify batches are properly parsed and typed
+      expect(Array.isArray(result.batches)).toBe(true);
+      expect(result.batches.length).toBe(1);
+      expect(result.batches[0].id).toBe('751Kf000018uaV7IAI');
+      expect(result.batches[0].state).toBe('Completed');
+
+      // CRITICAL: Numbers should be converted from XML strings
+      expect(typeof result.batches[0].numberRecordsProcessed).toBe('number');
+      expect(result.batches[0].numberRecordsProcessed).toBe(251);
+      expect(typeof result.batches[0].numberRecordsFailed).toBe('number');
+      expect(result.batches[0].numberRecordsFailed).toBe(251);
+    });
+
+    it('should handle multiple batches in XML batchInfoList', async () => {
+      const mockFetch = createMockFetch({
+        '/services/async/65.0/job/750Kf00000R1wzRIAR': BULK_XML_RESPONSES.JOB_INFO_CLOSED,
+        '/services/async/65.0/job/750Kf00000R1wzRIAR/batch': BULK_XML_RESPONSES.BATCH_INFO_LIST_MULTIPLE,
+      });
+
+      const connection = createConnectionWithXmlParsing(mockFetch);
+      const apiBulk = new ApiBulk(connection);
+
+      const result = await apiBulk.getJob('750Kf00000R1wzRIAR');
+
+      // Verify multiple batches parsed correctly
+      expect(result.batches.length).toBe(2);
+
+      // First batch
+      expect(typeof result.batches[0].numberRecordsProcessed).toBe('number');
+      expect(result.batches[0].numberRecordsProcessed).toBe(100);
+      expect(result.batches[0].numberRecordsFailed).toBe(50);
+
+      // Second batch
+      expect(typeof result.batches[1].numberRecordsProcessed).toBe('number');
+      expect(result.batches[1].numberRecordsProcessed).toBe(151);
+      expect(result.batches[1].numberRecordsFailed).toBe(201);
+    });
+
+    it('should handle empty batchInfoList XML', async () => {
+      const mockFetch = createMockFetch({
+        '/services/async/65.0/job/750Kf00000R1wzRIAR': BULK_XML_RESPONSES.JOB_INFO_OPEN,
+        '/services/async/65.0/job/750Kf00000R1wzRIAR/batch': BULK_XML_RESPONSES.BATCH_INFO_LIST_EMPTY,
+      });
+
+      const connection = createConnectionWithXmlParsing(mockFetch);
+      const apiBulk = new ApiBulk(connection);
+
+      const result = await apiBulk.getJob('750Kf00000R1wzRIAR');
+
+      // Empty XML should result in empty array
+      expect(result.batches).toEqual([]);
+    });
+  });
+
+  describe('addBatchToJob - XML parsing', () => {
+    it('should parse batchInfo XML and convert numeric fields', async () => {
+      const mockFetch = createMockFetch({
+        '/services/async/65.0/job/750Kf00000R1wzRIAR/batch': BULK_XML_RESPONSES.BATCH_INFO_QUEUED,
+      });
+
+      const connection = createConnectionWithXmlParsing(mockFetch);
+      const apiBulk = new ApiBulk(connection);
+
+      const result = await apiBulk.addBatchToJob('csv,data', '750Kf00000R1wzRIAR');
+
+      expect(result.id).toBe('751Kf000018uaV7IAI');
+      expect(result.jobId).toBe('750Kf00000R1wzRIAR');
+      expect(result.state).toBe('Queued');
+
+      // Verify type conversions
+      expect(typeof result.numberRecordsProcessed).toBe('number');
+      expect(result.numberRecordsProcessed).toBe(0);
+      expect(typeof result.numberRecordsFailed).toBe('number');
+      expect(result.numberRecordsFailed).toBe(0);
+    });
+  });
+
+  describe('getQueryResultsJobIds - XML parsing', () => {
+    it('should parse result-list XML with single result', async () => {
+      const mockFetch = createMockFetch({
+        '/services/async/65.0/job/750Kf00000R1wzRIAR/batch/751Kf000018uaV7IAI/result':
+          BULK_XML_RESPONSES.RESULT_LIST_SINGLE,
+      });
+
+      const connection = createConnectionWithXmlParsing(mockFetch);
+      const apiBulk = new ApiBulk(connection);
+
+      const result = await apiBulk.getQueryResultsJobIds('750Kf00000R1wzRIAR', '751Kf000018uaV7IAI');
+
+      // Single result should become an array
+      expect(Array.isArray(result)).toBe(true);
+      expect(result.length).toBe(1);
+      expect(result[0]).toBe('752Kf000018uaV9IAI');
+    });
+
+    it('should parse result-list XML with multiple results', async () => {
+      const mockFetch = createMockFetch({
+        '/services/async/65.0/job/750Kf00000R1wzRIAR/batch/751Kf000018uaV7IAI/result':
+          BULK_XML_RESPONSES.RESULT_LIST_MULTIPLE,
+      });
+
+      const connection = createConnectionWithXmlParsing(mockFetch);
+      const apiBulk = new ApiBulk(connection);
+
+      const result = await apiBulk.getQueryResultsJobIds('750Kf00000R1wzRIAR', '751Kf000018uaV7IAI');
+
+      // Multiple results should be an array
+      expect(result.length).toBe(3);
+      expect(result[0]).toBe('752Kf000018uaV9IAI');
+      expect(result[1]).toBe('752Kf000018uaVAIAI');
+      expect(result[2]).toBe('752Kf000018uaVBIAI');
+    });
+  });
+
+  describe('XML namespace and attribute handling', () => {
+    it('should handle and remove XML namespace attributes after parsing', async () => {
+      // The XML responses include xmlns="http://www.force.com/2009/06/asyncapi/dataload"
+      // bulkApiEnsureTyped should remove @xmlns attributes
+      const mockFetch = createMockFetch({
+        '/services/async/65.0/job': BULK_XML_RESPONSES.JOB_INFO_OPEN,
+      });
+
+      const connection = createConnectionWithXmlParsing(mockFetch);
+      const apiBulk = new ApiBulk(connection);
+
+      const payload: BulkApiCreateJobRequestPayload = {
+        type: 'UPDATE',
+        sObject: 'Account',
+      };
+
+      const result = await apiBulk.createJob(payload);
+
+      // Namespace attributes should be cleaned up
+      expect(result['@xmlns']).toBeUndefined();
+      expect(result.id).toBe('750Kf00000R1wzRIAR');
+    });
+  });
+
+  describe('XML parsing edge cases', () => {
+    it('should handle XML with various numeric formats', async () => {
+      // Test that various numeric string formats get converted correctly
+      const mockFetch = createMockFetch({
+        '/services/async/65.0/job': BULK_XML_RESPONSES.JOB_INFO_CLOSED,
+      });
+
+      const connection = createConnectionWithXmlParsing(mockFetch);
+      const apiBulk = new ApiBulk(connection);
+
+      const payload: BulkApiCreateJobRequestPayload = {
+        type: 'UPDATE',
+        sObject: 'Account',
+      };
+
+      const result = await apiBulk.createJob(payload);
+
+      // Verify all numeric fields are properly converted
+      const numericFields = [
+        'numberBatchesQueued',
+        'numberBatchesInProgress',
+        'numberBatchesCompleted',
+        'numberBatchesFailed',
+        'numberBatchesTotal',
+        'numberRecordsProcessed',
+        'numberRetries',
+        'apiVersion',
+        'numberRecordsFailed',
+        'totalProcessingTime',
+        'apiActiveProcessingTime',
+        'apexProcessingTime',
+      ];
+
+      numericFields.forEach((field) => {
+        expect(typeof result[field]).toBe('number');
+        expect(Number.isNaN(result[field])).toBe(false);
+      });
+    });
+  });
+});

--- a/libs/salesforce-api/src/lib/__tests__/api-metadata.spec.ts
+++ b/libs/salesforce-api/src/lib/__tests__/api-metadata.spec.ts
@@ -1,0 +1,389 @@
+import { describe, it, expect, vi } from 'vitest';
+import { ApiMetadata } from '../api-metadata';
+import { ApiConnection } from '../connection';
+import { getApiRequestFactoryFn } from '../callout-adapter';
+
+// Real SOAP XML responses from Salesforce Metadata API
+const METADATA_SOAP_RESPONSES = {
+  DESCRIBE_METADATA: `<?xml version="1.0" encoding="UTF-8"?>
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns="http://soap.sforce.com/2006/04/metadata">
+  <soapenv:Body>
+    <describeMetadataResponse>
+      <result>
+        <organizationNamespace></organizationNamespace>
+        <partialSaveAllowed>true</partialSaveAllowed>
+        <testRequired>false</testRequired>
+        <metadataObjects>
+          <directoryName>installedPackages</directoryName>
+          <inFolder>false</inFolder>
+          <metaFile>false</metaFile>
+          <suffix>installedPackage</suffix>
+          <xmlName>InstalledPackage</xmlName>
+        </metadataObjects>
+        <metadataObjects>
+          <childXmlNames>CustomLabel</childXmlNames>
+          <childXmlNames>CustomFieldTranslation</childXmlNames>
+          <directoryName>labels</directoryName>
+          <inFolder>false</inFolder>
+          <metaFile>false</metaFile>
+          <suffix>labels</suffix>
+          <xmlName>CustomLabels</xmlName>
+        </metadataObjects>
+      </result>
+    </describeMetadataResponse>
+  </soapenv:Body>
+</soapenv:Envelope>`,
+
+  LIST_METADATA_MULTIPLE: `<?xml version="1.0" encoding="UTF-8"?>
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns="http://soap.sforce.com/2006/04/metadata">
+  <soapenv:Body>
+    <listMetadataResponse>
+      <result>
+        <createdById>0056g000004tCpaAAE</createdById>
+        <createdByName>Austin Turner</createdByName>
+        <createdDate>2021-10-01T02:46:23.000Z</createdDate>
+        <fileName>classes/FieldDescriptorTests.cls</fileName>
+        <fullName>FieldDescriptorTests</fullName>
+        <id>01p6g00000RGbskAAD</id>
+        <type>ApexClass</type>
+      </result>
+      <result>
+        <createdById>0056g000004tCpaAAE</createdById>
+        <createdByName>Austin Turner</createdByName>
+        <createdDate>2022-03-02T02:52:39.000Z</createdDate>
+        <fileName>classes/CalloutServiceMock.cls</fileName>
+        <fullName>CalloutServiceMock</fullName>
+        <id>01p6g00000SlXzQAAV</id>
+        <type>ApexClass</type>
+      </result>
+    </listMetadataResponse>
+  </soapenv:Body>
+</soapenv:Envelope>`,
+
+  LIST_METADATA_EMPTY: `<?xml version="1.0" encoding="UTF-8"?>
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns="http://soap.sforce.com/2006/04/metadata">
+  <soapenv:Body>
+    <listMetadataResponse/>
+  </soapenv:Body>
+</soapenv:Envelope>`,
+
+  LIST_METADATA_SINGLE: `<?xml version="1.0" encoding="UTF-8"?>
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns="http://soap.sforce.com/2006/04/metadata">
+  <soapenv:Body>
+    <listMetadataResponse>
+      <result>
+        <createdById>0056g000004tCpaAAE</createdById>
+        <fullName>TestClass</fullName>
+        <type>ApexClass</type>
+        <namespacePrefix xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+      </result>
+    </listMetadataResponse>
+  </soapenv:Body>
+</soapenv:Envelope>`,
+
+  CHECK_RETRIEVE_STATUS: `<?xml version="1.0" encoding="UTF-8"?>
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns="http://soap.sforce.com/2006/04/metadata">
+  <soapenv:Body>
+    <checkRetrieveStatusResponse>
+      <result>
+        <done>true</done>
+        <success>true</success>
+        <fileProperties>
+          <createdById>0056g000004tCpaAAE</createdById>
+          <fileName>classes/TestClass.cls</fileName>
+          <fullName>TestClass</fullName>
+          <id>01p6g00000RikTBAAZ</id>
+          <type>ApexClass</type>
+        </fileProperties>
+        <fileProperties>
+          <createdById>0056g000004tCpaAAE</createdById>
+          <fileName>classes/TestClass2.cls</fileName>
+          <fullName>TestClass2</fullName>
+          <id>01p6g00000SlXyzAAF</id>
+          <type>ApexClass</type>
+        </fileProperties>
+        <messages/>
+        <zipFile>UEsDBBQACAgIAJl8TFwAAAA=</zipFile>
+      </result>
+    </checkRetrieveStatusResponse>
+  </soapenv:Body>
+</soapenv:Envelope>`,
+
+  DEPLOY_RESPONSE: `<?xml version="1.0" encoding="UTF-8"?>
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns="http://soap.sforce.com/2006/04/metadata">
+  <soapenv:Body>
+    <deployResponse>
+      <result>
+        <done>false</done>
+        <id>0Af6g00000TestAAA</id>
+        <state>Queued</state>
+      </result>
+    </deployResponse>
+  </soapenv:Body>
+</soapenv:Envelope>`,
+
+  CHECK_DEPLOY_STATUS: `<?xml version="1.0" encoding="UTF-8"?>
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns="http://soap.sforce.com/2006/04/metadata">
+  <soapenv:Body>
+    <checkDeployStatusResponse>
+      <result>
+        <done>true</done>
+        <success>true</success>
+        <status>Succeeded</status>
+        <numberComponentErrors>0</numberComponentErrors>
+        <numberComponentsDeployed>5</numberComponentsDeployed>
+        <numberComponentsTotal>5</numberComponentsTotal>
+        <numberTestErrors>0</numberTestErrors>
+        <numberTestsCompleted>3</numberTestsCompleted>
+        <numberTestsTotal>3</numberTestsTotal>
+        <details>
+          <componentSuccesses>
+            <fullName>TestClass</fullName>
+            <componentType>ApexClass</componentType>
+            <success>true</success>
+          </componentSuccesses>
+          <componentSuccesses>
+            <fullName>TestClass2</fullName>
+            <componentType>ApexClass</componentType>
+            <success>true</success>
+          </componentSuccesses>
+          <componentFailures/>
+        </details>
+      </result>
+    </checkDeployStatusResponse>
+  </soapenv:Body>
+</soapenv:Envelope>`,
+};
+
+// Helper to create a mock fetch that returns SOAP XML
+const createMockFetch = (responses: Record<string, string>) => {
+  return vi.fn((url: string | URL) => {
+    const urlStr = typeof url === 'string' ? url : url.toString();
+
+    // Find the most specific matching key (longest match wins)
+    const matchedKey = Object.keys(responses)
+      .filter((key) => urlStr.includes(key))
+      .sort((a, b) => b.length - a.length)[0];
+
+    if (!matchedKey) {
+      throw new Error(`No mock response for URL: ${urlStr}`);
+    }
+
+    return Promise.resolve({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      headers: new Headers({ 'content-type': 'text/xml; charset=UTF-8' }),
+      type: 'basic' as ResponseType,
+      url: urlStr,
+      text: () => Promise.resolve(responses[matchedKey]),
+      json: () => Promise.reject(new Error('Not JSON')),
+      clone() {
+        return this;
+      },
+    } as any);
+  });
+};
+
+// Helper to create connection with real SOAP/XML parsing
+const createConnectionWithSoapParsing = (mockFetch: any) => {
+  const apiRequest = getApiRequestFactoryFn(mockFetch)();
+  return {
+    apiRequest,
+    sessionInfo: {
+      accessToken: 'test-token',
+      instanceUrl: 'https://test.salesforce.com',
+      apiVersion: '65.0',
+      userId: 'test-user-id',
+      organizationId: 'test-org-id',
+    },
+    logger: console,
+  } as unknown as ApiConnection;
+};
+
+describe('ApiMetadata SOAP XML parsing and type handling', () => {
+  describe('describe - SOAP XML parsing', () => {
+    it('should parse describeMetadata SOAP response and convert types', async () => {
+      const mockFetch = createMockFetch({
+        '/services/Soap/m/65.0': METADATA_SOAP_RESPONSES.DESCRIBE_METADATA,
+      });
+
+      const connection = createConnectionWithSoapParsing(mockFetch);
+      const apiMetadata = new ApiMetadata(connection);
+
+      const result = await apiMetadata.describe();
+
+      // Verify boolean conversions from string "true"/"false" to actual booleans
+      expect(typeof result.partialSaveAllowed).toBe('boolean');
+      expect(typeof result.testRequired).toBe('boolean');
+      expect(result.partialSaveAllowed).toBe(true);
+      expect(result.testRequired).toBe(false);
+
+      // Verify empty string handling - empty elements get converted to null by correctInvalidXmlResponseTypes
+      // But api-metadata.ts line 49 converts back to empty string if it's a string: isString(x) ? x : null
+      // Since null is not a string, it becomes null
+      expect(result.organizationNamespace).toBe(null);
+
+      // Verify metadataObjects array handling
+      expect(Array.isArray(result.metadataObjects)).toBe(true);
+      expect(result.metadataObjects.length).toBe(2);
+      expect(result.metadataObjects[0].xmlName).toBe('InstalledPackage');
+      expect(result.metadataObjects[0].inFolder).toBe(false);
+
+      // Verify childXmlNames handling - should be arrays
+      expect(Array.isArray(result.metadataObjects[0].childXmlNames)).toBe(true);
+      expect(result.metadataObjects[0].childXmlNames).toEqual([]);
+      expect(Array.isArray(result.metadataObjects[1].childXmlNames)).toBe(true);
+      expect(result.metadataObjects[1].childXmlNames!.length).toBe(2);
+      expect(result.metadataObjects[1].childXmlNames!).toContain('CustomLabel');
+    });
+  });
+
+  describe('list - SOAP XML parsing', () => {
+    it('should parse listMetadata SOAP response with multiple results', async () => {
+      const mockFetch = createMockFetch({
+        '/services/Soap/m/65.0': METADATA_SOAP_RESPONSES.LIST_METADATA_MULTIPLE,
+      });
+
+      const connection = createConnectionWithSoapParsing(mockFetch);
+      const apiMetadata = new ApiMetadata(connection);
+
+      const result = await apiMetadata.list([{ type: 'ApexClass' }]);
+
+      // Should return array from XML parsing
+      expect(Array.isArray(result)).toBe(true);
+      expect(result.length).toBe(2);
+      expect(result[0].fullName).toBe('FieldDescriptorTests');
+      expect(result[0].type).toBe('ApexClass');
+      expect(result[1].fullName).toBe('CalloutServiceMock');
+    });
+
+    it('should handle empty listMetadata SOAP response', async () => {
+      const mockFetch = createMockFetch({
+        '/services/Soap/m/65.0': METADATA_SOAP_RESPONSES.LIST_METADATA_EMPTY,
+      });
+
+      const connection = createConnectionWithSoapParsing(mockFetch);
+      const apiMetadata = new ApiMetadata(connection);
+
+      const result = await apiMetadata.list([{ type: 'ApexClass' }]);
+
+      // Empty response should result in empty array
+      expect(Array.isArray(result)).toBe(true);
+      expect(result.length).toBe(0);
+    });
+
+    it('should handle single result and convert xsi:nil to null', async () => {
+      const mockFetch = createMockFetch({
+        '/services/Soap/m/65.0': METADATA_SOAP_RESPONSES.LIST_METADATA_SINGLE,
+      });
+
+      const connection = createConnectionWithSoapParsing(mockFetch);
+      const apiMetadata = new ApiMetadata(connection);
+
+      const result = await apiMetadata.list([{ type: 'ApexClass' }]);
+
+      // Single result should be converted to array
+      expect(Array.isArray(result)).toBe(true);
+      expect(result.length).toBe(1);
+      expect(result[0].fullName).toBe('TestClass');
+
+      // xsi:nil should be converted to null
+      expect(result[0].namespacePrefix).toBe(null);
+    });
+  });
+
+  describe('checkRetrieveStatus - SOAP XML parsing', () => {
+    it('should parse checkRetrieveStatus and handle fileProperties array', async () => {
+      const mockFetch = createMockFetch({
+        '/services/Soap/m/65.0': METADATA_SOAP_RESPONSES.CHECK_RETRIEVE_STATUS,
+      });
+
+      const connection = createConnectionWithSoapParsing(mockFetch);
+      const apiMetadata = new ApiMetadata(connection);
+
+      const result = await apiMetadata.checkRetrieveStatus('test-id');
+
+      // Verify boolean conversions
+      expect(typeof result.done).toBe('boolean');
+      expect(typeof result.success).toBe('boolean');
+      expect(result.done).toBe(true);
+      expect(result.success).toBe(true);
+
+      // fileProperties should be array even from XML
+      expect(Array.isArray(result.fileProperties)).toBe(true);
+      expect(result.fileProperties.length).toBe(2);
+      expect(result.fileProperties[0].fullName).toBe('TestClass');
+
+      // messages should be array - empty XML element becomes array with one item
+      expect(Array.isArray(result.messages)).toBe(true);
+      // XML parser returns empty element as empty object/string, which ensureArray converts to [{}] or ['']
+      expect(result.messages.length).toBeGreaterThanOrEqual(0);
+
+      // zipFile should be present
+      expect(result.zipFile).toBe('UEsDBBQACAgIAJl8TFwAAAA=');
+    });
+  });
+
+  describe('deploy - SOAP XML parsing', () => {
+    it('should parse deploy SOAP response and convert types', async () => {
+      const mockFetch = createMockFetch({
+        '/services/Soap/m/65.0': METADATA_SOAP_RESPONSES.DEPLOY_RESPONSE,
+      });
+
+      const connection = createConnectionWithSoapParsing(mockFetch);
+      const apiMetadata = new ApiMetadata(connection);
+
+      const result = await apiMetadata.deploy('base64zipfile', {});
+
+      // Verify boolean conversion
+      expect(typeof result.done).toBe('boolean');
+      expect(result.done).toBe(false);
+      expect(result.id).toBe('0Af6g00000TestAAA');
+      expect(result.state).toBe('Queued');
+    });
+  });
+
+  describe('checkDeployStatus - SOAP XML parsing and numeric conversions', () => {
+    it('should parse checkDeployStatus and convert all numeric fields', async () => {
+      const mockFetch = createMockFetch({
+        '/services/Soap/m/65.0': METADATA_SOAP_RESPONSES.CHECK_DEPLOY_STATUS,
+      });
+
+      const connection = createConnectionWithSoapParsing(mockFetch);
+      const apiMetadata = new ApiMetadata(connection);
+
+      const result = await apiMetadata.checkDeployStatus('0Af6g00000TestAAA', true);
+
+      // Verify boolean conversions
+      expect(typeof result.done).toBe('boolean');
+      expect(typeof result.success).toBe('boolean');
+      expect(result.done).toBe(true);
+      expect(result.success).toBe(true);
+
+      // CRITICAL: Verify numeric conversions from XML strings
+      expect(typeof result.numberComponentErrors).toBe('number');
+      expect(typeof result.numberComponentsDeployed).toBe('number');
+      expect(typeof result.numberComponentsTotal).toBe('number');
+      expect(typeof result.numberTestErrors).toBe('number');
+      expect(typeof result.numberTestsCompleted).toBe('number');
+      expect(typeof result.numberTestsTotal).toBe('number');
+
+      expect(result.numberComponentErrors).toBe(0);
+      expect(result.numberComponentsDeployed).toBe(5);
+      expect(result.numberComponentsTotal).toBe(5);
+
+      // Verify details arrays
+      expect(result.details).toBeDefined();
+      expect(Array.isArray(result.details!.componentSuccesses)).toBe(true);
+      expect(result.details!.componentSuccesses.length).toBe(2);
+      expect(Array.isArray(result.details!.componentFailures)).toBe(true);
+      // Empty XML element <componentFailures/> becomes array with empty item after parsing
+      expect(result.details!.componentFailures.length).toBeGreaterThanOrEqual(0);
+
+      // Verify boolean conversion in nested objects
+      expect(typeof result.details!.componentSuccesses[0].success).toBe('boolean');
+      expect(result.details!.componentSuccesses[0].success).toBe(true);
+    });
+  });
+});

--- a/libs/salesforce-api/src/lib/__tests__/callout-adapter.spec.ts
+++ b/libs/salesforce-api/src/lib/__tests__/callout-adapter.spec.ts
@@ -1,0 +1,688 @@
+import { describe, expect, it, vi } from 'vitest';
+import { ApiRequestError, getApiRequestFactoryFn } from '../callout-adapter';
+import type { FetchFn } from '../types';
+
+// Mock XML responses from Salesforce
+const MOCK_RESPONSES = {
+  SOAP_DESCRIBE_METADATA: `<?xml version="1.0" encoding="UTF-8"?><soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns="http://soap.sforce.com/2006/04/metadata"><soapenv:Body><describeMetadataResponse><result><metadataObjects><directoryName>installedPackages</directoryName><inFolder>false</inFolder><metaFile>false</metaFile><suffix>installedPackage</suffix><xmlName>InstalledPackage</xmlName></metadataObjects><metadataObjects><childXmlNames>CustomLabel</childXmlNames><directoryName>labels</directoryName><inFolder>false</inFolder><metaFile>false</metaFile><suffix>labels</suffix><xmlName>CustomLabels</xmlName></metadataObjects><organizationNamespace></organizationNamespace><partialSaveAllowed>true</partialSaveAllowed><testRequired>false</testRequired></result></describeMetadataResponse></soapenv:Body></soapenv:Envelope>`,
+
+  SOAP_EMPTY_LIST_METADATA: `<?xml version="1.0" encoding="UTF-8"?><soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns="http://soap.sforce.com/2006/04/metadata"><soapenv:Body><listMetadataResponse/></soapenv:Body></soapenv:Envelope>`,
+
+  SOAP_LIST_METADATA_WITH_RESULTS: `<?xml version="1.0" encoding="UTF-8"?>
+<soapenv:Envelope
+	xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
+	xmlns="http://soap.sforce.com/2006/04/metadata">
+	<soapenv:Body>
+		<listMetadataResponse>
+			<result>
+				<createdById>0056g000004tCpaAAE</createdById>
+				<createdByName>Austin Turner</createdByName>
+				<createdDate>2021-10-01T02:46:23.000Z</createdDate>
+				<fileName>classes/SBQQ__FieldDescriptorTests.cls</fileName>
+				<fullName>SBQQ__FieldDescriptorTests</fullName>
+				<id>01p6g00000RGbskAAD</id>
+				<lastModifiedById>0056g000004tCpaAAE</lastModifiedById>
+				<lastModifiedByName>Austin Turner</lastModifiedByName>
+				<lastModifiedDate>2021-10-01T02:46:23.000Z</lastModifiedDate>
+				<manageableState>installed</manageableState>
+				<namespacePrefix>SBQQ</namespacePrefix>
+				<type>ApexClass</type>
+			</result>
+			<result>
+				<createdById>0056g000004tCpaAAE</createdById>
+				<createdByName>Austin Turner</createdByName>
+				<createdDate>2022-03-02T02:52:39.000Z</createdDate>
+				<fileName>classes/ProjectCalloutServiceMockFailure.cls</fileName>
+				<fullName>ProjectCalloutServiceMockFailure</fullName>
+				<id>01p6g00000SlXzQAAV</id>
+				<lastModifiedById>0056g000004tCpaAAE</lastModifiedById>
+				<lastModifiedByName>Austin Turner</lastModifiedByName>
+				<lastModifiedDate>2022-03-02T02:52:39.000Z</lastModifiedDate>
+				<manageableState>unmanaged</manageableState>
+				<type>ApexClass</type>
+			</result>
+		</listMetadataResponse>
+	</soapenv:Body>
+</soapenv:Envelope>`,
+
+  SOAP_RETRIEVE_RESPONSE: `<?xml version="1.0" encoding="UTF-8"?><soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns="http://soap.sforce.com/2006/04/metadata"><soapenv:Body><retrieveResponse><result><done>false</done><id>09SKf000002knYIMAY</id><state>Queued</state></result></retrieveResponse></soapenv:Body></soapenv:Envelope>`,
+
+  SOAP_CHECK_RETRIEVE_STATUS: `<?xml version="1.0" encoding="UTF-8"?><soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns="http://soap.sforce.com/2006/04/metadata"><soapenv:Body><checkRetrieveStatusResponse><result><done>true</done><fileProperties><createdById>0056g000004tCpaAAE</createdById><createdByName>Austin Turner</createdByName><createdDate>2021-02-01T03:16:19.000Z</createdDate><fileName>classes/AddPrimaryContactTest.cls</fileName><fullName>AddPrimaryContactTest</fullName><id>01p6g00000RikTBAAZ</id><lastModifiedById>0056g000004tCpaAAE</lastModifiedById><lastModifiedByName>Austin Turner</lastModifiedByName><lastModifiedDate>2022-03-02T02:52:38.000Z</lastModifiedDate><manageableState>unmanaged</manageableState><type>ApexClass</type></fileProperties><id>09SKf000002knYIMAY</id><status>Succeeded</status><success>true</success><zipFile>UEsDBBQACAgIAJl8TFwAAAA=</zipFile></result></checkRetrieveStatusResponse></soapenv:Body></soapenv:Envelope>`,
+
+  SOAP_EXECUTE_ANONYMOUS: `<?xml version="1.0" encoding="UTF-8"?><soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns="http://soap.sforce.com/2006/08/apex" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><soapenv:Header><DebuggingInfo><debugLog>65.0 APEX_CODE,FINEST
+Execute Anonymous: System.debug(&apos;test&apos;);
+07:37:50.55 (56900211)|USER_DEBUG|[1]|DEBUG|test
+</debugLog></DebuggingInfo></soapenv:Header><soapenv:Body><executeAnonymousResponse><result><column>-1</column><compileProblem xsi:nil="true"/><compiled>true</compiled><exceptionMessage xsi:nil="true"/><exceptionStackTrace xsi:nil="true"/><line>-1</line><success>true</success></result></executeAnonymousResponse></soapenv:Body></soapenv:Envelope>`,
+
+  XML_SOBJECT_DESCRIBE: `<?xml version="1.0" encoding="UTF-8"?>
+<Account xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <objectDescribe>
+        <activateable>false</activateable>
+        <associateEntityType xsi:nil="true"/>
+        <associateParentEntity xsi:nil="true"/>
+        <createable>true</createable>
+        <custom>false</custom>
+        <customSetting>false</customSetting>
+        <keyPrefix>001</keyPrefix>
+        <label>Account</label>
+        <labelPlural>Accounts</labelPlural>
+        <name>Account</name>
+        <queryable>true</queryable>
+    </objectDescribe>
+    <recentItems type="Account" url="/services/data/v65.0/sobjects/Account/001Kf00001FGIvKIAX">
+        <Id>001Kf00001FGIvKIAX</Id>
+        <Name>dsfds</Name>
+    </recentItems>
+    <recentItems type="Account" url="/services/data/v65.0/sobjects/Account/001Kf00001FGGCiIAP">
+        <Id>001Kf00001FGGCiIAP</Id>
+        <Name>test</Name>
+    </recentItems>
+</Account>`,
+
+  SOAP_ERROR_INVALID_SESSION: `<?xml version="1.0" encoding="UTF-8"?><soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:sf="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><soapenv:Body><soapenv:Fault><faultcode>sf:INVALID_SESSION_ID</faultcode><faultstring>INVALID_SESSION_ID: Invalid Session ID found in SessionHeader: Illegal Session</faultstring></soapenv:Fault></soapenv:Body></soapenv:Envelope>`,
+
+  SOAP_ERROR_GENERIC: `<?xml version="1.0" encoding="UTF-8"?><soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"><soapenv:Body><soapenv:Fault><faultcode>soapenv:Client</faultcode><faultstring>Invalid request data</faultstring></soapenv:Fault></soapenv:Body></soapenv:Envelope>`,
+
+  BULK_XML_ERROR: `<?xml version="1.0" encoding="UTF-8"?><error xmlns="http://www.force.com/2009/06/asyncapi/dataload"><exceptionCode>InvalidBatch</exceptionCode><exceptionMessage>Records not found for this batch</exceptionMessage></error>`,
+
+  BULK_JOB_INFO_OPEN: `<?xml version="1.0" encoding="UTF-8"?><jobInfo
+   xmlns="http://www.force.com/2009/06/asyncapi/dataload">
+ <id>750Kf00000R1wzRIAR</id>
+ <operation>update</operation>
+ <object>Account</object>
+ <createdById>0056g000004tCpaAAE</createdById>
+ <createdDate>2026-02-12T15:43:48.000Z</createdDate>
+ <systemModstamp>2026-02-12T15:43:48.000Z</systemModstamp>
+ <state>Open</state>
+ <concurrencyMode>Parallel</concurrencyMode>
+ <contentType>CSV</contentType>
+ <numberBatchesQueued>0</numberBatchesQueued>
+ <numberBatchesInProgress>0</numberBatchesInProgress>
+ <numberBatchesCompleted>0</numberBatchesCompleted>
+ <numberBatchesFailed>0</numberBatchesFailed>
+ <numberBatchesTotal>0</numberBatchesTotal>
+ <numberRecordsProcessed>0</numberRecordsProcessed>
+ <numberRetries>0</numberRetries>
+ <apiVersion>65.0</apiVersion>
+ <numberRecordsFailed>0</numberRecordsFailed>
+ <totalProcessingTime>0</totalProcessingTime>
+ <apiActiveProcessingTime>0</apiActiveProcessingTime>
+ <apexProcessingTime>0</apexProcessingTime>
+</jobInfo>`,
+
+  BULK_BATCH_INFO: `<?xml version="1.0" encoding="UTF-8"?><batchInfo
+   xmlns="http://www.force.com/2009/06/asyncapi/dataload">
+ <id>751Kf000018uaV7IAI</id>
+ <jobId>750Kf00000R1wzRIAR</jobId>
+ <state>Queued</state>
+ <createdDate>2026-02-12T15:44:04.000Z</createdDate>
+ <systemModstamp>2026-02-12T15:44:04.000Z</systemModstamp>
+ <numberRecordsProcessed>0</numberRecordsProcessed>
+ <numberRecordsFailed>0</numberRecordsFailed>
+ <totalProcessingTime>0</totalProcessingTime>
+ <apiActiveProcessingTime>0</apiActiveProcessingTime>
+ <apexProcessingTime>0</apexProcessingTime>
+</batchInfo>`,
+
+  BULK_JOB_INFO_CLOSED: `<?xml version="1.0" encoding="UTF-8"?><jobInfo
+   xmlns="http://www.force.com/2009/06/asyncapi/dataload">
+ <id>750Kf00000R1wzRIAR</id>
+ <operation>update</operation>
+ <object>Account</object>
+ <createdById>0056g000004tCpaAAE</createdById>
+ <createdDate>2026-02-12T15:43:48.000Z</createdDate>
+ <systemModstamp>2026-02-12T15:44:11.000Z</systemModstamp>
+ <state>Closed</state>
+ <concurrencyMode>Parallel</concurrencyMode>
+ <contentType>CSV</contentType>
+ <numberBatchesQueued>0</numberBatchesQueued>
+ <numberBatchesInProgress>0</numberBatchesInProgress>
+ <numberBatchesCompleted>1</numberBatchesCompleted>
+ <numberBatchesFailed>0</numberBatchesFailed>
+ <numberBatchesTotal>1</numberBatchesTotal>
+ <numberRecordsProcessed>251</numberRecordsProcessed>
+ <numberRetries>0</numberRetries>
+ <apiVersion>65.0</apiVersion>
+ <numberRecordsFailed>251</numberRecordsFailed>
+ <totalProcessingTime>741</totalProcessingTime>
+ <apiActiveProcessingTime>497</apiActiveProcessingTime>
+ <apexProcessingTime>0</apexProcessingTime>
+</jobInfo>`,
+
+  BULK_BATCH_INFO_LIST: `<?xml version="1.0" encoding="UTF-8"?><batchInfoList
+   xmlns="http://www.force.com/2009/06/asyncapi/dataload">
+ <batchInfo>
+  <id>751Kf000018uaV7IAI</id>
+  <jobId>750Kf00000R1wzRIAR</jobId>
+  <state>Completed</state>
+  <createdDate>2026-02-12T15:44:04.000Z</createdDate>
+  <systemModstamp>2026-02-12T15:44:06.000Z</systemModstamp>
+  <numberRecordsProcessed>251</numberRecordsProcessed>
+  <numberRecordsFailed>251</numberRecordsFailed>
+  <totalProcessingTime>741</totalProcessingTime>
+  <apiActiveProcessingTime>497</apiActiveProcessingTime>
+  <apexProcessingTime>0</apexProcessingTime>
+ </batchInfo>
+</batchInfoList>`,
+};
+
+describe('callout-adapter XML parsing', () => {
+  const mockSessionInfo = {
+    accessToken: 'test-token',
+    instanceUrl: 'https://test.salesforce.com',
+    apiVersion: '65.0',
+    userId: 'test-user-id',
+    organizationId: 'test-org-id',
+  };
+
+  // Helper to find a key that contains a specific string (handles namespace variations)
+  const findKey = (obj: any, search: string): string | undefined => {
+    return Object.keys(obj).find((k) => k.includes(search));
+  };
+
+  // Helper to navigate SOAP envelope structure (handles different namespace prefixes)
+  const getSoapBody = (result: any): any => {
+    const envelopeKey = findKey(result, 'Envelope');
+    if (!envelopeKey) throw new Error('No Envelope found in result');
+    const envelope = result[envelopeKey];
+    const bodyKey = findKey(envelope, 'Body');
+    if (!bodyKey) throw new Error('No Body found in envelope');
+    return envelope[bodyKey];
+  };
+
+  // Helper to get SOAP header
+  const getSoapHeader = (result: any): any => {
+    const envelopeKey = findKey(result, 'Envelope');
+    if (!envelopeKey) throw new Error('No Envelope found in result');
+    const envelope = result[envelopeKey];
+    const headerKey = findKey(envelope, 'Header');
+    if (!headerKey) throw new Error('No Header found in envelope');
+    return envelope[headerKey];
+  };
+
+  // Helper to create a mock fetch function
+  const createMockFetch = (responses: Record<string, { status: number; body: string; headers?: Record<string, string> }>): FetchFn => {
+    return vi.fn((url: string | URL, options?: RequestInit) => {
+      const urlStr = typeof url === 'string' ? url : url.toString();
+      const matchedKey = Object.keys(responses).find((key) => urlStr.includes(key));
+
+      if (!matchedKey) {
+        throw new Error(`No mock response for URL: ${urlStr}`);
+      }
+
+      const mockResponse = responses[matchedKey];
+      const headers = new Headers({
+        'content-type': 'text/xml; charset=UTF-8',
+        ...mockResponse.headers,
+      });
+
+      return Promise.resolve({
+        ok: mockResponse.status >= 200 && mockResponse.status < 300,
+        status: mockResponse.status,
+        statusText: mockResponse.status === 200 ? 'OK' : 'Error',
+        headers,
+        type: 'basic' as ResponseType,
+        url: urlStr,
+        text: () => Promise.resolve(mockResponse.body),
+        json: () => Promise.reject(new Error('Not JSON')),
+        clone() {
+          return this;
+        },
+      } as any);
+    }) as FetchFn;
+  };
+
+  describe('SOAP XML parsing (outputType: soap)', () => {
+    it('should parse describeMetadata SOAP response', async () => {
+      const mockFetch = createMockFetch({
+        '/services/Soap/m/': { status: 200, body: MOCK_RESPONSES.SOAP_DESCRIBE_METADATA },
+      });
+
+      const apiRequest = getApiRequestFactoryFn(mockFetch)();
+      const result = await apiRequest({
+        url: '/services/Soap/m/65.0',
+        method: 'POST',
+        sessionInfo: mockSessionInfo,
+        outputType: 'soap',
+      });
+
+      expect(result).toBeDefined();
+      const body = getSoapBody(result);
+      expect(body).toHaveProperty('describeMetadataResponse');
+      expect(body.describeMetadataResponse).toHaveProperty('result');
+      expect(body.describeMetadataResponse.result).toHaveProperty('metadataObjects');
+    });
+
+    it('should parse empty listMetadata SOAP response', async () => {
+      const mockFetch = createMockFetch({
+        '/services/Soap/m/': { status: 200, body: MOCK_RESPONSES.SOAP_EMPTY_LIST_METADATA },
+      });
+
+      const apiRequest = getApiRequestFactoryFn(mockFetch)();
+      const result = await apiRequest({
+        url: '/services/Soap/m/65.0',
+        method: 'POST',
+        sessionInfo: mockSessionInfo,
+        outputType: 'soap',
+      });
+
+      expect(result).toBeDefined();
+      const body = getSoapBody(result);
+      expect(body).toHaveProperty('listMetadataResponse');
+    });
+
+    it('should parse listMetadata SOAP response with multiple results', async () => {
+      const mockFetch = createMockFetch({
+        '/services/Soap/m/': { status: 200, body: MOCK_RESPONSES.SOAP_LIST_METADATA_WITH_RESULTS },
+      });
+
+      const apiRequest = getApiRequestFactoryFn(mockFetch)();
+      const result = await apiRequest({
+        url: '/services/Soap/m/65.0',
+        method: 'POST',
+        sessionInfo: mockSessionInfo,
+        outputType: 'soap',
+      });
+
+      expect(result).toBeDefined();
+      const body = getSoapBody(result);
+      const response = body.listMetadataResponse;
+      expect(response).toHaveProperty('result');
+
+      // Should have multiple results - parser may return array or single object
+      const results = Array.isArray(response.result) ? response.result : [response.result];
+      expect(results.length).toBeGreaterThan(0);
+      expect(results[0]).toHaveProperty('fullName');
+      expect(results[0]).toHaveProperty('fileName');
+      expect(results[0]).toHaveProperty('type');
+    });
+
+    it('should parse retrieve SOAP response', async () => {
+      const mockFetch = createMockFetch({
+        '/services/Soap/m/': { status: 200, body: MOCK_RESPONSES.SOAP_RETRIEVE_RESPONSE },
+      });
+
+      const apiRequest = getApiRequestFactoryFn(mockFetch)();
+      const result = await apiRequest({
+        url: '/services/Soap/m/65.0',
+        method: 'POST',
+        sessionInfo: mockSessionInfo,
+        outputType: 'soap',
+      });
+
+      expect(result).toBeDefined();
+      const body = getSoapBody(result);
+      const response = body.retrieveResponse;
+      expect(response).toHaveProperty('result');
+      expect(response.result).toHaveProperty('done');
+      expect(response.result).toHaveProperty('id');
+      expect(response.result).toHaveProperty('state');
+    });
+
+    it('should parse checkRetrieveStatus SOAP response with zipFile', async () => {
+      const mockFetch = createMockFetch({
+        '/services/Soap/m/': { status: 200, body: MOCK_RESPONSES.SOAP_CHECK_RETRIEVE_STATUS },
+      });
+
+      const apiRequest = getApiRequestFactoryFn(mockFetch)();
+      const result = await apiRequest({
+        url: '/services/Soap/m/65.0',
+        method: 'POST',
+        sessionInfo: mockSessionInfo,
+        outputType: 'soap',
+      });
+
+      expect(result).toBeDefined();
+      const body = getSoapBody(result);
+      const response = body.checkRetrieveStatusResponse;
+      expect(response).toHaveProperty('result');
+      expect(response.result).toHaveProperty('done');
+      expect(response.result).toHaveProperty('fileProperties');
+      expect(response.result).toHaveProperty('zipFile');
+      expect(response.result.zipFile).toBeTruthy();
+    });
+
+    it('should parse executeAnonymous SOAP response with header', async () => {
+      const mockFetch = createMockFetch({
+        '/services/Soap/s/': { status: 200, body: MOCK_RESPONSES.SOAP_EXECUTE_ANONYMOUS },
+      });
+
+      const apiRequest = getApiRequestFactoryFn(mockFetch)();
+      const result = await apiRequest({
+        url: '/services/Soap/s/65.0',
+        method: 'POST',
+        sessionInfo: mockSessionInfo,
+        outputType: 'soap',
+      });
+
+      expect(result).toBeDefined();
+      const header = getSoapHeader(result);
+      expect(header).toHaveProperty('DebuggingInfo');
+      expect(header.DebuggingInfo).toHaveProperty('debugLog');
+
+      const body = getSoapBody(result);
+      const response = body.executeAnonymousResponse;
+      expect(response).toHaveProperty('result');
+      expect(response.result).toHaveProperty('compiled');
+      expect(response.result).toHaveProperty('success');
+    });
+  });
+
+  describe('XML parsing (outputType: xml)', () => {
+    it('should parse sObject describe XML response', async () => {
+      const mockFetch = createMockFetch({
+        '/services/data/': { status: 200, body: MOCK_RESPONSES.XML_SOBJECT_DESCRIBE },
+      });
+
+      const apiRequest = getApiRequestFactoryFn(mockFetch)();
+      const result = await apiRequest({
+        url: '/services/data/v65.0/sobjects/Account/describe',
+        method: 'GET',
+        sessionInfo: mockSessionInfo,
+        outputType: 'xml',
+      });
+
+      expect(result).toBeDefined();
+      const account = result as any;
+      expect(account).toHaveProperty('Account');
+      expect(account.Account).toHaveProperty('objectDescribe');
+      expect(account.Account.objectDescribe).toHaveProperty('label');
+      expect(account.Account.objectDescribe.label).toBe('Account');
+      expect(account.Account).toHaveProperty('recentItems');
+
+      // Check recent items
+      const recentItems = Array.isArray(account.Account.recentItems) ? account.Account.recentItems : [account.Account.recentItems];
+      expect(recentItems.length).toBeGreaterThan(0);
+      expect(recentItems[0]).toHaveProperty('Id');
+      expect(recentItems[0]).toHaveProperty('Name');
+    });
+
+    it('should parse Bulk API jobInfo (open state)', async () => {
+      const mockFetch = createMockFetch({
+        '/services/async/': { status: 200, body: MOCK_RESPONSES.BULK_JOB_INFO_OPEN },
+      });
+
+      const apiRequest = getApiRequestFactoryFn(mockFetch)();
+      const result = await apiRequest({
+        url: '/services/async/65.0/job',
+        method: 'POST',
+        sessionInfo: mockSessionInfo,
+        outputType: 'xml',
+      });
+
+      expect(result).toBeDefined();
+      const data = result as any;
+      expect(data).toHaveProperty('jobInfo');
+      expect(data.jobInfo).toHaveProperty('id');
+      expect(data.jobInfo).toHaveProperty('operation');
+      expect(data.jobInfo).toHaveProperty('object');
+      expect(data.jobInfo).toHaveProperty('state');
+      expect(data.jobInfo.state).toBe('Open');
+      expect(data.jobInfo).toHaveProperty('numberBatchesTotal');
+      expect(data.jobInfo).toHaveProperty('numberRecordsProcessed');
+    });
+
+    it('should parse Bulk API jobInfo (closed state)', async () => {
+      const mockFetch = createMockFetch({
+        '/services/async/': { status: 200, body: MOCK_RESPONSES.BULK_JOB_INFO_CLOSED },
+      });
+
+      const apiRequest = getApiRequestFactoryFn(mockFetch)();
+      const result = await apiRequest({
+        url: '/services/async/65.0/job/750Kf00000R1wzRIAR',
+        method: 'GET',
+        sessionInfo: mockSessionInfo,
+        outputType: 'xml',
+      });
+
+      expect(result).toBeDefined();
+      const data = result as any;
+      expect(data).toHaveProperty('jobInfo');
+      expect(data.jobInfo.state).toBe('Closed');
+      expect(data.jobInfo.numberBatchesCompleted).toBe(1);
+      expect(data.jobInfo.numberRecordsProcessed).toBe(251);
+      expect(data.jobInfo.numberRecordsFailed).toBe(251);
+    });
+
+    it('should parse Bulk API batchInfo', async () => {
+      const mockFetch = createMockFetch({
+        '/services/async/': { status: 200, body: MOCK_RESPONSES.BULK_BATCH_INFO },
+      });
+
+      const apiRequest = getApiRequestFactoryFn(mockFetch)();
+      const result = await apiRequest({
+        url: '/services/async/65.0/job/750Kf00000R1wzRIAR/batch',
+        method: 'POST',
+        sessionInfo: mockSessionInfo,
+        outputType: 'xml',
+      });
+
+      expect(result).toBeDefined();
+      const data = result as any;
+      expect(data).toHaveProperty('batchInfo');
+      expect(data.batchInfo).toHaveProperty('id');
+      expect(data.batchInfo).toHaveProperty('jobId');
+      expect(data.batchInfo).toHaveProperty('state');
+      expect(data.batchInfo.state).toBe('Queued');
+      expect(data.batchInfo).toHaveProperty('numberRecordsProcessed');
+      expect(data.batchInfo).toHaveProperty('numberRecordsFailed');
+    });
+
+    it('should parse Bulk API batchInfoList', async () => {
+      const mockFetch = createMockFetch({
+        '/services/async/': { status: 200, body: MOCK_RESPONSES.BULK_BATCH_INFO_LIST },
+      });
+
+      const apiRequest = getApiRequestFactoryFn(mockFetch)();
+      const result = await apiRequest({
+        url: '/services/async/65.0/job/750Kf00000R1wzRIAR/batch',
+        method: 'GET',
+        sessionInfo: mockSessionInfo,
+        outputType: 'xml',
+      });
+
+      expect(result).toBeDefined();
+      const data = result as any;
+      expect(data).toHaveProperty('batchInfoList');
+      expect(data.batchInfoList).toHaveProperty('batchInfo');
+
+      // batchInfo may be array or single object depending on parser
+      const batchInfos = Array.isArray(data.batchInfoList.batchInfo) ? data.batchInfoList.batchInfo : [data.batchInfoList.batchInfo];
+
+      expect(batchInfos.length).toBeGreaterThan(0);
+      expect(batchInfos[0]).toHaveProperty('id');
+      expect(batchInfos[0]).toHaveProperty('jobId');
+      expect(batchInfos[0]).toHaveProperty('state');
+      expect(batchInfos[0].state).toBe('Completed');
+    });
+  });
+
+  describe('SOAP error parsing', () => {
+    it('should extract error message from SOAP fault response', async () => {
+      const mockFetch = createMockFetch({
+        '/services/Soap/m/': { status: 500, body: MOCK_RESPONSES.SOAP_ERROR_GENERIC },
+      });
+
+      const apiRequest = getApiRequestFactoryFn(mockFetch)();
+
+      await expect(async () => {
+        await apiRequest({
+          url: '/services/Soap/m/65.0',
+          method: 'POST',
+          sessionInfo: mockSessionInfo,
+          outputType: 'soap',
+        });
+      }).rejects.toThrow(ApiRequestError);
+
+      try {
+        await apiRequest({
+          url: '/services/Soap/m/65.0',
+          method: 'POST',
+          sessionInfo: mockSessionInfo,
+          outputType: 'soap',
+        });
+      } catch (error) {
+        expect(error).toBeInstanceOf(ApiRequestError);
+        expect((error as ApiRequestError).message).toBe('Invalid request data');
+      }
+    });
+
+    it('should extract error message from INVALID_SESSION_ID SOAP fault', async () => {
+      const mockFetch = createMockFetch({
+        '/services/Soap/m/': { status: 500, body: MOCK_RESPONSES.SOAP_ERROR_INVALID_SESSION },
+      });
+
+      const apiRequest = getApiRequestFactoryFn(mockFetch)();
+
+      try {
+        await apiRequest({
+          url: '/services/Soap/m/65.0',
+          method: 'POST',
+          sessionInfo: mockSessionInfo,
+          outputType: 'soap',
+        });
+        // Should not reach here
+        expect(true).toBe(false);
+      } catch (error) {
+        expect(error).toBeInstanceOf(ApiRequestError);
+        expect((error as ApiRequestError).message).toContain('INVALID_SESSION_ID');
+      }
+    });
+  });
+
+  describe('Bulk XML error parsing', () => {
+    it('should extract error message from Bulk API XML error', async () => {
+      const mockFetch = createMockFetch({
+        '/services/async/': { status: 400, body: MOCK_RESPONSES.BULK_XML_ERROR },
+      });
+
+      const apiRequest = getApiRequestFactoryFn(mockFetch)();
+
+      try {
+        await apiRequest({
+          url: '/services/async/65.0/job/123/batch/456',
+          method: 'GET',
+          sessionInfo: mockSessionInfo,
+          outputType: 'xml',
+        });
+        // Should not reach here
+        expect(true).toBe(false);
+      } catch (error) {
+        expect(error).toBeInstanceOf(ApiRequestError);
+        expect((error as ApiRequestError).message).toBe('Records not found for this batch');
+      }
+    });
+  });
+
+  describe('Edge cases and special characters', () => {
+    it('should handle XML with attributes on elements', async () => {
+      const mockFetch = createMockFetch({
+        '/services/data/': { status: 200, body: MOCK_RESPONSES.XML_SOBJECT_DESCRIBE },
+      });
+
+      const apiRequest = getApiRequestFactoryFn(mockFetch)();
+      const result = await apiRequest({
+        url: '/services/data/v65.0/sobjects/Account/describe',
+        method: 'GET',
+        sessionInfo: mockSessionInfo,
+        outputType: 'xml',
+      });
+
+      const account = result as any;
+      const recentItems = Array.isArray(account.Account.recentItems) ? account.Account.recentItems : [account.Account.recentItems];
+
+      // Check that attributes are preserved (different parsers may use @attr or just attr)
+      const firstItem = recentItems[0];
+      const hasTypeAttr = firstItem['@_type'] || firstItem.type;
+      expect(hasTypeAttr).toBeTruthy();
+      // If attributes are preserved with @, check they match expected values
+      if (firstItem['@_type']) {
+        expect(firstItem['@_type']).toBe('Account');
+      }
+    });
+
+    it('should handle empty elements', async () => {
+      const mockFetch = createMockFetch({
+        '/services/Soap/m/': { status: 200, body: MOCK_RESPONSES.SOAP_EMPTY_LIST_METADATA },
+      });
+
+      const apiRequest = getApiRequestFactoryFn(mockFetch)();
+      const result = await apiRequest({
+        url: '/services/Soap/m/65.0',
+        method: 'POST',
+        sessionInfo: mockSessionInfo,
+        outputType: 'soap',
+      });
+
+      expect(result).toBeDefined();
+      const body = getSoapBody(result);
+      expect(body.listMetadataResponse).toBeDefined();
+    });
+
+    it('should handle xsi:nil attributes', async () => {
+      const mockFetch = createMockFetch({
+        '/services/Soap/s/': { status: 200, body: MOCK_RESPONSES.SOAP_EXECUTE_ANONYMOUS },
+      });
+
+      const apiRequest = getApiRequestFactoryFn(mockFetch)();
+      const result = await apiRequest({
+        url: '/services/Soap/s/65.0',
+        method: 'POST',
+        sessionInfo: mockSessionInfo,
+        outputType: 'soap',
+      });
+
+      const body = getSoapBody(result);
+      const resultData = body.executeAnonymousResponse.result;
+
+      // Elements with xsi:nil="true" should be present (may be null/undefined or have @_nil attribute)
+      expect(resultData).toHaveProperty('compileProblem');
+      expect(resultData).toHaveProperty('exceptionMessage');
+      expect(resultData).toHaveProperty('exceptionStackTrace');
+    });
+  });
+
+  describe('Namespace handling', () => {
+    it('should preserve or normalize namespace prefixes in SOAP responses', async () => {
+      const mockFetch = createMockFetch({
+        '/services/Soap/m/': { status: 200, body: MOCK_RESPONSES.SOAP_DESCRIBE_METADATA },
+      });
+
+      const apiRequest = getApiRequestFactoryFn(mockFetch)();
+      const result = await apiRequest({
+        url: '/services/Soap/m/65.0',
+        method: 'POST',
+        sessionInfo: mockSessionInfo,
+        outputType: 'soap',
+      });
+
+      expect(result).toBeDefined();
+      // Check that some form of Envelope exists (namespace prefix may vary)
+      const envelopeKey = findKey(result as any, 'Envelope');
+      expect(envelopeKey).toBeDefined();
+    });
+
+    it('should handle default namespace in XML responses', async () => {
+      const mockFetch = createMockFetch({
+        '/services/Soap/m/': { status: 200, body: MOCK_RESPONSES.SOAP_LIST_METADATA_WITH_RESULTS },
+      });
+
+      const apiRequest = getApiRequestFactoryFn(mockFetch)();
+      const result = await apiRequest({
+        url: '/services/Soap/m/65.0',
+        method: 'POST',
+        sessionInfo: mockSessionInfo,
+        outputType: 'soap',
+      });
+
+      const body = getSoapBody(result);
+      const response = body.listMetadataResponse;
+
+      // Elements without namespace prefix should still be accessible
+      expect(response.result).toBeDefined();
+      const results = Array.isArray(response.result) ? response.result : [response.result];
+      expect(results[0]).toHaveProperty('createdById');
+      expect(results[0]).toHaveProperty('fullName');
+    });
+  });
+});

--- a/libs/salesforce-api/src/lib/__tests__/salesforce-package.utils.spec.ts
+++ b/libs/salesforce-api/src/lib/__tests__/salesforce-package.utils.spec.ts
@@ -52,7 +52,8 @@ describe('buildPackageXml', () => {
     <name>ApexPage</name>
   </types>
   <version>60.0</version>
-</Package>`);
+</Package>
+`);
   });
 });
 
@@ -61,13 +62,19 @@ describe('getRetrieveRequestFromManifest', () => {
     expect(
       getRetrieveRequestFromManifest(`<?xml version="1.0" encoding="UTF-8"?>
 <Package xmlns="http://soap.sforce.com/2006/04/metadata">
+  <!--Comments should be ignored 1-->
   <types>
     <members>AccountOverrideControllerExt</members>
     <members>AccountTriggerHandler</members>
     <members>AddPrimaryContact</members>
-    <members>ApexUtilsTest</members>
+    <members>
+      <!--Spaces and whitespace should be trimmed-->
+      ApexUtilsTest
+    </members>
     <members>SBQQ__AccountExtController</members>
-    <name>ApexClass</name>
+    <!--Spaces and whitespace should be trimmed-->
+    <name>   ApexClass
+    </name>
   </types>
   <types>
     <members>SiteFooter</members>
@@ -77,6 +84,7 @@ describe('getRetrieveRequestFromManifest', () => {
     <members>AnswersHome</members>
     <name>ApexPage</name>
   </types>
+  <!--Comments should be ignored 2-->
   <version>60.0</version>
 </Package>`),
     ).toEqual({

--- a/libs/salesforce-api/src/lib/api-apex.ts
+++ b/libs/salesforce-api/src/lib/api-apex.ts
@@ -1,6 +1,5 @@
-import { getValueOrSoapNull, toBoolean, unSanitizeXml } from '@jetstream/shared/utils';
+import { getValueOrSoapNull, unSanitizeXml } from '@jetstream/shared/utils';
 import { AnonymousApexResponse, ApexCompletionResponse, Maybe } from '@jetstream/types';
-import toNumber from 'lodash/toNumber';
 import { ApiConnection } from './connection';
 import { SalesforceApi } from './utils';
 
@@ -29,7 +28,7 @@ export class ApiApex extends SalesforceApi {
     };
 
     return this.apiRequest<{
-      'ns1:Envelope': {
+      Envelope: {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         Body: Record<string, any>;
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -45,18 +44,18 @@ export class ApiApex extends SalesforceApi {
       }),
     }).then((soapResponse) => {
       // FIXME: if we fail here, we should return a proper error
-      const header = soapResponse['ns1:Envelope']?.['Header'];
-      const body = soapResponse['ns1:Envelope']?.['Body']?.executeAnonymousResponse?.result || {};
+      const header = soapResponse.Envelope?.Header;
+      const body = soapResponse.Envelope?.Body?.executeAnonymousResponse?.result || {};
       const results: AnonymousApexResponse = {
         debugLog: header?.DebuggingInfo?.debugLog || '',
         result: {
-          column: toNumber(getValueOrSoapNull(body.column) || -1),
-          compileProblem: getValueOrSoapNull(body.compileProblem) || null,
-          compiled: toBoolean(getValueOrSoapNull(body.compiled)) || false,
-          exceptionMessage: getValueOrSoapNull(body.exceptionMessage) || null,
-          exceptionStackTrace: getValueOrSoapNull(body.exceptionStackTrace) || null,
-          line: toNumber(getValueOrSoapNull(body.line)) || -1,
-          success: toBoolean(getValueOrSoapNull(body.success)) || false,
+          column: (getValueOrSoapNull(body.column) as number) || -1,
+          compileProblem: (getValueOrSoapNull(body.compileProblem) as string) || null,
+          compiled: (getValueOrSoapNull(body.compiled) as boolean) || false,
+          exceptionMessage: (getValueOrSoapNull(body.exceptionMessage) as string) || null,
+          exceptionStackTrace: (getValueOrSoapNull(body.exceptionStackTrace) as string) || null,
+          line: (getValueOrSoapNull(body.line) as number) || -1,
+          success: (getValueOrSoapNull(body.success) as boolean) || false,
         },
       };
       if (typeof results.debugLog !== 'string') {

--- a/libs/salesforce-api/src/lib/api-metadata.ts
+++ b/libs/salesforce-api/src/lib/api-metadata.ts
@@ -29,7 +29,7 @@ export class ApiMetadata extends SalesforceApi {
   async describe(): Promise<DescribeMetadataResult> {
     // for some types, if folder is null then no data will be returned
     return this.apiRequest<{
-      'ns1:Envelope': {
+      Envelope: {
         Body: {
           describeMetadataResponse: {
             result: DescribeMetadataResult;
@@ -44,9 +44,10 @@ export class ApiMetadata extends SalesforceApi {
         },
       }),
     )
-      .then((response) => correctInvalidXmlResponseTypes(response['ns1:Envelope'].Body.describeMetadataResponse.result))
+      .then((response) => correctInvalidXmlResponseTypes(response.Envelope.Body.describeMetadataResponse.result))
       .then((response) => {
-        response.organizationNamespace = isString(response.organizationNamespace) ? response.organizationNamespace : null;
+        response.organizationNamespace =
+          isString(response.organizationNamespace) && response.organizationNamespace ? response.organizationNamespace : null;
         response.partialSaveAllowed = correctInvalidXmlResponseTypes(response.partialSaveAllowed);
         response.testRequired = correctInvalidXmlResponseTypes(response.testRequired);
         response.metadataObjects = correctInvalidArrayXmlResponseTypes(response.metadataObjects).map((item) => {
@@ -72,7 +73,7 @@ export class ApiMetadata extends SalesforceApi {
           },
         },
       }),
-    ).then((response) => correctInvalidArrayXmlResponseTypes(response['ns1:Envelope'].Body.listMetadataResponse?.result || []));
+    ).then((response) => correctInvalidArrayXmlResponseTypes(response.Envelope.Body.listMetadataResponse?.result || []));
   }
 
   async read(type: string, fullNames: ReadMetadataRequest['fullNames']): Promise<MetadataInfo[]> {
@@ -90,7 +91,7 @@ export class ApiMetadata extends SalesforceApi {
               },
             }),
           ).then((response) => {
-            return correctInvalidArrayXmlResponseTypes(response['ns1:Envelope'].Body.readMetadataResponse?.result.records || []);
+            return correctInvalidArrayXmlResponseTypes(response.Envelope.Body.readMetadataResponse?.result.records || []);
           }),
         ),
       )
@@ -132,7 +133,7 @@ export class ApiMetadata extends SalesforceApi {
         },
       }),
     )
-      .then((result) => result['ns1:Envelope'].Body.deployResponse.result)
+      .then((result) => result.Envelope.Body.deployResponse.result)
       .then(correctInvalidXmlResponseTypes);
   }
 
@@ -148,7 +149,7 @@ export class ApiMetadata extends SalesforceApi {
         },
       }),
     )
-      .then((result) => result['ns1:Envelope'].Body.checkDeployStatusResponse.result)
+      .then((result) => result.Envelope.Body.checkDeployStatusResponse.result)
       .then(correctDeployMetadataResultTypes);
   }
 
@@ -164,7 +165,7 @@ export class ApiMetadata extends SalesforceApi {
       .then((results) => {
         return results;
       })
-      .then((result) => correctInvalidXmlResponseTypes(result['ns1:Envelope'].Body.retrieveResponse.result));
+      .then((result) => correctInvalidXmlResponseTypes(result.Envelope.Body.retrieveResponse.result));
   }
 
   async checkRetrieveStatus(asyncProcessId: string) {
@@ -176,7 +177,7 @@ export class ApiMetadata extends SalesforceApi {
         },
       }),
     )
-      .then((result) => result['ns1:Envelope'].Body.checkRetrieveStatusResponse.result)
+      .then((result) => result.Envelope.Body.checkRetrieveStatusResponse.result)
       .then((results) => {
         results.fileProperties = ensureArray(results.fileProperties);
         results.messages = ensureArray(results.messages);

--- a/libs/salesforce-api/src/lib/api-sobject.ts
+++ b/libs/salesforce-api/src/lib/api-sobject.ts
@@ -160,7 +160,7 @@ export class ApiSObject extends SalesforceApi {
             body: { undelete: { ids } },
           }),
         ).then((response) => {
-          return correctRecordResultSoapXmlResponse(response['ns1:Envelope'].Body.undeleteResponse.result);
+          return correctRecordResultSoapXmlResponse(response.Envelope.Body.undeleteResponse.result);
         });
         break;
       }

--- a/libs/salesforce-api/src/lib/types.ts
+++ b/libs/salesforce-api/src/lib/types.ts
@@ -14,7 +14,7 @@ export interface SessionInfo {
 export type SoapNamespace = 'http://soap.sforce.com/2006/04/metadata' | 'http://soap.sforce.com/2006/08/apex';
 
 export type SoapResponse<Key extends string, T> = {
-  'ns1:Envelope': {
+  Envelope: {
     Body: Record<Key, { result: T }>;
     Header?: any;
   };
@@ -87,11 +87,9 @@ export interface ApiRequestOptions {
 export type ApiRequestOutputType = 'json' | 'text' | 'xml' | 'soap' | 'arrayBuffer' | 'stream' | 'void' | 'response';
 
 export interface SoapErrorResponse {
-  'soapenv:Envelope': {
-    '@xmlns:soapenv': string;
-    '@xmlns:sf': string;
-    'soapenv:Body': {
-      'soapenv:Fault': {
+  Envelope: {
+    Body: {
+      Fault: {
         faultcode: string;
         faultstring: string;
       };

--- a/libs/salesforce-api/src/lib/utils.ts
+++ b/libs/salesforce-api/src/lib/utils.ts
@@ -241,14 +241,14 @@ export function correctDeployMetadataResultTypes(results: DeployResult) {
 export function correctRecordResultSoapXmlResponse(results: RecordResult | RecordResult[]): RecordResult[] {
   return ensureArray(results).map((row: RecordResult) => ({
     ...row,
-    errors: (row.success as any) === 'true' ? undefined : ensureArray((row as any).errors),
+    errors: row.success ? undefined : ensureArray(row.errors),
     success: ensureBoolean(row.success),
   })) as RecordResult[];
 }
 
 export function correctInvalidArrayXmlResponseTypes<T = any>(item: T[] | T): T[] {
   if (!Array.isArray(item)) {
-    if (!item || (isObject(item) && item?.['@xsi:nil'] === 'true')) {
+    if (!item || (isObject(item) && item?.['@_nil'] === 'true')) {
       return []; // null response
     }
     item = [item] as any;
@@ -257,7 +257,7 @@ export function correctInvalidArrayXmlResponseTypes<T = any>(item: T[] | T): T[]
 }
 
 export function correctInvalidXmlResponseTypes<T = any>(item: T): T {
-  if (isObject(item) && (item?.['@xsi:nil'] === 'true' || isEmpty(item))) {
+  if (isObject(item) && (item?.['@_nil'] === 'true' || isEmpty(item))) {
     return null as any;
   }
   // TODO: what about number types?
@@ -265,7 +265,7 @@ export function correctInvalidXmlResponseTypes<T = any>(item: T): T {
     if (
       !Array.isArray((item as any)[key]) &&
       isObject((item as any)[key]) &&
-      ((item as any)[key]?.['@xsi:nil'] === 'true' || isEmpty((item as any)[key]))
+      ((item as any)[key]?.['@_nil'] === 'true' || isEmpty((item as any)[key]))
     ) {
       (item as any)[key] = null;
     } else if (isString((item as any)[key]) && ((item as any)[key] === 'true' || (item as any)[key] === 'false')) {

--- a/libs/shared/utils/src/lib/utils.ts
+++ b/libs/shared/utils/src/lib/utils.ts
@@ -579,9 +579,12 @@ export function getHttpMethod(type: InsertUpdateUpsertDelete): HttpMethod {
   }
 }
 
-export function getValueOrSoapNull(value?: string | SoapNil, unSanitize = true): string | null {
+export function getValueOrSoapNull(value?: string | number | boolean | SoapNil, unSanitize = true): string | number | boolean | null {
   if (isString(value)) {
     return unSanitize ? unSanitizeXml(value) : value;
+  }
+  if (isNumber(value) || isBoolean(value)) {
+    return value;
   }
   return null;
 }

--- a/libs/types/src/lib/salesforce/apex.types.ts
+++ b/libs/types/src/lib/salesforce/apex.types.ts
@@ -1,13 +1,13 @@
 import { SoapNil } from './misc.types';
 
 export interface AnonymousApexSoapResponse {
-  'soapenv:Envelope': {
-    'soapenv:Header': {
+  Envelope: {
+    Header: {
       DebuggingInfo: {
         debugLog: string;
       };
     };
-    'soapenv:Body': {
+    Body: {
       executeAnonymousResponse: {
         result: {
           column: string | SoapNil;

--- a/libs/types/src/lib/salesforce/record.types.ts
+++ b/libs/types/src/lib/salesforce/record.types.ts
@@ -499,7 +499,7 @@ export interface RecordTypeMetadataToolingPicklistValue {
 }
 
 export interface ReadMetadataRecordType {
-  '@xsi:type'?: 'RecordType';
+  '@_type'?: 'RecordType';
   active: boolean;
   businessProcess?: string;
   compactLayoutAssignment?: string;

--- a/package.json
+++ b/package.json
@@ -316,6 +316,7 @@
     "express-rate-limit": "^8.2.1",
     "express-session": "^1.18.2",
     "fast-jwt": "^6.0.2",
+    "fast-xml-parser": "^5.3.5",
     "file-saver": "^2.0.5",
     "filesize": "^11.0.13",
     "formulon": "^6.25.6",
@@ -372,7 +373,6 @@
     "webextension-polyfill": "^0.12.0",
     "write-file-atomic": "^7.0.0",
     "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz",
-    "xmlbuilder2": "^3.1.1",
     "zod": "^4.3.6",
     "zod-openapi": "^5.4.6"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7183,35 +7183,6 @@
   dependencies:
     "@octokit/openapi-types" "^22.2.0"
 
-"@oozcitak/dom@1.15.10":
-  version "1.15.10"
-  resolved "https://registry.yarnpkg.com/@oozcitak/dom/-/dom-1.15.10.tgz#dca7289f2b292cff2a901ea4fbbcc0a1ab0b05c2"
-  integrity sha512-0JT29/LaxVgRcGKvHmSrUTEvZ8BXvZhGl2LASRUgHqDTC1M5g1pLmVv56IYNyt3bG2CUjDkc67wnyZC14pbQrQ==
-  dependencies:
-    "@oozcitak/infra" "1.0.8"
-    "@oozcitak/url" "1.0.4"
-    "@oozcitak/util" "8.3.8"
-
-"@oozcitak/infra@1.0.8":
-  version "1.0.8"
-  resolved "https://registry.yarnpkg.com/@oozcitak/infra/-/infra-1.0.8.tgz#b0b089421f7d0f6878687608301fbaba837a7d17"
-  integrity sha512-JRAUc9VR6IGHOL7OGF+yrvs0LO8SlqGnPAMqyzOuFZPSZSXI7Xf2O9+awQPSMXgIWGtgUf/dA6Hs6X6ySEaWTg==
-  dependencies:
-    "@oozcitak/util" "8.3.8"
-
-"@oozcitak/url@1.0.4":
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/@oozcitak/url/-/url-1.0.4.tgz#ca8b1c876319cf5a648dfa1123600a6aa5cda6ba"
-  integrity sha512-kDcD8y+y3FCSOvnBI6HJgl00viO/nGbQoCINmQ0h98OhnGITrWR3bOGfwYCthgcrV8AnTJz8MzslTQbC3SOAmw==
-  dependencies:
-    "@oozcitak/infra" "1.0.8"
-    "@oozcitak/util" "8.3.8"
-
-"@oozcitak/util@8.3.8":
-  version "8.3.8"
-  resolved "https://registry.yarnpkg.com/@oozcitak/util/-/util-8.3.8.tgz#10f65fe1891fd8cde4957360835e78fd1936bfdd"
-  integrity sha512-T8TbSnGsxo6TDBJx/Sgv/BlVJL3tshxZP7Aq5R1mSnM5OcHY2dQaxLMu2+E8u3gN0MLOzdjurqN4ZRVuzQycOQ==
-
 "@oslojs/asn1@1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@oslojs/asn1/-/asn1-1.0.0.tgz#25edb31585b369efdc103e9a1eb822df9c235174"
@@ -16180,6 +16151,13 @@ fast-xml-parser@5.3.4:
   dependencies:
     strnum "^2.1.0"
 
+fast-xml-parser@^5.3.5:
+  version "5.3.5"
+  resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-5.3.5.tgz#3e914cb852e636923cb555deaa356f7366e18b49"
+  integrity sha512-JeaA2Vm9ffQKp9VjvfzObuMCjUYAp5WDYhRYL5LrBPY/jUDlUtOvDfot0vKSkB9tuX885BDHjtw4fZadD95wnA==
+  dependencies:
+    strnum "^2.1.2"
+
 fastq@^1.6.0:
   version "1.13.0"
   resolved "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz"
@@ -19129,7 +19107,7 @@ js-tokens@^9.0.1:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-9.0.1.tgz#2ec43964658435296f6761b34e10671c2d9527f4"
   integrity sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==
 
-js-yaml@3.14.1, js-yaml@^3.10.0, js-yaml@^3.13.1:
+js-yaml@^3.10.0, js-yaml@^3.13.1:
   version "3.14.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.1.tgz#dae812fdb3825fa306609a8717383c50c36a0537"
   integrity sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==
@@ -25507,6 +25485,11 @@ strnum@^2.1.0:
   resolved "https://registry.yarnpkg.com/strnum/-/strnum-2.1.1.tgz#cf2a6e0cf903728b8b2c4b971b7e36b4e82d46ab"
   integrity sha512-7ZvoFTiCnGxBtDqJ//Cu6fWtZtc7Y3x+QOirG15wztbdngGSkht27o2pyGWrVy0b4WAy3jbKmnoK6g5VlVNUUw==
 
+strnum@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/strnum/-/strnum-2.1.2.tgz#a5e00ba66ab25f9cafa3726b567ce7a49170937a"
+  integrity sha512-l63NF9y/cLROq/yqKXSLtcMeeyOfnSQlfMSlzFt/K73oIaD8DGaQWd7Z34X9GPiKqP5rbSh84Hl4bOlLcjiSrQ==
+
 strtok3@^9.0.1:
   version "9.1.1"
   resolved "https://registry.yarnpkg.com/strtok3/-/strtok3-9.1.1.tgz#f8feb188b3fcdbf9b8819cc9211a824c3731df38"
@@ -27434,16 +27417,6 @@ xml2js@^0.6.2:
   dependencies:
     sax ">=0.6.0"
     xmlbuilder "~11.0.0"
-
-xmlbuilder2@^3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/xmlbuilder2/-/xmlbuilder2-3.1.1.tgz#b977ef8a6fb27a1ea7ffa7d850d2c007ff343bc0"
-  integrity sha512-WCSfbfZnQDdLQLiMdGUQpMxxckeQ4oZNMNhLVkcekTu7xhD4tuUDyAPoY8CwXvBYE6LwBHd6QW2WZXlOWr1vCw==
-  dependencies:
-    "@oozcitak/dom" "1.15.10"
-    "@oozcitak/infra" "1.0.8"
-    "@oozcitak/util" "8.3.8"
-    js-yaml "3.14.1"
 
 xmlbuilder@>=11.0.1, xmlbuilder@^15.1.1:
   version "15.1.1"


### PR DESCRIPTION
xmlbuilder2 no longer works in browsers with their latest update which prompted this change

the new XML parser is usable in browser environments with one 1 dependency
and was already a transient dependency