### PR TITLE
fix: ensure package name is encoded

### DIFF
--- a/libs/features/deploy/src/add-to-changeset/AddToChangeset.tsx
+++ b/libs/features/deploy/src/add-to-changeset/AddToChangeset.tsx
@@ -55,7 +55,7 @@ export const AddToChangeset = ({ className, selectedOrg, loading, selectedRows }
     deployOptions: DeployOptions,
     changeset?: Maybe<ChangeSet>,
   ) {
-    setChangesetPackageName(packageName);
+    setChangesetPackageName(encodeURIComponent(packageName));
     setChangesetPackageDescription(changesetDescription);
     setDeployOptions(deployOptions);
     setSelectedChangeset(changeset);

--- a/libs/features/deploy/src/add-to-changeset/AddToChangesetConfigModal.tsx
+++ b/libs/features/deploy/src/add-to-changeset/AddToChangesetConfigModal.tsx
@@ -27,7 +27,7 @@ export interface AddToChangesetConfigModalProps {
   onChangesetPackages: (changesetPackages: ListItem<string, ChangeSet>[]) => void;
   onSelection: (changesetPackage: string) => void;
   onClose: () => void;
-  onDeploy: (changesetPackage: string, changesetDescription: string, deployOptions: DeployOptions, changeset?: Maybe<ChangeSet>) => void;
+  onDeploy: (packageName: string, changesetDescription: string, deployOptions: DeployOptions, changeset?: Maybe<ChangeSet>) => void;
 }
 
 export const AddToChangesetConfigModal: FunctionComponent<AddToChangesetConfigModalProps> = ({


### PR DESCRIPTION
Ensure that an outbound package name is encoded properly to avoid "No package.xml found"