### PR TITLE
fix: show actual error on bulk update failure

### DIFF
--- a/libs/shared/ui-core/src/mass-update-records/MassUpdateRecordsDeploymentRow.tsx
+++ b/libs/shared/ui-core/src/mass-update-records/MassUpdateRecordsDeploymentRow.tsx
@@ -56,7 +56,7 @@ export const MassUpdateRecordsDeploymentRow = ({
   const { hasGoogleDriveAccess, googleShowUpgradeToPro } = useAtomValue(googleDriveAccessState);
   const skipFrontDoorAuth = useAtomValue(selectSkipFrontdoorAuth);
 
-  const { done, processingErrors, status, jobInfo, processingEndTime, processingStartTime } = deployResults;
+  const { done, processingErrors, status, fatalErrorMessage, jobInfo, processingEndTime, processingStartTime } = deployResults;
 
   useEffect(() => {
     onModalOpenChange && onModalOpenChange(downloadModalData.open || resultsModalData.open);
@@ -260,7 +260,7 @@ export const MassUpdateRecordsDeploymentRow = ({
         )}
         {status === 'Error' && (
           <ScopedNotification theme="error" className="slds-m-around_small">
-            <SupportLink />
+            {fatalErrorMessage || <SupportLink />}
           </ScopedNotification>
         )}
       </Card>

--- a/libs/shared/ui-core/src/mass-update-records/mass-update-records.types.tsx
+++ b/libs/shared/ui-core/src/mass-update-records/mass-update-records.types.tsx
@@ -32,6 +32,7 @@ export interface DeployResults {
   processingStartTime?: Maybe<string>;
   processingEndTime?: Maybe<string>;
   lastChecked?: string; // {formatDate(lastChecked, 'h:mm:ss')}
+  fatalErrorMessage?: Maybe<string>;
 }
 
 export interface ValidationResults {

--- a/libs/shared/ui-core/src/mass-update-records/useDeployRecords.ts
+++ b/libs/shared/ui-core/src/mass-update-records/useDeployRecords.ts
@@ -176,6 +176,7 @@ export function useDeployRecords(
             processingStartTime: row.deployResults.processingStartTime || convertDateToLocale(new Date()),
             processingEndTime: convertDateToLocale(new Date()),
             status: 'Error',
+            fatalErrorMessage: getErrorMessage(ex),
           };
 
           isMounted.current && onDeployResults(row.sobject, deployResults);
@@ -261,6 +262,7 @@ export function useDeployRecords(
           processingStartTime: deployResults.processingStartTime || convertDateToLocale(new Date()),
           processingEndTime: convertDateToLocale(new Date()),
           status: 'Error',
+          fatalErrorMessage: getErrorMessage(ex),
         };
 
         onDeployResults(sobject, newDeployResults);


### PR DESCRIPTION
When updating records without a file ensure we show the error message returned from the server instead of a generic message