### PR TITLE
Update web extension asset path to public directory

### DIFF
--- a/scripts/copy-monaco-assets.mjs
+++ b/scripts/copy-monaco-assets.mjs
@@ -14,7 +14,7 @@ const destinationConfigs = {
     includeAll: true,
   },
   'web-extension': {
-    path: join(__dirname, '..', 'apps', 'jetstream-web-extension', 'src', 'assets', 'js', 'monaco', 'vs'),
+    path: join(__dirname, '..', 'apps', 'jetstream-web-extension', 'public', 'assets', 'js', 'monaco', 'vs'),
     includeAll: false,
     includeLanguages: ['apex', 'css', 'html', 'javascript', 'xml'],
   },


### PR DESCRIPTION
Change the asset path for the web extension to point to the public directory, ensuring proper access to resources.