### PR TITLE
Refactor logging levels for improved granularity

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -17,7 +17,8 @@
       "Bash(npx prettier:*)",
       "Bash(npx nx run landing:build)",
       "Bash(npx nx:*)",
-      "Bash(yarn build:ci)"
+      "Bash(yarn build:ci)",
+      "Bash(gh api:*)"
     ],
     "deny": [],
     "ask": []

--- a/apps/api/src/app/controllers/desktop-app.controller.ts
+++ b/apps/api/src/app/controllers/desktop-app.controller.ts
@@ -156,7 +156,7 @@ const initSession = createRoute(routeDefinition.initSession.validators, async ({
     const decoded = externalAuthService.decodeToken(decryptedToken);
     const expiresAt = fromUnixTime(decoded.exp);
 
-    res.log.info({ userId: user.id, deviceId, expiresAt }, 'Reusing existing desktop token');
+    res.log.debug({ userId: user.id, deviceId, expiresAt }, 'Reusing existing desktop token');
 
     sendJson(res, { accessToken: decryptedToken });
     createUserActivityFromReq(req, res, {
@@ -222,15 +222,15 @@ const verifyToken = createRoute(routeDefinition.verifyToken.validators, async ({
           userAgent: req.get('User-Agent') || 'unknown',
         });
         if (rotatedAccessToken) {
-          res.log.info({ userId: userProfile.id, deviceId }, 'Desktop App token verified and rotated');
+          res.log.debug({ userId: userProfile.id, deviceId }, 'Desktop App token verified and rotated');
         } else {
-          res.log.info({ userId: userProfile.id, deviceId }, 'Desktop App token verified (rotation skipped — concurrent race)');
+          res.log.debug({ userId: userProfile.id, deviceId }, 'Desktop App token verified (rotation skipped — concurrent race)');
         }
       }
     }
 
     if (!supportsRotation) {
-      res.log.info({ userId: userProfile.id, deviceId }, 'Desktop App token verified');
+      res.log.debug({ userId: userProfile.id, deviceId }, 'Desktop App token verified');
     }
 
     sendJson(res, { success: true, userProfile, encryptionKey, accessToken: rotatedAccessToken });

--- a/apps/api/src/app/controllers/oauth.controller.ts
+++ b/apps/api/src/app/controllers/oauth.controller.ts
@@ -95,7 +95,7 @@ const salesforceOauthCallback = createRoute(
         returnParams.message = queryParams.error_description
           ? (queryParams.error_description as string)
           : 'There was an error authenticating with Salesforce.';
-        req.log.info({ ...queryParams, requestId: res.locals.requestId, queryParams }, '[OAUTH][ERROR] %s', queryParams.error);
+        res.log.warn({ ...queryParams, requestId: res.locals.requestId, queryParams }, '[OAUTH][ERROR] %s', queryParams.error);
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         return res.redirect(`/oauth-link/?${new URLSearchParams(returnParams as any).toString().replaceAll('+', '%20')}`);
       } else if (!orgAuth) {
@@ -103,7 +103,7 @@ const salesforceOauthCallback = createRoute(
         returnParams.message = queryParams.error_description
           ? (queryParams.error_description as string)
           : 'There was an error authenticating with Salesforce.';
-        req.log.info({ ...queryParams, requestId: res.locals.requestId, queryParams }, '[OAUTH][ERROR] Missing orgAuth from session');
+        res.log.warn({ ...queryParams, requestId: res.locals.requestId, queryParams }, '[OAUTH][ERROR] Missing orgAuth from session');
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         return res.redirect(`/oauth-link/?${new URLSearchParams(returnParams as any).toString().replaceAll('+', '%20')}`);
       }
@@ -135,7 +135,7 @@ const salesforceOauthCallback = createRoute(
         instanceUrl: (userInfo.urls?.custom_domain as string) || loginUrl,
         refreshToken: refresh_token,
         logger: res.log || req.log || logger,
-        logging: ENV.LOG_LEVEL === 'trace',
+        enableLogging: ENV.LOG_LEVEL === 'trace',
       });
 
       const salesforceOrg = await initConnectionFromOAuthResponse({
@@ -167,7 +167,7 @@ const salesforceOauthCallback = createRoute(
         };
       }
 
-      req.log.info({ ...errorLogObj }, '[OAUTH][ERROR]');
+      res.log.warn({ ...errorLogObj }, '[OAUTH][ERROR]');
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       return res.redirect(`/oauth-link/?${new URLSearchParams(returnParams as any).toString().replaceAll('+', '%20')}`);

--- a/apps/api/src/app/controllers/orgs.controller.ts
+++ b/apps/api/src/app/controllers/orgs.controller.ts
@@ -102,10 +102,10 @@ const checkOrgHealth = createRoute(routeDefinition.checkOrgHealth.validators, as
     try {
       await jetstreamConn.org.identity();
       connectionError = null;
-      req.log.warn('[ORG CHECK][VALID ORG][IDENTITY]');
+      res.log.debug('[ORG CHECK][VALID ORG][IDENTITY]');
     } catch (ex) {
       connectionError = ERROR_MESSAGES.SFDC_EXPIRED_TOKEN;
-      req.log.warn(getExceptionLog(ex), '[ORG CHECK][INVALID ORG] %s', getErrorMessage(ex));
+      res.log.debug(getExceptionLog(ex), '[ORG CHECK][INVALID ORG] %s', getErrorMessage(ex));
     }
 
     // Ensure full API access, identity API works even without API access
@@ -114,11 +114,11 @@ const checkOrgHealth = createRoute(routeDefinition.checkOrgHealth.validators, as
       try {
         await jetstreamConn.query.query<SObjectOrganization>(`SELECT Id, TrialExpirationDate FROM Organization`);
         connectionError = null;
-        req.log.warn('[ORG CHECK][VALID ORG][API ACCESS]');
+        res.log.debug('[ORG CHECK][VALID ORG][API ACCESS]');
       } catch (ex) {
         if (ex instanceof ApiRequestError && ERROR_MESSAGES.SFDC_REST_API_NOT_ENABLED.test(getErrorMessage(ex))) {
           connectionError = ERROR_MESSAGES.SFDC_REST_API_NOT_ENABLED_MSG;
-          req.log.warn(getExceptionLog(ex), '[ORG CHECK][INVALID ORG] %s', getErrorMessage(ex));
+          res.log.debug(getExceptionLog(ex), '[ORG CHECK][INVALID ORG] %s', getErrorMessage(ex));
         }
       }
     }
@@ -128,7 +128,7 @@ const checkOrgHealth = createRoute(routeDefinition.checkOrgHealth.validators, as
         await salesforceOrgsDb.updateOrg_UNSAFE(org, { connectionError });
       }
     } catch (ex) {
-      req.log.warn({ orgId: org?.id, ...getExceptionLog(ex) }, '[ERROR UPDATING INVALID ORG] %s', getErrorMessage(ex));
+      res.log.warn({ orgId: org?.id, ...getExceptionLog(ex) }, '[ERROR UPDATING INVALID ORG] %s', getErrorMessage(ex));
     }
 
     if (connectionError) {

--- a/apps/api/src/app/controllers/web-extension.controller.ts
+++ b/apps/api/src/app/controllers/web-extension.controller.ts
@@ -143,7 +143,7 @@ const initSession = createRoute(routeDefinition.initSession.validators, async ({
     const decoded = externalAuthService.decodeToken(decryptedToken);
     const expiresAt = fromUnixTime(decoded.exp);
 
-    res.log.info({ userId: user.id, deviceId, expiresAt }, 'Reusing existing web extension token');
+    res.log.debug({ userId: user.id, deviceId, expiresAt }, 'Reusing existing web extension token');
 
     sendJson(res, { accessToken: decryptedToken });
     createUserActivityFromReq(req, res, {
@@ -201,15 +201,15 @@ const verifyToken = createRoute(routeDefinition.verifyToken.validators, async ({
           userAgent: req.get('User-Agent') || 'unknown',
         });
         if (rotatedAccessToken) {
-          res.log.info({ userId: userProfile.id, deviceId }, 'Web extension token verified and rotated');
+          res.log.debug({ userId: userProfile.id, deviceId }, 'Web extension token verified and rotated');
         } else {
-          res.log.info({ userId: userProfile.id, deviceId }, 'Web extension token verified (rotation skipped — concurrent race)');
+          res.log.debug({ userId: userProfile.id, deviceId }, 'Web extension token verified (rotation skipped — concurrent race)');
         }
       }
     }
 
     if (!supportsRotation) {
-      res.log.info({ userId: userProfile.id, deviceId }, 'Web extension token verified');
+      res.log.debug({ userId: userProfile.id, deviceId }, 'Web extension token verified');
     }
 
     sendJson(res, { success: true, userProfile, accessToken: rotatedAccessToken });

--- a/apps/api/src/app/routes/route.middleware.ts
+++ b/apps/api/src/app/routes/route.middleware.ts
@@ -204,10 +204,10 @@ export async function checkAuth(req: express.Request, res: express.Response, nex
 
   if (req.session.userAgent && req.session.userAgent !== userAgent) {
     if (!checkUserAgentSimilarity(req.session.userAgent, userAgent || '')) {
-      req.log.error(`[AUTH][UNAUTHORIZED] User-Agent mismatch: ${req.session.userAgent} !== ${userAgent}`);
+      res.log.warn(`[AUTH][UNAUTHORIZED] User-Agent mismatch: ${req.session.userAgent} !== ${userAgent}`);
       req.session.destroy((err) => {
         if (err) {
-          (res.log || logger).error({ ...getExceptionLog(err) }, '[AUTH][UNAUTHORIZED][ERROR] Error destroying session');
+          (res.log || req.log || logger).error({ ...getExceptionLog(err) }, '[AUTH][UNAUTHORIZED][ERROR] Error destroying session');
         }
         // TODO: Send email to user about potential suspicious activity
         next(new AuthenticationError('Unauthorized'));
@@ -220,7 +220,7 @@ export async function checkAuth(req: express.Request, res: express.Response, nex
     return next();
   }
 
-  req.log.error('[AUTH][UNAUTHORIZED]');
+  res.log.warn('[AUTH][UNAUTHORIZED]');
   next(new AuthenticationError('Unauthorized'));
 }
 
@@ -259,7 +259,7 @@ export async function addOrgsToLocal(req: express.Request, res: express.Response
       }
     }
   } catch (ex) {
-    req.log.warn(getExceptionLog(ex), '[INIT-ORG][ERROR]');
+    res.log.warn(getExceptionLog(ex), '[INIT-ORG][ERROR]');
     if (ex instanceof NotFoundError) {
       return next(ex);
     }
@@ -289,17 +289,17 @@ export const verifyEntitlement =
     }
   };
 
-export function ensureOrgExists(req: express.Request, res: express.Response, next: express.NextFunction) {
+export function ensureOrgExists(_req: express.Request, res: express.Response, next: express.NextFunction) {
   if (!res.locals?.jetstreamConn) {
-    req.log.info('[INIT-ORG][ERROR] An org did not exist on locals');
+    res.log.warn('[INIT-ORG][ERROR] An org did not exist on locals');
     return next(new UserFacingError('An org is required for this action'));
   }
   next();
 }
 
-export function ensureTargetOrgExists(req: express.Request, res: express.Response, next: express.NextFunction) {
+export function ensureTargetOrgExists(_req: express.Request, res: express.Response, next: express.NextFunction) {
   if (!res.locals?.targetJetstreamConn) {
-    req.log.info('[INIT-ORG][ERROR] A target org did not exist on locals');
+    res.log.warn('[INIT-ORG][ERROR] A target org did not exist on locals');
     return next(new UserFacingError('A target org is required for this action'));
   }
   next();
@@ -417,7 +417,7 @@ export async function getOrgForRequest(
       callOptions,
       instanceUrl,
       refreshToken,
-      logging: ENV.LOG_LEVEL === 'trace',
+      enableLogging: ENV.LOG_LEVEL === 'trace',
       logger,
       sfdcClientId: ENV.SFDC_CONSUMER_KEY,
       sfdcClientSecret: ENV.SFDC_CONSUMER_SECRET,

--- a/apps/api/src/app/routes/test.routes.ts
+++ b/apps/api/src/app/routes/test.routes.ts
@@ -56,7 +56,8 @@ routes.post('/e2e-integration-org', async (_: express.Request, res: express.Resp
     accessToken: access_token,
     apiVersion: ENV.SFDC_API_VERSION,
     instanceUrl: instance_url,
-    logging: false,
+    enableLogging: false,
+    logger,
   });
 
   const salesforceOrg = await initConnectionFromOAuthResponse({

--- a/apps/api/src/app/services/external-auth.service.ts
+++ b/apps/api/src/app/services/external-auth.service.ts
@@ -177,7 +177,7 @@ export async function getUserAndDeviceIdForExternalAuth(
     }
     return { user, deviceId };
   } catch (ex) {
-    req.log.info({ audience, deviceId, ...getErrorMessageAndStackObj(ex) }, '[EXTERNAL-AUTH][AUTH ERROR] Error decoding token');
+    res.log.warn({ audience, deviceId, ...getErrorMessageAndStackObj(ex) }, '[EXTERNAL-AUTH][AUTH ERROR] Error decoding token');
     return { user: null, deviceId };
   }
 }
@@ -215,7 +215,10 @@ export function getExternalAuthMiddleware(audience: Audience) {
       res.locals.deviceId = deviceId;
       next();
     } catch (ex) {
-      req.log.info('[EXTERNAL AUTH ERROR] Error decoding token', ex);
+      res.log.warn(
+        { audience, deviceId: getDeviceId(req, res), ...getErrorMessageAndStackObj(ex) },
+        '[EXTERNAL AUTH ERROR] Error decoding token',
+      );
       next(new AuthenticationError('Unauthorized', { skipLogout: true }));
     }
   };

--- a/apps/api/src/app/utils/__tests__/response.handlers.spec.ts
+++ b/apps/api/src/app/utils/__tests__/response.handlers.spec.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const prismaMocks = vi.hoisted(() => {
+  class PrismaClientKnownRequestError extends Error {
+    code = 'P2002';
+  }
+  class PrismaClientUnknownRequestError extends Error {}
+  class PrismaClientValidationError extends Error {}
+
+  return {
+    PrismaClientKnownRequestError,
+    PrismaClientUnknownRequestError,
+    PrismaClientValidationError,
+  };
+});
+
+vi.mock('@jetstream/api-config', () => ({
+  ENV: {
+    JETSTREAM_SERVER_URL: 'https://getjetstream.app',
+  },
+  getExceptionLog: (error: unknown, includeStack = false) => ({
+    error: error instanceof Error ? error.message : error,
+    stack: includeStack && error instanceof Error ? error.stack : undefined,
+  }),
+  logger: {
+    debug: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+  },
+  prisma: {},
+  rollbarServer: {
+    warn: vi.fn(),
+  },
+}));
+
+vi.mock('@jetstream/auth/server', () => ({
+  AuthError: class AuthError extends Error {
+    type = 'auth_error';
+  },
+  createCSRFToken: vi.fn(),
+  getCookieConfig: vi.fn(),
+}));
+
+vi.mock('@jetstream/prisma', () => ({
+  isPrismaError: (error: unknown) => Boolean((error as { isPrismaError?: boolean })?.isPrismaError),
+  Prisma: {
+    PrismaClientKnownRequestError: prismaMocks.PrismaClientKnownRequestError,
+    PrismaClientUnknownRequestError: prismaMocks.PrismaClientUnknownRequestError,
+    PrismaClientValidationError: prismaMocks.PrismaClientValidationError,
+  },
+  toTypedPrismaError: (error: { code?: string }) => ({ code: error.code }),
+}));
+
+vi.mock('../../db/salesforce-org.db', () => ({
+  updateOrg_UNSAFE: vi.fn(),
+}));
+
+import { AuthenticationError, NotFoundError, UserFacingError } from '../error-handler';
+import { uncaughtErrorHandler } from '../response.handlers';
+
+function createMockReq() {
+  return {
+    get: vi.fn(() => 'application/json'),
+    method: 'POST',
+    originalUrl: '/api/test',
+    params: {},
+    query: {},
+    body: {},
+    session: {},
+    url: '/api/test',
+  };
+}
+
+function createMockRes() {
+  const res = {
+    headersSent: false,
+    locals: {
+      cookies: {},
+      requestId: 'request-id',
+    },
+    log: {
+      debug: vi.fn(),
+      error: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+    },
+    json: vi.fn(),
+    redirect: vi.fn(),
+    set: vi.fn(),
+    status: vi.fn(),
+    appendHeader: vi.fn(),
+  };
+  res.status.mockReturnValue(res);
+  res.json.mockReturnValue(res);
+  res.redirect.mockReturnValue(res);
+  res.set.mockReturnValue(res);
+  return res;
+}
+
+async function handleError(error: unknown) {
+  const req = createMockReq();
+  const res = createMockRes();
+  await uncaughtErrorHandler(error, req as any, res as any, vi.fn());
+  return { req, res };
+}
+
+describe('uncaughtErrorHandler logging levels', () => {
+  it('logs expected user-facing 400s at debug only', async () => {
+    const { res } = await handleError(new UserFacingError('Invalid SOQL'));
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.log.debug).toHaveBeenCalledWith(expect.objectContaining({ error: 'Invalid SOQL', statusCode: 400 }), '[RESPONSE][ERROR]');
+    expect(res.log.warn).not.toHaveBeenCalled();
+    expect(res.log.error).not.toHaveBeenCalled();
+  });
+
+  it('logs validation/database 400s at warn', async () => {
+    const error = new prismaMocks.PrismaClientKnownRequestError('Unique constraint failed') as Error & { isPrismaError: boolean };
+    error.isPrismaError = true;
+
+    const { res } = await handleError(error);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.log.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ error: 'Unique constraint failed', statusCode: 400 }),
+      '[RESPONSE][ERROR][DATABASE]',
+    );
+    expect(res.log.error).not.toHaveBeenCalled();
+  });
+
+  it('logs authentication 401s at warn', async () => {
+    const { res } = await handleError(new AuthenticationError('Unauthorized'));
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.log.warn).toHaveBeenCalledWith(expect.objectContaining({ error: 'Unauthorized', statusCode: 401 }), '[RESPONSE][ERROR]');
+    expect(res.log.error).not.toHaveBeenCalled();
+  });
+
+  it('logs normal 404s at debug only', async () => {
+    const { res } = await handleError(new NotFoundError('Route not found'));
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.log.debug).toHaveBeenCalledWith(expect.objectContaining({ error: 'Route not found', statusCode: 404 }), '[RESPONSE][ERROR]');
+    expect(res.log.warn).not.toHaveBeenCalled();
+    expect(res.log.error).not.toHaveBeenCalled();
+  });
+
+  it('logs unknown 500s at error', async () => {
+    const { res } = await handleError(new Error('Database unavailable'));
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.log.error).toHaveBeenCalledWith(
+      expect.objectContaining({ error: 'Database unavailable', statusCode: 500 }),
+      '[RESPONSE][ERROR]',
+    );
+  });
+
+  it('logs fallback errors with the actual computed response status', async () => {
+    const error = new Error('Upstream unavailable') as Error & { status: number };
+    error.status = 503;
+
+    const { res } = await handleError(error);
+
+    expect(res.status).toHaveBeenCalledWith(503);
+    expect(res.log.error).toHaveBeenCalledWith(
+      expect.objectContaining({ error: 'Upstream unavailable', statusCode: 503 }),
+      '[RESPONSE][ERROR]',
+    );
+  });
+});

--- a/apps/api/src/app/utils/error-handler.ts
+++ b/apps/api/src/app/utils/error-handler.ts
@@ -43,7 +43,7 @@ export class UserFacingError extends Error {
       this.stack = message.stack;
     } else if (message instanceof Error) {
       if (message.message.startsWith('<?xml')) {
-        console.warn('[XML ERROR]', { message: message.message });
+        logger.warn({ message: message.message }, '[XML ERROR]');
         message.message = 'An unexpected error has occurred';
       }
       super(message.message);
@@ -52,7 +52,7 @@ export class UserFacingError extends Error {
       this.stack = message.stack;
     } else {
       if (message.startsWith('<?xml')) {
-        console.warn('[XML ERROR]', { message });
+        logger.warn({ message }, '[XML ERROR]');
         message = 'An unexpected error has occurred';
       }
       super(message);

--- a/apps/api/src/app/utils/response.handlers.ts
+++ b/apps/api/src/app/utils/response.handlers.ts
@@ -345,7 +345,7 @@ export async function uncaughtErrorHandler(err: any, req: express.Request, res: 
         return res.redirect(`/?${params}`); // TODO: can we show an error message to the user on this page or redirect to alternate page?
       }
     } else if (err instanceof NotFoundError) {
-      responseLogger.warn({ ...getExceptionLog(err), statusCode: 404 }, '[RESPONSE][ERROR]');
+      responseLogger.debug({ ...getExceptionLog(err), statusCode: 404 }, '[RESPONSE][ERROR]');
       res.status(status || 404);
       if (isJson) {
         return res.json({
@@ -363,11 +363,11 @@ export async function uncaughtErrorHandler(err: any, req: express.Request, res: 
     }
 
     const errorMessage = 'There was an error processing the request';
-    if (!status || status < 100 || status > 500) {
+    if (!status || status < 100 || status > 599) {
       status = 500;
     }
     res.status(status);
-    responseLogger.warn({ ...getExceptionLog(err, true), statusCode: 500 }, '[RESPONSE][ERROR]');
+    responseLogger.error({ ...getExceptionLog(err, true), statusCode: status }, '[RESPONSE][ERROR]');
     // Return JSON error response for all other scenarios
     return res.json({
       error: errorMessage,
@@ -400,7 +400,7 @@ function getPrismaErrorMessage(
 ) {
   if (error instanceof Prisma.PrismaClientKnownRequestError) {
     const prismaError = toTypedPrismaError(error);
-    logger.error({ error: error.message, code: error.code }, '[DB][PRISMA][ERROR]');
+    logger.warn({ error: error.message, code: error.code }, '[DB][PRISMA][WARN]');
     if (prismaError.code === 'P2002') {
       return `A record with the same unique field already exists.`;
     } else if (prismaError.code === 'P2022') {

--- a/apps/api/src/app/utils/route.utils.ts
+++ b/apps/api/src/app/utils/route.utils.ts
@@ -120,11 +120,11 @@ export function createRoute<TParamsSchema extends z.ZodTypeAny, TBodySchema exte
         },
       };
       if (hasSourceOrg && !data.jetstreamConn) {
-        logger.info('[INIT-ORG][ERROR] A source org did not exist on locals');
+        logger.warn('[INIT-ORG][ERROR] A source org did not exist on locals');
         return next(new UserFacingError('An org is required for this action'));
       }
       if (hasTargetOrg && !data.targetJetstreamConn) {
-        logger.info('[INIT-ORG][ERROR] A target org did not exist on locals');
+        logger.warn('[INIT-ORG][ERROR] A target org did not exist on locals');
         return next(new UserFacingError('A source and target org are required for this action'));
       }
       try {
@@ -150,7 +150,7 @@ export function createRoute<TParamsSchema extends z.ZodTypeAny, TBodySchema exte
         next(new UserFacingError(ex));
       }
     } catch (ex) {
-      logger.error(getExceptionLog(ex), '[ROUTE][VALIDATION ERROR]');
+      logger.warn(getExceptionLog(ex), '[ROUTE][VALIDATION ERROR]');
       if (logErrorToBugTracker) {
         rollbarServer.error(ex, req, {
           ...getExceptionLog(ex, true),

--- a/apps/jetstream-desktop/src/services/ipc.service.ts
+++ b/apps/jetstream-desktop/src/services/ipc.service.ts
@@ -227,7 +227,7 @@ const handleAddOrgEvent: MainIpcHandler<'addOrg'> = async (event, payload) => {
         instanceUrl: userInfo.urls.custom_domain || payload.loginUrl,
         refreshToken: refresh_token,
         logger: logger as any,
-        logging: false,
+        enableLogging: false,
       });
 
       const salesforceOrg = await initConnectionFromOAuthResponse({

--- a/apps/jetstream-desktop/src/utils/route.utils.ts
+++ b/apps/jetstream-desktop/src/utils/route.utils.ts
@@ -234,7 +234,7 @@ export function initApiConnection(
       instanceUrl: org.instanceUrl,
       refreshToken,
       logger: logger as any,
-      logging: false,
+      enableLogging: false,
       sfdcClientId: ENV.DESKTOP_SFDC_CLIENT_ID,
     },
     handleRefresh,

--- a/apps/jetstream-web-extension/src/utils/api-client.ts
+++ b/apps/jetstream-web-extension/src/utils/api-client.ts
@@ -14,7 +14,7 @@ export function initApiClient({ key: accessToken, hostname }: SessionInfo): ApiC
     instanceUrl,
     // refreshToken: refresh_token,
     logger,
-    logging: false,
+    enableLogging: false,
   });
 }
 

--- a/libs/api-config/src/lib/__tests__/logging-policy.spec.ts
+++ b/libs/api-config/src/lib/__tests__/logging-policy.spec.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { getHttpLogLevel, resolveLogLevel } from '../logging-policy';
+
+describe('logging policy', () => {
+  describe('resolveLogLevel', () => {
+    it('uses an explicit LOG_LEVEL when provided', () => {
+      expect(resolveLogLevel({ logLevel: 'trace', environment: 'production' })).toBe('trace');
+      expect(resolveLogLevel({ logLevel: 'warn', environment: 'development' })).toBe('warn');
+    });
+
+    it('defaults production to info', () => {
+      expect(resolveLogLevel({ environment: 'production' })).toBe('info');
+      expect(resolveLogLevel({ nodeEnv: 'production' })).toBe('info');
+      expect(resolveLogLevel({})).toBe('info');
+    });
+
+    it('defaults non-production to debug', () => {
+      expect(resolveLogLevel({ environment: 'development', nodeEnv: 'development' })).toBe('debug');
+      expect(resolveLogLevel({ environment: 'test', nodeEnv: 'test' })).toBe('debug');
+    });
+  });
+
+  describe('getHttpLogLevel', () => {
+    it('logs non-500 responses at info', () => {
+      expect(getHttpLogLevel({}, { statusCode: 200 })).toBe('info');
+      expect(getHttpLogLevel({}, { statusCode: 400 })).toBe('info');
+      expect(getHttpLogLevel({}, { statusCode: 404 })).toBe('info');
+    });
+
+    it('logs 500 responses and request errors at error', () => {
+      expect(getHttpLogLevel({}, { statusCode: 500 })).toBe('error');
+      expect(getHttpLogLevel({}, { statusCode: 503 })).toBe('error');
+      expect(getHttpLogLevel({}, { statusCode: 200 }, new Error('socket closed'))).toBe('error');
+    });
+  });
+});

--- a/libs/api-config/src/lib/api-db-config.ts
+++ b/libs/api-config/src/lib/api-db-config.ts
@@ -5,7 +5,7 @@ import { getExceptionLog, logger } from './api-logger';
 import { ENV } from './env-config';
 
 process.on('uncaughtException', function (err) {
-  console.log(err);
+  logger.error(getExceptionLog(err, true), '[PROCESS][UNCAUGHT_EXCEPTION]');
 });
 
 const log: Array<Prisma.LogLevel | Prisma.LogDefinition> = ['info'];

--- a/libs/api-config/src/lib/api-logger.ts
+++ b/libs/api-config/src/lib/api-logger.ts
@@ -4,6 +4,7 @@ import pino from 'pino';
 import pinoHttp from 'pino-http';
 import { v4 as uuid } from 'uuid';
 import { ENV } from './env-config';
+import { getHttpLogLevel } from './logging-policy';
 
 export const logger = pino({
   level: ENV.LOG_LEVEL,
@@ -20,6 +21,7 @@ const ignoreLogsFileExtensions = /.*\.(js|map|css|png|jpg|jpeg|gif|svg|ico|woff|
 export const httpLogger = pinoHttp<express.Request, express.Response>({
   logger,
   genReqId: (_, res) => res.locals.requestId || uuid(),
+  customLogLevel: getHttpLogLevel,
   autoLogging: {
     // ignore static files based on file extension
     ignore: (req) =>

--- a/libs/api-config/src/lib/env-config.ts
+++ b/libs/api-config/src/lib/env-config.ts
@@ -6,6 +6,7 @@ import { readFileSync } from 'fs-extra';
 import isNumber from 'lodash/isNumber';
 import { join } from 'path';
 import { z } from 'zod';
+import { resolveLogLevel } from './logging-policy';
 
 dotenv.config();
 
@@ -23,6 +24,10 @@ function ensureBoolean(value: Maybe<string | boolean>): boolean {
     return value.toLowerCase().startsWith('t');
   }
   return false;
+}
+
+function writeEnvConfigWarning(message: string) {
+  process.stderr.write(`${message}\n`);
 }
 
 /**
@@ -76,7 +81,13 @@ const envSchema = z.object({
   LOG_LEVEL: z
     .enum(['trace', 'debug', 'info', 'warn', 'error', 'fatal', 'silent'])
     .optional()
-    .transform((value) => value ?? 'debug'),
+    .transform((value) =>
+      resolveLogLevel({
+        logLevel: value,
+        environment: process.env.ENVIRONMENT,
+        nodeEnv: process.env.NODE_ENV,
+      }),
+    ),
   PRETTY_LOGS: booleanSchema,
   CI: booleanSchema,
   // LOCAL OVERRIDE
@@ -154,7 +165,7 @@ const envSchema = z.object({
     .optional()
     .transform((val) => {
       if (!val) {
-        console.warn('AUTH_SFDC_CLIENT_ID is not set - Logging in with Salesforce will not be available');
+        writeEnvConfigWarning('AUTH_SFDC_CLIENT_ID is not set - Logging in with Salesforce will not be available');
       }
       return val || '';
     }),
@@ -163,7 +174,7 @@ const envSchema = z.object({
     .optional()
     .transform((val) => {
       if (!val) {
-        console.warn('AUTH_SFDC_CLIENT_SECRET is not set - Logging in with Salesforce will not be available');
+        writeEnvConfigWarning('AUTH_SFDC_CLIENT_SECRET is not set - Logging in with Salesforce will not be available');
       }
       return val || '';
     }),
@@ -172,7 +183,7 @@ const envSchema = z.object({
     .optional()
     .transform((val) => {
       if (!val) {
-        console.warn('AUTH_GOOGLE_CLIENT_ID is not set - Logging in with Google will not be available');
+        writeEnvConfigWarning('AUTH_GOOGLE_CLIENT_ID is not set - Logging in with Google will not be available');
       }
       return val || '';
     }),
@@ -181,7 +192,7 @@ const envSchema = z.object({
     .optional()
     .transform((val) => {
       if (!val) {
-        console.warn('AUTH_GOOGLE_CLIENT_SECRET is not set - Logging in with Google will not be available');
+        writeEnvConfigWarning('AUTH_GOOGLE_CLIENT_SECRET is not set - Logging in with Google will not be available');
       }
       return val || '';
     }),
@@ -284,7 +295,7 @@ const parseResults = envSchema.safeParse({
 });
 
 if (!parseResults.success) {
-  console.error(`❌ ${chalk.red('Error parsing environment variables:')}
+  process.stderr.write(`❌ ${chalk.red('Error parsing environment variables:')}
 ${chalk.yellow(JSON.stringify(z.treeifyError(parseResults.error), null, 2))}
 `);
   process.exit(1);

--- a/libs/api-config/src/lib/logging-policy.ts
+++ b/libs/api-config/src/lib/logging-policy.ts
@@ -1,0 +1,30 @@
+import { Maybe } from '@jetstream/types';
+import type pino from 'pino';
+
+export function resolveLogLevel({
+  logLevel,
+  environment,
+  nodeEnv,
+}: {
+  logLevel?: Maybe<pino.LevelWithSilent>;
+  environment?: Maybe<string>;
+  nodeEnv?: Maybe<string>;
+}): pino.LevelWithSilent {
+  if (logLevel) {
+    return logLevel;
+  }
+  if (environment) {
+    return environment === 'production' ? 'info' : 'debug';
+  }
+  if (nodeEnv) {
+    return nodeEnv === 'production' ? 'info' : 'debug';
+  }
+  return 'info';
+}
+
+export function getHttpLogLevel(_: unknown, res: { statusCode?: number }, error?: Error): pino.LevelWithSilent {
+  if (error || (res.statusCode ?? 0) >= 500) {
+    return 'error';
+  }
+  return 'info';
+}

--- a/libs/salesforce-api/src/lib/__tests__/callout-adapter.spec.ts
+++ b/libs/salesforce-api/src/lib/__tests__/callout-adapter.spec.ts
@@ -758,4 +758,62 @@ describe('callout-adapter XML parsing', () => {
       expect(results[0]).toHaveProperty('fullName');
     });
   });
+
+  describe('request logging', () => {
+    it('does not log request or response details when logging is disabled', async () => {
+      const mockFetch = createMockFetch({
+        '/services/data/': { status: 200, body: 'ok' },
+      });
+      const mockLogger = {
+        trace: vi.fn(),
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+      };
+
+      const apiRequest = getApiRequestFactoryFn(mockFetch)(mockLogger, undefined, undefined, false);
+      const result = await apiRequest({
+        url: '/services/data/v65.0/test',
+        method: 'GET',
+        sessionInfo: mockSessionInfo,
+        outputType: 'text',
+      });
+
+      await Promise.resolve();
+
+      expect(result).toBe('ok');
+      expect(mockLogger.trace).not.toHaveBeenCalled();
+      expect(mockLogger.debug).not.toHaveBeenCalled();
+    });
+
+    it('logs request, response, and optional response body details at trace', async () => {
+      const mockFetch = createMockFetch({
+        '/services/data/': { status: 200, body: 'ok' },
+      });
+      const mockLogger = {
+        trace: vi.fn(),
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+      };
+
+      const apiRequest = getApiRequestFactoryFn(mockFetch)(mockLogger, undefined, undefined, true);
+      const result = await apiRequest({
+        url: '/services/data/v65.0/test',
+        method: 'GET',
+        sessionInfo: mockSessionInfo,
+        outputType: 'text',
+      });
+
+      await Promise.resolve();
+
+      expect(result).toBe('ok');
+      expect(mockLogger.trace).toHaveBeenCalledWith('[API REQUEST]: GET https://test.salesforce.com/services/data/v65.0/test');
+      expect(mockLogger.trace).toHaveBeenCalledWith('[API RESPONSE]: 200');
+      expect(mockLogger.trace).toHaveBeenCalledWith({ responseBody: 'ok' });
+      expect(mockLogger.debug).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/libs/salesforce-api/src/lib/__tests__/utils.spec.ts
+++ b/libs/salesforce-api/src/lib/__tests__/utils.spec.ts
@@ -1,5 +1,6 @@
 import { vi } from 'vitest';
 import { ApiConnection } from '../connection';
+import { Logger } from '../types';
 import {
   SalesforceApi,
   correctInvalidArrayXmlResponseTypes,
@@ -10,6 +11,15 @@ import {
   toSoapXML,
 } from '../utils';
 
+const NOOP_LOG = () => undefined;
+const testLogger: Logger = {
+  trace: NOOP_LOG,
+  debug: NOOP_LOG,
+  info: NOOP_LOG,
+  warn: NOOP_LOG,
+  error: NOOP_LOG,
+};
+
 describe('getRestApiUrl', () => {
   const apiConnection = new ApiConnection({
     accessToken: 'test',
@@ -19,8 +29,9 @@ describe('getRestApiUrl', () => {
     organizationId: 'test',
     userId: 'test',
     callOptions: {},
-    logging: false,
+    enableLogging: false,
     refreshToken: 'test',
+    logger: testLogger,
   });
   const sfdcApi = new SalesforceApi(apiConnection);
   it('should return correct URL for non-tooling case', () => {
@@ -66,8 +77,9 @@ describe('getRestApiUrl', () => {
     organizationId: 'test',
     userId: 'test',
     callOptions: {},
-    logging: false,
+    enableLogging: false,
     refreshToken: 'test',
+    logger: testLogger,
   });
   const sfdcApi = new SalesforceApi(apiConnection);
   it('should return correct URL for non-tooling case', () => {
@@ -135,8 +147,9 @@ describe('getRestApiUrl', () => {
     organizationId: 'test',
     userId: 'test',
     callOptions: {},
-    logging: false,
+    enableLogging: false,
     refreshToken: 'test',
+    logger: testLogger,
   });
   const sfdcApi = new SalesforceApi(apiConnection);
   it('should return correct URL for non-tooling case', () => {

--- a/libs/salesforce-api/src/lib/api-query.ts
+++ b/libs/salesforce-api/src/lib/api-query.ts
@@ -36,14 +36,14 @@ export class ApiQuery extends SalesforceApi {
         columns: tempColumns.columnMetadata?.flatMap((column) => flattenQueryColumn(column)),
       };
     } catch (ex) {
-      this.logger.warn({ message: getErrorMessage(ex) }, 'Error fetching columns');
+      this.logger.debug({ message: getErrorMessage(ex) }, 'Error fetching columns');
     }
 
     // Attempt to parse columns from query
     try {
       parsedQuery = parseQuery(soql);
     } catch (ex) {
-      this.logger.warn({ message: getErrorMessage(ex) }, 'Error parsing query');
+      this.logger.debug({ message: getErrorMessage(ex) }, 'Error parsing query');
     }
 
     return { queryResults, columns, parsedQuery };

--- a/libs/salesforce-api/src/lib/callout-adapter.ts
+++ b/libs/salesforce-api/src/lib/callout-adapter.ts
@@ -45,10 +45,10 @@ function parseXml(value: string) {
  */
 export function getApiRequestFactoryFn(fetch: FetchFn) {
   return (
+    logger: Logger,
     onRefresh?: (accessToken: string) => void,
     onConnectionError?: (accessToken: string) => void,
     enableLogging?: boolean,
-    logger: Logger = console,
   ) => {
     const apiRequest = async <Response = unknown>(options: ApiRequestOptions, attemptRefresh = true): Promise<Response> => {
       // eslint-disable-next-line prefer-const
@@ -61,7 +61,9 @@ export function getApiRequestFactoryFn(fetch: FetchFn) {
         body = JSON.stringify(body);
       }
 
-      logger.debug(`[API REQUEST]: ${method} ${url}`);
+      if (enableLogging) {
+        logger.trace(`[API REQUEST]: ${method} ${url}`);
+      }
 
       return fetch(url, {
         method,
@@ -78,13 +80,13 @@ export function getApiRequestFactoryFn(fetch: FetchFn) {
         },
       })
         .then(async (response) => {
-          logger.debug(`[API RESPONSE]: ${response.status}`);
           if (enableLogging) {
+            logger.trace(`[API RESPONSE]: ${response.status}`);
             if (response.status !== 204) {
               response
                 .clone()
                 .text()
-                .then((responseBody) => logger.debug({ responseBody }))
+                .then((responseBody) => logger.trace({ responseBody }))
                 // eslint-disable-next-line @typescript-eslint/no-empty-function
                 .catch(() => {});
             }

--- a/libs/salesforce-api/src/lib/connection.ts
+++ b/libs/salesforce-api/src/lib/connection.ts
@@ -19,10 +19,10 @@ export interface ApiConnectionOptions {
   refreshToken?: string;
   apiVersion: string;
   callOptions?: Record<string, string | boolean | number>;
-  logging?: boolean;
+  enableLogging?: boolean;
   sfdcClientId?: string;
   sfdcClientSecret?: string;
-  logger?: Logger;
+  logger: Logger;
 }
 
 export class ApiConnection {
@@ -52,16 +52,16 @@ export class ApiConnection {
       accessToken,
       refreshToken,
       callOptions,
-      logging,
+      enableLogging = false,
       sfdcClientId,
       sfdcClientSecret,
-      logger = console,
+      logger,
     }: ApiConnectionOptions,
     refreshCallback?: (accessToken: string, refreshToken: string) => void,
     onConnectionError?: (error: string) => void,
   ) {
     this.logger = logger;
-    this.apiRequest = apiRequestAdapter(this.handleRefresh.bind(this), this.handleConnectionError.bind(this), logging, logger);
+    this.apiRequest = apiRequestAdapter(logger, this.handleRefresh.bind(this), this.handleConnectionError.bind(this), enableLogging);
     this.refreshCallback = refreshCallback;
     this.onConnectionError = onConnectionError;
     this.sessionInfo = {


### PR DESCRIPTION
Change log levels from info/warn to debug for better logging granularity, enhancing the ability to trace application behavior without cluttering logs with less critical information. Additionally, introduce a logging policy to determine log levels based on the environment and response status.