### PR TITLE
Handle placeholder user ID in activity logging and constants

### DIFF
--- a/libs/auth/server/src/lib/auth-logging.db.service.ts
+++ b/libs/auth/server/src/lib/auth-logging.db.service.ts
@@ -1,6 +1,7 @@
 import { logger, prisma } from '@jetstream/api-config';
 import { Maybe } from '@jetstream/types';
 import type { Request, Response } from 'express';
+import { PLACEHOLDER_USER_ID } from './auth.constants';
 import { AuthError } from './auth.errors';
 import { getApiAddressFromReq } from './auth.utils';
 
@@ -94,7 +95,10 @@ export async function createUserActivityFromReq(
   try {
     const ipAddress = getApiAddressFromReq(req);
     const userAgent = req.get('user-agent');
-    const userId = data.userId || req.session?.user?.id;
+    const resolvedUserId = data.userId || req.session?.user?.id;
+    // Placeholder sessions (e.g., registering with an already-in-use email) have no real User row,
+    // so the FK on LoginActivity.userId would reject the insert. Drop the id but keep the audit row.
+    const userId = resolvedUserId === PLACEHOLDER_USER_ID ? null : resolvedUserId;
     const email = data.email || req.session?.user?.email;
     const requestId = data.requestId || res.locals?.['requestId'];
 

--- a/libs/auth/server/src/lib/auth.constants.ts
+++ b/libs/auth/server/src/lib/auth.constants.ts
@@ -1,5 +1,10 @@
 export const CURRENT_TOS_VERSION = '2026-03-19';
 
+// Used as a stand-in user for pre-auth flows that should not reveal whether an account exists
+// (e.g., registering with an already-in-use email). Never references a real User row, so any
+// code writing rows that FK to User must treat this id as "no user" and store null instead.
+export const PLACEHOLDER_USER_ID = '00000000-0000-0000-0000-000000000000';
+
 export const PASSWORD_RESET_DURATION_MINUTES = 30;
 export const TOKEN_DURATION_MINUTES = 15;
 export const EMAIL_VERIFICATION_TOKEN_DURATION_HOURS = 1;

--- a/libs/auth/server/src/lib/auth.db.service.ts
+++ b/libs/auth/server/src/lib/auth.db.service.ts
@@ -47,6 +47,7 @@ import {
   DELETE_MAILGUN_WEBHOOK_DAYS,
   DELETE_TOKEN_DAYS,
   PASSWORD_RESET_DURATION_MINUTES,
+  PLACEHOLDER_USER_ID,
 } from './auth.constants';
 import {
   AccountLocked,
@@ -72,7 +73,6 @@ const LOGIN_CONFIGURATION_CACHE = new LRUCache<string, { value: LoginConfigurati
   ttl: 1000 * 60,
 });
 
-export const PLACEHOLDER_USER_ID = '00000000-0000-0000-0000-000000000000';
 export const PLACEHOLDER_USER = AuthenticatedUserSchema.parse({
   id: PLACEHOLDER_USER_ID,
   userId: `invalid|${PLACEHOLDER_USER_ID}`,


### PR DESCRIPTION
This pull request improves how placeholder users are handled in authentication flows, especially for cases where a user ID should not be associated with a real user record (such as pre-authentication or privacy-preserving scenarios). The changes ensure that placeholder user IDs are consistently defined and used, and that database integrity is maintained by not referencing non-existent user records.

**Placeholder user handling improvements:**

* Moved the `PLACEHOLDER_USER_ID` constant from `auth.db.service.ts` to a shared location in `auth.constants.ts`, and updated all imports to use the new location for consistency. [[1]](diffhunk://#diff-680f29bd1d0b85033dc884433cd1ea062e680f089209ac0c411d6f99360b4705R3-R7) [[2]](diffhunk://#diff-1d84add16369a91418fc434c78000fa44eb9f8381e90b1b6628f65ae847d339cR50) [[3]](diffhunk://#diff-1d84add16369a91418fc434c78000fa44eb9f8381e90b1b6628f65ae847d339cL75) [[4]](diffhunk://#diff-dbffb0823f4a5e4f51749292b2f51699dd93cd7a288de2ff64f2ea9fcd976088R4)
* Updated the logic in `createUserActivityFromReq` to store `null` for `userId` in audit logs when the placeholder user ID is encountered, preventing foreign key violations and ensuring audit rows are still created for pre-auth flows.