### PR TITLE
feat: add redirectIfNotAuthenticatedMiddleware to enforce authentication before accessing app routes

### DIFF
--- a/apps/api/src/app/routes/route.middleware.ts
+++ b/apps/api/src/app/routes/route.middleware.ts
@@ -167,6 +167,22 @@ export async function redirectIfMfaEnrollmentRequiredMiddleware(req: express.Req
   next();
 }
 
+/**
+ * Must run AFTER the pending-* gates (pendingVerification, pendingTosAcceptance, pendingMfaEnrollment)
+ * so that sessions still in a mid-auth state (including temporary/placeholder sessions with pendingVerification)
+ * are routed to their appropriate flow before falling through to /auth/login.
+ */
+export async function redirectIfNotAuthenticatedMiddleware(req: express.Request, res: express.Response, next: express.NextFunction) {
+  const user = req.session.user;
+
+  if (!user || user.id === PLACEHOLDER_USER_ID) {
+    res.redirect(302, '/auth/login');
+    return;
+  }
+
+  next();
+}
+
 export async function checkAuth(req: express.Request, res: express.Response, next: express.NextFunction) {
   const userAgent = req.get('User-Agent');
 

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -39,6 +39,7 @@ import {
   destroySessionIfPendingVerificationIsExpired,
   notFoundMiddleware,
   redirectIfMfaEnrollmentRequiredMiddleware,
+  redirectIfNotAuthenticatedMiddleware,
   redirectIfPendingTosAcceptanceMiddleware,
   redirectIfPendingVerificationMiddleware,
   setApplicationCookieMiddleware,
@@ -430,6 +431,7 @@ if (ENV.NODE_ENV === 'production' && !ENV.CI && cluster.isPrimary) {
       redirectIfPendingVerificationMiddleware,
       redirectIfPendingTosAcceptanceMiddleware,
       redirectIfMfaEnrollmentRequiredMiddleware,
+      redirectIfNotAuthenticatedMiddleware,
       helmet.contentSecurityPolicy({
         directives: buildCspDirectives(['*.google.com', '*.googleusercontent.com', 'accounts.google.com']),
       }),


### PR DESCRIPTION
We were previously relying on API calls to redirect the user on app load, but if the user does not have a session then there is no reason to server the application