### PR TITLE
Implement verification attempt limits for authentication flows

### DIFF
--- a/apps/api/src/app/controllers/auth.controller.ts
+++ b/apps/api/src/app/controllers/auth.controller.ts
@@ -35,6 +35,7 @@ import {
   InvalidVerificationToken,
   linkIdentityToUser,
   getProviders as listProviders,
+  MAX_VERIFICATION_ATTEMPTS,
   oidcService,
   PASSWORD_RESET_DURATION_MINUTES,
   PLACEHOLDER_USER_ID,
@@ -45,6 +46,7 @@ import {
   setUserEmailVerified,
   timingSafeStringCompare,
   TOKEN_DURATION_MINUTES,
+  TooManyVerificationAttempts,
   validateCallback,
   validateRedirectUrl,
   verify2faTotpOrThrow,
@@ -199,7 +201,7 @@ export const routeDefinition = {
     validators: {
       body: z.object({
         email: z.email().toLowerCase(),
-        token: z.string(),
+        token: z.uuid(),
         password: PasswordSchema,
         csrfToken: z.string(),
         captchaToken: z.string().nullish(),
@@ -711,35 +713,66 @@ const verification = createRoute(
         throw new ExpiredVerificationToken(`Pending verification is expired: ${pendingVerification.exp}`);
       }
 
-      switch (pendingVerification.type) {
-        case 'email': {
-          const { token } = pendingVerification;
-          if (!timingSafeStringCompare(token, code)) {
-            throw new InvalidVerificationToken('Provided code does not match');
+      try {
+        switch (pendingVerification.type) {
+          case 'email': {
+            const { token } = pendingVerification;
+            if (!timingSafeStringCompare(token, code)) {
+              throw new InvalidVerificationToken('Provided code does not match');
+            }
+            if (!isPlaceholderUser) {
+              req.session.user = (await setUserEmailVerified(req.session.user.id)) as UserProfileSession;
+            }
+            break;
           }
-          if (!isPlaceholderUser) {
-            req.session.user = (await setUserEmailVerified(req.session.user.id)) as UserProfileSession;
+          case '2fa-email': {
+            const { token } = pendingVerification;
+            if (!timingSafeStringCompare(token, code)) {
+              throw new InvalidVerificationToken('Provided code does not match');
+            }
+            rememberDeviceId = rememberDevice ? generateRandomString(32) : undefined;
+            break;
           }
-          break;
-        }
-        case '2fa-email': {
-          const { token } = pendingVerification;
-          if (!timingSafeStringCompare(token, code)) {
-            throw new InvalidVerificationToken('Provided code does not match');
+          case '2fa-otp': {
+            const { secret } = await getTotpAuthenticationFactor(req.session.user.id);
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            await verify2faTotpOrThrow(secret!, code);
+            rememberDeviceId = rememberDevice ? generateRandomString(32) : undefined;
+            break;
           }
-          rememberDeviceId = rememberDevice ? generateRandomString(32) : undefined;
-          break;
+          default: {
+            throw new InvalidVerificationToken(`Invalid verification type`);
+          }
         }
-        case '2fa-otp': {
-          const { secret } = await getTotpAuthenticationFactor(req.session.user.id);
-          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-          await verify2faTotpOrThrow(secret!, code);
-          rememberDeviceId = rememberDevice ? generateRandomString(32) : undefined;
-          break;
+      } catch (verifyEx) {
+        // Only bad-code errors count against the attempt budget; session/CSRF/expired errors bail early above.
+        if (verifyEx instanceof InvalidVerificationToken) {
+          const nextAttempts = (req.session.pendingVerificationAttempts ?? 0) + 1;
+          if (nextAttempts >= MAX_VERIFICATION_ATTEMPTS) {
+            // Capture before destroy so the audit row for the abuse event remains attributable.
+            const userIdForAudit = req.session.user?.id;
+            res.log.warn(
+              {
+                userId: userIdForAudit,
+                email: req.session.user?.email,
+                type: pendingVerification.type,
+                attempts: nextAttempts,
+              },
+              '[AUTH][VERIFY][TOO_MANY_ATTEMPTS] Session destroyed after exceeding attempt budget',
+            );
+            await new Promise<void>((resolve) => {
+              req.session.destroy((destroyErr) => {
+                if (destroyErr) {
+                  res.log.error({ ...getExceptionLog(destroyErr) }, '[AUTH][TOO_MANY_ATTEMPTS][ERROR] Error destroying session');
+                }
+                resolve();
+              });
+            });
+            throw new TooManyVerificationAttempts('Too many failed verification attempts', { userId: userIdForAudit });
+          }
+          req.session.pendingVerificationAttempts = nextAttempts;
         }
-        default: {
-          throw new InvalidVerificationToken(`Invalid verification type`);
-        }
+        throw verifyEx;
       }
 
       // Redirect back to sign in page
@@ -768,6 +801,7 @@ const verification = createRoute(
       }
 
       req.session.pendingVerification = null;
+      req.session.pendingVerificationAttempts = 0;
 
       if (req.session.sendNewUserEmailAfterVerify && req.session.user) {
         req.session.sendNewUserEmailAfterVerify = undefined;
@@ -834,6 +868,9 @@ const resendVerification = createRoute(routeDefinition.resendVerification.valida
     await verifyCSRFFromRequestOrThrow(csrfToken, req.headers.cookie || '');
     const exp = addMinutes(new Date(), TOKEN_DURATION_MINUTES).getTime();
     const token = generateRandomCode(6);
+
+    // Resending a code issues a fresh challenge — reset the per-session attempt budget.
+    req.session.pendingVerificationAttempts = 0;
 
     // Refresh all pending verifications
     req.session.pendingVerification = req.session.pendingVerification.map((item) => {

--- a/apps/api/src/app/routes/api.routes.ts
+++ b/apps/api/src/app/routes/api.routes.ts
@@ -13,9 +13,9 @@ import { routeDefinition as metadataToolingController } from '../controllers/sf-
 import { routeDefinition as miscController } from '../controllers/sf-misc.controller';
 import { routeDefinition as queryController } from '../controllers/sf-query.controller';
 import { routeDefinition as recordController } from '../controllers/sf-record.controller';
+import { routeDefinition as testController } from '../controllers/test.controller';
 import * as userFeedbackController from '../controllers/user-feedback.controller';
 import { routeDefinition as userController } from '../controllers/user.controller';
-import { routeDefinition as testController } from '../controllers/test.controller';
 import { deferredResponseMiddleware as dfr } from '../utils/deferred-response.middleware';
 import { sendJson } from '../utils/response.handlers';
 import {
@@ -25,6 +25,7 @@ import {
   ensureTargetOrgExists,
   feedbackRateLimit,
   feedbackUploadMiddleware,
+  passwordResetEmailRateLimit,
   validateDoubleCSRF,
   verifyEntitlement,
 } from './route.middleware';
@@ -70,7 +71,7 @@ routes.delete('/me/profile/sessions', userController.revokeAllSessions.controlle
  * Password Management Routes
  */
 routes.post('/me/profile/password/init', userController.initPassword.controllerFn());
-routes.post('/me/profile/password/reset', userController.initResetPassword.controllerFn());
+routes.post('/me/profile/password/reset', passwordResetEmailRateLimit, userController.initResetPassword.controllerFn());
 // TODO: should we allow users to remove their password if they have social login?
 routes.delete('/me/profile/password', userController.deletePassword.controllerFn());
 /**

--- a/apps/api/src/app/routes/auth.routes.ts
+++ b/apps/api/src/app/routes/auth.routes.ts
@@ -1,4 +1,5 @@
 import { createRateLimit } from '@jetstream/api-config';
+import { MAX_VERIFICATION_ATTEMPTS } from '@jetstream/auth/server';
 import express, { Router } from 'express';
 import * as authController from '../controllers/auth.controller';
 import { rateLimitGetKeyGenerator, rateLimitGetMaxRequests } from '../utils/route.utils';
@@ -26,6 +27,20 @@ const STRICT_2X_AuthRateLimit = createRateLimit('auth_strict_2x', {
   keyGenerator: rateLimitGetKeyGenerator(),
 });
 
+// Session-scoped cap on /auth/verify: bounds parallel bursts so concurrent requests can't exceed
+// MAX_VERIFICATION_ATTEMPTS even when the session-stored attempt counter races under last-write-wins.
+// This rate-limit window (15 min) does NOT reset when a user requests a resend — resend clears
+// req.session.pendingVerificationAttempts, but the rate-limit counter persists. That's intentional:
+// it prevents resend-as-counter-reset abuse by keeping the hard ceiling of MAX_VERIFICATION_ATTEMPTS
+// /verify calls per session per 15-min window regardless of how many resends occur. Falls back to IP
+// only in the defensive case of a missing session (verify always requires one in normal flow).
+const verifyIpKeyGenerator = rateLimitGetKeyGenerator();
+const VerifyAttemptRateLimit = createRateLimit('auth_verify_attempt', {
+  windowMs: 1000 * 60 * 15, // 15 minutes
+  limit: rateLimitGetMaxRequests(MAX_VERIFICATION_ATTEMPTS),
+  keyGenerator: (req, res) => req.sessionID || verifyIpKeyGenerator(req, res),
+});
+
 export const routes: express.Router = Router();
 
 routes.get('/logout', LAX_AuthRateLimit, authController.routeDefinition.logout.controllerFn());
@@ -42,7 +57,7 @@ routes.post('/signin/:provider', STRICT_AuthRateLimit, authController.routeDefin
 routes.get('/callback/:provider', STRICT_AuthRateLimit, authController.routeDefinition.callback.controllerFn());
 routes.post('/callback/:provider', STRICT_AuthRateLimit, verifyCaptcha, authController.routeDefinition.callback.controllerFn());
 // 2FA and email verification
-routes.post('/verify', STRICT_AuthRateLimit, authController.routeDefinition.verification.controllerFn());
+routes.post('/verify', STRICT_AuthRateLimit, VerifyAttemptRateLimit, authController.routeDefinition.verification.controllerFn());
 routes.post('/verify/resend', STRICT_2X_AuthRateLimit, authController.routeDefinition.resendVerification.controllerFn());
 // Terms of Service acceptance gate
 routes.post('/accept-terms', LAX_AuthRateLimit, authController.routeDefinition.acceptTerms.controllerFn());

--- a/apps/api/src/app/routes/route.middleware.ts
+++ b/apps/api/src/app/routes/route.middleware.ts
@@ -28,6 +28,7 @@ import * as salesforceOrgsDb from '../db/salesforce-org.db';
 import { checkUserEntitlement } from '../db/user.db';
 import * as sfdcEncService from '../services/salesforce-org-encryption.service';
 import { AuthenticationError, NotFoundError, UserFacingError } from '../utils/error-handler';
+import { rateLimitGetKeyGenerator, rateLimitGetMaxRequests } from '../utils/route.utils';
 
 export function basicAuthMiddleware(req: express.Request, res: express.Response, next: express.NextFunction) {
   try {
@@ -620,9 +621,18 @@ export function setCacheControlForApiRoutes(_req: express.Request, res: express.
   next();
 }
 
+const feedbackIpKeyGenerator = rateLimitGetKeyGenerator();
 export const feedbackRateLimit = createRateLimit('api_feedback_submission', {
   windowMs: 1000 * 60 * 15, // 15 minutes
   limit: ENV.CI || ENV.ENVIRONMENT === 'development' ? 10000 : 5,
+  keyGenerator: (req, res) => (req as Request).externalAuth?.user?.id || req.session.user?.id || feedbackIpKeyGenerator(req, res),
+});
+
+const passwordResetEmailIpKeyGenerator = rateLimitGetKeyGenerator();
+export const passwordResetEmailRateLimit = createRateLimit('api_password_reset_email', {
+  windowMs: 1000 * 60 * 15, // 15 minutes
+  limit: rateLimitGetMaxRequests(3),
+  keyGenerator: (req, res) => req.session.user?.id || passwordResetEmailIpKeyGenerator(req, res),
 });
 
 // User uploads files and they are stored on disk temporarily, we delete them after processing

--- a/apps/jetstream-e2e/src/tests/authentication/login-forms/verification-attempt-limits.spec.ts
+++ b/apps/jetstream-e2e/src/tests/authentication/login-forms/verification-attempt-limits.spec.ts
@@ -1,0 +1,118 @@
+import { MAX_VERIFICATION_ATTEMPTS } from '@jetstream/auth/server';
+import { getPasswordResetToken, getUserSessionsByEmail, hasPasswordResetToken } from '@jetstream/test/e2e-utils';
+import { expect, test } from '../../../fixtures/fixtures';
+
+test.describe.configure({ mode: 'parallel' });
+
+// Reset storage state for this file to avoid being authenticated
+test.use({ storageState: { cookies: [], origins: [] } });
+
+const BAD_CODE = '000000';
+const BAD_RESET_TOKEN = '00000000-0000-0000-0000-000000000000';
+
+const invalidVerificationMessage = 'Your verification token is invalid.';
+const tooManyVerificationAttemptsMessage = 'Too many incorrect attempts. Please sign in again to request a new code.';
+const invalidResetTokenMessage = 'Your reset token is invalid, Restart the reset process.';
+
+test.describe('Verification attempt limits', () => {
+  test.beforeEach(async ({ page, authenticationPage }) => {
+    await page.goto('/');
+    await authenticationPage.acceptCookieBanner();
+  });
+
+  test('Destroys session after MAX failed codes on /auth/verify', async ({ page, authenticationPage }) => {
+    const { email } = await authenticationPage.signUpWithoutEmailVerification();
+
+    // Sanity check: a pending verification exists for this user
+    const sessionsBefore = await getUserSessionsByEmail(email);
+    const pendingBefore = sessionsBefore.find((session) => session.pendingVerification?.length)?.pendingVerification || [];
+    expect(pendingBefore.length).toBeGreaterThan(0);
+
+    // Submit MAX-1 bad codes — each should show the generic invalid-token message.
+    for (let attempt = 1; attempt < MAX_VERIFICATION_ATTEMPTS; attempt++) {
+      await authenticationPage.verificationCodeInput.fill(BAD_CODE);
+      await authenticationPage.continueButton.click();
+      await expect(page.getByText(invalidVerificationMessage)).toBeVisible();
+    }
+
+    // Final attempt trips the session-scoped budget: session is destroyed and the
+    // TooManyVerificationAttempts message is surfaced.
+    await authenticationPage.verificationCodeInput.fill(BAD_CODE);
+    await authenticationPage.continueButton.click();
+    await expect(page.getByText(tooManyVerificationAttemptsMessage)).toBeVisible();
+
+    // Session should no longer carry a pendingVerification for this user.
+    const sessionsAfter = await getUserSessionsByEmail(email);
+    const pendingAfter = sessionsAfter.flatMap((session) => session.pendingVerification || []);
+    expect(pendingAfter).toHaveLength(0);
+  });
+
+  test('Resending a verification code resets the attempt counter', async ({ page, authenticationPage }) => {
+    await authenticationPage.signUpWithoutEmailVerification();
+
+    // Burn MAX-1 attempts — one more would lock out the session.
+    for (let attempt = 1; attempt < MAX_VERIFICATION_ATTEMPTS; attempt++) {
+      await authenticationPage.verificationCodeInput.fill(BAD_CODE);
+      await authenticationPage.continueButton.click();
+      await expect(page.getByText(invalidVerificationMessage)).toBeVisible();
+    }
+
+    // Resend should reset pendingVerificationAttempts back to 0. The resend CTA hides itself
+    // after a successful send (the component's hasResent state gates the form) — we use that
+    // as the signal that the request completed.
+    const resendButton = page.getByRole('button', { name: 'Send a new code' });
+    await resendButton.click();
+    await expect(resendButton).toBeHidden();
+
+    // The next bad code should still show the generic message — not the lockout — because
+    // the counter was reset. Previously this attempt would have been the "nth failure" that
+    // destroyed the session.
+    await authenticationPage.verificationCodeInput.fill(BAD_CODE);
+    await authenticationPage.continueButton.click();
+    await expect(page.getByText(invalidVerificationMessage)).toBeVisible();
+    await expect(page.getByText(tooManyVerificationAttemptsMessage)).toBeHidden();
+  });
+
+  test('Invalidates reset token after MAX failed password-reset submissions', async ({ page, authenticationPage, playwrightPage }) => {
+    const { email } = await authenticationPage.signUpAndVerifyEmail();
+    await playwrightPage.logout();
+
+    await authenticationPage.goToPasswordReset();
+    await authenticationPage.fillOutResetPasswordForm(email);
+    // Wait for the confirmation message so the POST that creates the reset-token row has
+    // completed before we query the DB — otherwise the read races the request.
+    await expect(
+      page.getByText('You will receive an email with instructions if an account exists and is eligible for password reset.'),
+    ).toBeVisible();
+
+    // A reset token row should exist in the DB at this point.
+    const issuedToken = await getPasswordResetToken(email);
+    expect(issuedToken).toBeTruthy();
+
+    const password = authenticationPage.generateTestPassword();
+
+    // Submit MAX-1 bad tokens. Each submission reloads the verify page with the bad code so the
+    // form defaults are a fresh non-matching token. After submit, the page redirects back to the
+    // verify URL with an `error=` query param — we wait for the redirect each iteration.
+    for (let attempt = 1; attempt < MAX_VERIFICATION_ATTEMPTS; attempt++) {
+      await authenticationPage.goToPasswordResetVerify({ email, code: BAD_RESET_TOKEN });
+      await authenticationPage.fillOutResetPasswordVerifyForm(password, password);
+      // After a bad-token error the form clears the email/code query params, leaving only ?error=…
+      await page.waitForURL(/\/auth\/(password-reset\/verify|login).*[?&]error=/);
+      // Token row must still exist until the final attempt trips the budget.
+      expect(await hasPasswordResetToken(email, issuedToken!.token)).toBe(true);
+    }
+
+    // Final submission trips the DB-level attempt budget and deletes the row.
+    await authenticationPage.goToPasswordResetVerify({ email, code: BAD_RESET_TOKEN });
+    await authenticationPage.fillOutResetPasswordVerifyForm(password, password);
+    await page.waitForURL(/\/auth\/(password-reset\/verify|login).*[?&]error=/);
+
+    expect(await hasPasswordResetToken(email, issuedToken!.token)).toBe(false);
+
+    // Even the correct token no longer works — the row is gone, so the server treats it as invalid.
+    await authenticationPage.goToPasswordResetVerify({ email, code: issuedToken!.token });
+    await authenticationPage.fillOutResetPasswordVerifyForm(password, password);
+    await expect(page.getByText(invalidResetTokenMessage)).toBeVisible();
+  });
+});

--- a/libs/auth/server/src/lib/auth.constants.ts
+++ b/libs/auth/server/src/lib/auth.constants.ts
@@ -9,6 +9,10 @@ export const PASSWORD_RESET_DURATION_MINUTES = 30;
 export const TOKEN_DURATION_MINUTES = 15;
 export const EMAIL_VERIFICATION_TOKEN_DURATION_HOURS = 1;
 
+// Maximum failed OTP / reset-token submissions before we invalidate the attempt
+// (destroy the session for /auth/verify, delete the reset row for /password/reset/verify).
+export const MAX_VERIFICATION_ATTEMPTS = 5;
+
 export const DELETE_AUTH_ACTIVITY_DAYS = 365;
 export const DELETE_EMAIL_ACTIVITY_DAYS = 180;
 export const DELETE_TOKEN_DAYS = 3;

--- a/libs/auth/server/src/lib/auth.db.service.ts
+++ b/libs/auth/server/src/lib/auth.db.service.ts
@@ -46,6 +46,7 @@ import {
   DELETE_EXPIRED_DOMAIN_VERIFICATION_DAYS,
   DELETE_MAILGUN_WEBHOOK_DAYS,
   DELETE_TOKEN_DAYS,
+  MAX_VERIFICATION_ATTEMPTS,
   PASSWORD_RESET_DURATION_MINUTES,
   PLACEHOLDER_USER_ID,
 } from './auth.constants';
@@ -64,7 +65,7 @@ import {
   ProviderNotAllowed,
 } from './auth.errors';
 import { ensureAuthError, lookupGeoLocationFromIpAddresses } from './auth.service';
-import { checkUserAgentSimilarity, hashPassword, REMEMBER_DEVICE_DAYS, verifyPassword } from './auth.utils';
+import { checkUserAgentSimilarity, hashPassword, REMEMBER_DEVICE_DAYS, timingSafeStringCompare, verifyPassword } from './auth.utils';
 
 // This is potentially accessed multiple times in a transaction for a user, cache data to avoid DB access
 const LOGIN_CONFIGURATION_CACHE = new LRUCache<string, { value: LoginConfiguration | null }>({
@@ -930,22 +931,71 @@ export const generatePasswordResetToken = async (email: string) => {
 export const resetUserPassword = async (email: string, token: string, password: string) => {
   email = email.toLowerCase();
 
-  const resetToken = await prisma.passwordResetToken.findUnique({
+  // Load every row for this email so we can (a) detect bad-token attempts and charge them against the
+  // per-row attempt budget, and (b) tolerate the race where two concurrent generatePasswordResetToken
+  // calls leave multiple live rows (delete+insert is not transactional, and email is not uniquely
+  // constrained on its own). Prefer the row whose token matches the submitted value; fall back to the
+  // newest row so the attempt counter is charged against something deterministic.
+  const resetTokens = await prisma.passwordResetToken.findMany({
     select: {
+      token: true,
       userId: true,
       expiresAt: true,
       user: {
         select: { teamMembership: { select: { status: true } } },
       },
     },
-    where: { email_token: { email, token } },
+    where: { email },
+    // Secondary `token` order breaks ties when two concurrent generatePasswordResetToken calls
+    // land on the same `expiresAt` timestamp, so the charged attempt row stays deterministic.
+    orderBy: [{ expiresAt: 'desc' }, { token: 'desc' }],
   });
 
-  if (!resetToken) {
-    throw new InvalidOrExpiredResetToken('Missing reset token');
+  // Generic message used for all invalid/expired/inactive cases below to avoid leaking
+  // whether a reset token is currently active for the supplied email over the API.
+  // Server-side `logger.warn` at each branch preserves context for ops/debug.
+  const GENERIC_INVALID_RESET_TOKEN_MESSAGE = 'Invalid or expired reset token';
+
+  if (resetTokens.length === 0) {
+    logger.warn({ email }, '[AUTH][PASSWORD_RESET][NO_TOKEN] No reset token exists for email');
+    throw new InvalidOrExpiredResetToken(GENERIC_INVALID_RESET_TOKEN_MESSAGE);
   }
 
-  const { expiresAt, user, userId } = resetToken;
+  const matchingToken = resetTokens.find(({ token: stored }) => timingSafeStringCompare(stored, token));
+  const resetToken = matchingToken ?? resetTokens[0];
+
+  const { expiresAt, user, userId, token: storedToken } = resetToken;
+
+  if (!matchingToken) {
+    // Atomic increment — concurrent bad-token attempts must each advance the counter,
+    // otherwise parallelized guesses would never push it past MAX_VERIFICATION_ATTEMPTS.
+    try {
+      const { attempts: updatedAttempts } = await prisma.passwordResetToken.update({
+        where: { token: storedToken },
+        data: { attempts: { increment: 1 } },
+        select: { attempts: true },
+      });
+      if (updatedAttempts >= MAX_VERIFICATION_ATTEMPTS) {
+        logger.warn(
+          { email, userId, attempts: updatedAttempts, expiresAt },
+          '[AUTH][PASSWORD_RESET][TOO_MANY_ATTEMPTS] Reset token invalidated after exceeding attempt budget',
+        );
+        await prisma.passwordResetToken.deleteMany({ where: { email } });
+        throw new InvalidOrExpiredResetToken(GENERIC_INVALID_RESET_TOKEN_MESSAGE);
+      }
+    } catch (ex) {
+      if (ex instanceof InvalidOrExpiredResetToken) {
+        throw ex;
+      }
+      // Row was replaced/deleted by a concurrent password-reset request — treat as invalid.
+      if (!(ex instanceof Prisma.PrismaClientKnownRequestError) || ex.code !== 'P2025') {
+        throw ex;
+      }
+    }
+    logger.warn({ email, userId }, '[AUTH][PASSWORD_RESET][MISMATCH] Provided reset token does not match stored token');
+    throw new InvalidOrExpiredResetToken(GENERIC_INVALID_RESET_TOKEN_MESSAGE);
+  }
+
   const { teamMembership } = user;
 
   // Used only if password re-use caused the failure
@@ -956,17 +1006,26 @@ export const resetUserPassword = async (email: string, token: string, password: 
     });
   }
 
-  // delete token - we don't need it anymore and if we fail later, the user will need to reset again
-  await prisma.passwordResetToken.delete({
-    where: { email_token: { email, token } },
+  // Delete all reset tokens for this email — concurrent generatePasswordResetToken calls can leave
+  // multiple live rows (see findMany above). We must invalidate all of them so a successful reset
+  // cannot be followed by another reset using a sibling token from the same burst. If the password
+  // change fails downstream (e.g. password reuse), restoreResetTokenOnPasswordReuse re-creates the
+  // matched token so the user can retry.
+  await prisma.passwordResetToken.deleteMany({
+    where: { email },
   });
 
   if (teamMembership && teamMembership.status !== TEAM_MEMBER_STATUS_ACTIVE) {
-    throw new InvalidOrExpiredResetToken('User is inactive and their password cannot be reset');
+    logger.warn(
+      { email, userId, teamStatus: teamMembership.status },
+      '[AUTH][PASSWORD_RESET][INACTIVE_USER] User is inactive and their password cannot be reset',
+    );
+    throw new InvalidOrExpiredResetToken(GENERIC_INVALID_RESET_TOKEN_MESSAGE);
   }
 
   if (expiresAt < new Date()) {
-    throw new InvalidOrExpiredResetToken(`Expired at ${expiresAt.toISOString()}`);
+    logger.warn({ email, userId, expiresAt }, '[AUTH][PASSWORD_RESET][EXPIRED] Reset token is expired');
+    throw new InvalidOrExpiredResetToken(GENERIC_INVALID_RESET_TOKEN_MESSAGE);
   }
 
   await changeUserPassword(userId, password, restoreResetTokenOnPasswordReuse);

--- a/libs/auth/server/src/lib/auth.errors.ts
+++ b/libs/auth/server/src/lib/auth.errors.ts
@@ -24,7 +24,8 @@ type ErrorType =
   | 'ProviderEmailNotVerified'
   | 'SsoAutoProvisioningDisabled'
   | 'SsoInvalidAction'
-  | 'SsoLicenseLimitExceeded';
+  | 'SsoLicenseLimitExceeded'
+  | 'TooManyVerificationAttempts';
 
 type ErrorOptions = Error | Record<string, unknown>;
 
@@ -114,6 +115,10 @@ export class InvalidVerificationToken extends AuthError {
 
 export class InvalidOrExpiredResetToken extends AuthError {
   static type: ErrorType = 'InvalidOrExpiredResetToken';
+}
+
+export class TooManyVerificationAttempts extends AuthError {
+  static type: ErrorType = 'TooManyVerificationAttempts';
 }
 
 export class InactiveUser extends AuthError {

--- a/libs/auth/server/src/lib/auth.service.ts
+++ b/libs/auth/server/src/lib/auth.service.ts
@@ -365,6 +365,7 @@ export function initSession(
         req.session.user = user;
         req.session.pendingMfaEnrollment = undefined;
         req.session.pendingVerification = undefined;
+        req.session.pendingVerificationAttempts = 0;
         req.session.pendingTosAcceptance = undefined;
 
         // Generate and set HMAC CSRF token (same token used for both cookie and header validation)

--- a/libs/auth/types/src/lib/auth-types.ts
+++ b/libs/auth/types/src/lib/auth-types.ts
@@ -160,6 +160,12 @@ export interface SessionData {
         exp: number;
       }
   > | null;
+  /**
+   * Count of failed /auth/verify submissions for the current pendingVerification.
+   * Reset on resend and on successful verification. Session is destroyed once the
+   * counter reaches MAX_VERIFICATION_ATTEMPTS.
+   */
+  pendingVerificationAttempts?: number;
   loginTime: number;
   provider: OauthProviderType | SsoProviderType | 'credentials';
   // TODO: lastActivity: number;

--- a/libs/shared/constants/src/lib/shared-constants.ts
+++ b/libs/shared/constants/src/lib/shared-constants.ts
@@ -1129,4 +1129,5 @@ export const AUTH_ERROR_MESSAGES = {
   SsoLicenseLimitExceeded:
     'Your account cannot be provisioned because the team has reached its maximum user count or the account is not active. Please contact your administrator.',
   TooManyRequests: 'Too many attempts. Please wait a moment before trying again.',
+  TooManyVerificationAttempts: 'Too many incorrect attempts. Please sign in again to request a new code.',
 };

--- a/prisma/migrations/20260418202437_add_counter_pw_reset_attempt/migration.sql
+++ b/prisma/migrations/20260418202437_add_counter_pw_reset_attempt/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "PasswordResetToken" ADD COLUMN     "attempts" INTEGER NOT NULL DEFAULT 0;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -221,6 +221,7 @@ model PasswordResetToken {
   email     String
   token     String   @unique @default(dbgenerated("uuid_generate_v4()")) @db.Uuid
   expiresAt DateTime
+  attempts  Int      @default(0)
 
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 


### PR DESCRIPTION
Introduce limits on verification attempts for authentication processes, expiring tokens after a set number of invalid attempts to enhance security. Rate limits have been added to internal password reset endpoints to prevent abuse.