### PR TITLE
Fix session revocation and error handling in verification process

### DIFF
--- a/apps/jetstream-e2e/src/tests/authentication/login-forms/verification-attempt-limits.spec.ts
+++ b/apps/jetstream-e2e/src/tests/authentication/login-forms/verification-attempt-limits.spec.ts
@@ -35,10 +35,12 @@ test.describe('Verification attempt limits', () => {
       await expect(page.getByText(invalidVerificationMessage)).toBeVisible();
     }
 
-    // Final attempt trips the session-scoped budget: session is destroyed and the
-    // TooManyVerificationAttempts message is surfaced.
+    // Final attempt trips the session-scoped budget: session is destroyed and the user is bounced
+    // to the login page with the lockout message preserved as a query param. The redirect matters
+    // because a refresh on /auth/verify would silently lose the error context.
     await authenticationPage.verificationCodeInput.fill(BAD_CODE);
     await authenticationPage.continueButton.click();
+    await page.waitForURL(/\/auth\/login.*[?&]error=TooManyVerificationAttempts/);
     await expect(page.getByText(tooManyVerificationAttemptsMessage)).toBeVisible();
 
     // Session should no longer carry a pendingVerification for this user.

--- a/apps/landing/components/auth/VerifyEmailOr2fa.tsx
+++ b/apps/landing/components/auth/VerifyEmailOr2fa.tsx
@@ -59,7 +59,7 @@ export function VerifyEmailOr2fa({ csrfToken, email, pendingVerifications }: Ver
     handleSubmit,
     setValue,
     watch,
-    formState: { errors },
+    formState: { errors, isSubmitting },
   } = useForm({
     resolver: zodResolver(FormSchema),
     defaultValues: {
@@ -98,6 +98,14 @@ export function VerifyEmailOr2fa({ csrfToken, email, pendingVerifications }: Ver
       .then((res: { data: { error: boolean; errorType?: string; redirect?: string } }) => res.data);
 
     if (!response.ok || error) {
+      // Session-ending errors (e.g. too many failed attempts) destroy the pending verification on
+      // the server. Refreshing this page would silently bounce the user to login with no context,
+      // so redirect now with the error preserved as a query param. This also covers the multi-tab
+      // case where the session was killed by another tab and this tab sees InvalidSession.
+      if (errorType === 'TooManyVerificationAttempts' || errorType === 'InvalidSession') {
+        router.push(`${ROUTES.AUTH.login}?${new URLSearchParams({ error: errorType })}`);
+        return;
+      }
       setError(errorType || 'UNKNOWN_ERROR');
       return;
     }
@@ -177,6 +185,7 @@ export function VerifyEmailOr2fa({ csrfToken, email, pendingVerifications }: Ver
             <div>
               <button
                 type="submit"
+                disabled={isSubmitting}
                 className="flex w-full justify-center rounded-md bg-blue-600 px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-xs hover:bg-blue-700 disabled:bg-gray-300 disabled:cursor-not-allowed focus-visible:outline-solid focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600"
               >
                 Continue

--- a/libs/auth/server/src/lib/auth.db.service.ts
+++ b/libs/auth/server/src/lib/auth.db.service.ts
@@ -846,8 +846,9 @@ export async function revokeAllUserSessions(userId: string, exceptId?: Maybe<str
         }
       : { userId },
   });
+  // exceptId refers to a session sid, never a webExtensionToken UUID — always clear all of the user's tokens.
   await prisma.webExtensionToken.deleteMany({
-    where: exceptId ? { userId, NOT: { id: exceptId } } : { userId },
+    where: { userId },
   });
 }
 


### PR DESCRIPTION
Ensure all user tokens are cleared during session revocation and preserve error context during session-ending errors. This prevents loss of error information when users are redirected after failed verification attempts.