### PR TITLE
HOTFIX: Delegate authentication-strength decisions to IdP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [9.15.1](https://github.com/jetstreamapp/jetstream/compare/v9.15.0...v9.15.1) (2026-04-22)
+
+### Features
+
+* delegate authentication-strength decisions to IdP by disabling requestedAuthnContext ([fc6a886](https://github.com/jetstreamapp/jetstream/commit/fc6a8867a27487371758b452292fdd2698b52b8b))
+
 ## [9.15.0](https://github.com/jetstreamapp/jetstream/compare/v9.14.0...v9.15.0) (2026-04-21)
 
 ### Features

--- a/libs/auth/server/src/lib/saml.service.ts
+++ b/libs/auth/server/src/lib/saml.service.ts
@@ -77,6 +77,11 @@ export class SamlService {
       // Many IdPs (Okta, Google, etc.) sign only the assertion, not the response envelope.
       // Assertion-level signing is sufficient when wantAssertionsSigned is true.
       wantAuthnResponseSigned: false,
+      // Delegate authentication-strength decisions to the IdP. node-saml defaults to
+      // requesting PasswordProtectedTransport, which rejects users authenticating via
+      // certificates, FIDO2, passwordless, etc. and triggers errors like Azure's AADSTS75011.
+      // Letting the IdP enforce its own conditional-access / MFA policy is the modern norm.
+      disableRequestedAuthnContext: true,
 
       // InResponseTo validation: ensures SAML responses correspond to requests we initiated
       // and that each response can only be consumed once (anti-replay).

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "url": "https://github.com/jetstreamapp/jetstream"
   },
   "author": "Jetstream Solutions, LLC",
-  "version": "9.15.0",
+  "version": "9.15.1",
   "license": "SEE LICENSE IN LICENSE.md",
   "engines": {
     "node": ">=22 <23",


### PR DESCRIPTION
Disable the requestedAuthnContext to allow the IdP to manage authentication strength, accommodating various authentication methods and preventing related errors.