### PR TITLE
Implement SSO user resolution and identity linking with error handling

### DIFF
--- a/libs/auth/server/src/lib/__tests__/sso-auth.service.spec.ts
+++ b/libs/auth/server/src/lib/__tests__/sso-auth.service.spec.ts
@@ -1,0 +1,445 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { linkSsoIdentity, resolveSsoUser } from '../sso-auth.service';
+
+const loggerMock = vi.hoisted(() => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }));
+
+const prismaMock = vi.hoisted(() => ({
+  authIdentity: {
+    findFirst: vi.fn(),
+    findUnique: vi.fn(),
+    update: vi.fn(),
+    create: vi.fn(),
+  },
+  user: {
+    findMany: vi.fn(),
+  },
+  webExtensionToken: {
+    updateMany: vi.fn(),
+  },
+  $transaction: vi.fn(),
+}));
+
+const prismaErrorMock = vi.hoisted(() => {
+  class PrismaUniqueConstraintError extends Error {}
+  return {
+    PrismaUniqueConstraintError,
+    isPrismaError: vi.fn(() => false),
+    toTypedPrismaError: vi.fn(() => null),
+  };
+});
+
+vi.mock('@jetstream/api-config', () => ({
+  ENV: {},
+  logger: loggerMock,
+  prisma: prismaMock,
+}));
+
+vi.mock('@jetstream/prisma', () => ({
+  isPrismaError: prismaErrorMock.isPrismaError,
+  PrismaUniqueConstraintError: prismaErrorMock.PrismaUniqueConstraintError,
+  toTypedPrismaError: prismaErrorMock.toTypedPrismaError,
+}));
+
+vi.mock('@jetstream/types', () => ({
+  BILLABLE_ROLES: new Set(['ADMIN', 'BILLING', 'MEMBER']),
+  TEAM_BILLING_STATUS_PAST_DUE: 'PAST_DUE',
+  TEAM_MEMBER_STATUS_ACTIVE: 'ACTIVE',
+}));
+
+vi.mock('@jetstream/auth/types', () => ({
+  AuthenticatedUserSchema: {
+    parse: (value: unknown) => value,
+  },
+}));
+
+vi.mock('../auth-logging.db.service', () => ({ createUserActivity: vi.fn() }));
+
+vi.mock('../auth.db.service', () => ({
+  AuthenticatedUserSelect: {},
+  discoverSsoByDomain: vi.fn(),
+  getLoginConfiguration: vi.fn(),
+}));
+
+vi.mock('../auth.service', () => ({ initSession: vi.fn() }));
+
+const fakeUser = (overrides: Record<string, unknown> = {}) => ({
+  id: 'user-1',
+  email: 'user@example.com',
+  ...overrides,
+});
+
+/** Make the next error thrown pass isUniqueConstraintError(). */
+function makeUniqueConstraintThrow(): Error {
+  const err = new Error('unique_violation');
+  prismaErrorMock.isPrismaError.mockReturnValueOnce(true);
+  prismaErrorMock.toTypedPrismaError.mockReturnValueOnce(new prismaErrorMock.PrismaUniqueConstraintError() as any);
+  return err;
+}
+
+describe('resolveSsoUser', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    prismaErrorMock.isPrismaError.mockReturnValue(false);
+    prismaErrorMock.toTypedPrismaError.mockReturnValue(null);
+    prismaMock.$transaction.mockImplementation(async (operations: unknown[]) => operations);
+  });
+
+  it('returns the user identified by subject when an AuthIdentity matches', async () => {
+    prismaMock.authIdentity.findFirst.mockResolvedValueOnce({ user: fakeUser() });
+
+    const result = await resolveSsoUser({
+      provider: 'saml',
+      email: 'user@example.com',
+      subject: 'nameid-abc-123',
+      teamId: 'team-1',
+      samlConfigurationId: 'saml-1',
+    });
+
+    expect(result).toEqual(fakeUser());
+    expect(prismaMock.authIdentity.findFirst).toHaveBeenCalledTimes(1);
+    expect(prismaMock.authIdentity.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          provider: 'saml',
+          providerAccountId: 'nameid-abc-123',
+          samlConfigurationId: 'saml-1',
+        }),
+      }),
+    );
+    expect(prismaMock.user.findMany).not.toHaveBeenCalled();
+    expect(prismaMock.$transaction).not.toHaveBeenCalled();
+  });
+
+  it('falls back to legacy email-keyed identity and migrates it to the subject key', async () => {
+    prismaMock.authIdentity.findFirst
+      .mockResolvedValueOnce(null) // lookup by subject misses
+      .mockResolvedValueOnce({ user: fakeUser() }); // legacy email lookup hits
+
+    const result = await resolveSsoUser({
+      provider: 'saml',
+      email: 'user@example.com',
+      subject: 'nameid-abc-123',
+      teamId: 'team-1',
+      samlConfigurationId: 'saml-1',
+    });
+
+    expect(result).toEqual(fakeUser());
+    expect(prismaMock.$transaction).toHaveBeenCalledTimes(1);
+    expect(prismaMock.authIdentity.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { provider_providerAccountId: { provider: 'saml', providerAccountId: 'user@example.com' } },
+        data: { providerAccountId: 'nameid-abc-123' },
+      }),
+    );
+    expect(prismaMock.webExtensionToken.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { userId: 'user-1', provider: 'saml', providerAccountId: 'user@example.com' },
+        data: { providerAccountId: 'nameid-abc-123' },
+      }),
+    );
+    expect(prismaMock.user.findMany).not.toHaveBeenCalled();
+  });
+
+  it('throws SsoAmbiguousAccount when multiple users share the email and none can be disambiguated by team', async () => {
+    prismaMock.authIdentity.findFirst.mockResolvedValue(null);
+    prismaMock.user.findMany.mockResolvedValueOnce([fakeUser({ id: 'user-1' }), fakeUser({ id: 'user-2' })]);
+
+    await expect(
+      resolveSsoUser({
+        provider: 'saml',
+        email: 'user@example.com',
+        subject: 'nameid-abc-123',
+        teamId: 'team-1',
+        samlConfigurationId: 'saml-1',
+      }),
+    ).rejects.toMatchObject({ type: 'SsoAmbiguousAccount' });
+
+    expect(loggerMock.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ email: 'user@example.com', matchCount: 2, teamMatchCount: 0 }),
+      expect.stringContaining('multiple users share this email'),
+    );
+  });
+
+  it('disambiguates multiple email matches by preferring the user already in this team', async () => {
+    prismaMock.authIdentity.findFirst.mockResolvedValue(null);
+    prismaMock.user.findMany.mockResolvedValueOnce([
+      fakeUser({ id: 'user-1', teamMembership: { teamId: 'team-other' } }),
+      fakeUser({ id: 'user-2', teamMembership: { teamId: 'team-1' } }),
+    ]);
+
+    const result = await resolveSsoUser({
+      provider: 'saml',
+      email: 'user@example.com',
+      subject: 'nameid-abc-123',
+      teamId: 'team-1',
+      samlConfigurationId: 'saml-1',
+    });
+
+    expect(result).toMatchObject({ id: 'user-2' });
+  });
+
+  it('throws SsoAmbiguousAccount when multiple users with this email are members of the same team', async () => {
+    prismaMock.authIdentity.findFirst.mockResolvedValue(null);
+    prismaMock.user.findMany.mockResolvedValueOnce([
+      fakeUser({ id: 'user-1', teamMembership: { teamId: 'team-1' } }),
+      fakeUser({ id: 'user-2', teamMembership: { teamId: 'team-1' } }),
+    ]);
+
+    await expect(
+      resolveSsoUser({
+        provider: 'saml',
+        email: 'user@example.com',
+        subject: 'nameid-abc-123',
+        teamId: 'team-1',
+        samlConfigurationId: 'saml-1',
+      }),
+    ).rejects.toMatchObject({ type: 'SsoAmbiguousAccount' });
+
+    expect(loggerMock.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ matchCount: 2, teamMatchCount: 2 }),
+      expect.stringContaining('multiple users share this email'),
+    );
+  });
+
+  it('returns the single matching user via email fallback when no identity exists yet', async () => {
+    prismaMock.authIdentity.findFirst.mockResolvedValue(null);
+    prismaMock.user.findMany.mockResolvedValueOnce([fakeUser()]);
+
+    const result = await resolveSsoUser({
+      provider: 'saml',
+      email: 'user@example.com',
+      subject: 'nameid-abc-123',
+      teamId: 'team-1',
+      samlConfigurationId: 'saml-1',
+    });
+
+    expect(result).toEqual(fakeUser());
+    expect(prismaMock.$transaction).not.toHaveBeenCalled();
+  });
+
+  it('returns null when no identity and no user matches (triggers JIT in caller)', async () => {
+    prismaMock.authIdentity.findFirst.mockResolvedValue(null);
+    prismaMock.user.findMany.mockResolvedValueOnce([]);
+
+    const result = await resolveSsoUser({
+      provider: 'oidc',
+      email: 'new@example.com',
+      subject: 'sub-999',
+      teamId: 'team-1',
+      oidcConfigurationId: 'oidc-1',
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it('skips subject lookup when IdP did not provide a subject', async () => {
+    prismaMock.authIdentity.findFirst.mockResolvedValueOnce({ user: fakeUser() });
+
+    const result = await resolveSsoUser({
+      provider: 'saml',
+      email: 'user@example.com',
+      subject: undefined,
+      teamId: 'team-1',
+      samlConfigurationId: 'saml-1',
+    });
+
+    expect(result).toEqual(fakeUser());
+    expect(prismaMock.authIdentity.findFirst).toHaveBeenCalledTimes(1);
+    expect(prismaMock.authIdentity.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ providerAccountId: 'user@example.com' }),
+      }),
+    );
+  });
+
+  it('does not migrate the identity key when subject equals email (no-op case)', async () => {
+    prismaMock.authIdentity.findFirst.mockResolvedValueOnce({ user: fakeUser() });
+
+    await resolveSsoUser({
+      provider: 'saml',
+      email: 'user@example.com',
+      subject: 'user@example.com',
+      teamId: 'team-1',
+      samlConfigurationId: 'saml-1',
+    });
+
+    expect(prismaMock.$transaction).not.toHaveBeenCalled();
+    expect(prismaMock.authIdentity.update).not.toHaveBeenCalled();
+  });
+
+  it('blocks the login when a non-constraint migration failure occurs (avoids orphan rows)', async () => {
+    prismaMock.authIdentity.findFirst.mockResolvedValueOnce(null).mockResolvedValueOnce({ user: fakeUser() });
+    prismaMock.$transaction.mockRejectedValueOnce(new Error('db unavailable'));
+
+    await expect(
+      resolveSsoUser({
+        provider: 'saml',
+        email: 'user@example.com',
+        subject: 'nameid-abc-123',
+        teamId: 'team-1',
+        samlConfigurationId: 'saml-1',
+      }),
+    ).rejects.toMatchObject({ type: 'SsoInvalidAction' });
+
+    expect(loggerMock.error).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: 'user-1', email: 'user@example.com', subject: 'nameid-abc-123' }),
+      expect.stringContaining('blocking login to avoid creating an orphan'),
+    );
+  });
+
+  it('throws SsoAmbiguousAccount when the migration hits a unique-constraint violation', async () => {
+    prismaMock.authIdentity.findFirst.mockResolvedValueOnce(null).mockResolvedValueOnce({ user: fakeUser() });
+    prismaMock.$transaction.mockRejectedValueOnce(makeUniqueConstraintThrow());
+
+    await expect(
+      resolveSsoUser({
+        provider: 'saml',
+        email: 'user@example.com',
+        subject: 'nameid-abc-123',
+        teamId: 'team-1',
+        samlConfigurationId: 'saml-1',
+      }),
+    ).rejects.toMatchObject({ type: 'SsoAmbiguousAccount' });
+
+    expect(loggerMock.error).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: 'user-1', subject: 'nameid-abc-123' }),
+      expect.stringContaining('migration blocked'),
+    );
+  });
+
+  it('scopes OIDC identity lookups by oidcConfigurationId', async () => {
+    prismaMock.authIdentity.findFirst.mockResolvedValueOnce({ user: fakeUser() });
+
+    await resolveSsoUser({
+      provider: 'oidc',
+      email: 'user@example.com',
+      subject: 'sub-xyz',
+      teamId: 'team-1',
+      oidcConfigurationId: 'oidc-1',
+    });
+
+    expect(prismaMock.authIdentity.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          provider: 'oidc',
+          providerAccountId: 'sub-xyz',
+          oidcConfigurationId: 'oidc-1',
+        }),
+      }),
+    );
+    const calledArgs = prismaMock.authIdentity.findFirst.mock.calls[0]?.[0] as { where: Record<string, unknown> };
+    expect(calledArgs.where).not.toHaveProperty('samlConfigurationId');
+  });
+});
+
+describe('linkSsoIdentity', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('creates a new identity row keyed by subject when none exists', async () => {
+    prismaMock.authIdentity.findUnique.mockResolvedValueOnce(null);
+
+    await linkSsoIdentity(
+      'user-1',
+      'saml',
+      'user@example.com',
+      { email: 'user@example.com', userName: 'user', subject: 'nameid-abc' },
+      { samlConfigurationId: 'saml-1' },
+    );
+
+    expect(prismaMock.authIdentity.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          userId: 'user-1',
+          provider: 'saml',
+          providerAccountId: 'nameid-abc',
+          samlConfigurationId: 'saml-1',
+          oidcConfigurationId: undefined,
+        }),
+      }),
+    );
+  });
+
+  it('falls back to email-keyed identity when IdP did not provide a subject', async () => {
+    prismaMock.authIdentity.findUnique.mockResolvedValueOnce(null);
+
+    await linkSsoIdentity(
+      'user-1',
+      'saml',
+      'user@example.com',
+      { email: 'user@example.com', userName: 'user' },
+      { samlConfigurationId: 'saml-1' },
+    );
+
+    expect(prismaMock.authIdentity.findUnique).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { provider_providerAccountId: { provider: 'saml', providerAccountId: 'user@example.com' } },
+      }),
+    );
+    expect(prismaMock.authIdentity.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ providerAccountId: 'user@example.com' }),
+      }),
+    );
+  });
+
+  it('no-ops when the existing identity already belongs to this user', async () => {
+    prismaMock.authIdentity.findUnique.mockResolvedValueOnce({ userId: 'user-1' });
+
+    await linkSsoIdentity(
+      'user-1',
+      'saml',
+      'user@example.com',
+      { email: 'user@example.com', userName: 'user', subject: 'nameid-abc' },
+      { samlConfigurationId: 'saml-1' },
+    );
+
+    expect(prismaMock.authIdentity.create).not.toHaveBeenCalled();
+  });
+
+  it('throws SsoInvalidAction when called with neither or both config ids', async () => {
+    await expect(
+      linkSsoIdentity(
+        'user-1',
+        'saml',
+        'user@example.com',
+        { email: 'user@example.com', userName: 'user', subject: 'nameid-abc' },
+        {},
+      ),
+    ).rejects.toMatchObject({ type: 'SsoInvalidAction' });
+
+    await expect(
+      linkSsoIdentity(
+        'user-1',
+        'saml',
+        'user@example.com',
+        { email: 'user@example.com', userName: 'user', subject: 'nameid-abc' },
+        { samlConfigurationId: 'saml-1', oidcConfigurationId: 'oidc-1' },
+      ),
+    ).rejects.toMatchObject({ type: 'SsoInvalidAction' });
+
+    expect(prismaMock.authIdentity.findUnique).not.toHaveBeenCalled();
+    expect(prismaMock.authIdentity.create).not.toHaveBeenCalled();
+  });
+
+  it('throws SsoAmbiguousAccount when an identity row exists for a different user', async () => {
+    prismaMock.authIdentity.findUnique.mockResolvedValueOnce({ userId: 'other-user' });
+
+    await expect(
+      linkSsoIdentity(
+        'user-1',
+        'saml',
+        'user@example.com',
+        { email: 'user@example.com', userName: 'user', subject: 'nameid-abc' },
+        { samlConfigurationId: 'saml-1' },
+      ),
+    ).rejects.toMatchObject({ type: 'SsoAmbiguousAccount' });
+
+    expect(loggerMock.error).toHaveBeenCalledWith(
+      expect.objectContaining({ existingUserId: 'other-user', newUserId: 'user-1', provider: 'saml', providerAccountId: 'nameid-abc' }),
+      expect.stringContaining('row exists for a different user'),
+    );
+    expect(prismaMock.authIdentity.create).not.toHaveBeenCalled();
+  });
+});

--- a/libs/auth/server/src/lib/auth.errors.ts
+++ b/libs/auth/server/src/lib/auth.errors.ts
@@ -22,6 +22,7 @@ type ErrorType =
   | 'PasswordResetRequired'
   | 'ProviderNotAllowed'
   | 'ProviderEmailNotVerified'
+  | 'SsoAmbiguousAccount'
   | 'SsoAutoProvisioningDisabled'
   | 'SsoInvalidAction'
   | 'SsoLicenseLimitExceeded'
@@ -161,6 +162,10 @@ export class AccountLocked extends AuthError {
     super(message);
     this.lockedUntil = lockedUntil;
   }
+}
+
+export class SsoAmbiguousAccount extends AuthError {
+  static type: ErrorType = 'SsoAmbiguousAccount';
 }
 
 export class SsoAutoProvisioningDisabled extends AuthError {

--- a/libs/auth/server/src/lib/oidc.service.ts
+++ b/libs/auth/server/src/lib/oidc.service.ts
@@ -186,6 +186,7 @@ export class OidcService {
         userName,
         firstName,
         lastName,
+        subject: claims.sub,
       };
     } catch (error) {
       logger.error({ error }, 'Failed to extract user info from OIDC token');

--- a/libs/auth/server/src/lib/saml.service.ts
+++ b/libs/auth/server/src/lib/saml.service.ts
@@ -267,6 +267,7 @@ export class SamlService {
       userName,
       firstName,
       lastName,
+      subject: profile.nameID,
     };
   }
 

--- a/libs/auth/server/src/lib/sso-auth.service.ts
+++ b/libs/auth/server/src/lib/sso-auth.service.ts
@@ -5,7 +5,13 @@ import { isPrismaError, PrismaUniqueConstraintError, toTypedPrismaError } from '
 import { BILLABLE_ROLES, TEAM_BILLING_STATUS_PAST_DUE, TEAM_MEMBER_STATUS_ACTIVE, TeamMemberRole } from '@jetstream/types';
 import { createUserActivity } from './auth-logging.db.service';
 import { AuthenticatedUserSelect, discoverSsoByDomain, getLoginConfiguration } from './auth.db.service';
-import { ProviderNotAllowed, SsoAutoProvisioningDisabled, SsoInvalidAction, SsoLicenseLimitExceeded } from './auth.errors';
+import {
+  ProviderNotAllowed,
+  SsoAmbiguousAccount,
+  SsoAutoProvisioningDisabled,
+  SsoInvalidAction,
+  SsoLicenseLimitExceeded,
+} from './auth.errors';
 import { initSession } from './auth.service';
 import { SsoUserInfo } from './sso.types';
 
@@ -120,6 +126,129 @@ async function checkJitLicenseAvailability(teamId: string, hasInvitation: boolea
 }
 
 /**
+ * Look up a user via their AuthIdentity row. The lookup is scoped to the team's
+ * SAML/OIDC config so we don't resolve to an identity row from a different config
+ * that happens to share the same provider/providerAccountId. This scoping does not
+ * itself prevent cross-tenant collisions — AuthIdentity uniqueness is still global
+ * on (provider, providerAccountId), so conflicting rows surface as write failures
+ * handled by the callers of this helper.
+ */
+async function findUserBySsoIdentity(params: {
+  provider: SsoProviderType;
+  providerAccountId: string;
+  samlConfigurationId?: string | null;
+  oidcConfigurationId?: string | null;
+}): Promise<AuthenticatedUser | null> {
+  const { provider, providerAccountId, samlConfigurationId, oidcConfigurationId } = params;
+  // AuthIdentity rows set exactly one of these (SAML rows have samlConfigurationId, OIDC rows
+  // have oidcConfigurationId). Callers must mirror that invariant — passing neither leaves the
+  // lookup tenant-unscoped; passing both produces an AND filter no row can match.
+  if (!!samlConfigurationId === !!oidcConfigurationId) {
+    throw new SsoInvalidAction('SSO identity lookup requires exactly one of samlConfigurationId or oidcConfigurationId');
+  }
+  const identity = await prisma.authIdentity.findFirst({
+    where: {
+      provider,
+      providerAccountId,
+      ...(samlConfigurationId ? { samlConfigurationId } : {}),
+      ...(oidcConfigurationId ? { oidcConfigurationId } : {}),
+    },
+    select: { user: { select: AuthenticatedUserSelect } },
+  });
+  return identity?.user ? AuthenticatedUserSchema.parse(identity.user) : null;
+}
+
+/**
+ * Resolve the user for an incoming SSO login, preferring stable IdP subject over email.
+ *
+ * Lookup order:
+ * 1. AuthIdentity keyed by IdP subject (NameID / sub) — the normal path once rows are migrated.
+ * 2. AuthIdentity keyed by email — backward compat for rows created before subject-based keying.
+ *    If hit and we have a different subject, migrate the identity (and any matching extension
+ *    tokens) to the new key so subsequent logins take the fast path.
+ * 3. User.findMany by email with a dupe guard — first-time SSO for a user whose account
+ *    pre-existed. If multiple users share this email, we cannot safely pick one and throw.
+ */
+export async function resolveSsoUser(params: {
+  provider: SsoProviderType;
+  email: string;
+  subject: string | undefined;
+  teamId: string;
+  samlConfigurationId?: string | null;
+  oidcConfigurationId?: string | null;
+}): Promise<AuthenticatedUser | null> {
+  const { provider, email, subject, teamId, samlConfigurationId, oidcConfigurationId } = params;
+  const configScope = { samlConfigurationId, oidcConfigurationId };
+
+  if (subject) {
+    const bySubject = await findUserBySsoIdentity({ provider, providerAccountId: subject, ...configScope });
+    if (bySubject) {
+      return bySubject;
+    }
+  }
+
+  if (!subject || subject !== email) {
+    const byLegacyEmail = await findUserBySsoIdentity({ provider, providerAccountId: email, ...configScope });
+    if (byLegacyEmail) {
+      if (subject && subject !== email) {
+        try {
+          await prisma.$transaction([
+            prisma.authIdentity.update({
+              where: { provider_providerAccountId: { provider, providerAccountId: email } },
+              data: { providerAccountId: subject },
+            }),
+            prisma.webExtensionToken.updateMany({
+              where: { userId: byLegacyEmail.id, provider, providerAccountId: email },
+              data: { providerAccountId: subject },
+            }),
+          ]);
+        } catch (err) {
+          if (isUniqueConstraintError(err)) {
+            // Another row already owns (provider, subject). Silently returning byLegacyEmail
+            // would let next login's subject-first lookup resolve to the wrong user. Surface
+            // the collision so an admin can sort it out.
+            logger.error(
+              { err, userId: byLegacyEmail.id, provider, email, subject },
+              'SSO identity migration blocked: another row already owns (provider, subject). Possible account collision.',
+            );
+            throw new SsoAmbiguousAccount('Your SSO identity is in conflict with another account. Please contact your administrator for assistance.');
+          }
+          // Returning byLegacyEmail after a failed migration would cause the downstream
+          // upsert in handleSsoLogin to create a second subject-keyed row (the where-clause
+          // would miss the still-email-keyed legacy row), leaving an orphan. Block the login
+          // instead — a transient re-login is better than accumulating duplicate identity rows.
+          logger.error(
+            { err, userId: byLegacyEmail.id, provider, email, subject },
+            'SSO identity migration failed: blocking login to avoid creating an orphan identity row',
+          );
+          throw new SsoInvalidAction('We could not complete your sign-in. Please try again in a moment.');
+        }
+      }
+      return byLegacyEmail;
+    }
+  }
+
+  const usersWithEmail = await prisma.user.findMany({ where: { email }, select: AuthenticatedUserSelect });
+  if (usersWithEmail.length === 0) {
+    return null;
+  }
+  if (usersWithEmail.length === 1) {
+    return AuthenticatedUserSchema.parse(usersWithEmail[0]);
+  }
+  // Multiple users share this email globally — try to disambiguate by scoping to this team's
+  // membership. Each user has at most one teamMembership, so a single match in this scope is safe.
+  const teamMatches = usersWithEmail.filter((user) => user.teamMembership?.teamId === teamId);
+  if (teamMatches.length === 1) {
+    return AuthenticatedUserSchema.parse(teamMatches[0]);
+  }
+  logger.warn(
+    { email, provider, teamId, matchCount: usersWithEmail.length, teamMatchCount: teamMatches.length },
+    'SSO login blocked: multiple users share this email and no SSO identity exists to disambiguate',
+  );
+  throw new SsoAmbiguousAccount('Your account cannot be uniquely identified. Please contact your administrator for assistance.');
+}
+
+/**
  * Handle SSO login flow for both SAML and OIDC
  *
  * Security model:
@@ -151,6 +280,7 @@ export async function handleSsoLogin(
 ): Promise<AuthenticatedUser> {
   userInfo = sanitizeUserInfo(userInfo);
   const email = userInfo.email.toLowerCase();
+  const subject = userInfo.subject?.trim() || undefined;
 
   // Validate SSO is enabled for this team
   const loginConfig = await getLoginConfiguration({ teamId });
@@ -176,6 +306,14 @@ export async function handleSsoLogin(
     throw new ProviderNotAllowed(`Expected ${expectedProvider} but received ${provider}`);
   }
 
+  // Only the config matching the active provider should be stamped on AuthIdentity rows or passed
+  // to lookups — findUserBySsoIdentity/linkSsoIdentity require exactly one to be set, and a team
+  // may legitimately have both SAML and OIDC configurations stored even though only one is active.
+  const configScope = {
+    samlConfigurationId: provider === 'saml' ? loginConfig.samlConfiguration?.id : undefined,
+    oidcConfigurationId: provider === 'oidc' ? loginConfig.oidcConfiguration?.id : undefined,
+  };
+
   // Check for team invitation (used for both new users and existing users not in team)
   const invitation = await prisma.teamMemberInvitation.findFirst({
     where: {
@@ -185,14 +323,15 @@ export async function handleSsoLogin(
     },
   });
 
-  // Find user by email
-  // Note: This uses email from SSO assertion which is trusted (verified by IdP)
-  const existingUser = await prisma.user
-    .findFirst({
-      where: { email },
-      select: AuthenticatedUserSelect,
-    })
-    .then((user) => (user ? AuthenticatedUserSchema.parse(user) : null));
+  // Resolve the user via AuthIdentity first (stable IdP subject), falling back to email
+  // lookup with a duplicate-email guard. See resolveSsoUser for details.
+  const existingUser = await resolveSsoUser({
+    provider,
+    email,
+    subject,
+    teamId,
+    ...configScope,
+  });
 
   // User doesn't exist - create new user via JIT provisioning or invitation
   // If a concurrent request already created the user (race condition), catch the
@@ -224,7 +363,7 @@ export async function handleSsoLogin(
               create: {
                 type: 'sso',
                 provider,
-                providerAccountId: email,
+                providerAccountId: subject || email,
                 email,
                 emailVerified: true,
                 username: userInfo.userName,
@@ -232,9 +371,7 @@ export async function handleSsoLogin(
                 givenName: userInfo.firstName,
                 familyName: userInfo.lastName,
                 isPrimary: true,
-                // Only one of these will be set based on provider
-                samlConfigurationId: loginConfig.samlConfiguration?.id,
-                oidcConfigurationId: loginConfig.oidcConfiguration?.id,
+                ...configScope,
               },
             },
             authFactors: {
@@ -284,7 +421,7 @@ export async function handleSsoLogin(
         user: newUser,
         isNewUser: true,
         provider,
-        providerAccountId: email,
+        providerAccountId: subject || email,
         providerType: 'sso',
         teamInviteResponse: null,
         mfaEnrollmentRequired: newUserMfa.mfaEnrollmentRequired,
@@ -304,15 +441,16 @@ export async function handleSsoLogin(
     }
   }
 
-  // Re-fetch the user (either was already found above, or was just created by a concurrent request)
+  // Re-resolve the user (either already found above, or just created by a concurrent request)
   const user =
     existingUser ||
-    (await prisma.user
-      .findFirst({
-        where: { email },
-        select: AuthenticatedUserSelect,
-      })
-      .then((u) => (u ? AuthenticatedUserSchema.parse(u) : null)));
+    (await resolveSsoUser({
+      provider,
+      email,
+      subject,
+      teamId,
+      ...configScope,
+    }));
 
   if (!user) {
     // Should not happen, but guard against it
@@ -368,7 +506,7 @@ export async function handleSsoLogin(
       .then((u) => AuthenticatedUserSchema.parse(u));
 
     // Link SSO identity if not already linked
-    await linkSsoIdentity(reloadedUser.id, provider, email, userInfo);
+    await linkSsoIdentity(reloadedUser.id, provider, email, userInfo, configScope);
 
     logger.info({ userId: reloadedUser.id, teamId, provider, email }, 'Existing user added to team via SSO');
 
@@ -383,7 +521,7 @@ export async function handleSsoLogin(
       user: reloadedUser,
       isNewUser: false,
       provider,
-      providerAccountId: email,
+      providerAccountId: subject || email,
       providerType: 'sso',
       teamInviteResponse: null,
       mfaEnrollmentRequired: addedUserMfa.mfaEnrollmentRequired,
@@ -405,6 +543,24 @@ export async function handleSsoLogin(
     throw new SsoInvalidAction('User team membership is inactive');
   }
 
+  const providerAccountId = subject || email;
+
+  // AuthIdentity's composite PK (provider, providerAccountId) is global. If another user already
+  // owns this row (e.g. cross-tenant subject collision), the nested upsert below would route to
+  // CREATE and blow up with a raw unique-constraint error. Surface it as SsoAmbiguousAccount
+  // for a consistent UX with linkSsoIdentity.
+  const existingIdentity = await prisma.authIdentity.findUnique({
+    where: { provider_providerAccountId: { provider, providerAccountId } },
+    select: { userId: true },
+  });
+  if (existingIdentity && existingIdentity.userId !== user.id) {
+    logger.error(
+      { existingUserId: existingIdentity.userId, currentUserId: user.id, provider, providerAccountId },
+      'SSO login blocked: identity row already belongs to a different user',
+    );
+    throw new SsoAmbiguousAccount('Your SSO identity is in conflict with another account. Please contact your administrator for assistance.');
+  }
+
   // Update last login
   await prisma.user.update({
     where: { id: user.id },
@@ -416,7 +572,7 @@ export async function handleSsoLogin(
           create: {
             type: 'sso',
             provider,
-            providerAccountId: email,
+            providerAccountId,
             email,
             emailVerified: true,
             username: email,
@@ -424,15 +580,16 @@ export async function handleSsoLogin(
             givenName: userInfo.firstName,
             familyName: userInfo.lastName,
             isPrimary: true,
-            samlConfigurationId: loginConfig.samlConfiguration?.id,
-            oidcConfigurationId: loginConfig.oidcConfiguration?.id,
+            ...configScope,
           },
           update: {
             email,
             name: [userInfo.firstName, userInfo.lastName].filter(Boolean).join(' ') || email,
             username: userInfo.userName,
+            // Opportunistic backfill for rows created by paths that predated config-id tracking.
+            ...configScope,
           },
-          where: { provider_providerAccountId: { provider, providerAccountId: email } },
+          where: { provider_providerAccountId: { provider, providerAccountId } },
         },
       },
     },
@@ -444,7 +601,7 @@ export async function handleSsoLogin(
     user,
     isNewUser: false,
     provider,
-    providerAccountId: email,
+    providerAccountId,
     providerType: 'sso',
     teamInviteResponse: null,
     mfaEnrollmentRequired: returningUserMfa.mfaEnrollmentRequired,
@@ -460,25 +617,53 @@ export async function handleSsoLogin(
 }
 
 /**
- * Link SSO identity to user if not already linked
+ * Link SSO identity to user if not already linked. Keyed by IdP subject when available,
+ * falling back to email for backward compat / IdPs that don't send a subject.
  */
-async function linkSsoIdentity(userId: string, provider: SsoProviderType, email: string, _userInfo: SsoUserInfo): Promise<void> {
-  const userInfo = sanitizeUserInfo(_userInfo);
+export async function linkSsoIdentity(
+  userId: string,
+  provider: SsoProviderType,
+  email: string,
+  userInfoInput: SsoUserInfo,
+  config: { samlConfigurationId?: string | null; oidcConfigurationId?: string | null },
+): Promise<void> {
+  // Mirror findUserBySsoIdentity's invariant: AuthIdentity rows set exactly one of these.
+  // Refusing to write a row that doesn't conform prevents a future caller bug from silently
+  // producing unscoped legacy-shaped rows.
+  if (!!config.samlConfigurationId === !!config.oidcConfigurationId) {
+    throw new SsoInvalidAction('SSO identity link requires exactly one of samlConfigurationId or oidcConfigurationId');
+  }
+  const userInfo = sanitizeUserInfo(userInfoInput);
+  const providerAccountId = userInfo.subject?.trim() || email;
+
   const existingIdentity = await prisma.authIdentity.findUnique({
     where: {
       provider_providerAccountId: {
         provider,
-        providerAccountId: email,
+        providerAccountId,
       },
     },
+    select: { userId: true },
   });
+
+  // AuthIdentity PK is (provider, providerAccountId) globally — a row may already exist
+  // for a different user (e.g. cross-tenant NameID collision). Silently returning would leave
+  // this user with no linked identity, and on next login the subject-first lookup could resolve
+  // to the other account. Refuse to proceed.
+  if (existingIdentity && existingIdentity.userId !== userId) {
+    logger.error(
+      { existingUserId: existingIdentity.userId, newUserId: userId, provider, providerAccountId },
+      'SSO identity link blocked: row exists for a different user',
+    );
+    throw new SsoAmbiguousAccount('Your SSO identity is in conflict with another account. Please contact your administrator for assistance.');
+  }
 
   if (!existingIdentity) {
     await prisma.authIdentity.create({
       data: {
         userId,
         provider: provider as any, // SSO providers stored as strings in DB
-        providerAccountId: email,
+        providerAccountId,
         email,
         emailVerified: true,
         username: email,
@@ -487,6 +672,8 @@ async function linkSsoIdentity(userId: string, provider: SsoProviderType, email:
         familyName: userInfo.lastName,
         type: 'sso',
         isPrimary: false,
+        samlConfigurationId: config.samlConfigurationId,
+        oidcConfigurationId: config.oidcConfigurationId,
       },
     });
   }

--- a/libs/auth/server/src/lib/sso.types.ts
+++ b/libs/auth/server/src/lib/sso.types.ts
@@ -13,6 +13,9 @@ export interface SsoUserInfo {
   userName: string;
   firstName?: Maybe<string>;
   lastName?: Maybe<string>;
+  // Stable IdP-issued identifier (SAML NameID / OIDC sub). Preferred over email
+  // for identity lookups since email can change and is not unique per user.
+  subject?: Maybe<string>;
 }
 
 export interface SsoDiscoveryResult {

--- a/libs/shared/constants/src/lib/shared-constants.ts
+++ b/libs/shared/constants/src/lib/shared-constants.ts
@@ -1129,6 +1129,7 @@ export const AUTH_ERROR_MESSAGES = {
   PasswordReused: 'You cannot reuse your previously used passwords. Choose a different password.',
   ProviderEmailNotVerified: 'You must first verify your email address with the provider in order to register.',
   ProviderNotAllowed: `This login method is not allowed, login using an approved method.`,
+  SsoAmbiguousAccount: 'Your account cannot be uniquely identified. Please contact your administrator for assistance.',
   SsoAutoProvisioningDisabled: 'You are not a member of this team. Ask an admin to invite you or enable auto-provisioning for SSO.',
   SsoInvalidAction:
     'Your credentials are invalid or you are not authorized to perform this action. Contact your administrator for assistance.',


### PR DESCRIPTION
Introduce error handling for ambiguous accounts during SSO user resolution and identity linking. This includes adding a stable identifier for users and a specific error type for ambiguous accounts. Update error messages to guide users in case of identification issues.