### PR TITLE
Implement inline 404 handling with landing page response and regression test

### DIFF
--- a/apps/api/src/app/utils/response.handlers.ts
+++ b/apps/api/src/app/utils/response.handlers.ts
@@ -352,12 +352,17 @@ export async function uncaughtErrorHandler(err: any, req: express.Request, res: 
           message: err.message,
           data: err.additionalData,
         });
-      } else {
-        if (req.hostname === 'localhost') {
-          return res.send('404');
-        }
-        return res.redirect('/404/');
       }
+      // Serve the landing 404 page inline with a real 404 status so the URL stays
+      // visible in the access log (previously a 302 → /404/ redirect masked it).
+      const notFoundHtml = req.app.locals.notFoundHtml as string | null | undefined;
+      res.setHeader('Cache-Control', 'no-store');
+      if (notFoundHtml) {
+        res.setHeader('Content-Type', 'text/html; charset=utf-8');
+        return res.send(notFoundHtml);
+      }
+      res.setHeader('Content-Type', 'text/plain; charset=utf-8');
+      return res.send('404');
     }
 
     const errorMessage = 'There was an error processing the request';

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -297,6 +297,22 @@ if (ENV.NODE_ENV === 'production' && !ENV.CI && cluster.isPrimary) {
   app.use('/fonts', express.static(join(__dirname, './assets/fonts')));
   app.use(express.static(join(__dirname, '../landing')));
 
+  // Load the landing site's 404 page so uncaughtErrorHandler can serve it inline
+  // with a real 404 status (instead of redirecting to /404/, which logged as 302
+  // and masked which URLs were actually missing). Next.js export emits either
+  // `404/index.html` (trailingSlash) or `404.html` depending on build config.
+  let notFoundHtml: string | null = null;
+  try {
+    notFoundHtml = readFileSync(join(__dirname, '../landing/404/index.html'), 'utf8');
+  } catch {
+    try {
+      notFoundHtml = readFileSync(join(__dirname, '../landing/404.html'), 'utf8');
+    } catch (error) {
+      logger.error(getExceptionLog(error), '[404] Failed to read landing 404 page — 404 responses will fall back to plain text');
+    }
+  }
+  app.locals.notFoundHtml = notFoundHtml;
+
   if (environment.production || ENV.CI || ENV.JETSTREAM_CLIENT_URL.replace('/app', '') === ENV.JETSTREAM_SERVER_URL) {
     // Rate limiter for SPA entry point - lenient to allow frequent refreshes and asset loading
     // Most assets should be cached at the edge, so this generally should not matter

--- a/apps/jetstream-e2e/src/tests/app/not-found.spec.ts
+++ b/apps/jetstream-e2e/src/tests/app/not-found.spec.ts
@@ -1,0 +1,24 @@
+import { expect, test } from '../../fixtures/fixtures';
+
+test.describe.configure({ mode: 'parallel' });
+
+test.describe('404 handling', () => {
+  // Regression guard for the fix that replaced `res.redirect('/404/')` with an
+  // inline 404 response. A 302 → /404/ redirect made access-log status-code metrics
+  // unable to identify which URLs actually 404'd. The status code returned by the
+  // server must be 404 (not 302), and the original URL must stay visible.
+  test('Unknown URL returns a real 404 with the landing 404 page HTML', async ({ page }) => {
+    const bogusPath = `/this-path-does-not-exist-${Date.now()}.php7`;
+
+    const response = await page.goto(bogusPath);
+
+    expect(response).not.toBeNull();
+    expect(response?.status()).toBe(404);
+    expect(page.url()).toContain(bogusPath);
+
+    const contentType = response?.headers()['content-type'] ?? '';
+    expect(contentType).toContain('text/html');
+
+    await expect(page.getByRole('heading', { name: 'Page not found' })).toBeVisible();
+  });
+});


### PR DESCRIPTION
Introduce inline handling for 404 errors to serve the landing page directly, ensuring the original URL remains visible in access logs. Add a regression test to verify the correct status code and content type for unknown URLs.