### PR TITLE
fix: allow referrer header to be set + google drive origin

### DIFF
--- a/apps/api/src/app/routes/canvas.routes.ts
+++ b/apps/api/src/app/routes/canvas.routes.ts
@@ -43,6 +43,8 @@ const routes: express.Router = Router();
 
 routes.use(
   helmet({
+    crossOriginOpenerPolicy: false,
+    referrerPolicy: { policy: 'strict-origin-when-cross-origin' },
     contentSecurityPolicy: {
       directives: {
         defaultSrc: ["'self'"],

--- a/apps/api/src/app/routes/desktop-app.routes.ts
+++ b/apps/api/src/app/routes/desktop-app.routes.ts
@@ -30,6 +30,7 @@ export const routes: express.Router = Router();
 routes.use(
   helmet({
     crossOriginOpenerPolicy: false,
+    referrerPolicy: { policy: 'strict-origin-when-cross-origin' },
     contentSecurityPolicy: {
       directives: {
         defaultSrc: ["'self'"],

--- a/apps/api/src/app/routes/web-extension-server.routes.ts
+++ b/apps/api/src/app/routes/web-extension-server.routes.ts
@@ -30,6 +30,7 @@ export const routes: express.Router = Router();
 routes.use(
   helmet({
     crossOriginOpenerPolicy: false,
+    referrerPolicy: { policy: 'strict-origin-when-cross-origin' },
     contentSecurityPolicy: {
       directives: {
         defaultSrc: ["'self'"],

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -142,8 +142,9 @@ if (ENV.NODE_ENV === 'production' && !ENV.CI && cluster.isPrimary) {
   // popup-based third-party auth.
   app.use(
     helmet({
-      contentSecurityPolicy: { directives: buildCspDirectives() },
       crossOriginOpenerPolicy: false,
+      referrerPolicy: { policy: 'strict-origin-when-cross-origin' },
+      contentSecurityPolicy: { directives: buildCspDirectives() },
       hsts: buildHstsConfig(),
     }),
   );

--- a/apps/landing/hooks/google-picker-shared.ts
+++ b/apps/landing/hooks/google-picker-shared.ts
@@ -258,6 +258,7 @@ export async function runPickerFlow(
       };
 
       const pickerBuilder = new google.picker.PickerBuilder()
+        .setOrigin(`${window.location.protocol}//${window.location.host}`)
         .setAppId(config.appId)
         .setDeveloperKey(config.apiKey)
         .setOAuthToken(googleAccessToken)

--- a/libs/shared/ui-utils/src/lib/hooks/useDrivePicker.ts
+++ b/libs/shared/ui-utils/src/lib/hooks/useDrivePicker.ts
@@ -64,6 +64,7 @@ export function useDrivePicker(apiConfig: GoogleApiClientConfig) {
       const token = await getToken();
 
       picker.current = new google.picker.PickerBuilder()
+        .setOrigin(`${window.location.protocol}//${window.location.host}`)
         .setAppId(apiConfig.appId)
         .setDeveloperKey(apiConfig.apiKey)
         .setOAuthToken(token.access_token)


### PR DESCRIPTION
In order to allow google drive APIs to be restricted to an origin, the referrer header must be set