### PR TITLE
Add date shortcuts and improve permission filtering

### DIFF
--- a/libs/connected/connected-ui/src/lib/useListMetadata.tsx
+++ b/libs/connected/connected-ui/src/lib/useListMetadata.tsx
@@ -218,7 +218,10 @@ async function fetchListMetadataForItemsInFolder(
   }
 
   // we need to fetch for each folder, split into sets of 3
-  const folderFullNames = data.filter((folder) => folder.manageableState === 'unmanaged').map(({ fullName }) => fullName);
+  // dedupe folder names — EmailTemplate queries both EmailFolder and EmailTemplateFolder which can share folder names like `unfiled$public`
+  const folderFullNames = Array.from(
+    new Set(data.filter((folder) => folder.manageableState === 'unmanaged').map(({ fullName }) => fullName)),
+  );
   const folderItems = splitArrayToMaxSize(folderFullNames, MAX_FOLDER_REQUESTS);
 
   for (const currFolderItem of folderItems) {
@@ -422,10 +425,13 @@ export function useListMetadata(selectedOrg: SalesforceOrgUi) {
             }
 
             // Some sobjects are in the list twice (Salesforce bug - specifically Account shows up twice)
+            // Include id in the dedup key so Classic and Lightning EmailTemplates that share a fullName but have different ids are both kept
             if (responseItem?.items) {
               responseItem.items = uniqWith(
                 responseItem.items,
-                (currValue, otherValue) => `${currValue.type}:${currValue.fullName}` === `${otherValue.type}:${otherValue.fullName}`,
+                (currValue, otherValue) =>
+                  `${currValue.type}:${currValue.fullName}:${currValue.id}` ===
+                  `${otherValue.type}:${otherValue.fullName}:${otherValue.id}`,
               );
             }
 
@@ -485,7 +491,7 @@ export function useListMetadata(selectedOrg: SalesforceOrgUi) {
             : previousItems,
         );
 
-        let responseItem = await fetchListMetadata(selectedOrg, item, true);
+        let responseItem: ListMetadataResultItem;
         if (inFolder) {
           // handle additional fetches required if type is in folder
           responseItem = await fetchListMetadataForItemsInFolder(selectedOrg, item, true);
@@ -496,6 +502,14 @@ export function useListMetadata(selectedOrg: SalesforceOrgUi) {
         // Ensure nested folders have the full path in their name
         if (item.type.endsWith('Folder')) {
           await mutateFullNameForFolderToIncludeFullPath(selectedOrg, responseItem);
+        }
+
+        if (responseItem?.items) {
+          responseItem.items = uniqWith(
+            responseItem.items,
+            (currValue, otherValue) =>
+              `${currValue.type}:${currValue.fullName}:${currValue.id}` === `${otherValue.type}:${otherValue.fullName}:${otherValue.id}`,
+          );
         }
 
         if (!isMounted.current) {

--- a/libs/features/deploy/src/delete-metadata/DeleteMetadataConfigModal.tsx
+++ b/libs/features/deploy/src/delete-metadata/DeleteMetadataConfigModal.tsx
@@ -174,7 +174,7 @@ export const DeleteMetadataConfigModal: FunctionComponent<DeleteMetadataConfigMo
                   {Object.values(selectedMetadata)
                     .flatMap((items) => items)
                     .map((item) => (
-                      <li key={item.fullName} className="slds-item">
+                      <li key={`${item.type}-${item.fullName}-${item.id}`} className="slds-item">
                         {item.fullName} ({item.type})
                       </li>
                     ))}

--- a/libs/features/deploy/src/selection-components/DateSelection.tsx
+++ b/libs/features/deploy/src/selection-components/DateSelection.tsx
@@ -5,6 +5,8 @@ import { fromDeployMetadataState } from '@jetstream/ui-core';
 import { addDays } from 'date-fns/addDays';
 import { isAfter } from 'date-fns/isAfter';
 import { isSameDay } from 'date-fns/isSameDay';
+import { startOfDay } from 'date-fns/startOfDay';
+import { subDays } from 'date-fns/subDays';
 import { useAtom } from 'jotai';
 import { Fragment, FunctionComponent, useEffect, useState } from 'react';
 import { RadioButtonItem, RadioButtonSelection } from './RadioButtonSelection';
@@ -20,6 +22,16 @@ const DATE_RANGE_RADIO_BUTTONS: RadioButtonItem<AllUser>[] = [
     label: 'Specific Date',
     value: 'user',
   },
+];
+
+// Each shortcut sets only the start date; combined with the "Modified since" framing this reads as
+// "since today" or "since N days ago" — durations are preferred over single-day labels (e.g. "Yesterday")
+// since end is left null and the filter would otherwise include items modified after that day too
+const DATE_SHORTCUTS: { label: string; getStart: () => Date }[] = [
+  { label: 'Today', getStart: () => startOfDay(new Date()) },
+  { label: 'Last 7 days', getStart: () => startOfDay(subDays(new Date(), 7)) },
+  { label: 'Last 30 days', getStart: () => startOfDay(subDays(new Date(), 30)) },
+  { label: 'Last 90 days', getStart: () => startOfDay(subDays(new Date(), 90)) },
 ];
 export interface DateSelectionProps {
   requireConfirmSelection?: boolean;
@@ -45,6 +57,13 @@ export const DateSelection: FunctionComponent<DateSelectionProps | DateSelection
   const [dateRangeSelection, setDateRangeSelection] = useState(_dateRangeSelection);
   const [dateRangeStart, setDateRangeStart] = useState(_dateRangeStart);
   const [dateRangeEnd, setDateRangeEnd] = useState(_dateRangeEnd);
+  const [datePickerKey, setDatePickerKey] = useState(0);
+
+  function handleShortcutClick(getStart: () => Date) {
+    setDateRangeStart(getStart());
+    setDateRangeEnd(null);
+    setDatePickerKey((prev) => prev + 1);
+  }
 
   useEffect(() => {
     if (dateRangeSelection && !dateRangeStart && !dateRangeEnd) {
@@ -65,19 +84,19 @@ export const DateSelection: FunctionComponent<DateSelectionProps | DateSelection
     if (!requireConfirmSelection) {
       _setDateRangeSelection(dateRangeSelection);
     }
-  }, [dateRangeSelection]);
+  }, [_setDateRangeSelection, dateRangeSelection, requireConfirmSelection]);
 
   useEffect(() => {
     if (!requireConfirmSelection) {
       _setDateRangeStart(dateRangeStart);
     }
-  }, [dateRangeStart]);
+  }, [_setDateRangeStart, dateRangeStart, requireConfirmSelection]);
 
   useEffect(() => {
     if (!requireConfirmSelection) {
       _setDateRangeEnd(dateRangeEnd);
     }
-  }, [dateRangeEnd]);
+  }, [_setDateRangeEnd, dateRangeEnd, requireConfirmSelection]);
 
   function handleSubmit() {
     _setDateRangeSelection(dateRangeSelection);
@@ -111,7 +130,15 @@ export const DateSelection: FunctionComponent<DateSelectionProps | DateSelection
       >
         {dateRangeSelection === 'user' && (
           <Fragment>
+            <Grid className="slds-m-top_small" wrap align="center">
+              {DATE_SHORTCUTS.map(({ label, getStart }) => (
+                <button key={label} type="button" className="slds-button slds-button_neutral" onClick={() => handleShortcutClick(getStart)}>
+                  {label}
+                </button>
+              ))}
+            </Grid>
             <DatePicker
+              key={`modified-start-${datePickerKey}`}
               id="modified-start"
               label="Modified After"
               className="slds-m-top_small slds-form-element_stacked slds-is-editing"
@@ -124,6 +151,7 @@ export const DateSelection: FunctionComponent<DateSelectionProps | DateSelection
               onChange={setDateRangeStart}
             />
             <DatePicker
+              key={`modified-end-${datePickerKey}`}
               id="modified-end"
               label="Modified Before"
               className="slds-m-top_small slds-form-element_stacked slds-is-editing"

--- a/libs/features/load-records/src/components/LoadRecordsFieldMappingStaticRow.tsx
+++ b/libs/features/load-records/src/components/LoadRecordsFieldMappingStaticRow.tsx
@@ -2,8 +2,19 @@ import { css } from '@emotion/react';
 import { EditableFields, UiRecordFormField, convertMetadataToEditableFields } from '@jetstream/record-form';
 import { useNonInitialEffect } from '@jetstream/shared/ui-utils';
 import { FieldMappingItemStatic, FieldWithRelatedEntities, ListItem, Maybe, PicklistFieldValues, SalesforceOrgUi } from '@jetstream/types';
-import { ComboboxWithItems, Icon } from '@jetstream/ui';
-import { FunctionComponent, useEffect, useId, useState } from 'react';
+import { ComboboxWithItems, Icon, Picklist } from '@jetstream/ui';
+import { FunctionComponent, useEffect, useId, useMemo, useState } from 'react';
+
+type ValueInputMode = NonNullable<FieldMappingItemStatic['valueInputMode']>;
+
+const VALUE_INPUT_MODE_OPTIONS: ListItem[] = [
+  { id: 'picklist', label: 'Picklist Value', value: 'picklist' },
+  { id: 'text', label: 'Text', value: 'text' },
+];
+
+// Salesforce caps a multipicklist write at 100 selected values, each up to 255 chars
+const MULTIPICKLIST_MAX_TEXT_LENGTH = 100 * 255;
+
 function getComboboxFieldName(item: ListItem) {
   return `${item.label} (${item.value})`;
 }
@@ -44,6 +55,21 @@ export const LoadRecordsFieldMappingStaticRow: FunctionComponent<LoadRecordsFiel
   const errorId = useId();
   const [fieldListItems, setFieldListItems] = useState<ListItem<string, FieldWithRelatedEntities>[]>(() => getFieldListItems(fields));
   const [editableField, setEditableField] = useState<Maybe<EditableFields>>(null);
+  const valueInputMode: ValueInputMode = fieldMappingItem.valueInputMode ?? 'picklist';
+
+  // Source field is derived from the latest `fields` prop so that picklist values stay
+  // fresh after the user reloads metadata. Falls back to the snapshot stored on the
+  // mapping item if the field is no longer present in the refreshed list.
+  const sourceField = useMemo(() => {
+    if (!fieldMappingItem.targetField) {
+      return null;
+    }
+    return fields.find((field) => field.name === fieldMappingItem.targetField)?.field ?? fieldMappingItem.fieldMetadata?.field ?? null;
+  }, [fields, fieldMappingItem.targetField, fieldMappingItem.fieldMetadata]);
+
+  const isPicklistField = sourceField?.type === 'picklist' || sourceField?.type === 'multipicklist';
+  const isMultiPicklistField = sourceField?.type === 'multipicklist';
+  const isRestrictedPicklistField = isPicklistField && sourceField?.restrictedPicklist === true;
 
   useNonInitialEffect(() => {
     setFieldListItems(getFieldListItems(fields));
@@ -60,28 +86,37 @@ export const LoadRecordsFieldMappingStaticRow: FunctionComponent<LoadRecordsFiel
   }, [editableField]);
 
   useEffect(() => {
-    if (fieldMappingItem.fieldMetadata?.field) {
-      const picklistValues: PicklistFieldValues = {};
-      if (fieldMappingItem.fieldMetadata.field.type === 'picklist' || fieldMappingItem.fieldMetadata.field.type === 'multipicklist') {
-        picklistValues[fieldMappingItem.fieldMetadata.field.name] = {
-          controllerValues: {},
-          defaultValue: fieldMappingItem.fieldMetadata.field.picklistValues?.find((value) => value.defaultValue)?.value,
-          eTag: '',
-          url: '',
-          values:
-            fieldMappingItem.fieldMetadata.field.picklistValues?.map(({ value, label }) => ({
-              value,
-              label: label || value,
-              attributes: null,
-              validFor: null,
-            })) || [],
-        };
-      }
-      setEditableField(
-        convertMetadataToEditableFields([fieldMappingItem.fieldMetadata.field], picklistValues, 'create', {}, isCustomMetadata)[0],
-      );
+    if (!sourceField) {
+      return;
     }
-  }, [fieldMappingItem.fieldMetadata, isCustomMetadata]);
+    const picklistValues: PicklistFieldValues = {};
+    let fieldForEditable = sourceField;
+
+    if (valueInputMode === 'text' && isPicklistField) {
+      // Override the type so the form renders a free-text input/textarea instead of a picklist
+      // For multipicklist, allow up to Salesforce's max write size; for single picklist, the original
+      // length reflects the longest defined value, which is the right ceiling for an ad-hoc value
+      fieldForEditable = isMultiPicklistField
+        ? { ...sourceField, type: 'textarea', length: MULTIPICKLIST_MAX_TEXT_LENGTH }
+        : { ...sourceField, type: 'string' };
+    } else if (isPicklistField) {
+      picklistValues[sourceField.name] = {
+        controllerValues: {},
+        defaultValue: sourceField.picklistValues?.find((value) => value.defaultValue)?.value,
+        eTag: '',
+        url: '',
+        values:
+          sourceField.picklistValues?.map(({ value, label }) => ({
+            value,
+            label: label || value,
+            attributes: null,
+            validFor: null,
+          })) || [],
+      };
+    }
+
+    setEditableField(convertMetadataToEditableFields([fieldForEditable], picklistValues, 'create', {}, isCustomMetadata)[0]);
+  }, [sourceField, valueInputMode, isPicklistField, isMultiPicklistField, isCustomMetadata]);
 
   function handleValueChange(field: EditableFields, staticValue: string | boolean | null) {
     onSelectionChanged({
@@ -99,16 +134,38 @@ export const LoadRecordsFieldMappingStaticRow: FunctionComponent<LoadRecordsFiel
         mappedToLookup: false,
         targetLookupField: undefined,
         fieldMetadata: field,
+        valueInputMode: 'picklist',
       });
+    }
+  }
+
+  function handleValueInputModeChange(items: ListItem[]) {
+    const selected = items[0]?.id as ValueInputMode | undefined;
+    if (selected && selected !== valueInputMode) {
+      // Clear the value when switching into picklist mode, keep value when going to manual mode
+      const staticValue = selected === 'picklist' ? null : fieldMappingItem.staticValue;
+      onSelectionChanged({ ...fieldMappingItem, valueInputMode: selected, staticValue });
     }
   }
 
   return (
     <tr>
       <th scope="row" colSpan={2} className="slds-align-top slds-text-color_weak bg-color-backdrop-tint">
+        {isPicklistField && (
+          <Picklist
+            className="slds-p-horizontal_x-small"
+            label="Value Input Type"
+            hideLabel
+            containerClassName="slds-m-bottom_x-small"
+            items={VALUE_INPUT_MODE_OPTIONS}
+            selectedItemIds={[valueInputMode]}
+            allowDeselection={false}
+            onChange={handleValueInputModeChange}
+          />
+        )}
         {editableField && (
           <UiRecordFormField
-            key={fieldMappingItem.targetField}
+            key={`${fieldMappingItem.targetField}-${valueInputMode}`}
             org={org}
             field={editableField}
             hideLabel
@@ -119,6 +176,14 @@ export const LoadRecordsFieldMappingStaticRow: FunctionComponent<LoadRecordsFiel
             usePortal
             onChange={handleValueChange}
           />
+        )}
+        {valueInputMode === 'text' && isMultiPicklistField && (
+          <p className="slds-text-body_small slds-text-color_weak slds-m-top_xx-small">Separate multiple values with a semicolon.</p>
+        )}
+        {valueInputMode === 'text' && isRestrictedPicklistField && (
+          <p className="slds-text-body_small slds-text-color_error slds-m-top_xx-small">
+            This is a restricted picklist — values that aren't defined on the field will be rejected by Salesforce.
+          </p>
         )}
       </th>
       <td className="slds-align-top">

--- a/libs/features/manage-permissions/src/utils/permission-manager-utils.ts
+++ b/libs/features/manage-permissions/src/utils/permission-manager-utils.ts
@@ -33,15 +33,13 @@ import { Query, WhereClause, composeQuery, getField } from '@jetstreamapp/soql-p
 const MAX_OBJ_IN_QUERY = 100;
 
 export function filterPermissionsSobjects(sobject: DescribeGlobalSObjectResult | null) {
-  return (
-    !!sobject &&
-    (sobject.name.endsWith('__e') ||
-      (sobject.createable &&
-        sobject.updateable &&
-        !sobject.name.endsWith('__History') &&
-        !sobject.name.endsWith('__Tag') &&
-        !sobject.name.endsWith('__Share')))
-  );
+  if (!sobject) {
+    return false;
+  }
+  if (sobject.name.endsWith('History') || sobject.name.endsWith('Tag') || sobject.name.endsWith('Share')) {
+    return false;
+  }
+  return sobject.createable || sobject.updateable || sobject.name.endsWith('__e');
 }
 
 export function getFieldDefinitionKey(record: EntityParticlePermissionsRecord) {

--- a/libs/types/src/lib/ui/load-records-types.ts
+++ b/libs/types/src/lib/ui/load-records-types.ts
@@ -81,6 +81,8 @@ export interface FieldMappingItemCsv extends FieldMappingItemBase {
 export interface FieldMappingItemStatic extends FieldMappingItemBase {
   type: 'STATIC';
   staticValue: string | boolean | null;
+  // For picklist target fields: 'picklist' lets the user pick from defined values, 'text' lets them type a value freely
+  valueInputMode?: 'picklist' | 'text';
   mappedToLookup: false;
   selectedReferenceTo?: never;
   relationshipName?: never;


### PR DESCRIPTION
Introduce date shortcuts for quick selection in the DateSelection component.

Enhance the permission filtering logic to better handle various objects.

Improve handling of value input modes in the LoadRecordsFieldMappingStaticRow component to ensure correct display of picklist values.

---

fix: metadata folder name resolution for deploy/compare metadata

Fix issue where email templates in a folder may not have been queried

In addition duplicate folder keys caused table rendering issues depending on what metadata types were fetched