### PR TITLE
Enable select all option for SObject export

### DIFF
--- a/libs/features/sobject-export/src/SObjectExport.tsx
+++ b/libs/features/sobject-export/src/SObjectExport.tsx
@@ -277,7 +277,7 @@ export const SObjectExport: FunctionComponent<SObjectExportProps> = () => {
                 selectedOrg={selectedOrg}
                 sobjects={sobjects}
                 selectedSObjects={selectedSObjects}
-                allowSelectAll={false}
+                allowSelectAll
                 recentItemsEnabled
                 recentItemsKey="sobject"
                 onSobjects={handleSobjectChange}


### PR DESCRIPTION
Introduce a select all feature for exporting SObjects, enhancing user experience by allowing bulk selection.