### PR TITLE
fix: refresh token rotation

### DIFF
--- a/apps/api/src/app/db/__tests__/salesforce-org.db.spec.ts
+++ b/apps/api/src/app/db/__tests__/salesforce-org.db.spec.ts
@@ -1,0 +1,179 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Covers `refreshTokensWithLock` — the cross-worker coordination piece of the refresh-token
+ * rotation fix. End-to-end exercise of the actual Postgres advisory lock semantics requires a
+ * real test DB and isn't worth the CI plumbing; the lock itself is a thin Postgres call we can
+ * trust. What we DO want to lock down here:
+ *
+ *   1. The optimistic check correctly skips the Salesforce call when the DB has already been
+ *      updated by another worker (this is the whole point of the fix).
+ *   2. `pg_advisory_xact_lock` is requested with the org id before any reads.
+ *   3. The transaction is opened with `timeout: 20_000` so a slow `/services/oauth2/token` call
+ *      can't blow Prisma's default 5s budget and leave the lock in a weird state.
+ *   4. SF's rotated refresh_token (when present) is persisted; when not present (rotation off),
+ *      the existing refresh_token is preserved.
+ *   5. Hard failure modes (missing org, undecryptable tokens) surface as clear errors rather than
+ *      silent recoveries that would mask real issues.
+ */
+
+const txMock = vi.hoisted(() => ({
+  $executeRaw: vi.fn(),
+  salesforceOrg: {
+    findUnique: vi.fn(),
+    update: vi.fn(),
+  },
+}));
+
+const prismaMock = vi.hoisted(() => ({
+  $transaction: vi.fn(),
+}));
+
+const encServiceMock = vi.hoisted(() => ({
+  DUMMY_INVALID_ENCRYPTED_TOKEN: '__dummy_invalid__',
+  decryptAccessToken: vi.fn(),
+  encryptAccessToken: vi.fn(),
+}));
+
+vi.mock('@jetstream/api-config', () => ({
+  ENV: {},
+  prisma: prismaMock,
+}));
+
+vi.mock('@jetstream/audit-logs', () => ({
+  AuditLogAction: {},
+  AuditLogResource: {},
+  createAuditLog: vi.fn(),
+}));
+
+vi.mock('../../services/salesforce-org-encryption.service', () => encServiceMock);
+
+const { refreshTokensWithLock } = await import('../salesforce-org.db');
+
+const ORG_ID = 42;
+const USER_ID = 'user-abc';
+const STALE_ACCESS = 'stale-access-token';
+const STALE_REFRESH = 'stale-refresh-token';
+const NEW_ACCESS = 'new-access-token';
+const ROTATED_REFRESH = 'rotated-refresh-token';
+
+describe('refreshTokensWithLock', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    prismaMock.$transaction.mockImplementation(async (callback: (tx: typeof txMock) => unknown) => callback(txMock));
+    txMock.$executeRaw.mockResolvedValue(1);
+    txMock.salesforceOrg.findUnique.mockResolvedValue({ id: ORG_ID, accessToken: 'encrypted-blob' });
+    txMock.salesforceOrg.update.mockResolvedValue({ id: ORG_ID });
+    encServiceMock.decryptAccessToken.mockResolvedValue([STALE_ACCESS, STALE_REFRESH]);
+    encServiceMock.encryptAccessToken.mockResolvedValue('encrypted-new-blob');
+  });
+
+  it('opens a transaction with a 20s timeout so a slow Salesforce call cannot blow the default 5s budget', async () => {
+    const callSalesforce = vi.fn().mockResolvedValue({ access_token: NEW_ACCESS, refresh_token: ROTATED_REFRESH });
+
+    await refreshTokensWithLock({ orgId: ORG_ID, userId: USER_ID, currentAccessToken: STALE_ACCESS, callSalesforce });
+
+    expect(prismaMock.$transaction).toHaveBeenCalledWith(expect.any(Function), { timeout: 20_000 });
+  });
+
+  it('acquires the per-org advisory lock before reading the row', async () => {
+    const callSalesforce = vi.fn().mockResolvedValue({ access_token: NEW_ACCESS, refresh_token: ROTATED_REFRESH });
+
+    await refreshTokensWithLock({ orgId: ORG_ID, userId: USER_ID, currentAccessToken: STALE_ACCESS, callSalesforce });
+
+    expect(txMock.$executeRaw).toHaveBeenCalledTimes(1);
+    const [strings, ...values] = txMock.$executeRaw.mock.calls[0];
+    // Prisma tagged-template captures the SQL fragments and interpolated values separately.
+    expect(strings.join('')).toContain('pg_advisory_xact_lock');
+    expect(values).toEqual([ORG_ID]);
+
+    // Lock must come before the SELECT — otherwise two workers could both read stale tokens
+    // before either acquires the lock.
+    const lockOrder = txMock.$executeRaw.mock.invocationCallOrder[0];
+    const findOrder = txMock.salesforceOrg.findUnique.mock.invocationCallOrder[0];
+    expect(lockOrder).toBeLessThan(findOrder);
+  });
+
+  it('refreshes via Salesforce when the DB still matches the caller-supplied stale token', async () => {
+    const callSalesforce = vi.fn().mockResolvedValue({ access_token: NEW_ACCESS, refresh_token: ROTATED_REFRESH });
+
+    const result = await refreshTokensWithLock({ orgId: ORG_ID, userId: USER_ID, currentAccessToken: STALE_ACCESS, callSalesforce });
+
+    expect(callSalesforce).toHaveBeenCalledWith(STALE_REFRESH);
+    expect(encServiceMock.encryptAccessToken).toHaveBeenCalledWith({
+      userId: USER_ID,
+      accessToken: NEW_ACCESS,
+      refreshToken: ROTATED_REFRESH,
+    });
+    expect(txMock.salesforceOrg.update).toHaveBeenCalledWith({ where: { id: ORG_ID }, data: { accessToken: 'encrypted-new-blob' } });
+    expect(result).toEqual({ accessToken: NEW_ACCESS, refreshToken: ROTATED_REFRESH, refreshed: true });
+  });
+
+  it('skips the Salesforce call and returns the canonical tokens when another worker already rotated', async () => {
+    // DB shows different tokens than what the caller had — the other worker won the race.
+    encServiceMock.decryptAccessToken.mockResolvedValue(['someone-elses-new-access', 'someone-elses-new-refresh']);
+    const callSalesforce = vi.fn();
+
+    const result = await refreshTokensWithLock({
+      orgId: ORG_ID,
+      userId: USER_ID,
+      currentAccessToken: STALE_ACCESS,
+      callSalesforce,
+    });
+
+    expect(callSalesforce).not.toHaveBeenCalled();
+    expect(txMock.salesforceOrg.update).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      accessToken: 'someone-elses-new-access',
+      refreshToken: 'someone-elses-new-refresh',
+      refreshed: false,
+    });
+  });
+
+  it('keeps the existing refresh_token when Salesforce does not rotate (rotation disabled on the Connected App)', async () => {
+    const callSalesforce = vi.fn().mockResolvedValue({ access_token: NEW_ACCESS }); // no refresh_token returned
+
+    const result = await refreshTokensWithLock({ orgId: ORG_ID, userId: USER_ID, currentAccessToken: STALE_ACCESS, callSalesforce });
+
+    expect(encServiceMock.encryptAccessToken).toHaveBeenCalledWith({
+      userId: USER_ID,
+      accessToken: NEW_ACCESS,
+      refreshToken: STALE_REFRESH,
+    });
+    expect(result.refreshToken).toBe(STALE_REFRESH);
+    expect(result.refreshed).toBe(true);
+  });
+
+  it('throws NotFoundError if the org row vanished between request init and lock acquisition', async () => {
+    txMock.salesforceOrg.findUnique.mockResolvedValue(null);
+    const callSalesforce = vi.fn();
+
+    await expect(
+      refreshTokensWithLock({ orgId: ORG_ID, userId: USER_ID, currentAccessToken: STALE_ACCESS, callSalesforce }),
+    ).rejects.toThrow('An org with the provided id does not exist');
+    expect(callSalesforce).not.toHaveBeenCalled();
+  });
+
+  it('throws (rather than silently retrying with the sentinel) when the stored tokens are undecryptable', async () => {
+    encServiceMock.decryptAccessToken.mockResolvedValue([
+      encServiceMock.DUMMY_INVALID_ENCRYPTED_TOKEN,
+      encServiceMock.DUMMY_INVALID_ENCRYPTED_TOKEN,
+    ]);
+    const callSalesforce = vi.fn();
+
+    await expect(
+      refreshTokensWithLock({ orgId: ORG_ID, userId: USER_ID, currentAccessToken: STALE_ACCESS, callSalesforce }),
+    ).rejects.toThrow(/Stored Salesforce tokens are not decryptable/);
+    expect(callSalesforce).not.toHaveBeenCalled();
+  });
+
+  it('propagates Salesforce errors and does NOT persist anything on failure', async () => {
+    const callSalesforce = vi.fn().mockRejectedValue(new Error('invalid_grant'));
+
+    await expect(
+      refreshTokensWithLock({ orgId: ORG_ID, userId: USER_ID, currentAccessToken: STALE_ACCESS, callSalesforce }),
+    ).rejects.toThrow('invalid_grant');
+    expect(encServiceMock.encryptAccessToken).not.toHaveBeenCalled();
+    expect(txMock.salesforceOrg.update).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/app/db/salesforce-org.db.ts
+++ b/apps/api/src/app/db/salesforce-org.db.ts
@@ -90,6 +90,82 @@ export async function updateAccessToken_UNSAFE({
   });
 }
 
+/**
+ * Coordinates Salesforce refresh-token rotation across cluster workers.
+ *
+ * Holds a per-org Postgres advisory lock for the duration of the transaction. Inside the lock,
+ * re-reads the current encrypted tokens from the source of truth and runs an optimistic check:
+ *   - If the DB's accessToken no longer matches the caller's stale token, another worker already
+ *     completed the rotation. Returns the canonical tokens without calling Salesforce.
+ *   - Otherwise this caller is the chosen refresher: invokes `callSalesforce` with the canonical
+ *     refresh token, encrypts the result, persists, and returns the new tokens.
+ *
+ * The advisory lock is transaction-scoped, so it auto-releases on commit/rollback and survives
+ * worker crashes (released on connection close).
+ *
+ * Pairs with the in-process single-flight cache in `callout-adapter.ts` to fully eliminate
+ * Salesforce-side token-rotation races without losing rotation's security benefit.
+ */
+export async function refreshTokensWithLock({
+  orgId,
+  userId,
+  currentAccessToken,
+  callSalesforce,
+}: {
+  orgId: number;
+  userId: string;
+  currentAccessToken: string;
+  callSalesforce: (currentRefreshToken: string) => Promise<{ access_token: string; refresh_token?: string }>;
+}): Promise<{ accessToken: string; refreshToken: string; refreshed: boolean }> {
+  return prisma.$transaction(
+    async (tx) => {
+      // Per-org advisory lock. Other workers attempting to refresh the same org block here until
+      // this transaction commits or rolls back. Auto-released on transaction end.
+      await tx.$executeRaw`SELECT pg_advisory_xact_lock(${orgId})`;
+
+      const freshOrg = await tx.salesforceOrg.findUnique({ where: { id: orgId } });
+      if (!freshOrg) {
+        throw new NotFoundError('An org with the provided id does not exist');
+      }
+
+      const [freshAccessToken, freshRefreshToken] = await sfdcEncService.decryptAccessToken({
+        encryptedAccessToken: freshOrg.accessToken,
+        userId,
+      });
+
+      if (freshAccessToken === sfdcEncService.DUMMY_INVALID_ENCRYPTED_TOKEN) {
+        throw new Error('Stored Salesforce tokens are not decryptable — org needs to be reconnected');
+      }
+
+      // Optimistic check: did another worker already rotate while we waited for the lock?
+      if (freshAccessToken !== currentAccessToken) {
+        return { accessToken: freshAccessToken, refreshToken: freshRefreshToken, refreshed: false };
+      }
+
+      const { access_token: newAccessToken, refresh_token: rotatedRefreshToken } = await callSalesforce(freshRefreshToken);
+      // Salesforce returns the rotated refresh token only when rotation is enabled on the Connected
+      // App. When it isn't, keep the existing refresh token.
+      const newRefreshToken = rotatedRefreshToken ?? freshRefreshToken;
+      const encryptedToken = await sfdcEncService.encryptAccessToken({
+        userId,
+        accessToken: newAccessToken,
+        refreshToken: newRefreshToken,
+      });
+      await tx.salesforceOrg.update({
+        where: { id: orgId },
+        data: { accessToken: encryptedToken },
+      });
+      return { accessToken: newAccessToken, refreshToken: newRefreshToken, refreshed: true };
+    },
+    {
+      // The transaction wraps a Salesforce HTTP call (bounded internally by a 15s AbortSignal).
+      // Set the tx timeout slightly above that so the fetch aborts first and we get a clean
+      // "SF auth endpoint is unreachable" error rather than a confusing Prisma P2028.
+      timeout: 20_000,
+    },
+  );
+}
+
 export async function updateOrg_UNSAFE(org: SalesforceOrg, data: Partial<SalesforceOrg>) {
   return await prisma.salesforceOrg.update({
     where: { id: org.id },

--- a/apps/api/src/app/routes/route.middleware.ts
+++ b/apps/api/src/app/routes/route.middleware.ts
@@ -13,7 +13,7 @@ import {
   validateHMACDoubleCSRFToken,
 } from '@jetstream/auth/server';
 import { UserProfileSession } from '@jetstream/auth/types';
-import { ApiConnection, getApiRequestFactoryFn } from '@jetstream/salesforce-api';
+import { ApiConnection, exchangeRefreshToken, getApiRequestFactoryFn } from '@jetstream/salesforce-api';
 import { HTTP } from '@jetstream/shared/constants';
 import { ensureBoolean, getErrorMessageAndStackObj } from '@jetstream/shared/utils';
 import { parseCookie } from 'cookie';
@@ -367,14 +367,14 @@ export async function getOrgForRequest(
     callOptions = { ...callOptions, defaultNamespace: orgNamespacePrefix };
   }
 
-  // Handle org refresh - then remove event listener if refreshed
+  // Legacy refresh callback. Retained for the `getFreshTokens` race-recovery path which still
+  // invokes it with `skipPersistence=true` (in-memory sync only). The primary refresh path now
+  // runs through `refreshTokens` below, which holds the advisory lock and writes the DB itself.
   const handleRefresh = async (accessToken: string, refreshToken: string) => {
-    // Refresh event will be fired when renewed access token
-    // to store it in your storage for next request
     try {
       await salesforceOrgsDb.updateAccessToken_UNSAFE({ accessToken, refreshToken, org, userId: user.id });
     } catch (ex) {
-      logger.error({ requestId, err: ex }, '[ORG][REFRESH] Error saving refresh token');
+      logger.error({ requestId, orgId: org.id, userId: user.id, err: ex }, '[ORG][REFRESH] Error saving refresh token');
     }
   };
 
@@ -382,8 +382,44 @@ export async function getOrgForRequest(
     try {
       await salesforceOrgsDb.updateOrg_UNSAFE(org, { connectionError: error });
     } catch (ex) {
-      logger.error({ requestId, err: ex }, '[ORG][UPDATE] Error updating connection error on org');
+      logger.error({ requestId, orgId: org.id, userId: user.id, err: ex }, '[ORG][UPDATE] Error updating connection error on org');
     }
+  };
+
+  /**
+   * Primary refresh path. Coordinated across cluster workers via a Postgres advisory lock and
+   * across same-process concurrent callers via the single-flight cache inside the adapter.
+   */
+  const refreshTokens = async (currentAccessToken: string) => {
+    const result = await salesforceOrgsDb.refreshTokensWithLock({
+      orgId: org.id,
+      userId: user.id,
+      currentAccessToken,
+      callSalesforce: async (currentRefreshToken) =>
+        exchangeRefreshToken(fetch, {
+          // Build the sessionInfo expected by exchangeRefreshToken — only the fields it reads.
+          accessToken: currentAccessToken,
+          refreshToken: currentRefreshToken,
+          instanceUrl,
+          apiVersion,
+          userId: salesforceUserId,
+          organizationId,
+          sfdcClientId: ENV.SFDC_CONSUMER_KEY,
+          sfdcClientSecret: ENV.SFDC_CONSUMER_SECRET,
+        }),
+    });
+    logger.info(
+      {
+        requestId,
+        orgId: org.id,
+        userId: user.id,
+        refreshed: result.refreshed,
+      },
+      result.refreshed
+        ? '[TOKEN REFRESH] Salesforce token rotated and persisted'
+        : '[TOKEN REFRESH] Lock acquired but DB already had fresh tokens — cross-worker race avoided',
+    );
+    return { accessToken: result.accessToken, refreshToken: result.refreshToken };
   };
 
   // Re-reads current tokens from DB so concurrent workers that lose the refresh token rotation race
@@ -405,7 +441,10 @@ export async function getOrgForRequest(
       }
       return { accessToken: freshAccessToken, refreshToken: freshRefreshToken };
     } catch (ex) {
-      logger.error({ requestId, err: ex }, '[ORG][REFRESH] Error fetching fresh tokens for race condition check');
+      logger.error(
+        { requestId, orgId: org.id, userId: user.id, err: ex },
+        '[ORG][REFRESH] Error fetching fresh tokens for race condition check',
+      );
       return null;
     }
   };
@@ -424,6 +463,7 @@ export async function getOrgForRequest(
       logger,
       sfdcClientId: ENV.SFDC_CONSUMER_KEY,
       sfdcClientSecret: ENV.SFDC_CONSUMER_SECRET,
+      refreshTokens,
       getFreshTokens,
     },
     handleRefresh,

--- a/apps/jetstream-desktop/src/utils/route.utils.ts
+++ b/apps/jetstream-desktop/src/utils/route.utils.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { ApiConnection, getApiRequestFactoryFn } from '@jetstream/salesforce-api';
+import { ApiConnection, exchangeRefreshToken, getApiRequestFactoryFn } from '@jetstream/salesforce-api';
 import { ERROR_MESSAGES, HTTP } from '@jetstream/shared/constants';
 import { ensureBoolean, getErrorMessage } from '@jetstream/shared/utils';
 import { Maybe, SalesforceOrgUi } from '@jetstream/types';
@@ -200,9 +200,23 @@ export function initApiConnection(
   const accessToken = plaintext.slice(0, spaceIndex);
   const refreshToken = plaintext.slice(spaceIndex + 1);
 
+  const readTokensFromStore = (): { accessToken: string; refreshToken: string } | null => {
+    const freshOrg = getSalesforceOrgById(org.uniqueId);
+    if (!freshOrg) {
+      return null;
+    }
+    const plaintext = decryptTokenPortable(freshOrg.accessToken);
+    const spaceIndex = plaintext.indexOf(' ');
+    if (spaceIndex === -1) {
+      logger.warn('[ORG][REFRESH] Stored token payload is malformed and missing expected separator');
+      return null;
+    }
+    return { accessToken: plaintext.slice(0, spaceIndex), refreshToken: plaintext.slice(spaceIndex + 1) };
+  };
+
+  // Legacy refresh hook retained for the `getFreshTokens` race-recovery path (skipPersistence=true,
+  // in-memory sync only). Primary refresh path runs through `refreshTokens` below.
   const handleRefresh = async (accessToken: string, refreshToken: string) => {
-    // Refresh event will be fired when renewed access token
-    // to store it in your storage for next request
     try {
       await updateAccessTokens(org.uniqueId, { accessToken, refreshToken });
     } catch (ex) {
@@ -218,21 +232,40 @@ export function initApiConnection(
     }
   };
 
-  // Re-reads current tokens from the in-memory store so concurrent requests that lose the
-  // refresh token rotation race can retry with the tokens written by the request that won.
+  /**
+   * Primary refresh path for desktop. Single-process so no cross-process lock is needed — the
+   * in-process single-flight cache inside the adapter already collapses concurrent callers.
+   * Still runs an optimistic check against the in-memory store in case any code path bypasses
+   * the single-flight cache (e.g. independently constructed ApiConnections for the same org).
+   */
+  const refreshTokens = async (currentAccessToken: string) => {
+    const stored = readTokensFromStore();
+    if (!stored) {
+      throw new Error('Stored Salesforce tokens are missing or unreadable — org needs to be reconnected');
+    }
+    if (stored.accessToken !== currentAccessToken) {
+      logger.info('[TOKEN REFRESH] Store already has fresh tokens — concurrent refresh avoided');
+      return stored;
+    }
+    const { access_token: newAccessToken, refresh_token: rotatedRefreshToken } = await exchangeRefreshToken(fetch, {
+      accessToken: currentAccessToken,
+      refreshToken: stored.refreshToken,
+      instanceUrl: org.instanceUrl,
+      apiVersion,
+      userId: org.userId,
+      organizationId: org.organizationId,
+      sfdcClientId: ENV.DESKTOP_SFDC_CLIENT_ID,
+    });
+    const newRefreshToken = rotatedRefreshToken ?? stored.refreshToken;
+    await updateAccessTokens(org.uniqueId, { accessToken: newAccessToken, refreshToken: newRefreshToken });
+    logger.info('[TOKEN REFRESH] Salesforce token rotated and persisted');
+    return { accessToken: newAccessToken, refreshToken: newRefreshToken };
+  };
+
+  // Defense-in-depth fallback used by the legacy refresh path inside the adapter.
   const getFreshTokens = async () => {
     try {
-      const freshOrg = getSalesforceOrgById(org.uniqueId);
-      if (!freshOrg) {
-        return null;
-      }
-      const plaintext = decryptTokenPortable(freshOrg.accessToken);
-      const spaceIndex = plaintext.indexOf(' ');
-      if (spaceIndex === -1) {
-        logger.warn('[ORG][REFRESH] Fresh token payload is malformed and missing expected separator');
-        return null;
-      }
-      return { accessToken: plaintext.slice(0, spaceIndex), refreshToken: plaintext.slice(spaceIndex + 1) };
+      return readTokensFromStore();
     } catch (ex) {
       logger.error('[ORG][REFRESH] Error fetching fresh tokens for race condition check', getErrorMessage(ex));
       return null;
@@ -252,6 +285,7 @@ export function initApiConnection(
       logger: logger as any,
       enableLogging: false,
       sfdcClientId: ENV.DESKTOP_SFDC_CLIENT_ID,
+      refreshTokens,
       getFreshTokens,
     },
     handleRefresh,

--- a/libs/salesforce-api/src/lib/__tests__/callout-adapter.spec.ts
+++ b/libs/salesforce-api/src/lib/__tests__/callout-adapter.spec.ts
@@ -820,7 +820,7 @@ describe('callout-adapter XML parsing', () => {
         error: vi.fn(),
       };
 
-      const apiRequest = getApiRequestFactoryFn(mockFetch)(mockLogger, undefined, undefined, false);
+      const apiRequest = getApiRequestFactoryFn(mockFetch)({ logger: mockLogger, enableLogging: false });
       const result = await apiRequest({
         url: '/services/data/v65.0/test',
         method: 'GET',
@@ -847,7 +847,7 @@ describe('callout-adapter XML parsing', () => {
         error: vi.fn(),
       };
 
-      const apiRequest = getApiRequestFactoryFn(mockFetch)(mockLogger, undefined, undefined, true);
+      const apiRequest = getApiRequestFactoryFn(mockFetch)({ logger: mockLogger, enableLogging: true });
       const result = await apiRequest({
         url: '/services/data/v65.0/test',
         method: 'GET',
@@ -863,5 +863,86 @@ describe('callout-adapter XML parsing', () => {
       expect(mockLogger.trace).toHaveBeenCalledWith({ responseBody: 'ok' });
       expect(mockLogger.debug).not.toHaveBeenCalled();
     });
+  });
+});
+
+describe('callout-adapter refresh token rotation', () => {
+  const mockSessionInfo = {
+    accessToken: 'stale-access-token',
+    refreshToken: 'stale-refresh-token',
+    sfdcClientId: 'test-client-id',
+    instanceUrl: 'https://test.salesforce.com',
+    apiVersion: '65.0',
+    userId: 'test-user-id',
+    organizationId: 'test-org-id',
+  };
+
+  const makeJsonResponse = (status: number, body: unknown) =>
+    Promise.resolve({
+      ok: status >= 200 && status < 300,
+      status,
+      statusText: status === 200 ? 'OK' : 'Error',
+      headers: new Headers({ 'content-type': 'application/json' }),
+      type: 'basic' as ResponseType,
+      url: '',
+      text: () => Promise.resolve(typeof body === 'string' ? body : JSON.stringify(body)),
+      json: () => Promise.resolve(body),
+      clone() {
+        return this;
+      },
+    } as any);
+
+  it('collapses N concurrent 401s on the same connection into a single refreshTokens call', async () => {
+    const refreshTokens = vi.fn(async () => ({
+      accessToken: 'new-access-token',
+      refreshToken: 'new-refresh-token',
+    }));
+
+    const mockFetch = vi.fn((_url: string | URL, opts: any) => {
+      const auth = opts?.headers?.Authorization;
+      // First-attempt 401 on the stale bearer; retry succeeds with the rotated bearer.
+      if (auth === `Bearer ${mockSessionInfo.accessToken}`) {
+        return makeJsonResponse(401, { message: 'Session expired or invalid' });
+      }
+      return makeJsonResponse(200, { ok: true });
+    }) as unknown as FetchFn;
+
+    const apiRequest = getApiRequestFactoryFn(mockFetch)({ refreshTokens });
+    const results = await Promise.all(
+      Array.from({ length: 10 }, () =>
+        apiRequest({
+          url: '/services/data/v65.0/sobjects/Account',
+          method: 'GET',
+          sessionInfo: { ...mockSessionInfo },
+          outputType: 'json',
+        }),
+      ),
+    );
+
+    expect(results).toHaveLength(10);
+    expect(refreshTokens).toHaveBeenCalledTimes(1);
+    expect(refreshTokens).toHaveBeenCalledWith(mockSessionInfo.accessToken);
+  });
+
+  it('falls through to onConnectionError when refreshTokens closure rejects', async () => {
+    const refreshTokens = vi.fn(async () => {
+      throw new Error('refresh failed');
+    });
+    const onConnectionError = vi.fn();
+    const fetchTracker = vi.fn(() => makeJsonResponse(401, { message: 'Session expired or invalid' })) as unknown as FetchFn;
+
+    const apiRequest = getApiRequestFactoryFn(fetchTracker)({ refreshTokens, onConnectionError });
+
+    await expect(
+      apiRequest({
+        url: '/services/data/v65.0/sobjects/Account',
+        method: 'GET',
+        sessionInfo: { ...mockSessionInfo },
+        outputType: 'json',
+      }),
+    ).rejects.toThrow();
+
+    expect(refreshTokens).toHaveBeenCalledTimes(1);
+    expect(onConnectionError).toHaveBeenCalledWith('expired access/refresh token');
   });
 });

--- a/libs/salesforce-api/src/lib/callout-adapter.ts
+++ b/libs/salesforce-api/src/lib/callout-adapter.ts
@@ -57,26 +57,97 @@ export function sanitizeCallerHeaders(headers: Record<string, string> | undefine
   return sanitized;
 }
 
+export interface RefreshedTokens {
+  accessToken: string;
+  refreshToken: string;
+}
+
+/**
+ * Caller-supplied refresh orchestrator. Owns:
+ *  - cross-process coordination (e.g. Postgres advisory lock on web; in-memory check on desktop)
+ *  - the optimistic re-read against the source of truth
+ *  - the Salesforce `exchangeRefreshToken` call (only when this caller is the chosen refresher)
+ *  - persistence of the rotated tokens
+ *
+ * Invoked at most once per `(userId, organizationId)` per process via the in-process single-flight
+ * cache below — concurrent callers within the same process share the same in-flight promise.
+ */
+export type RefreshTokensFn = (currentAccessToken: string) => Promise<RefreshedTokens>;
+
+export interface ApiRequestFactoryOptions {
+  logger?: Logger;
+  /**
+   * Primary refresh entrypoint. When provided, takes precedence over the legacy `onRefresh`
+   * path and is wrapped in an in-process single-flight cache so that N concurrent 401s on the
+   * same connection collapse to one Salesforce token exchange.
+   */
+  refreshTokens?: RefreshTokensFn;
+  onConnectionError?: (error: string) => void;
+  /** Trace-level request/response body logging. Refresh-flow logs are always emitted. */
+  enableLogging?: boolean;
+  /**
+   * Defense-in-depth fallback. Only fires when `refreshTokens` is not provided AND the
+   * legacy `onRefresh` path's Salesforce call rejected (i.e. another worker won the rotation
+   * race before this one wrote). Returns the canonical tokens from the source of truth so
+   * the loser can retry without re-calling Salesforce.
+   */
+  getFreshTokens?: () => Promise<RefreshedTokens | null>;
+  /**
+   * @deprecated Use `refreshTokens` instead. Retained for callers that have not yet migrated
+   * to the single-flight refresh pattern. Will be removed once all callers are migrated.
+   */
+  onRefresh?: (accessToken: string, refreshToken?: string, skipPersistence?: boolean) => Promise<void> | void;
+}
+
+/**
+ * Per-process single-flight cache keyed by `${userId}::${organizationId}`. While a refresh is
+ * in flight for a key, concurrent 401 handlers on the same connection (e.g. Promise.all over
+ * batched metadata reads) all await the same promise instead of each calling Salesforce —
+ * which would invalidate every loser's refresh token under refresh-token-rotation.
+ */
+const REFRESH_IN_FLIGHT = new Map<string, Promise<RefreshedTokens>>();
+
+function singleFlightKey(userId: string, organizationId: string): string {
+  return `${userId}::${organizationId}`;
+}
+
+async function runSingleFlightRefresh(
+  key: string,
+  currentAccessToken: string,
+  refreshTokens: RefreshTokensFn,
+  logger: Logger,
+): Promise<RefreshedTokens> {
+  const inFlight = REFRESH_IN_FLIGHT.get(key);
+  if (inFlight) {
+    logger.debug({ key }, '[TOKEN REFRESH] Joining in-flight refresh');
+    return inFlight;
+  }
+  const promise = refreshTokens(currentAccessToken).finally(() => {
+    REFRESH_IN_FLIGHT.delete(key);
+  });
+  REFRESH_IN_FLIGHT.set(key, promise);
+  return promise;
+}
+
+const NOOP_LOGGER: Logger = {
+  trace: () => undefined,
+  error: () => undefined,
+  warn: () => undefined,
+  info: () => undefined,
+  debug: () => undefined,
+};
+
 /**
  * Factory function to get api request
  * Requires a fetch compatible function to avoid relying any specific fetch implementation
  */
 export function getApiRequestFactoryFn(fetch: FetchFn) {
-  return (
-    logger: Logger,
-    onRefresh?: (accessToken: string, refreshToken?: string, skipPersistence?: boolean) => Promise<void> | void,
-    onConnectionError?: (error: string) => void,
-    /**
-     * Enable logging only applies to request/response data
-     * other logging for refresh flow and logic errors will still be logged
-     */
-    enableLogging?: boolean,
-    getFreshTokens?: () => Promise<{ accessToken: string; refreshToken: string } | null>,
-  ) => {
-    const apiRequest = async <Response = unknown>(options: ApiRequestOptions, attemptRefresh = true): Promise<Response> => {
+  return (options: ApiRequestFactoryOptions = {}) => {
+    const { logger = NOOP_LOGGER, refreshTokens, onConnectionError, enableLogging, getFreshTokens, onRefresh } = options;
+    const apiRequest = async <Response = unknown>(requestOptions: ApiRequestOptions, attemptRefresh = true): Promise<Response> => {
       // eslint-disable-next-line prefer-const
-      let { url, body, outputType, duplex } = options;
-      const { method = 'GET', sessionInfo, headers, rawBody = false } = options;
+      let { url, body, outputType, duplex } = requestOptions;
+      const { method = 'GET', sessionInfo, headers, rawBody = false } = requestOptions;
       const { accessToken, instanceUrl } = sessionInfo;
       url = `${instanceUrl}${url}`;
       outputType = outputType || 'json';
@@ -148,51 +219,87 @@ export function getApiRequestFactoryFn(fetch: FetchFn) {
             sessionInfo.sfdcClientId &&
             sessionInfo.refreshToken
           ) {
-            try {
-              logger.debug({ url, method, status: response.status }, '[TOKEN REFRESH] Attempting token refresh');
-              const { access_token: newAccessToken, refresh_token: newRefreshToken } = await exchangeRefreshToken(fetch, sessionInfo);
-              logger.debug({ url, method, tokenRotated: !!newRefreshToken }, '[TOKEN REFRESH] Token refresh successful');
-              await onRefresh?.(newAccessToken, newRefreshToken);
-              // replace token in body
-              if (typeof options.body === 'string' && options.body.includes(accessToken)) {
-                // if the response is soap, we need to return the response as is
-                options.body = options.body.replace(accessToken, newAccessToken);
-              }
+            const logContext = {
+              url,
+              method,
+              orgId: sessionInfo.organizationId,
+              userId: sessionInfo.userId,
+              status: response.status,
+            };
 
-              return apiRequest({ ...options, sessionInfo: { ...sessionInfo, accessToken: newAccessToken } }, false);
-            } catch (ex) {
-              logger.warn({ url, method, ...getErrorMessageAndStackObj(ex) }, '[TOKEN REFRESH] Unable to refresh accessToken');
-
-              // Check if another worker already refreshed (race condition on token rotation).
-              // If the DB has a different access token, a concurrent request won the race — retry with fresh tokens.
-              // `return await` (not bare `return`) is deliberate: it keeps the recursive retry inside this
-              // try/catch so a second failure still falls through to onConnectionError below.
-              if (getFreshTokens) {
-                try {
-                  const freshTokens = await getFreshTokens();
-                  if (freshTokens && freshTokens.accessToken !== accessToken) {
-                    logger.info({ url, method }, '[TOKEN REFRESH] Concurrent refresh detected — retrying with tokens from another worker');
-                    // Sync the connection's canonical session state without re-persisting (DB already has these
-                    // tokens — that's how we got them). Also mutates the shared sessionInfo reference so
-                    // subsequent requests on this connection stop hitting the stale token path.
-                    await onRefresh?.(freshTokens.accessToken, freshTokens.refreshToken, true);
-                    // replace token in body
-                    if (typeof options.body === 'string' && options.body.includes(accessToken)) {
-                      // if the response is soap, we need to return the response as is
-                      options.body = options.body.replace(accessToken, freshTokens.accessToken);
-                    }
-                    return await apiRequest({ ...options, sessionInfo: { ...sessionInfo, ...freshTokens } }, false);
-                  }
-                } catch (freshEx) {
-                  logger.warn(
-                    { url, method, ...getErrorMessageAndStackObj(freshEx) },
-                    '[TOKEN REFRESH] Failed to retrieve fresh tokens for race condition check',
-                  );
+            // Preferred path: single-flight + caller-owned refresh orchestrator. The closure handles
+            // optimistic re-read, the Salesforce token exchange, and persistence. Losers within the
+            // same process await the winner's promise rather than racing on Salesforce.
+            if (refreshTokens) {
+              try {
+                const key = singleFlightKey(sessionInfo.userId, sessionInfo.organizationId);
+                logger.debug(logContext, '[TOKEN REFRESH] Attempting refresh via injected closure');
+                const refreshed = await runSingleFlightRefresh(key, accessToken, refreshTokens, logger);
+                logger.debug(
+                  { ...logContext, tokenRotated: refreshed.refreshToken !== sessionInfo.refreshToken },
+                  '[TOKEN REFRESH] Refresh resolved',
+                );
+                // sessionInfo is a shared reference with ApiConnection — mutating it here updates the
+                // connection's canonical state for all future requests without an extra callback hop.
+                sessionInfo.accessToken = refreshed.accessToken;
+                sessionInfo.refreshToken = refreshed.refreshToken;
+                // replace token in body for SOAP requests that embed the bearer
+                if (typeof requestOptions.body === 'string' && requestOptions.body.includes(accessToken)) {
+                  requestOptions.body = requestOptions.body.replace(accessToken, refreshed.accessToken);
                 }
+                return apiRequest({ ...requestOptions, sessionInfo: { ...sessionInfo, accessToken: refreshed.accessToken } }, false);
+              } catch (ex) {
+                logger.warn(
+                  { ...logContext, ...getErrorMessageAndStackObj(ex) },
+                  '[TOKEN REFRESH] Refresh closure failed — marking connection invalid',
+                );
+                responseText = ERROR_MESSAGES.SFDC_EXPIRED_TOKEN;
+                onConnectionError?.(ERROR_MESSAGES.SFDC_EXPIRED_TOKEN);
               }
+            } else {
+              // Legacy path retained for callers not yet migrated to `refreshTokens`. Still vulnerable
+              // to the rotation race; the `getFreshTokens` fallback below is best-effort recovery.
+              try {
+                logger.debug(logContext, '[TOKEN REFRESH] Attempting token refresh (legacy path)');
+                const { access_token: newAccessToken, refresh_token: newRefreshToken } = await exchangeRefreshToken(fetch, sessionInfo);
+                logger.debug({ ...logContext, tokenRotated: !!newRefreshToken }, '[TOKEN REFRESH] Token refresh successful (legacy path)');
+                await onRefresh?.(newAccessToken, newRefreshToken);
+                if (typeof requestOptions.body === 'string' && requestOptions.body.includes(accessToken)) {
+                  requestOptions.body = requestOptions.body.replace(accessToken, newAccessToken);
+                }
+                return apiRequest({ ...requestOptions, sessionInfo: { ...sessionInfo, accessToken: newAccessToken } }, false);
+              } catch (ex) {
+                logger.warn({ ...logContext, ...getErrorMessageAndStackObj(ex) }, '[TOKEN REFRESH] Unable to refresh accessToken');
 
-              responseText = ERROR_MESSAGES.SFDC_EXPIRED_TOKEN;
-              onConnectionError?.(ERROR_MESSAGES.SFDC_EXPIRED_TOKEN);
+                // Check if another worker already refreshed (race condition on token rotation).
+                // If the DB has a different access token, a concurrent request won the race — retry with fresh tokens.
+                // `return await` (not bare `return`) is deliberate: it keeps the recursive retry inside this
+                // try/catch so a second failure still falls through to onConnectionError below.
+                if (getFreshTokens) {
+                  try {
+                    const freshTokens = await getFreshTokens();
+                    if (freshTokens && freshTokens.accessToken !== accessToken) {
+                      logger.info(logContext, '[TOKEN REFRESH] Concurrent refresh detected — retrying with tokens from another worker');
+                      // Sync the connection's canonical session state without re-persisting (DB already has these
+                      // tokens — that's how we got them). Also mutates the shared sessionInfo reference so
+                      // subsequent requests on this connection stop hitting the stale token path.
+                      await onRefresh?.(freshTokens.accessToken, freshTokens.refreshToken, true);
+                      if (typeof requestOptions.body === 'string' && requestOptions.body.includes(accessToken)) {
+                        requestOptions.body = requestOptions.body.replace(accessToken, freshTokens.accessToken);
+                      }
+                      return await apiRequest({ ...requestOptions, sessionInfo: { ...sessionInfo, ...freshTokens } }, false);
+                    }
+                  } catch (freshEx) {
+                    logger.warn(
+                      { ...logContext, ...getErrorMessageAndStackObj(freshEx) },
+                      '[TOKEN REFRESH] Failed to retrieve fresh tokens for race condition check',
+                    );
+                  }
+                }
+
+                responseText = ERROR_MESSAGES.SFDC_EXPIRED_TOKEN;
+                onConnectionError?.(ERROR_MESSAGES.SFDC_EXPIRED_TOKEN);
+              }
             }
           } else if (response.status === 420 && response.headers.get(HTTP.HEADERS.CONTENT_TYPE) === 'text/html') {
             responseText = 'An unexpected response was received from Salesforce. Please try again.';
@@ -246,9 +353,27 @@ function handleSalesforceApiError(outputType: ApiRequestOutputType, responseText
   return output;
 }
 
-function exchangeRefreshToken(
+/**
+ * Bounds the Salesforce token exchange so a stalled `/services/oauth2/token` endpoint can't
+ * pin a DB connection (held by `refreshTokensWithLock`'s transaction) indefinitely. SF's auth
+ * endpoint is normally <500ms; 15s is comfortably above any healthy response time and well
+ * below the surrounding transaction timeout so the abort fires first and we get a clean error.
+ */
+export const REFRESH_TOKEN_EXCHANGE_TIMEOUT_MS = 15_000;
+
+/**
+ * Exchanges a refresh token for a new access token (and possibly rotated refresh token).
+ *
+ * Exported so caller-supplied `RefreshTokensFn` closures (web middleware, desktop main process)
+ * can invoke it from inside their own coordination (advisory lock, in-memory check, etc).
+ *
+ * The fetch is bounded by an `AbortSignal.timeout` so the call cannot hang forever — important
+ * because the web path holds a Postgres advisory-lock transaction across this call.
+ */
+export function exchangeRefreshToken(
   fetch: FetchFn,
   sessionInfo: ApiRequestOptions['sessionInfo'],
+  { timeoutMs = REFRESH_TOKEN_EXCHANGE_TIMEOUT_MS }: { timeoutMs?: number } = {},
 ): Promise<{ access_token: string; refresh_token?: string }> {
   const searchParams = new URLSearchParams({
     grant_type: 'refresh_token',
@@ -269,6 +394,7 @@ function exchangeRefreshToken(
       [HTTP.HEADERS.CONTENT_TYPE]: HTTP.CONTENT_TYPE.FORM_URL,
       [HTTP.HEADERS.ACCEPT]: HTTP.CONTENT_TYPE.JSON,
     },
+    signal: AbortSignal.timeout(timeoutMs),
   })
     .then((response) => {
       if (response.ok) {

--- a/libs/salesforce-api/src/lib/connection.ts
+++ b/libs/salesforce-api/src/lib/connection.ts
@@ -7,7 +7,7 @@ import { ApiOrg } from './api-org';
 import { ApiQuery } from './api-query';
 import { ApiRequest } from './api-request';
 import { ApiSObject } from './api-sobject';
-import { getApiRequestFactoryFn } from './callout-adapter';
+import { getApiRequestFactoryFn, RefreshedTokens, RefreshTokensFn } from './callout-adapter';
 import { Logger, SessionInfo } from './types';
 
 export interface ApiConnectionOptions {
@@ -23,8 +23,18 @@ export interface ApiConnectionOptions {
   sfdcClientId?: string;
   sfdcClientSecret?: string;
   logger: Logger;
-  /** Re-reads current tokens from the source of truth (e.g. DB) to handle concurrent refresh token rotation across workers */
-  getFreshTokens?: () => Promise<{ accessToken: string; refreshToken: string } | null>;
+  /**
+   * Caller-supplied refresh orchestrator. Owns cross-process coordination (advisory lock,
+   * in-memory check), the optimistic re-read, the Salesforce token exchange, and persistence.
+   * Wrapped in a per-process single-flight cache inside the adapter so that N concurrent 401s
+   * collapse to a single Salesforce call.
+   */
+  refreshTokens?: RefreshTokensFn;
+  /**
+   * Defense-in-depth fallback for the legacy refresh path. Almost never fires when
+   * `refreshTokens` is wired up. Kept for safety while we migrate all callers.
+   */
+  getFreshTokens?: () => Promise<RefreshedTokens | null>;
 }
 
 export class ApiConnection {
@@ -58,19 +68,13 @@ export class ApiConnection {
       sfdcClientId,
       sfdcClientSecret,
       logger,
+      refreshTokens,
       getFreshTokens,
     }: ApiConnectionOptions,
     refreshCallback?: (accessToken: string, refreshToken: string) => Promise<void> | void,
     onConnectionError?: (error: string) => void,
   ) {
     this.logger = logger;
-    this.apiRequest = apiRequestAdapter(
-      logger,
-      this.handleRefresh.bind(this),
-      this.handleConnectionError.bind(this),
-      enableLogging,
-      getFreshTokens,
-    );
     this.refreshCallback = refreshCallback;
     this.onConnectionError = onConnectionError;
     this.sessionInfo = {
@@ -84,6 +88,17 @@ export class ApiConnection {
       sfdcClientId,
       sfdcClientSecret,
     };
+    this.apiRequest = apiRequestAdapter({
+      logger,
+      // Legacy hook — preserved while callers without `refreshTokens` finish migrating. Once
+      // `refreshTokens` is wired up, the adapter mutates sessionInfo directly and this callback
+      // is unused for the primary path; it still fires from the `getFreshTokens` fallback.
+      onRefresh: this.handleRefresh.bind(this),
+      onConnectionError: this.handleConnectionError.bind(this),
+      enableLogging,
+      getFreshTokens,
+      refreshTokens,
+    });
 
     this.apex = new ApiApex(this);
     this.binary = new ApiBinaryDownload(this);

--- a/libs/salesforce-api/src/lib/types.ts
+++ b/libs/salesforce-api/src/lib/types.ts
@@ -50,6 +50,7 @@ export interface FetchOptions {
   body?: BodyInit | null;
   headers?: [string, string][] | Record<string, string> | Headers;
   duplex?: ApiRequestOptions['duplex'];
+  signal?: AbortSignal;
 }
 
 export interface FetchResponse<T = unknown> {


### PR DESCRIPTION
There is very likely a race condition in refresh token rotation as some users are getting logged out every day

This PR attempts to lock rotation to ensure any concurrent requests cannot clobber each other when the token expires and is refreshed while multiple requests are made at the same time

resolves #1726