### PR TITLE
Add additional audit logs for Salesforce org actions

### DIFF
--- a/apps/api/src/app/controllers/oauth.controller.ts
+++ b/apps/api/src/app/controllers/oauth.controller.ts
@@ -1,4 +1,6 @@
 import { ENV, logger } from '@jetstream/api-config';
+import { AuditLogAction, AuditLogResource, createTeamAuditLog } from '@jetstream/audit-logs';
+import { getApiAddressFromReq } from '@jetstream/auth/server';
 import { ApiConnection, ApiRequestError, getApiRequestFactoryFn } from '@jetstream/salesforce-api';
 import * as oauthService from '@jetstream/salesforce-oauth';
 import { ERROR_MESSAGES } from '@jetstream/shared/constants';
@@ -138,11 +140,32 @@ const salesforceOauthCallback = createRoute(
         enableLogging: ENV.LOG_LEVEL === 'trace',
       });
 
-      const salesforceOrg = await initConnectionFromOAuthResponse({
+      const { salesforceOrg, created } = await initConnectionFromOAuthResponse({
         jetstreamConn,
         userId: user.id,
         orgGroupId,
       });
+
+      const teamId = user.teamMembership?.teamId;
+      if (teamId) {
+        createTeamAuditLog({
+          userId: user.id,
+          teamId,
+          action: created ? AuditLogAction.ORG_ADDED : AuditLogAction.ORG_REACTIVATED,
+          resource: AuditLogResource.SALESFORCE_ORG,
+          resourceId: salesforceOrg.uniqueId,
+          metadata: {
+            uniqueId: salesforceOrg.uniqueId,
+            username: salesforceOrg.username,
+            orgName: salesforceOrg.orgName,
+            loginUrl: salesforceOrg.loginUrl,
+            instanceUrl: salesforceOrg.instanceUrl,
+            isSandbox: salesforceOrg.orgIsSandbox,
+          },
+          ipAddress: res.locals.ipAddress || getApiAddressFromReq(req),
+          userAgent: req.get('user-agent'),
+        });
+      }
 
       returnParams.data = JSON.stringify(salesforceOrg);
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -242,6 +265,6 @@ export async function initConnectionFromOAuthResponse({
     }
   }
 
-  const salesforceOrg = await salesforceOrgsDb.createOrUpdateSalesforceOrg(userId, salesforceOrgUi);
-  return salesforceOrg;
+  const { org: salesforceOrg, created } = await salesforceOrgsDb.createOrUpdateSalesforceOrg(userId, salesforceOrgUi);
+  return { salesforceOrg, created };
 }

--- a/apps/api/src/app/controllers/orgs.controller.ts
+++ b/apps/api/src/app/controllers/orgs.controller.ts
@@ -1,3 +1,5 @@
+import { AuditLogAction, AuditLogResource, createTeamAuditLog } from '@jetstream/audit-logs';
+import { getApiAddressFromReq } from '@jetstream/auth/server';
 import { ApiRequestError } from '@jetstream/salesforce-api';
 import { ERROR_MESSAGES } from '@jetstream/shared/constants';
 import { getErrorMessage } from '@jetstream/shared/utils';
@@ -80,11 +82,33 @@ const updateOrg = createRoute(routeDefinition.updateOrg.validators, async ({ bod
   }
 });
 
-const deleteOrg = createRoute(routeDefinition.deleteOrg.validators, async ({ params, user }, _, res, next) => {
+const deleteOrg = createRoute(routeDefinition.deleteOrg.validators, async ({ params, user }, req, res, next) => {
   try {
-    await salesforceOrgsDb.deleteSalesforceOrg(user.id, params.uniqueId);
+    const deletedOrg = await salesforceOrgsDb.deleteSalesforceOrg(user.id, params.uniqueId);
 
     sendJson(res, undefined, 204);
+
+    const teamId = user.teamMembership?.teamId;
+    if (teamId) {
+      createTeamAuditLog({
+        userId: user.id,
+        teamId,
+        action: AuditLogAction.ORG_DELETED,
+        resource: AuditLogResource.SALESFORCE_ORG,
+        resourceId: deletedOrg.uniqueId,
+        metadata: {
+          uniqueId: deletedOrg.uniqueId,
+          username: deletedOrg.username,
+          orgName: deletedOrg.orgName,
+          label: deletedOrg.label,
+          loginUrl: deletedOrg.loginUrl,
+          instanceUrl: deletedOrg.instanceUrl,
+          isSandbox: deletedOrg.orgIsSandbox,
+        },
+        ipAddress: res.locals.ipAddress || getApiAddressFromReq(req),
+        userAgent: req.get('user-agent'),
+      });
+    }
   } catch (ex) {
     next(new UserFacingError(ex));
   }

--- a/apps/api/src/app/db/salesforce-org.db.ts
+++ b/apps/api/src/app/db/salesforce-org.db.ts
@@ -249,7 +249,7 @@ export async function createOrUpdateSalesforceOrg(userId: string, salesforceOrgU
     if (orgToDelete) {
       await prisma.salesforceOrg.delete({ where: { id: orgToDelete.id } });
     }
-    return org;
+    return { org, created: false };
   } else {
     // create new
     const org = await prisma.salesforceOrg.create({
@@ -286,7 +286,7 @@ export async function createOrUpdateSalesforceOrg(userId: string, salesforceOrgU
     if (orgToDelete) {
       await prisma.salesforceOrg.delete({ where: { id: orgToDelete.id } });
     }
-    return org;
+    return { org, created: true };
   }
 }
 
@@ -343,7 +343,7 @@ export async function moveSalesforceOrg(
 
 export async function deleteSalesforceOrg(userId: string, uniqueId: string) {
   const existingOrg = await prisma.salesforceOrg.findUnique({
-    select: { id: true, username: true, label: true, orgName: true },
+    select: { id: true, uniqueId: true, username: true, label: true, orgName: true, loginUrl: true, instanceUrl: true, orgIsSandbox: true },
     where: findUniqueOrg({ userId, uniqueId }),
   });
 
@@ -355,6 +355,8 @@ export async function deleteSalesforceOrg(userId: string, uniqueId: string) {
     select: { id: true },
     where: { id: existingOrg.id },
   });
+
+  return existingOrg;
 }
 
 export async function updateLastActivity(orgId: number) {

--- a/apps/api/src/app/routes/route.middleware.ts
+++ b/apps/api/src/app/routes/route.middleware.ts
@@ -1,4 +1,5 @@
 import { createRateLimit, ENV, logger } from '@jetstream/api-config';
+import { AuditLogAction, AuditLogResource, createTeamAuditLog } from '@jetstream/audit-logs';
 import {
   AuthError,
   checkUserAgentSimilarity,
@@ -318,7 +319,10 @@ export async function getOrgFromHeaderOrQuery(
     return;
   }
 
-  return getOrgForRequest(user, uniqueId, res.log || req.log || logger, apiVersion, includeCallOptions, requestId);
+  return getOrgForRequest(user, uniqueId, res.log || req.log || logger, apiVersion, includeCallOptions, requestId, {
+    ipAddress: res.locals.ipAddress || getApiAddressFromReq(req),
+    userAgent: req.get('user-agent'),
+  });
 }
 
 export async function getOrgForRequest(
@@ -328,6 +332,7 @@ export async function getOrgForRequest(
   apiVersion?: string,
   includeCallOptions?: boolean,
   requestId?: string,
+  requestContext?: { ipAddress?: string; userAgent?: string },
 ) {
   const org = await salesforceOrgsDb.findByUniqueId_UNSAFE(user.id, uniqueId);
   if (!org || org.jetstreamUserId2 !== user.id) {
@@ -419,6 +424,26 @@ export async function getOrgForRequest(
         ? '[TOKEN REFRESH] Salesforce token rotated and persisted'
         : '[TOKEN REFRESH] Lock acquired but DB already had fresh tokens — cross-worker race avoided',
     );
+    const teamId = user.teamMembership?.teamId;
+    if (result.refreshed && teamId) {
+      createTeamAuditLog({
+        userId: user.id,
+        teamId,
+        action: AuditLogAction.ORG_TOKEN_REFRESHED,
+        resource: AuditLogResource.SALESFORCE_ORG,
+        resourceId: org.uniqueId,
+        metadata: {
+          uniqueId: org.uniqueId,
+          username: org.username,
+          orgName: org.orgName,
+          loginUrl: org.loginUrl,
+          instanceUrl: org.instanceUrl,
+          isSandbox: org.orgIsSandbox,
+        },
+        ipAddress: requestContext?.ipAddress,
+        userAgent: requestContext?.userAgent,
+      });
+    }
     return { accessToken: result.accessToken, refreshToken: result.refreshToken };
   };
 

--- a/apps/api/src/app/routes/scanner.routes.ts
+++ b/apps/api/src/app/routes/scanner.routes.ts
@@ -118,7 +118,7 @@ routes.post('/init-session', async (req: express.Request, res: express.Response,
           enableLogging: false,
           logger,
         });
-        const salesforceOrg = await initConnectionFromOAuthResponse({
+        const { salesforceOrg } = await initConnectionFromOAuthResponse({
           jetstreamConn,
           userId: scannerUser.id,
         });

--- a/apps/api/src/app/routes/test.routes.ts
+++ b/apps/api/src/app/routes/test.routes.ts
@@ -60,7 +60,7 @@ routes.post('/e2e-integration-org', async (_: express.Request, res: express.Resp
     logger,
   });
 
-  const salesforceOrg = await initConnectionFromOAuthResponse({
+  const { salesforceOrg } = await initConnectionFromOAuthResponse({
     jetstreamConn,
     userId: ENV.EXAMPLE_USER!.id,
   });

--- a/libs/audit-logs/src/lib/audit-logs.ts
+++ b/libs/audit-logs/src/lib/audit-logs.ts
@@ -4,6 +4,9 @@ import { NOOP } from '@jetstream/shared/utils';
 
 export enum AuditLogAction {
   // Org actions
+  ORG_ADDED = 'ORG_ADDED',
+  ORG_DELETED = 'ORG_DELETED',
+  ORG_TOKEN_REFRESHED = 'ORG_TOKEN_REFRESHED',
   ORG_REACTIVATED = 'ORG_REACTIVATED',
   ORG_EXPIRATION_WARNING = 'ORG_EXPIRATION_WARNING',
   ORG_EXPIRED = 'ORG_EXPIRED',


### PR DESCRIPTION
Enhance the auditing capabilities by adding logs for actions related to Salesforce organizations, including org addition, deletion, and token refresh events. This improves tracking and accountability for user interactions with Salesforce orgs.