### PR TITLE
Add build script for monorepo applications

### DIFF
--- a/scripts/render-build-monorepo-app.sh
+++ b/scripts/render-build-monorepo-app.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+# Use this script to build a nested workspace project (e.g. docs, apps-sfdx) on Render.
+# It ensures Corepack is enabled and the correct version of pnpm is used, then installs
+# the target project's dependencies (plus its workspace deps) and runs its build script.
+# Examples:
+#   ./scripts/render-build-monorepo-app.sh docs
+#   ./scripts/render-build-monorepo-app.sh apps-sfdx build
+
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+  echo "Usage: $0 <project-filter> [script]" >&2
+  exit 1
+fi
+
+PROJECT="$1"
+SCRIPT="${2:-build}"
+
+"$(dirname "$0")/render-enable-corepack.sh"
+
+pnpm install --prod=false --filter "${PROJECT}..."
+pnpm --filter "${PROJECT}" "${SCRIPT}"
+

--- a/scripts/render-build.sh
+++ b/scripts/render-build.sh
@@ -1,10 +1,14 @@
 #!/usr/bin/env bash
+
+# Use this script to build the render package for production.
+# It ensures Corepack is enabled and the correct version of pnpm is used, then installs dependencies and runs the build script.
+# Examples:
+#   ./scripts/render-build.sh
+#   ./scripts/render-build.sh build:cron
+
 set -euo pipefail
 
-PNPM_VERSION=$(node -p "require('./package.json').devEngines.packageManager.version")
-
-corepack enable
-corepack prepare "pnpm@${PNPM_VERSION}" --activate
+"$(dirname "$0")/render-enable-corepack.sh"
 
 pnpm install --prod=false
 pnpm "${1:-build}"

--- a/scripts/render-enable-corepack.sh
+++ b/scripts/render-enable-corepack.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PNPM_VERSION=$(node -p "require('./package.json').devEngines.packageManager.version")
+
+corepack enable
+corepack prepare "pnpm@${PNPM_VERSION}" --activate


### PR DESCRIPTION
Introduce a build script to facilitate building nested workspace projects, ensuring Corepack is enabled and the correct version of pnpm is used. This enhances the build process for documentation and other applications within the monorepo.