### PR TITLE
fix: add missing resourceDrillInOnLoad prop to ExpressionContainer

### DIFF
--- a/libs/ui/src/lib/expression-group/ExpressionContainer.tsx
+++ b/libs/ui/src/lib/expression-group/ExpressionContainer.tsx
@@ -529,6 +529,7 @@ export const ExpressionContainer: FunctionComponent<ExpressionContainerProps> = 
                     rowHelpText={childRow.helpText}
                     resources={resources}
                     resourceListHeader={resourceListHeader}
+                    resourceDrillInOnLoad={resourceDrillInOnLoad}
                     functions={functions}
                     operators={operators}
                     selected={childRow.selected}


### PR DESCRIPTION
Related fields in filter group did not trigger fetching data from cache/sfdc

fixes #1743