### PR TITLE
Update IP address range

### DIFF
--- a/apps/docs/docs/getting-started/_ip-address-ranges.mdx
+++ b/apps/docs/docs/getting-started/_ip-address-ranges.mdx
@@ -1,17 +1,18 @@
-:::info
-
-Starting on October 27th, 2025, the IP address ranges will change to: `74.220.50.0/24`, `74.220.58.0/24`.
-
-The old IP addresses may continue to be utilized until December 1, 2025.
-
-:::
+### Jetstream IP Addresses
 
 If you need to allow IP addresses for your org, Jetstream will use one of the following addresses:
 
-- `3.134.238.10` (Retired after December 1, 2025)
-- `3.129.111.220` (Retired after December 1, 2025)
-- `52.15.118.168` (Retired after December 1, 2025)
-- `74.220.58.0/24` (Live on October 27th, 2025)
+- `74.220.50.22`
+- `74.220.50.23`
+- `74.220.50.24`
+
+On Salesforce, configure as `74.220.50.22` to `74.220.50.24`.
+
+#### Prior IP Address Ranges:
+
+**Prior to May 28, 2026:**
+
+- `74.220.58.0/24`
   - On Salesforce, configure as `74.220.58.0` to `74.220.58.255`
-- `74.220.50.0/24` (Live on October 27th, 2025)
+- `74.220.50.0/24`
   - On Salesforce, configure as `74.220.50.0` to `74.220.50.255`

--- a/apps/docs/docs/getting-started/overview.mdx
+++ b/apps/docs/docs/getting-started/overview.mdx
@@ -78,8 +78,6 @@ When you are authorizing with Salesforce, you will see a consent screen with the
 
 <img src={require('./connecting-org.png').default} alt="Salesforce authorization screen" />
 
-### Jetstream IP Addresses
-
 <IpAddressRanges />
 
 ### Troubleshooting Tips

--- a/apps/docs/docs/getting-started/troubleshooting.mdx
+++ b/apps/docs/docs/getting-started/troubleshooting.mdx
@@ -12,8 +12,6 @@ import OrgTroubleshootingTable from './_org-troubleshooting-table.mdx';
 
 If you are having problems connecting to Salesforce, here are some tips to help you resolve any issues.
 
-### Jetstream IP Addresses
-
 <IpAddressRanges />
 
 ### Installing Jetstream


### PR DESCRIPTION
Update IP address range to include the new IP addresses.

Prior notice was not provided to customers since the new IP addresses are within the prior range, we have 3 possible outbound IP addresses instead of a range of 510 possible addresses.