### PR TITLE
fix: SSRF security hardening

### DIFF
--- a/apps/api/src/app/controllers/__tests__/team.controller.spec.ts
+++ b/apps/api/src/app/controllers/__tests__/team.controller.spec.ts
@@ -17,6 +17,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { fetchSamlMetadata, maskSsoSecrets } from '../team.controller';
 
 const assertDomainResolvesToPublicIpMock = vi.hoisted(() => vi.fn());
+// fetchSamlMetadata now validates+pins each hop's host via getPinnedPublicIpDispatcher (which
+// resolves the hostname, asserts it is public, and returns a cached undici Agent pinned to that IP),
+// replacing the prior assertDomainResolvesToPublicIp(url) call.
+const getPinnedPublicIpDispatcherMock = vi.hoisted(() => vi.fn());
 
 // Mock the transitive import chain of team.controller.ts down to the minimum needed
 // to load the module. We are exercising maskSsoSecrets and fetchSamlMetadata — nothing
@@ -50,6 +54,7 @@ vi.mock('@jetstream/auth/types', () => ({
 }));
 vi.mock('@jetstream/shared/node-utils', () => ({
   assertDomainResolvesToPublicIp: assertDomainResolvesToPublicIpMock,
+  getPinnedPublicIpDispatcher: getPinnedPublicIpDispatcherMock,
 }));
 vi.mock('@jetstream/prisma', () => ({
   Prisma: { PrismaClientKnownRequestError: class extends Error {} },
@@ -133,6 +138,9 @@ describe('fetchSamlMetadata', () => {
   beforeEach(() => {
     assertDomainResolvesToPublicIpMock.mockReset();
     assertDomainResolvesToPublicIpMock.mockResolvedValue(undefined);
+    getPinnedPublicIpDispatcherMock.mockReset();
+    // Default: validation passes, returns an undefined (unused-by-mocked-fetch) dispatcher.
+    getPinnedPublicIpDispatcherMock.mockResolvedValue(undefined);
     fetchMock = vi.fn();
     vi.stubGlobal('fetch', fetchMock);
   });
@@ -150,8 +158,8 @@ describe('fetchSamlMetadata', () => {
 
     expect(response.status).toBe(200);
     expect(text).toBe(body);
-    expect(assertDomainResolvesToPublicIpMock).toHaveBeenCalledTimes(1);
-    expect(assertDomainResolvesToPublicIpMock).toHaveBeenCalledWith('https://idp.okta.com/metadata');
+    expect(getPinnedPublicIpDispatcherMock).toHaveBeenCalledTimes(1);
+    expect(getPinnedPublicIpDispatcherMock).toHaveBeenCalledWith('idp.okta.com');
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(fetchMock.mock.calls[0][1].redirect).toBe('manual');
   });
@@ -164,14 +172,14 @@ describe('fetchSamlMetadata', () => {
     const response = await fetchSamlMetadata('https://idp.okta.com/metadata');
 
     expect(response.status).toBe(200);
-    expect(assertDomainResolvesToPublicIpMock).toHaveBeenCalledTimes(2);
-    expect(assertDomainResolvesToPublicIpMock.mock.calls[0][0]).toBe('https://idp.okta.com/metadata');
-    expect(assertDomainResolvesToPublicIpMock.mock.calls[1][0]).toBe('https://regional.okta.com/metadata');
+    expect(getPinnedPublicIpDispatcherMock).toHaveBeenCalledTimes(2);
+    expect(getPinnedPublicIpDispatcherMock.mock.calls[0][0]).toBe('idp.okta.com');
+    expect(getPinnedPublicIpDispatcherMock.mock.calls[1][0]).toBe('regional.okta.com');
   });
 
   it('rejects a redirect to a host that resolves to a private IP', async () => {
     fetchMock.mockResolvedValueOnce(new Response(null, { status: 301, headers: { location: 'https://internal.lan/metadata' } }));
-    assertDomainResolvesToPublicIpMock
+    getPinnedPublicIpDispatcherMock
       .mockResolvedValueOnce(undefined)
       .mockRejectedValueOnce(new Error('Hostname resolves to a private or reserved IP address'));
 
@@ -232,5 +240,6 @@ describe('fetchSamlMetadata', () => {
 
     expect(response.status).toBe(200);
     expect(assertDomainResolvesToPublicIpMock).not.toHaveBeenCalled();
+    expect(getPinnedPublicIpDispatcherMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/app/controllers/sf-misc.controller.ts
+++ b/apps/api/src/app/controllers/sf-misc.controller.ts
@@ -10,6 +10,21 @@ import { UserFacingError } from '../utils/error-handler';
 import { sendJson } from '../utils/response.handlers';
 import { createRoute, RouteValidator } from '../utils/route.utils';
 
+/**
+ * Defense-in-depth for the SSRF sinks (`streamFileDownload` / `salesforceRequestManual`): the
+ * `url` is forwarded to Salesforce with the org's session credentials, so we require a host-relative
+ * path. The callout adapter still pins the resolved request to the instance origin, but rejecting
+ * authority-override (`@host`), protocol-relative (`//host`), backslash, whitespace, and control-char
+ * tricks at the edge keeps malicious input from ever reaching the credentialed request.
+ */
+const HostRelativeUrlSchema = z
+  .string()
+  .min(1)
+  .startsWith('/', 'URL must be a host-relative path beginning with "/"')
+  // eslint-disable-next-line no-control-regex -- intentionally rejecting C0/DEL control chars in the path
+  .regex(/^\/(?!\/)[^\\\s\x00-\x1f\x7f]*$/, 'URL must be a host-relative path and may not contain "\\", whitespace, or control characters')
+  .refine((value) => !value.includes('@'), 'URL must not contain "@"');
+
 export const routeDefinition = {
   getFrontdoorLoginUrl: {
     controllerFn: () => getFrontdoorLoginUrl,
@@ -23,7 +38,7 @@ export const routeDefinition = {
     responseType: z.any(),
     validators: {
       query: z.object({
-        url: z.string().min(1),
+        url: HostRelativeUrlSchema,
       }),
     } satisfies RouteValidator,
   },
@@ -52,7 +67,10 @@ export const routeDefinition = {
     controllerFn: () => salesforceRequestManual,
     responseType: z.any(),
     validators: {
-      body: SalesforceRequestManualRequestSchema,
+      // `salesforceRequestManual` runs with `ensureRestUrl=false`, so its caller-supplied `url` is the
+      // SSRF sink — tighten it to a host-relative path. `salesforceRequest` above is safe because it
+      // passes `ensureRestUrl=true`, so its schema is intentionally left unchanged.
+      body: SalesforceRequestManualRequestSchema.extend({ url: HostRelativeUrlSchema }),
     } satisfies RouteValidator,
   },
 };

--- a/apps/api/src/app/controllers/team.controller.ts
+++ b/apps/api/src/app/controllers/team.controller.ts
@@ -3,7 +3,7 @@ import { AuditLogAction, AuditLogResource, createTeamAuditLog } from '@jetstream
 import * as authService from '@jetstream/auth/server';
 import { encryptSecret, oidcService, samlService } from '@jetstream/auth/server';
 import { OidcConfigurationRequestSchema, SamlConfigurationRequestSchema } from '@jetstream/auth/types';
-import { assertDomainResolvesToPublicIp } from '@jetstream/shared/node-utils';
+import { assertDomainResolvesToPublicIp, getPinnedPublicIpDispatcher } from '@jetstream/shared/node-utils';
 import { BLOCKED_PUBLIC_EMAIL_DOMAINS } from '@jetstream/shared/constants';
 import { getErrorMessage, getErrorMessageAndStackObj } from '@jetstream/shared/utils';
 import {
@@ -20,6 +20,7 @@ import {
 import * as crypto from 'crypto';
 import * as dns from 'dns/promises';
 import { unparse } from 'papaparse';
+import type { Dispatcher } from 'undici';
 import { z } from 'zod';
 import * as teamDb from '../db/team.db';
 import * as teamService from '../services/team.service';
@@ -71,16 +72,19 @@ export async function fetchSamlMetadata(initialUrl: string): Promise<Response> {
     // In dev/CI (USE_SECURE_COOKIES=false) we allow loopback/private targets so the local mock
     // IdP (mock-idp/docker-compose.yml, http://localhost:4000/api/saml/metadata) is reachable.
     // Parallels the OIDC runtime discovery path in libs/auth/server/src/lib/oidc.service.ts.
+    // In prod we pin the connection to the validated public IP so the validated address is the
+    // one actually connected to (defeats DNS-rebinding TOCTOU between the check and the fetch).
+    const fetchInit: RequestInit & { dispatcher?: Dispatcher } = {
+      signal,
+      headers: { Accept: 'application/xml, text/xml, */*' },
+      redirect: 'manual',
+    };
     if (ENV.USE_SECURE_COOKIES) {
-      await assertDomainResolvesToPublicIp(currentUrl);
+      fetchInit.dispatcher = await getPinnedPublicIpDispatcher(new URL(currentUrl).hostname);
     }
     let response: Response;
     try {
-      response = await fetch(currentUrl, {
-        signal,
-        headers: { Accept: 'application/xml, text/xml, */*' },
-        redirect: 'manual',
-      });
+      response = await fetch(currentUrl, fetchInit);
     } catch (err) {
       // AbortSignal.timeout's thrown error can surface as TimeoutError OR AbortError depending
       // on the Node/undici version — checking signal.aborted is deterministic, and since this
@@ -1191,21 +1195,10 @@ const verifyDomain = createRoute(routeDefinition.verifyDomain.validators, async 
     }
 
     // 2. Check File (if not verified by DNS)
-    // Validate that the domain resolves to a public IP to prevent SSRF attacks
-    let domainIsSafeToFetch = false;
+    // Pin each fetch to a freshly-validated public IP so the address we validate is the address
+    // we connect to (defeats DNS-rebinding TOCTOU). Each fileUrl can target a different host
+    // (the apex domain and the `_jetstream.` subdomain), so every URL is validated independently.
     if (!verified) {
-      try {
-        await assertDomainResolvesToPublicIp(verification.domain);
-        domainIsSafeToFetch = true;
-      } catch (error) {
-        res.log.warn(
-          { error: getErrorMessage(error), domain: verification.domain },
-          'Domain failed SSRF safety check, skipping file verification',
-        );
-      }
-    }
-
-    if (!verified && domainIsSafeToFetch) {
       const fileUrls = [
         `https://${verification.domain}/.well-known/jetstream-verification.txt`,
         `https://_jetstream.${verification.domain}/.well-known/jetstream-verification.txt`,
@@ -1213,7 +1206,13 @@ const verifyDomain = createRoute(routeDefinition.verifyDomain.validators, async 
       for (const fileUrl of fileUrls) {
         if (verified) break;
         try {
-          const response = await fetch(fileUrl, { signal: AbortSignal.timeout(5000), redirect: 'manual' });
+          const dispatcher = await getPinnedPublicIpDispatcher(new URL(fileUrl).hostname);
+          const fetchInit: RequestInit & { dispatcher?: Dispatcher } = {
+            signal: AbortSignal.timeout(5000),
+            redirect: 'manual',
+            dispatcher,
+          };
+          const response = await fetch(fileUrl, fetchInit);
           if (response.ok) {
             const text = await response.text();
             if (text.trim() === verification.verificationCode) {

--- a/libs/auth/server/src/lib/oidc.service.ts
+++ b/libs/auth/server/src/lib/oidc.service.ts
@@ -1,14 +1,43 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { ENV, logger } from '@jetstream/api-config';
 import type { OidcConfiguration } from '@jetstream/prisma';
-import { assertDomainResolvesToPublicIp } from '@jetstream/shared/node-utils';
+import { getPinnedPublicIpDispatcher } from '@jetstream/shared/node-utils';
 import { getErrorMessage } from '@jetstream/shared/utils';
 import { LRUCache } from 'lru-cache';
 import * as oauth from 'oauth4webapi';
+import type { Dispatcher } from 'undici';
 import { decryptSecret } from './sso-crypto.util';
 import { AttributeMapping, DiscoveredOidcConfig, SsoUserInfo } from './sso.types';
 
 const discoveryCache = new LRUCache<string, oauth.AuthorizationServer>({ max: 100, ttl: 1000 * 60 * 60 });
+
+type OidcCustomFetch = (url: string, options: oauth.CustomFetchOptions<string, BodyInit | null | undefined>) => Promise<Response>;
+
+/**
+ * Builds an oauth4webapi `customFetch` that pins every request to a freshly-validated public IP
+ * for the request URL's host. This covers the issuer (discovery) AND every discovered endpoint
+ * (token_endpoint, userinfo_endpoint, jwks_uri) — whichever URL oauth4webapi decides to call is
+ * re-validated and the connection is pinned to the validated address, closing the DNS-rebinding
+ * TOCTOU window (the validated IP is the IP actually connected to).
+ *
+ * In dev/CI (USE_SECURE_COOKIES=false) we skip pinning so local/loopback IdPs remain reachable,
+ * mirroring the SAML/file-verification fetch gating in team.controller.ts.
+ */
+function createPinnedCustomFetch(): OidcCustomFetch {
+  return async (url, options) => {
+    const fetchInit: RequestInit & { dispatcher?: Dispatcher } = {
+      body: options.body,
+      headers: options.headers,
+      method: options.method,
+      redirect: options.redirect,
+      signal: options.signal,
+    };
+    if (ENV.USE_SECURE_COOKIES) {
+      fetchInit.dispatcher = await getPinnedPublicIpDispatcher(new URL(url).hostname);
+    }
+    return fetch(url, fetchInit);
+  };
+}
 
 export class OidcService {
   /**
@@ -26,15 +55,13 @@ export class OidcService {
       }
 
       // SSRF protection: re-check at runtime (not just at save time) so DNS rebinding
-      // against a previously-public issuer cannot reach internal infrastructure.
-      // In dev/CI we allow insecure requests (loopback/private), so skip the check there too.
-      if (ENV.USE_SECURE_COOKIES) {
-        await assertDomainResolvesToPublicIp(issuerUrl.hostname);
-      }
-
-      // Perform discovery (allow HTTP for non-prod/local testing)
+      // against a previously-public issuer cannot reach internal infrastructure. The pinned
+      // customFetch resolves+validates the host once and connects to that exact IP, so the
+      // address validated is the address fetched (no rebind window between check and fetch).
+      // In dev/CI we allow insecure requests (loopback/private), so pinning is skipped there too.
       const response = await oauth.discoveryRequest(issuerUrl, {
         [oauth.allowInsecureRequests]: !ENV.USE_SECURE_COOKIES,
+        [oauth.customFetch]: createPinnedCustomFetch(),
       });
       const authServer = await oauth.processDiscoveryResponse(issuerUrl, response);
 
@@ -119,7 +146,10 @@ export class OidcService {
         params,
         `${ENV.JETSTREAM_SERVER_URL}/api/auth/sso/oidc/${teamId}/callback`,
         codeVerifier,
-        { [oauth.allowInsecureRequests]: !ENV.USE_SECURE_COOKIES },
+        {
+          [oauth.allowInsecureRequests]: !ENV.USE_SECURE_COOKIES,
+          [oauth.customFetch]: createPinnedCustomFetch(),
+        },
       );
 
       // Process the token response (for OpenID Connect)
@@ -168,6 +198,7 @@ export class OidcService {
       if (authServer.userinfo_endpoint && accessToken) {
         const response = await oauth.userInfoRequest(authServer, client, accessToken, {
           [oauth.allowInsecureRequests]: !ENV.USE_SECURE_COOKIES,
+          [oauth.customFetch]: createPinnedCustomFetch(),
         });
         const userinfoResponse = await oauth.processUserInfoResponse(authServer, client, claims.sub, response);
         allClaims = { ...allClaims, ...userinfoResponse };
@@ -178,10 +209,7 @@ export class OidcService {
       // team-verified domain check in sso-auth.service; we only reject the explicit-false
       // case where a compliant IdP tells us the email is not verified.
       if (allClaims.email_verified === false) {
-        logger.warn(
-          { sub: claims.sub, issuer: config.issuer },
-          '[SSO][OIDC] Rejecting login: provider reported email_verified=false',
-        );
+        logger.warn({ sub: claims.sub, issuer: config.issuer }, '[SSO][OIDC] Rejecting login: provider reported email_verified=false');
         throw new Error('OIDC provider reported the email address as unverified');
       }
 

--- a/libs/salesforce-api/src/lib/__tests__/callout-adapter.spec.ts
+++ b/libs/salesforce-api/src/lib/__tests__/callout-adapter.spec.ts
@@ -1,6 +1,39 @@
 import { describe, expect, it, vi } from 'vitest';
-import { ApiRequestError, getApiRequestFactoryFn, sanitizeCallerHeaders } from '../callout-adapter';
+import { ApiRequestError, getApiRequestFactoryFn, resolveSameOriginRequestUrl, sanitizeCallerHeaders } from '../callout-adapter';
 import type { FetchFn } from '../types';
+
+describe('resolveSameOriginRequestUrl', () => {
+  const instanceUrl = 'https://test.salesforce.com';
+
+  it('resolves host-relative paths against the instance origin', () => {
+    expect(resolveSameOriginRequestUrl('/services/data/v65.0/test', instanceUrl)).toBe(
+      'https://test.salesforce.com/services/data/v65.0/test',
+    );
+  });
+
+  it('allows an absolute URL that is already on the instance origin', () => {
+    expect(resolveSameOriginRequestUrl('https://test.salesforce.com/services/x', instanceUrl)).toBe(
+      'https://test.salesforce.com/services/x',
+    );
+  });
+
+  it('rejects authority-override, protocol-relative, and absolute cross-origin URLs', () => {
+    for (const maliciousUrl of [
+      '//evil.com/x',
+      'https://evil.com/x',
+      'http://test.salesforce.com/x',
+      '\\\\evil.com',
+      'ftp://test.salesforce.com/x',
+    ]) {
+      expect(() => resolveSameOriginRequestUrl(maliciousUrl, instanceUrl)).toThrow(/Salesforce instance origin/);
+    }
+  });
+
+  it('keeps the org bearer on the instance origin even when a caller smuggles an @ in a relative path', () => {
+    // `@evil.com/x` resolves to a same-origin PATH (not an authority), so credentials stay on Salesforce
+    expect(resolveSameOriginRequestUrl('@evil.com/x', instanceUrl)).toBe('https://test.salesforce.com/@evil.com/x');
+  });
+});
 
 describe('sanitizeCallerHeaders', () => {
   it('returns undefined when no headers are provided (caller omitted the field entirely)', () => {
@@ -804,6 +837,24 @@ describe('callout-adapter XML parsing', () => {
       const results = Array.isArray(response.result) ? response.result : [response.result];
       expect(results[0]).toHaveProperty('createdById');
       expect(results[0]).toHaveProperty('fullName');
+    });
+  });
+
+  describe('SSRF origin pinning', () => {
+    it('throws and never calls fetch when the url would escape the instance origin', async () => {
+      const mockFetch = vi.fn() as unknown as FetchFn;
+      const apiRequest = getApiRequestFactoryFn(mockFetch)();
+
+      await expect(
+        apiRequest({
+          url: 'https://evil.com/x',
+          method: 'GET',
+          sessionInfo: mockSessionInfo,
+          outputType: 'json',
+        }),
+      ).rejects.toThrow(/Salesforce instance origin/);
+
+      expect(mockFetch).not.toHaveBeenCalled();
     });
   });
 

--- a/libs/salesforce-api/src/lib/callout-adapter.ts
+++ b/libs/salesforce-api/src/lib/callout-adapter.ts
@@ -27,6 +27,26 @@ export class ApiRequestError extends Error {
   }
 }
 
+/**
+ * Resolves the outbound request URL against the org's `instanceUrl` and asserts it stays on the
+ * same origin over HTTPS before we attach the session's bearer/`X-SFDC-Session`. `url` on the
+ * manual-request and stream-download endpoints is fully caller-controlled, so a value like
+ * `@evil.com/x`, `//evil.com`, `https://evil.com`, or one using userinfo/backslash tricks could
+ * otherwise override the authority and exfiltrate the org's credentials to an attacker host.
+ *
+ * Resolving with `new URL(url, instanceUrl)` and pinning `resolved.origin === instance origin`
+ * neutralizes all of those regardless of the underlying fetch/undici runtime, and returning the
+ * resolved string means the actual fetch parses the exact same value we validated.
+ */
+export function resolveSameOriginRequestUrl(url: string, instanceUrl: string): string {
+  const instanceOrigin = new URL(instanceUrl).origin;
+  const resolved = new URL(url, instanceUrl);
+  if (resolved.origin !== instanceOrigin || resolved.protocol !== 'https:') {
+    throw new Error(`Request URL must stay on the Salesforce instance origin over HTTPS: ${url}`);
+  }
+  return resolved.toString();
+}
+
 export const CALLOUT_ADAPTER_PARSE_OPTIONS = {
   trimValues: true,
   ignoreAttributes: false,
@@ -149,7 +169,9 @@ export function getApiRequestFactoryFn(fetch: FetchFn) {
       let { url, body, outputType, duplex } = requestOptions;
       const { method = 'GET', sessionInfo, headers, rawBody = false } = requestOptions;
       const { accessToken, instanceUrl } = sessionInfo;
-      url = `${instanceUrl}${url}`;
+      // Resolve + assert same-origin/HTTPS before attaching session credentials so a caller-controlled
+      // `url` cannot redirect the org's bearer token to an attacker host (SSRF / credential exfiltration).
+      url = resolveSameOriginRequestUrl(url, instanceUrl);
       outputType = outputType || 'json';
       if (isObject(body) && !rawBody) {
         body = JSON.stringify(body);

--- a/libs/shared/node-utils/src/lib/__tests__/network.utils.spec.ts
+++ b/libs/shared/node-utils/src/lib/__tests__/network.utils.spec.ts
@@ -1,5 +1,6 @@
+import type { LookupAddress } from 'dns';
 import * as dns from 'dns/promises';
-import { assertDomainResolvesToPublicIp } from '../network.utils';
+import { assertDomainResolvesToPublicIp, resolveHostnameToValidatedPublicIps, selectPinnedLookupAddresses } from '../network.utils';
 
 // jsdom-environment tests can't auto-mock `dns/promises`, so stub the two functions we use.
 vi.mock('dns/promises', () => ({
@@ -130,3 +131,71 @@ describe('assertDomainResolvesToPublicIp', () => {
     await expect(assertDomainResolvesToPublicIp('example.com')).resolves.toBeUndefined();
   });
 });
+
+describe('resolveHostnameToValidatedPublicIps', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('returns validated IPv4 and IPv6 addresses with their family', async () => {
+    mockedDns.resolve4.mockResolvedValue(['93.184.216.34']);
+    mockedDns.resolve6.mockResolvedValue(['2606:4700:4700::1111']);
+
+    const addresses = await resolveHostnameToValidatedPublicIps('example.com');
+    expect(addresses).toEqual([
+      { address: '93.184.216.34', family: 4 },
+      { address: '2606:4700:4700::1111', family: 6 },
+    ]);
+  });
+
+  it('returns a raw public IP literal without a DNS lookup', async () => {
+    const addresses = await resolveHostnameToValidatedPublicIps('8.8.8.8');
+    expect(addresses).toEqual([{ address: '8.8.8.8', family: 4 }]);
+    expect(mockedDns.resolve4).not.toHaveBeenCalled();
+  });
+
+  it('rejects when any resolved address is private', async () => {
+    mockedDns.resolve4.mockResolvedValue(['93.184.216.34', '169.254.169.254']);
+    mockedDns.resolve6.mockRejectedValue(new Error('no AAAA'));
+
+    await expect(resolveHostnameToValidatedPublicIps('evil.com')).rejects.toThrow('private or reserved');
+  });
+
+  it('throws when the domain cannot be resolved', async () => {
+    mockedDns.resolve4.mockRejectedValue(new Error('NXDOMAIN'));
+    mockedDns.resolve6.mockRejectedValue(new Error('NXDOMAIN'));
+
+    await expect(resolveHostnameToValidatedPublicIps('nonexistent.invalid')).rejects.toThrow('Unable to resolve DNS');
+  });
+});
+
+describe('selectPinnedLookupAddresses', () => {
+  const ipv4: LookupAddress = { address: '93.184.216.34', family: 4 };
+  const ipv6: LookupAddress = { address: '2606:4700:4700::1111', family: 6 };
+
+  it('returns all validated addresses when no specific family is requested', () => {
+    expect(selectPinnedLookupAddresses([ipv4, ipv6], undefined)).toEqual([ipv4, ipv6]);
+    expect(selectPinnedLookupAddresses([ipv4, ipv6], 0)).toEqual([ipv4, ipv6]);
+  });
+
+  it('narrows to the requested IPv4 family', () => {
+    expect(selectPinnedLookupAddresses([ipv4, ipv6], 4)).toEqual([ipv4]);
+  });
+
+  it('narrows to the requested IPv6 family', () => {
+    expect(selectPinnedLookupAddresses([ipv4, ipv6], 6)).toEqual([ipv6]);
+  });
+
+  it('throws when no address matches the requested family', () => {
+    expect(() => selectPinnedLookupAddresses([ipv4], 6)).toThrow('No validated public IPv6 address');
+  });
+
+  it('throws when a pinned address is private/reserved at connect time', () => {
+    expect(() => selectPinnedLookupAddresses([{ address: '10.0.0.1', family: 4 }], undefined)).toThrow('private or reserved');
+  });
+});
+
+// NOTE: createPinnedPublicIpDispatcher() constructs an undici Agent (a Node-only dependency),
+// which cannot be loaded under this lib's jsdom test environment. Its IP-validation behavior is
+// exercised through resolveHostnameToValidatedPublicIps above (the helper it delegates to); the
+// connection-pinning (connect.lookup) is integration-tested at runtime.

--- a/libs/shared/node-utils/src/lib/network.utils.ts
+++ b/libs/shared/node-utils/src/lib/network.utils.ts
@@ -1,5 +1,8 @@
 import * as dns from 'dns/promises';
+import type { LookupAddress } from 'dns';
+import { LRUCache } from 'lru-cache';
 import * as net from 'net';
+import type { Agent } from 'undici';
 
 /**
  * Checks whether an IP address belongs to a private, reserved, or otherwise
@@ -50,42 +53,52 @@ function isPrivateOrReservedIp(ip: string): boolean {
 }
 
 /**
- * Resolves a hostname to IP addresses and validates that none of them
- * point to private or reserved IP ranges. This prevents SSRF attacks
- * where an attacker-controlled domain resolves to internal infrastructure.
- *
- * @throws Error if the domain resolves to a private/reserved IP
+ * Strip any protocol or path so we are left with just the hostname.
  */
-export async function assertDomainResolvesToPublicIp(hostname: string): Promise<void> {
-  // Strip any protocol or path — we only want the hostname
-  let cleanHostname = hostname;
+function extractHostname(hostnameOrUrl: string): string {
   try {
-    const url = new URL(hostname.includes('://') ? hostname : `https://${hostname}`);
-    cleanHostname = url.hostname;
+    const url = new URL(hostnameOrUrl.includes('://') ? hostnameOrUrl : `https://${hostnameOrUrl}`);
+    return url.hostname;
   } catch {
     // If URL parsing fails, use the raw value
+    return hostnameOrUrl;
   }
+}
 
-  // Reject if the hostname is already a raw IP literal
+/**
+ * Resolves a hostname a SINGLE time and validates that EVERY resolved address
+ * is public (not private/reserved). Returns the validated IPs (with their family)
+ * so callers can pin a connection to exactly the addresses that were checked,
+ * closing the DNS-rebinding TOCTOU window where a second lookup could resolve
+ * to an internal host.
+ *
+ * Raw IP literals are validated directly without a DNS lookup.
+ *
+ * @throws Error if the domain cannot be resolved or resolves to a private/reserved IP
+ */
+export async function resolveHostnameToValidatedPublicIps(hostnameOrUrl: string): Promise<LookupAddress[]> {
+  const cleanHostname = extractHostname(hostnameOrUrl);
+
+  // A raw IP literal needs no DNS lookup — validate it directly.
   if (net.isIP(cleanHostname)) {
     if (isPrivateOrReservedIp(cleanHostname)) {
       throw new Error(`Hostname resolves to a private or reserved IP address`);
     }
-    return;
+    return [{ address: cleanHostname, family: net.isIPv6(cleanHostname) ? 6 : 4 }];
   }
 
-  const addresses: string[] = [];
+  const addresses: LookupAddress[] = [];
 
   try {
     const ipv4Results = await dns.resolve4(cleanHostname);
-    addresses.push(...ipv4Results);
+    addresses.push(...ipv4Results.map((address) => ({ address, family: 4 as const })));
   } catch {
     // Domain may not have A records
   }
 
   try {
     const ipv6Results = await dns.resolve6(cleanHostname);
-    addresses.push(...ipv6Results);
+    addresses.push(...ipv6Results.map((address) => ({ address, family: 6 as const })));
   } catch {
     // Domain may not have AAAA records
   }
@@ -94,9 +107,150 @@ export async function assertDomainResolvesToPublicIp(hostname: string): Promise<
     throw new Error(`Unable to resolve DNS for hostname: ${cleanHostname}`);
   }
 
-  for (const ip of addresses) {
-    if (isPrivateOrReservedIp(ip)) {
+  for (const { address } of addresses) {
+    if (isPrivateOrReservedIp(address)) {
       throw new Error(`Hostname resolves to a private or reserved IP address`);
     }
   }
+
+  return addresses;
+}
+
+/**
+ * Resolves a hostname to IP addresses and validates that none of them
+ * point to private or reserved IP ranges. This prevents SSRF attacks
+ * where an attacker-controlled domain resolves to internal infrastructure.
+ *
+ * NOTE: this only validates — it does NOT pin the connection, so on its own it
+ * is vulnerable to DNS rebinding (the subsequent fetch re-resolves DNS). Prefer
+ * {@link createPinnedPublicIpDispatcher} for outbound requests so the validated
+ * IP is the IP actually connected to. Kept for back-compat / pure validation use.
+ *
+ * @throws Error if the domain resolves to a private/reserved IP
+ */
+export async function assertDomainResolvesToPublicIp(hostname: string): Promise<void> {
+  await resolveHostnameToValidatedPublicIps(hostname);
+}
+
+/**
+ * Builds an undici {@link Agent} that pins all outbound connections for the given
+ * hostname to a pre-validated public IP, defeating DNS-rebinding TOCTOU attacks.
+ *
+ * The hostname is resolved and validated ONCE up front. The returned agent installs
+ * a custom `connect.lookup` that returns ONLY those pre-validated IPs and re-checks
+ * each is public inside the callback, so undici/Node never performs an independent
+ * second DNS resolution that could rebind to 169.254.169.254 / internal hosts.
+ *
+ * The original Host header and TLS SNI (servername) are preserved because undici
+ * keys the connection on the original hostname and only the IP that the socket
+ * connects to is overridden.
+ *
+ * Usage: `fetch(url, { dispatcher: await createPinnedPublicIpDispatcher(new URL(url).hostname) })`
+ *
+ * @throws Error if the hostname cannot be resolved or resolves to a private/reserved IP
+ */
+/**
+ * Pure selection logic for the pinned `connect.lookup`: re-validates every pinned address and
+ * narrows to the family the caller requested. Extracted so it can be unit-tested without
+ * constructing an undici Agent (which can't load under this lib's jsdom test environment).
+ *
+ * @param requestedFamily Node passes `0`/undefined for "any" and `4`/`6` (or the `'IPv4'`/`'IPv6'`
+ *   string forms) for a specific family.
+ * @throws Error if a pinned address is now private/reserved, or none match the requested family.
+ */
+export function selectPinnedLookupAddresses(
+  validatedAddresses: LookupAddress[],
+  requestedFamily: number | 'IPv4' | 'IPv6' | undefined,
+): LookupAddress[] {
+  // Re-validate at connect time so a rebind cannot slip through even if the pinned
+  // list were ever tampered with; the addresses came from our single validated lookup.
+  for (const { address } of validatedAddresses) {
+    if (isPrivateOrReservedIp(address)) {
+      throw new Error('Hostname resolves to a private or reserved IP address');
+    }
+  }
+
+  // Honor an explicit IPv4-only / IPv6-only request; `0`/undefined means "any family".
+  const family =
+    requestedFamily === 4 || requestedFamily === 'IPv4' ? 4 : requestedFamily === 6 || requestedFamily === 'IPv6' ? 6 : undefined;
+  const matchingAddresses = family ? validatedAddresses.filter((address) => address.family === family) : validatedAddresses;
+
+  if (matchingAddresses.length === 0) {
+    throw new Error(`No validated public IPv${family} address is available for the host`);
+  }
+  return matchingAddresses;
+}
+
+export async function createPinnedPublicIpDispatcher(hostname: string): Promise<Agent> {
+  const validatedAddresses = await resolveHostnameToValidatedPublicIps(hostname);
+
+  // Node's `lookup` option signature: (hostname, options, callback). When `options.all`
+  // is set the callback expects an array of LookupAddress, otherwise (address, family).
+  const pinnedLookup: net.LookupFunction = (_lookupHostname, options, callback) => {
+    let matchingAddresses: LookupAddress[];
+    try {
+      matchingAddresses = selectPinnedLookupAddresses(validatedAddresses, options.family);
+    } catch (error) {
+      // Pass an empty LookupAddress[] (ignored by undici on the error path) so the shape is valid
+      // for both the `all` and single-address callback overloads.
+      callback(error as NodeJS.ErrnoException, []);
+      return;
+    }
+
+    if (options.all) {
+      callback(null, matchingAddresses);
+      return;
+    }
+
+    const [first] = matchingAddresses;
+    callback(null, first.address, first.family);
+  };
+
+  // undici is imported lazily so this Node-only dependency is not pulled into the module graph
+  // when only the pure validation helpers are used (e.g. in jsdom-based unit tests).
+  const { Agent } = await import('undici');
+  return new Agent({
+    connect: {
+      lookup: pinnedLookup,
+    },
+  });
+}
+
+/**
+ * Reuse pinned dispatchers per host instead of creating (and leaking) a fresh undici `Agent` for
+ * every outbound request. Each `Agent` owns a connection pool, so a new one per request would
+ * accumulate sockets/FDs under load. The cached promise also collapses concurrent first requests
+ * to the same host onto a single DNS validation + Agent. The TTL keeps the pinned IP fresh
+ * (re-validated when the entry expires) while still amortizing the Agent across a burst of requests.
+ *
+ * `dispose` fires on eviction/expiry/overwrite and closes the pool to release its sockets, so
+ * callers never have to manage the Agent lifecycle (important when the `Response` body outlives the
+ * function that issued the fetch, e.g. SAML metadata fetching).
+ */
+const pinnedDispatcherCache = new LRUCache<string, Promise<Agent>>({
+  max: 100,
+  ttl: 1000 * 60,
+  dispose: (dispatcherPromise) => {
+    dispatcherPromise.then((dispatcher) => dispatcher.close()).catch(() => undefined);
+  },
+});
+
+/**
+ * Cached, auto-closing variant of {@link createPinnedPublicIpDispatcher}. Prefer this for outbound
+ * requests so connection pools are reused per host and closed on eviction/expiry rather than leaked.
+ *
+ * @throws Error if the hostname cannot be resolved or resolves to a private/reserved IP
+ */
+export function getPinnedPublicIpDispatcher(hostname: string): Promise<Agent> {
+  const cached = pinnedDispatcherCache.get(hostname);
+  if (cached) {
+    return cached;
+  }
+  // If validation rejects, evict so a later request retries rather than caching a rejected promise.
+  const dispatcherPromise = createPinnedPublicIpDispatcher(hostname).catch((error) => {
+    pinnedDispatcherCache.delete(hostname);
+    throw error;
+  });
+  pinnedDispatcherCache.set(hostname, dispatcherPromise);
+  return dispatcherPromise;
 }

--- a/package.json
+++ b/package.json
@@ -369,6 +369,7 @@
     "tar": "^7.5.15",
     "tiny-request-router": "^1.2.2",
     "tslib": "^2.3.0",
+    "undici": "^7.25.0",
     "unzipper": "^0.12.3",
     "update-electron-app": "^3.2.0",
     "uuid": "^14.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -557,6 +557,9 @@ importers:
       tslib:
         specifier: ^2.3.0
         version: 2.8.1
+      undici:
+        specifier: ^7.25.0
+        version: 7.25.0
       unzipper:
         specifier: ^0.12.3
         version: 0.12.3
@@ -16929,10 +16932,6 @@ packages:
     resolution: {integrity: sha512-3IWdCpjgxp15CbJnsi/Y9TCDE7HWVN19j1hmzVhoAkY/+CJx449tVxT5wZc1Gwg8J+P0LWvzlBzxYRnHJ+1i7Q==}
     engines: {node: '>=20.18.1'}
 
-  undici@7.24.6:
-    resolution: {integrity: sha512-Xi4agocCbRzt0yYMZGMA6ApD7gvtUFaxm4ZmeacWI4cZxaF6C+8I8QfofC20NAePiB/IcvZmzkJ7XPa471AEtA==}
-    engines: {node: '>=20.18.1'}
-
   undici@7.24.7:
     resolution: {integrity: sha512-H/nlJ/h0ggGC+uRL3ovD+G0i4bqhvsDOpbDv7At5eFLlj2b41L8QliGbnl2H7SnDiYhENphh1tQFJZf+MyfLsQ==}
     engines: {node: '>=20.18.1'}
@@ -32607,7 +32606,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.1
-      undici: 7.24.6
+      undici: 7.25.0
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -38057,8 +38056,6 @@ snapshots:
   undici-types@7.8.0: {}
 
   undici@7.24.5: {}
-
-  undici@7.24.6: {}
 
   undici@7.24.7: {}
 


### PR DESCRIPTION
Tighten up validation for sso network requests

Improve url validation for user-provided manual request endpoints

Strip unnecessary headers when proxying request to Salesforce