### PR TITLE
feat: fix record lookup with existing value and improve value escaping

### DIFF
--- a/libs/ui/src/lib/form/combobox/RecordLookupCombobox.tsx
+++ b/libs/ui/src/lib/form/combobox/RecordLookupCombobox.tsx
@@ -4,6 +4,7 @@ import { logger } from '@jetstream/shared/client-logger';
 import { SFDC_BLANK_PICKLIST_VALUE } from '@jetstream/shared/constants';
 import { describeGlobal, describeSObject, query } from '@jetstream/shared/data';
 import { DescribeGlobalSObjectResult, FormGroupDropdownItem, ListItem, Maybe, SalesforceOrgUi } from '@jetstream/types';
+import { composeQuery, getField, Query } from '@jetstreamapp/soql-parser-js';
 import { useCallback, useEffect, useId, useRef, useState } from 'react';
 import { z } from 'zod';
 import { FormGroupDropdown } from '../formGroupDropDown/FormGroupDropdown';
@@ -87,8 +88,54 @@ export function RecordLookupCombobox({
   const selectedSObjectDescribeRef = useRef<Maybe<DescribeGlobalSObjectResult>>(null);
   const selectedSObjectRef = useRef(selectedSObject);
   selectedSObjectRef.current = selectedSObject;
+  // The record whose label must remain visible: resolved from the initial value on load (or a synthetic
+  // raw-Id fallback), then updated as the user changes selection. Always merged into `records` because
+  // each search only fetches the first 50 records, which may not include the selected record.
+  const pinnedRecordRef = useRef<ListItem<string, any> | null>(null);
 
-  // on initial load, if there is a value set - then we want to detect which object to auto-select
+  // Resolves and caches the object's name field (special casing Group, whose Name is always blank)
+  const ensureObjectMetadata = useCallback(
+    async (sobject: string) => {
+      if (sobject === 'Group') {
+        selectedObjectMetadata.current = { sobject, nameField: 'DeveloperName', keyPrefix: '00G' };
+      }
+      if (!selectedObjectMetadata.current || selectedObjectMetadata.current.sobject !== sobject) {
+        const sobjectDescribe = await describeSObject(org, sobject).then((result) => result.data);
+        selectedObjectMetadata.current = {
+          sobject,
+          nameField: sobjectDescribe.fields.find((field) => field.nameField)?.name || 'Name',
+          keyPrefix: sobjectDescribe?.keyPrefix,
+        };
+      }
+      return selectedObjectMetadata.current;
+    },
+    [org],
+  );
+
+  // Called when an initial value cannot be resolved to a record (no access, deleted, or its object
+  // is not one of the allowed lookup objects). Falls back to manual entry, or shows the raw Id.
+  const handleUnresolvedValue = useCallback(() => {
+    if (!value) {
+      return;
+    }
+    if (allowManualMode) {
+      // Automatic, value-driven fallback - intentionally not persisted to localStorage
+      setInputMode(INPUT_MODE_MANUAL);
+      return;
+    }
+    // Without manual mode, inject a synthetic item so the combobox shows the raw Id instead of appearing empty
+    const syntheticItem: ListItem<string, any> = {
+      id: value,
+      label: value,
+      value,
+      meta: { sobject: selectedSObjectRef.current },
+    };
+    pinnedRecordRef.current = syntheticItem;
+    setRecords([{ id: '', label: SFDC_BLANK_PICKLIST_VALUE, value: '' }, syntheticItem]);
+  }, [allowManualMode, value]);
+
+  // On initial load, if there is a value set, detect which object to auto-select and explicitly fetch
+  // the record by Id so its label can be shown even when it falls outside the first 50 search results.
   useEffect(() => {
     if (!value || (value.length !== 15 && value.length !== 18)) {
       return;
@@ -100,12 +147,46 @@ export function RecordLookupCombobox({
         const sobject = describeGlobalResults.data.sobjects.find((sobject) => sobject.keyPrefix === keyPrefix);
         const foundObject = sobjects.find((obj) => obj === sobject?.name);
         selectedSObjectDescribeRef.current = sobject;
-        if (foundObject) {
-          setSelectedSObject(foundObject);
-          setKey(Date.now());
+
+        if (!foundObject) {
+          handleUnresolvedValue();
+          return;
         }
+
+        const { nameField } = await ensureObjectMetadata(foundObject);
+        const { queryResults } = await query(
+          org,
+          composeQuery({
+            sObject: foundObject,
+            fields: [getField('Id'), getField(nameField)],
+            where: { left: { field: 'Id', value, literalType: 'STRING', operator: '=' } },
+            limit: 1,
+          }),
+        );
+        const record = queryResults.records[0];
+
+        if (!record) {
+          handleUnresolvedValue();
+          return;
+        }
+
+        const initialRecord: ListItem<string, any> = {
+          id: record.Id,
+          label: record[nameField] || record.Id,
+          secondaryLabel: record[nameField] ? record.Id : undefined,
+          secondaryLabelOnNewLine: true,
+          value: record.Id,
+          meta: { sobject: foundObject },
+        };
+        // Set the ref before remounting so the child's onSearch('') re-merges this record (see handleSearch)
+        pinnedRecordRef.current = initialRecord;
+        setSelectedRecord(initialRecord);
+        setRecords([{ id: '', label: SFDC_BLANK_PICKLIST_VALUE, value: '' }, initialRecord]);
+        setSelectedSObject(foundObject);
+        setKey(Date.now());
       } catch (ex) {
-        logger.warn('Error searching records', ex);
+        logger.warn('Error resolving initial record', ex);
+        handleUnresolvedValue();
       }
     })();
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -120,34 +201,24 @@ export function RecordLookupCombobox({
           setRecords([]);
           return;
         }
-        // "Name" is always blank for Group object, so we need to special case it
-        // If more special cases are needed in the future, we can extract and expand this logic
-        if (sobject === 'Group') {
-          selectedObjectMetadata.current = {
-            sobject,
-            nameField: 'DeveloperName',
-            keyPrefix: '0F9',
-          };
-        }
-        if (!selectedObjectMetadata.current || selectedObjectMetadata.current.sobject !== sobject) {
-          const sobjectDescribe = await describeSObject(org, sobject).then((result) => result.data);
+        const { nameField: name } = await ensureObjectMetadata(sobject);
 
-          selectedObjectMetadata.current = {
-            sobject,
-            nameField: sobjectDescribe.fields.find((field) => field.nameField)?.name || 'Name',
-            keyPrefix: sobjectDescribe?.keyPrefix,
-          };
-        }
-        const name = selectedObjectMetadata.current.nameField;
-
-        let soql = `SELECT Id, ${name} FROM ${sobject} ORDER BY ${name} LIMIT 50`;
+        const soqlQuery: Query = {
+          sObject: sobject,
+          fields: [getField('Id'), getField(name)],
+          orderBy: [{ field: name }],
+          limit: 50,
+        };
         if (searchTerm) {
-          if (searchTerm.length === 15 || searchTerm.length === 18) {
-            soql = `SELECT Id, ${name} FROM ${sobject} WHERE Id = '${searchTerm}' OR ${name} LIKE '%${searchTerm}%' ORDER BY ${name} LIMIT 50`;
-          } else {
-            soql = `SELECT Id, ${name} FROM ${sobject} WHERE ${name} LIKE '%${searchTerm}%' ORDER BY ${name} LIMIT 50`;
-          }
+          // Escape backslashes so they are treated literally, then escape `%` since it is a LIKE wildcard (composeQuery escapes quotes)
+          const likeValue = `%${searchTerm.replace(/\\/g, '\\\\').replace(/%/g, '\\%')}%`;
+          const nameCondition = { left: { field: name, operator: 'LIKE', value: likeValue, literalType: 'STRING' } } as const;
+          soqlQuery.where =
+            searchTerm.length === 15 || searchTerm.length === 18
+              ? { left: { field: 'Id', operator: '=', value: searchTerm, literalType: 'STRING' }, operator: 'OR', right: nameCondition }
+              : nameCondition;
         }
+        const soql = composeQuery(soqlQuery);
 
         if (sobject !== selectedSObjectRef.current) {
           return;
@@ -159,26 +230,28 @@ export function RecordLookupCombobox({
           return;
         }
 
-        setRecords([
-          {
-            id: '',
-            label: SFDC_BLANK_PICKLIST_VALUE,
-            value: '',
-          },
-          ...queryResults.records.map((record) => ({
-            id: record.Id,
-            label: record[name] || record.Id,
-            secondaryLabel: record[name] ? record.Id : undefined,
-            secondaryLabelOnNewLine: true,
-            value: record.Id,
-          })),
-        ]);
+        const mapped = queryResults.records.map((record) => ({
+          id: record.Id,
+          label: record[name] || record.Id,
+          secondaryLabel: record[name] ? record.Id : undefined,
+          secondaryLabelOnNewLine: true,
+          value: record.Id,
+        }));
+
+        // Keep the selected record visible even when it is not within the first 50 results
+        const pinnedRecord = pinnedRecordRef.current;
+        const merged =
+          pinnedRecord && pinnedRecord.meta?.sobject === sobject && !mapped.some((item) => item.id === pinnedRecord.id)
+            ? [pinnedRecord, ...mapped]
+            : mapped;
+
+        setRecords([{ id: '', label: SFDC_BLANK_PICKLIST_VALUE, value: '' }, ...merged]);
       } catch (ex) {
         logger.warn('Error searching records', ex);
         setRecords([]);
       }
     },
-    [org, selectedSObject],
+    [org, selectedSObject, ensureObjectMetadata],
   );
 
   // When the input type changes, we want to focus on the input
@@ -272,6 +345,7 @@ export function RecordLookupCombobox({
                   setSelectedSObject(sobject);
                   setRecords([]);
                   setSelectedRecord(null);
+                  pinnedRecordRef.current = null;
                   onChange(null);
                   setTimeout(() => handleSearch('', sobject), 0);
                   if (onObjectChange && item.id) {
@@ -306,7 +380,11 @@ export function RecordLookupCombobox({
       items={records}
       onSearch={handleSearch}
       selectedItemId={selectedRecord?.id || value}
-      onSelected={(item) => onChange(item?.value || null)}
+      onSelected={(item) => {
+        // Pin the new selection (or clear the pin) so prior selections are not re-merged into future search results
+        pinnedRecordRef.current = item?.value ? { ...item, meta: { ...item.meta, sobject: selectedSObject } } : null;
+        onChange(item?.value || null);
+      }}
     />
   );
 }

--- a/package.json
+++ b/package.json
@@ -270,7 +270,7 @@
     "@hookform/resolvers": "^5.2.2",
     "@jetstreamapp/sf-formula-parser": "^2.1.0",
     "@jetstreamapp/simple-xml": "^1.1.1",
-    "@jetstreamapp/soql-parser-js": "^7.2.0",
+    "@jetstreamapp/soql-parser-js": "^7.2.1",
     "@marsidev/react-turnstile": "^1.5.2",
     "@mdx-js/react": "^1.6.21",
     "@monaco-editor/react": "^4.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -266,8 +266,8 @@ importers:
         specifier: ^1.1.1
         version: 1.1.1
       '@jetstreamapp/soql-parser-js':
-        specifier: ^7.2.0
-        version: 7.2.0
+        specifier: ^7.2.1
+        version: 7.2.1
       '@marsidev/react-turnstile':
         specifier: ^1.5.2
         version: 1.5.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -4511,8 +4511,8 @@ packages:
   '@jetstreamapp/simple-xml@1.1.1':
     resolution: {integrity: sha512-H3LeZEvOb/JD8S2vs5vzK0HOlFoKu+IQCueTNbOJ1+smUEEMNWGFni38EEQK7cMYkQKPFGfrGFb5S4hynnDJaA==}
 
-  '@jetstreamapp/soql-parser-js@7.2.0':
-    resolution: {integrity: sha512-pzk0sXv3fZiO1NE0J8++PkfnG2KGF2Dr0CGYBzzLCE6JrdA26hjoVKgq80423P2eCxTZrMdn6npKnGqIrBaywg==}
+  '@jetstreamapp/soql-parser-js@7.2.1':
+    resolution: {integrity: sha512-WLR7gf6ukdEGp4lGIOpCNJWHl/OrzJkzQVOvczTwOBr38Pi6kmoTGmqVDFAsUP87OOrN2/YgGSs+v8siC4ylDg==}
     hasBin: true
 
   '@jridgewell/gen-mapping@0.3.13':
@@ -4668,11 +4668,14 @@ packages:
       react: ^17.0.2 || ^18.0.0 || ^19.0
       react-dom: ^17.0.2 || ^18.0.0 || ^19.0
 
-  '@maxim_mazurok/gapi.client.discovery-v1@0.5.20200806':
-    resolution: {integrity: sha512-oVq9hnnI5VhAtsx55iJbPz8NRfJtWFpI1kINKeuygzCvsx90b1GQDeN3MDUvhADXiQ7+Izs316cqBnJjoDxCow==}
+  '@maxim_mazurok/gapi.client.discovery-v1@0.6.20200806':
+    resolution: {integrity: sha512-QN6aGmIbLXcJW0SEf8tz9UWCpQTBMy2u4xSuZ04YofzMGknhWwMeUecySLntCZYAEstHzDoSgwxCf5Gb8GqIRQ==}
 
   '@maxim_mazurok/gapi.client.drive-v3@0.2.20260311':
     resolution: {integrity: sha512-2SVn8bIFZB9pq1JjqBNY/Agebv8gjHdr5k+ippSVsz07eWpl7d0Vxj4huX1O60ev0NDqrIx6a7w6MFFUIKlN6w==}
+
+  '@maxim_mazurok/gapi.client.drive-v3@0.2.20260602':
+    resolution: {integrity: sha512-BNDVj7gVop5Q4rx0hvAfHxjhACShaQrYB1Zmd8fJeNAszGpLK3zRoggqPGtehdYW3O72fmsHmEsWV89QObuAgw==}
 
   '@mdn/browser-compat-data@7.3.16':
     resolution: {integrity: sha512-JQ6SGcHeyqSYGVwWe7NzOeXfp/vZgo2yz+fsEbMOyWLyNRVP4RoG8+dqaF/VTx1zPtF4J8XvxiWXH1l2cMZTwQ==}
@@ -22635,7 +22638,7 @@ snapshots:
 
   '@jetstreamapp/simple-xml@1.1.1': {}
 
-  '@jetstreamapp/soql-parser-js@7.2.0': {}
+  '@jetstreamapp/soql-parser-js@7.2.1': {}
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -22840,12 +22843,17 @@ snapshots:
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
 
-  '@maxim_mazurok/gapi.client.discovery-v1@0.5.20200806':
+  '@maxim_mazurok/gapi.client.discovery-v1@0.6.20200806':
     dependencies:
       '@types/gapi.client': 1.0.8
       '@types/gapi.client.discovery-v1': 0.0.4
 
   '@maxim_mazurok/gapi.client.drive-v3@0.2.20260311':
+    dependencies:
+      '@types/gapi.client': 1.0.8
+      '@types/gapi.client.discovery-v1': 0.0.4
+
+  '@maxim_mazurok/gapi.client.drive-v3@0.2.20260602':
     dependencies:
       '@types/gapi.client': 1.0.8
       '@types/gapi.client.discovery-v1': 0.0.4
@@ -26084,11 +26092,11 @@ snapshots:
 
   '@types/gapi.client.discovery-v1@0.0.4':
     dependencies:
-      '@maxim_mazurok/gapi.client.discovery-v1': 0.5.20200806
+      '@maxim_mazurok/gapi.client.discovery-v1': 0.6.20200806
 
   '@types/gapi.client.drive-v3@0.0.5':
     dependencies:
-      '@maxim_mazurok/gapi.client.drive-v3': 0.2.20260311
+      '@maxim_mazurok/gapi.client.drive-v3': 0.2.20260602
 
   '@types/gapi.client@1.0.8': {}
 


### PR DESCRIPTION
If the existing value was not in the first 50 record, the lookup now correctly populates with a value as the record is searched for individually

if no value is found, the lookup reverts to a manual value

The record search properly escapes single quotes and we use soql-parser-js composeQuery to handle where clause escaping

Upgraded soql-parser-js for escaping WHERE clause values in latest patch version

fixes #1767