### PR TITLE
Security hardening

### DIFF
--- a/apps/api/src/app/controllers/team.controller.ts
+++ b/apps/api/src/app/controllers/team.controller.ts
@@ -9,6 +9,7 @@ import { getErrorMessage, getErrorMessageAndStackObj } from '@jetstream/shared/u
 import {
   TEAM_MEMBER_ROLE_ACCESS,
   TEAM_MEMBER_ROLE_MEMBER,
+  TEAM_MEMBER_STATUS_INACTIVE,
   TeamInvitationRequestSchema,
   TeamInvitationUpdateRequestSchema,
   TeamLoginConfigRequestSchema,
@@ -654,6 +655,12 @@ const updateTeamMemberStatusAndRole = createRoute(
     const { teamId, userId } = params;
     const { status, role } = body;
     const runningUserRole = user.teamMembership?.role || TEAM_MEMBER_ROLE_MEMBER;
+
+    // Deactivating yourself revokes all of your own sessions mid-request — a self-lockout footgun.
+    // The last-admin invariant in the DB layer additionally prevents a team being left admin-less.
+    if (status === TEAM_MEMBER_STATUS_INACTIVE && user.id === userId) {
+      throw new NotAllowedError('You cannot deactivate your own membership');
+    }
 
     const allowedRoleUpdates = new Set((TEAM_MEMBER_ROLE_ACCESS[runningUserRole] || []) as TeamMemberRole[]);
     if (role && !allowedRoleUpdates.has(role)) {

--- a/apps/api/src/app/db/__tests__/team.db.spec.ts
+++ b/apps/api/src/app/db/__tests__/team.db.spec.ts
@@ -8,24 +8,35 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import * as teamDb from '../team.db';
 
-const prismaMock = vi.hoisted(() => ({
-  teamMember: {
-    findUniqueOrThrow: vi.fn(),
-    update: vi.fn(),
-    findFirst: vi.fn(),
-  },
-  team: {
-    // canAddBillableMember (called internally by updateTeamMemberRole/StatusAndRole when
-    // transitioning TO a billable role) fetches the team; return an unconstrained billing
-    // account so the quota check always passes and we can focus on the isBillableAction result.
-    findFirstOrThrow: vi.fn().mockResolvedValue({
-      id: 'team-id',
-      billingStatus: 'ACTIVE',
-      billingAccount: null,
-      members: [],
-    }),
-  },
-}));
+const prismaMock = vi.hoisted(() => {
+  const mock: any = {
+    teamMember: {
+      findUniqueOrThrow: vi.fn(),
+      // The last-admin guard re-reads the target's current role/status transactionally via findUnique.
+      findUnique: vi.fn(),
+      update: vi.fn(),
+      findFirst: vi.fn(),
+      // The last-admin invariant counts OTHER active admins; default to 1 so a demotion/deactivation
+      // is allowed and the existing isBillableAction tests are unaffected.
+      count: vi.fn().mockResolvedValue(1),
+    },
+    team: {
+      // canAddBillableMember (called internally by updateTeamMemberRole/StatusAndRole when
+      // transitioning TO a billable role) fetches the team; return an unconstrained billing
+      // account so the quota check always passes and we can focus on the isBillableAction result.
+      findFirstOrThrow: vi.fn().mockResolvedValue({
+        id: 'team-id',
+        billingStatus: 'ACTIVE',
+        billingAccount: null,
+        members: [],
+      }),
+    },
+  };
+  // updateTeamMember* run the last-admin check + update inside a Serializable transaction; invoke
+  // the callback with the same mock so tx.teamMember.* resolve to the mocks configured per test.
+  mock.$transaction = vi.fn(async (fn: any) => fn(mock));
+  return mock;
+});
 
 vi.mock('@jetstream/api-config', () => ({
   ENV: {},
@@ -42,7 +53,10 @@ vi.mock('@jetstream/api-config', () => ({
 }));
 
 vi.mock('@jetstream/prisma', () => ({
-  Prisma: { PrismaClientKnownRequestError: class extends Error {} },
+  Prisma: {
+    PrismaClientKnownRequestError: class extends Error {},
+    TransactionIsolationLevel: { Serializable: 'Serializable' },
+  },
 }));
 
 function makeFullTeamMember(role: string, status = 'ACTIVE') {
@@ -83,6 +97,9 @@ describe('updateTeamMemberRole — isBillableAction transition matrix', () => {
       billingAccount: null,
       members: [],
     });
+    // Default: at least one OTHER active admin exists, and the update transaction runs inline.
+    prismaMock.teamMember.count.mockResolvedValue(1);
+    prismaMock.$transaction.mockImplementation(async (fn: any) => fn(prismaMock));
   });
 
   async function run(previousRole: string, newRole: string) {
@@ -136,6 +153,9 @@ describe('updateTeamMemberStatusAndRole — isBillableAction transition matrix',
       billingAccount: null,
       members: [],
     });
+    // Default: at least one OTHER active admin exists, and the update transaction runs inline.
+    prismaMock.teamMember.count.mockResolvedValue(1);
+    prismaMock.$transaction.mockImplementation(async (fn: any) => fn(prismaMock));
   });
 
   async function run({
@@ -195,5 +215,89 @@ describe('updateTeamMemberStatusAndRole — isBillableAction transition matrix',
 
     expect(isBillableAction).toBe(false);
     expect(prismaMock.teamMember.update).not.toHaveBeenCalled();
+  });
+});
+
+describe('last-admin invariant', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    prismaMock.team.findFirstOrThrow.mockResolvedValue({
+      id: 'team-id',
+      billingStatus: 'ACTIVE',
+      billingAccount: null,
+      members: [],
+    });
+    prismaMock.teamMember.count.mockResolvedValue(1);
+    prismaMock.$transaction.mockImplementation(async (fn: any) => fn(prismaMock));
+    // The guard re-reads the target's current role/status transactionally; default to active admin.
+    prismaMock.teamMember.findUnique.mockResolvedValue({ role: 'ADMIN', status: 'ACTIVE' });
+  });
+
+  it('rejects deactivating the last active admin', async () => {
+    prismaMock.teamMember.findUniqueOrThrow.mockResolvedValueOnce(makePreReadMember('ADMIN', 'ACTIVE'));
+    prismaMock.teamMember.findUnique.mockResolvedValueOnce({ role: 'ADMIN', status: 'ACTIVE' });
+    prismaMock.teamMember.count.mockResolvedValueOnce(0); // no OTHER active admins remain
+
+    await expect(
+      teamDb.updateTeamMemberStatusAndRole({
+        teamId: 'team-id',
+        userId: 'user-id',
+        runningUserId: 'admin-id',
+        status: 'INACTIVE' as any,
+      }),
+    ).rejects.toThrow(/at least one active administrator/i);
+    expect(prismaMock.teamMember.update).not.toHaveBeenCalled();
+  });
+
+  it('rejects demoting the last active admin to MEMBER', async () => {
+    prismaMock.teamMember.findUniqueOrThrow.mockResolvedValueOnce(makePreReadMember('ADMIN', 'ACTIVE'));
+    prismaMock.teamMember.findUnique.mockResolvedValueOnce({ role: 'ADMIN', status: 'ACTIVE' });
+    prismaMock.teamMember.count.mockResolvedValueOnce(0);
+
+    await expect(
+      teamDb.updateTeamMemberRole({
+        teamId: 'team-id',
+        userId: 'user-id',
+        runningUserId: 'admin-id',
+        data: { role: 'MEMBER' as any, features: ['ALL'] },
+      }),
+    ).rejects.toThrow(/at least one active administrator/i);
+    expect(prismaMock.teamMember.update).not.toHaveBeenCalled();
+  });
+
+  it('allows deactivating an admin when another active admin remains', async () => {
+    prismaMock.teamMember.findUniqueOrThrow.mockResolvedValueOnce(makePreReadMember('ADMIN', 'ACTIVE'));
+    prismaMock.teamMember.findUnique.mockResolvedValueOnce({ role: 'ADMIN', status: 'ACTIVE' });
+    prismaMock.teamMember.count.mockResolvedValueOnce(1); // one OTHER active admin remains
+    prismaMock.teamMember.update.mockResolvedValueOnce(makeFullTeamMember('ADMIN', 'INACTIVE'));
+
+    const result = await teamDb.updateTeamMemberStatusAndRole({
+      teamId: 'team-id',
+      userId: 'user-id',
+      runningUserId: 'admin-id',
+      status: 'INACTIVE' as any,
+    });
+
+    expect(result.teamMember.status).toBe('INACTIVE');
+    expect(prismaMock.teamMember.update).toHaveBeenCalledTimes(1);
+  });
+
+  it('allows demoting an already-INACTIVE admin even when no other active admins exist', async () => {
+    // Demoting a member who is not currently an active admin cannot reduce the active-admin count,
+    // so the invariant must not block it (guards against a false positive).
+    prismaMock.teamMember.findUniqueOrThrow.mockResolvedValueOnce(makePreReadMember('ADMIN', 'INACTIVE'));
+    prismaMock.teamMember.findUnique.mockResolvedValueOnce({ role: 'ADMIN', status: 'INACTIVE' });
+    prismaMock.teamMember.count.mockResolvedValueOnce(0); // would wrongly reject if current state were ignored
+    prismaMock.teamMember.update.mockResolvedValueOnce(makeFullTeamMember('MEMBER', 'INACTIVE'));
+
+    const result = await teamDb.updateTeamMemberRole({
+      teamId: 'team-id',
+      userId: 'user-id',
+      runningUserId: 'admin-id',
+      data: { role: 'MEMBER' as any, features: ['ALL'] },
+    });
+
+    expect(result.teamMember.role).toBe('MEMBER');
+    expect(prismaMock.teamMember.update).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/api/src/app/db/team.db.ts
+++ b/apps/api/src/app/db/team.db.ts
@@ -648,9 +648,10 @@ export async function revokeSessionThatViolateLoginConfiguration({
 /**
  * Enforce the invariant that a team always retains at least one active ADMIN.
  *
- * Rejects a member update that would leave the team with zero active admins by stripping the last
- * one of active-admin status. `nextRole`/`nextStatus` are the values the update will set; whichever
- * is omitted is left unchanged (e.g. a role-only update keeps the current status).
+ * Throws `NotAllowedError` when a member update would strip the last active admin of active-admin
+ * status, leaving the team with zero active admins. `nextRole`/`nextStatus` are the values the
+ * update will set; whichever is omitted is left unchanged (e.g. a role-only update keeps the
+ * current status).
  *
  * The target's CURRENT state is read inside this transaction (not from a snapshot taken before the
  * transaction opened) so the decision is consistent with the OTHER-admins count — closing a TOCTOU

--- a/apps/api/src/app/db/team.db.ts
+++ b/apps/api/src/app/db/team.db.ts
@@ -645,6 +645,50 @@ export async function revokeSessionThatViolateLoginConfiguration({
   return sessionsToRevoke.size;
 }
 
+/**
+ * Enforce the invariant that a team always retains at least one active ADMIN.
+ *
+ * Rejects a member update that would leave the team with zero active admins by stripping the last
+ * one of active-admin status. `nextRole`/`nextStatus` are the values the update will set; whichever
+ * is omitted is left unchanged (e.g. a role-only update keeps the current status).
+ *
+ * The target's CURRENT state is read inside this transaction (not from a snapshot taken before the
+ * transaction opened) so the decision is consistent with the OTHER-admins count — closing a TOCTOU
+ * where a concurrent status change between a pre-read and the transaction could be missed. Must run
+ * under Serializable isolation so two concurrent "deactivate a different admin" requests cannot each
+ * observe one remaining admin and both proceed.
+ */
+async function assertTeamRetainsActiveAdmin(
+  tx: Prisma.TransactionClient,
+  { teamId, userId, nextRole, nextStatus }: { teamId: string; userId: string; nextRole?: Maybe<string>; nextStatus?: Maybe<string> },
+): Promise<void> {
+  const current = await tx.teamMember.findUnique({
+    select: { role: true, status: true },
+    where: { teamId_userId: { teamId, userId } },
+  });
+  if (!current) {
+    return; // member not found — the update itself will surface the error
+  }
+
+  const isCurrentlyActiveAdmin = current.role === TEAM_MEMBER_ROLE_ADMIN && current.status === TEAM_MEMBER_STATUS_ACTIVE;
+  const effectiveRole = nextRole ?? current.role;
+  const effectiveStatus = nextStatus ?? current.status;
+  const willBeActiveAdmin = effectiveRole === TEAM_MEMBER_ROLE_ADMIN && effectiveStatus === TEAM_MEMBER_STATUS_ACTIVE;
+
+  // Only a transition OUT of active-admin can remove the team's last admin. Demoting/deactivating a
+  // member who is not currently an active admin cannot reduce the active-admin count.
+  if (!isCurrentlyActiveAdmin || willBeActiveAdmin) {
+    return;
+  }
+
+  const otherActiveAdmins = await tx.teamMember.count({
+    where: { teamId, role: TEAM_MEMBER_ROLE_ADMIN, status: TEAM_MEMBER_STATUS_ACTIVE, userId: { not: userId } },
+  });
+  if (otherActiveAdmins === 0) {
+    throw new NotAllowedError('A team must have at least one active administrator');
+  }
+}
+
 export async function updateTeamMemberRole({
   teamId,
   userId,
@@ -676,14 +720,22 @@ export async function updateTeamMemberRole({
     }
   }
 
-  return {
-    teamMember: await prisma.teamMember
-      .update({
+  // This function only changes role; status is left unchanged (nextStatus omitted), so the guard
+  // derives the effective status from the transactional read of the member's current state.
+  const updatedTeamMember = await prisma.$transaction(
+    async (tx) => {
+      await assertTeamRetainsActiveAdmin(tx, { teamId, userId, nextRole: data.role });
+      return tx.teamMember.update({
         select: SELECT_TEAM_MEMBER,
         where: { teamId_userId: { teamId, userId } },
         data: { ...TeamMemberUpdateRequestSchema.parse(data), updatedById: runningUserId },
-      })
-      .then((member) => TeamMemberSchema.parse(member)),
+      });
+    },
+    { isolationLevel: Prisma.TransactionIsolationLevel.Serializable },
+  );
+
+  return {
+    teamMember: TeamMemberSchema.parse(updatedTeamMember),
     previousMember: { role: teamMember.role, features: teamMember.features as string[], email: teamMember.user.email },
     // Trigger a Stripe sync whenever billable membership crosses in either direction
     // (e.g. BILLING→ADMIN/MEMBER would otherwise be skipped by only looking at the previous role).
@@ -748,14 +800,22 @@ export async function updateTeamMemberStatusAndRole({
     }
   }
 
-  return {
-    teamMember: await prisma.teamMember
-      .update({
+  // Both role and status are set explicitly here, so the guard's effective end-state is fully
+  // determined by the request (no dependency on the member's pre-transaction state).
+  const updatedTeamMember = await prisma.$transaction(
+    async (tx) => {
+      await assertTeamRetainsActiveAdmin(tx, { teamId, userId, nextRole: role, nextStatus: status });
+      return tx.teamMember.update({
         select: SELECT_TEAM_MEMBER,
         where: { teamId_userId: { teamId, userId } },
         data: { status, role, updatedById: runningUserId },
-      })
-      .then((member) => TeamMemberSchema.parse(member)),
+      });
+    },
+    { isolationLevel: Prisma.TransactionIsolationLevel.Serializable },
+  );
+
+  return {
+    teamMember: TeamMemberSchema.parse(updatedTeamMember),
     previousMember,
     // Trigger a Stripe sync whenever billable membership crosses in either direction
     // (e.g. MEMBER→BILLING would otherwise be skipped by only looking at the new role).

--- a/apps/api/src/app/utils/__tests__/response.handlers.spec.ts
+++ b/apps/api/src/app/utils/__tests__/response.handlers.spec.ts
@@ -131,6 +131,19 @@ describe('uncaughtErrorHandler logging levels', () => {
     expect(res.log.error).not.toHaveBeenCalled();
   });
 
+  it('maps a P2034 serialization conflict to 409', async () => {
+    const error = new prismaMocks.PrismaClientKnownRequestError('Write conflict') as Error & { isPrismaError: boolean; code: string };
+    error.isPrismaError = true;
+    error.code = 'P2034';
+
+    const { res } = await handleError(error);
+
+    expect(res.status).toHaveBeenCalledWith(409);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'This operation conflicted with a concurrent change. Please try again.' }),
+    );
+  });
+
   it('logs authentication 401s at warn', async () => {
     const { res } = await handleError(new AuthenticationError('Unauthorized'));
 

--- a/apps/api/src/app/utils/response.handlers.ts
+++ b/apps/api/src/app/utils/response.handlers.ts
@@ -312,8 +312,13 @@ export async function uncaughtErrorHandler(err: any, req: express.Request, res: 
       });
     } else if (isPrismaError(err)) {
       const message = getPrismaErrorMessage(err);
-      responseLogger.warn({ err, res: { statusCode: 400 } }, '[RESPONSE][ERROR][DATABASE]');
-      res.status(status || 400);
+      // P2034 is a Serializable-transaction write conflict (a fail-safe outcome, e.g. two admins
+      // mutating team membership at once). Surface it as 409 Conflict so the client can retry,
+      // rather than a generic 400/500.
+      const isWriteConflict = err instanceof Prisma.PrismaClientKnownRequestError && err.code === 'P2034';
+      const statusCode = isWriteConflict ? 409 : status || 400;
+      responseLogger.warn({ err, res: { statusCode } }, '[RESPONSE][ERROR][DATABASE]');
+      res.status(statusCode);
       return res.json({
         error: true,
         success: false,
@@ -411,6 +416,8 @@ function getPrismaErrorMessage(
       return `The requested record is ambiguous.`;
     } else if (prismaError.code === 'P2025') {
       return `The requested record does not exist.`;
+    } else if (prismaError.code === 'P2034') {
+      return `This operation conflicted with a concurrent change. Please try again.`;
     }
   }
   return `An error occurred while processing your request.`;

--- a/libs/api-config/src/lib/__tests__/api-sentry-config.spec.ts
+++ b/libs/api-config/src/lib/__tests__/api-sentry-config.spec.ts
@@ -1,0 +1,107 @@
+import type * as Sentry from '@sentry/node';
+import { describe, expect, it } from 'vitest';
+import { scrubSensitiveEventData } from '../api-sentry-config';
+
+describe('scrubSensitiveEventData', () => {
+  it('redacts sensitive keys in event.extra (incl. forwarded req.body) while preserving the rest', () => {
+    const event = {
+      extra: {
+        url: '/api/auth/callback/credentials',
+        userId: 'user-1',
+        requestId: 'req-1',
+        body: {
+          email: 'person@example.com',
+          password: 'hunter2',
+          csrfToken: 'abc.def',
+          code: '123456',
+          secretToken: 'totp-secret',
+        },
+      },
+    } as unknown as Sentry.Event;
+
+    const scrubbed = scrubSensitiveEventData(event);
+    const body = (scrubbed.extra as any).body;
+
+    expect(body.password).toBe('[REDACTED]');
+    expect(body.csrfToken).toBe('[REDACTED]');
+    expect(body.code).toBe('[REDACTED]');
+    expect(body.secretToken).toBe('[REDACTED]');
+    // non-sensitive values are preserved for debugging
+    expect(body.email).toBe('person@example.com');
+    expect((scrubbed.extra as any).url).toBe('/api/auth/callback/credentials');
+    expect((scrubbed.extra as any).userId).toBe('user-1');
+  });
+
+  it('redacts sensitive query/params inside the request context', () => {
+    const event = {
+      contexts: {
+        request: {
+          method: 'GET',
+          url: '/api/something',
+          query: { token: 'leak-me', page: '2' },
+          params: { id: 'abc' },
+        },
+      },
+    } as unknown as Sentry.Event;
+
+    const scrubbed = scrubSensitiveEventData(event);
+    const request = (scrubbed.contexts as any).request;
+
+    expect(request.query.token).toBe('[REDACTED]');
+    expect(request.query.page).toBe('2');
+    expect(request.params.id).toBe('abc');
+  });
+
+  it('does not over-redact ambiguous short keys used as substrings (statusCode, osId)', () => {
+    const event = {
+      extra: { meta: { statusCode: 500, osId: 'mac', accessToken: 'x' } },
+    } as unknown as Sentry.Event;
+
+    const meta = (scrubSensitiveEventData(event).extra as any).meta;
+    expect(meta.statusCode).toBe(500);
+    expect(meta.osId).toBe('mac');
+    // ...but real token keys are still caught via substring match
+    expect(meta.accessToken).toBe('[REDACTED]');
+  });
+
+  it('scrubs event.request headers and data (Authorization, cookie, SAMLResponse)', () => {
+    const event = {
+      request: {
+        method: 'POST',
+        url: '/api/auth/sso/saml/t1/acs',
+        headers: { authorization: 'Bearer tok', cookie: 'sessionid=abc', 'user-agent': 'UA' },
+        data: { SAMLResponse: 'base64blob', RelayState: '/app', password: 'x' },
+      },
+    } as unknown as Sentry.Event;
+
+    const request = scrubSensitiveEventData(event).request as any;
+    expect(request.headers.authorization).toBe('[REDACTED]');
+    expect(request.headers.cookie).toBe('[REDACTED]');
+    expect(request.headers['user-agent']).toBe('UA');
+    expect(request.data.SAMLResponse).toBe('[REDACTED]');
+    expect(request.data.password).toBe('[REDACTED]');
+    expect(request.data.RelayState).toBe('/app');
+  });
+
+  it('redacts subtrees deeper than the depth limit (fail-safe, not passed through)', () => {
+    // 7 nested levels exceeds MAX_REDACT_DEPTH (6), so the deepest container is redacted wholesale.
+    const event = { extra: { a: { b: { c: { d: { e: { f: { g: 'deep-secret' } } } } } } } } as unknown as Sentry.Event;
+    const extra = scrubSensitiveEventData(event).extra as any;
+    expect(extra.a.b.c.d.e.f).toBe('[REDACTED]');
+  });
+
+  it('handles arrays and circular references without throwing', () => {
+    const circular: Record<string, unknown> = { password: 'secret' };
+    circular.self = circular;
+    const event = {
+      extra: { list: [{ token: 'a' }, { ok: 'b' }], circular },
+    } as unknown as Sentry.Event;
+
+    const scrubbed = scrubSensitiveEventData(event);
+    const extra = scrubbed.extra as any;
+
+    expect(extra.list[0].token).toBe('[REDACTED]');
+    expect(extra.list[1].ok).toBe('b');
+    expect(extra.circular.password).toBe('[REDACTED]');
+  });
+});

--- a/libs/api-config/src/lib/api-sentry-config.ts
+++ b/libs/api-config/src/lib/api-sentry-config.ts
@@ -22,6 +22,7 @@ if (isEnabled) {
       if (isUserRateLimited(rateLimitKey)) {
         return null;
       }
+      scrubSensitiveEventData(event);
       return event;
     },
   });
@@ -73,6 +74,93 @@ function isUserRateLimited(userKey: string): boolean {
   hour.push(now);
   rateLimitCache.set(userKey, { minute, hour });
   return false;
+}
+
+// Substring match (case-insensitive) — catches accessToken, refreshToken, csrfToken, secretToken,
+// clientSecret, SAMLResponse, sessionId, etc. without needing to enumerate every variant.
+const SENSITIVE_KEY_SUBSTRINGS = [
+  'password',
+  'passwd',
+  'secret',
+  'token',
+  'csrf',
+  'cookie',
+  'authorization',
+  'privatekey',
+  'samlresponse',
+  'apikey',
+  'credential',
+  'sessionid',
+  'verifier',
+  'bearer',
+];
+// Exact match (case-insensitive) — short ambiguous keys we only redact when they are the WHOLE key,
+// so `code`/`sid`/`pin` don't also nuke `statusCode`, `osId`, etc.
+const SENSITIVE_KEY_EXACT = new Set(['code', 'otp', 'mfa', 'sid', 'pin', 'auth']);
+const REDACTED = '[REDACTED]';
+const MAX_REDACT_DEPTH = 6;
+
+function isSensitiveKey(key: string): boolean {
+  const lower = key.toLowerCase();
+  if (SENSITIVE_KEY_EXACT.has(lower)) {
+    return true;
+  }
+  return SENSITIVE_KEY_SUBSTRINGS.some((needle) => lower.includes(needle));
+}
+
+function isPlainObject(value: object): boolean {
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+}
+
+/**
+ * Recursively redact values under sensitive keys. Only recurses into plain objects/arrays so
+ * special objects (Date, Buffer, etc.) are preserved as-is; bounded depth + cycle tracking guard
+ * against pathological/circular structures.
+ */
+function redactSensitiveDeep(value: unknown, depth = 0, seen = new WeakSet<object>()): unknown {
+  if (value === null || typeof value !== 'object') {
+    return value;
+  }
+  if (seen.has(value)) {
+    return '[Circular]';
+  }
+  // Preserve special objects (Date, Buffer, etc.) as-is — only plain objects/arrays are traversed.
+  if (!Array.isArray(value) && !isPlainObject(value)) {
+    return value;
+  }
+  // At the depth limit, fail safe: redact the whole subtree rather than emit it un-scrubbed, so a
+  // secret nested deeper than the limit cannot leak.
+  if (depth >= MAX_REDACT_DEPTH) {
+    return REDACTED;
+  }
+  if (Array.isArray(value)) {
+    seen.add(value);
+    return value.map((item) => redactSensitiveDeep(item, depth + 1, seen));
+  }
+  seen.add(value);
+  const result: Record<string, unknown> = {};
+  for (const [key, val] of Object.entries(value as Record<string, unknown>)) {
+    result[key] = isSensitiveKey(key) ? REDACTED : redactSensitiveDeep(val, depth + 1, seen);
+  }
+  return result;
+}
+
+/**
+ * Strip known-sensitive fields from a Sentry event before it leaves the process. Covers the places
+ * request data lands: manual `extras`, the `request` context, and any auto-attached `request` data.
+ */
+export function scrubSensitiveEventData(event: Sentry.Event): Sentry.Event {
+  if (event.extra) {
+    event.extra = redactSensitiveDeep(event.extra) as Record<string, unknown>;
+  }
+  if (event.contexts) {
+    event.contexts = redactSensitiveDeep(event.contexts) as Sentry.Event['contexts'];
+  }
+  if (event.request) {
+    event.request = redactSensitiveDeep(event.request) as Sentry.Event['request'];
+  }
+  return event;
 }
 
 function isExpressRequest(value: unknown): value is Request {


### PR DESCRIPTION
Implement safeguards to prevent the removal or deactivation of the last admin on a team. Handle P2034 serialization conflicts as 409 errors in the uncaught error handler. Introduce a function to redact sensitive information from Sentry events, ensuring data privacy. Additionally, implement a function for stable SAML assertion replay protection.