### PR TITLE
fix: return raw 204 No Content responses from callout adapter

### DIFF
--- a/libs/salesforce-api/src/lib/__tests__/callout-adapter.spec.ts
+++ b/libs/salesforce-api/src/lib/__tests__/callout-adapter.spec.ts
@@ -917,6 +917,48 @@ describe('callout-adapter XML parsing', () => {
   });
 });
 
+describe('callout-adapter 204 No Content handling', () => {
+  const mockSessionInfo = {
+    accessToken: 'test-token',
+    instanceUrl: 'https://test.salesforce.com',
+    apiVersion: '65.0',
+    userId: 'test-user-id',
+    organizationId: 'test-org-id',
+  };
+
+  const make204Response = () => Promise.resolve(new Response(null, { status: 204, statusText: 'No Content' }));
+
+  it('returns the raw response for outputType "response" so callers can read the status (e.g. report DELETE via /api/request-manual)', async () => {
+    const mockFetch = vi.fn(() => make204Response()) as unknown as FetchFn;
+    const apiRequest = getApiRequestFactoryFn(mockFetch)();
+
+    const result = await apiRequest<Response>({
+      url: '/services/data/v65.0/analytics/reports/00OKf000001QnNbMAK',
+      method: 'DELETE',
+      sessionInfo: mockSessionInfo,
+      outputType: 'response',
+    });
+
+    expect(result).toBeDefined();
+    expect(result.status).toBe(204);
+    expect(await result.text()).toBe('');
+  });
+
+  it('returns undefined for body-producing output types', async () => {
+    const mockFetch = vi.fn(() => make204Response()) as unknown as FetchFn;
+    const apiRequest = getApiRequestFactoryFn(mockFetch)();
+
+    const result = await apiRequest({
+      url: '/services/data/v65.0/sobjects/Account/001Kf00001FGIvKIAX',
+      method: 'DELETE',
+      sessionInfo: mockSessionInfo,
+      outputType: 'json',
+    });
+
+    expect(result).toBeUndefined();
+  });
+});
+
 describe('callout-adapter refresh token rotation', () => {
   const mockSessionInfo = {
     accessToken: 'stale-access-token',

--- a/libs/salesforce-api/src/lib/callout-adapter.ts
+++ b/libs/salesforce-api/src/lib/callout-adapter.ts
@@ -209,6 +209,12 @@ export function getApiRequestFactoryFn(fetch: FetchFn) {
             }
           }
           if (response.ok) {
+            // Raw-response callers must get the response even for 204 No Content — the early
+            // return below would hand them `undefined`, which surfaced successful report
+            // DELETEs as 400 errors through /api/request-manual.
+            if (outputType === 'response') {
+              return response;
+            }
             if (response.status === 204) {
               return;
             }
@@ -222,8 +228,6 @@ export function getApiRequestFactoryFn(fetch: FetchFn) {
               return response.text().then((text) => parseXml(text));
             } else if (outputType === 'soap') {
               return response.text().then((text) => parseXml(text));
-            } else if (outputType === 'response') {
-              return response;
             } else if (outputType === 'void') {
               return;
             } else {

--- a/libs/shared/data/src/lib/client-data.ts
+++ b/libs/shared/data/src/lib/client-data.ts
@@ -190,7 +190,9 @@ export async function createInvitation(teamId: string, data: TeamInvitationReque
 }
 
 export async function resendInvitation(teamId: string, invitationId: string): Promise<TeamInviteUserFacing[]> {
-  return handleRequest({ method: 'PUT', url: `/api/teams/${teamId}/invitations/${invitationId}`, data: {} }).then(unwrapResponseIgnoreCache);
+  return handleRequest({ method: 'PUT', url: `/api/teams/${teamId}/invitations/${invitationId}`, data: {} }).then(
+    unwrapResponseIgnoreCache,
+  );
 }
 
 export async function cancelInvitation(teamId: string, invitationId: string): Promise<void> {
@@ -1279,7 +1281,7 @@ export async function deleteReportsById(org: SalesforceOrgUi, ids: string[], api
       output.push({ success: true, id });
     } catch {
       output.push({
-        errors: [{ fields: [], message: 'UNKOWN ERROR', statusCode: 'UNKNOWN' }],
+        errors: [{ fields: [], message: 'UNKNOWN ERROR', statusCode: 'UNKNOWN' }],
         success: false,
         id,
       });


### PR DESCRIPTION
## Summary

Fixes a production bug where successful Salesforce report DELETEs via `POST /api/request-manual` were returned to the client as HTTP 400 errors.

In the callout adapter, the `204 No Content` early-return ran before the `outputType === 'response'` check, so raw-response callers received `undefined` instead of the response. The `salesforceRequestManual` controller then threw `Cannot destructure property 'status' of 'apiResponse' as it is undefined.`, surfacing every successful delete as a 400 failure. This caused bulk report deletes from query results to report 100% failure while the reports were actually deleted (BetterStack incident on 2026-06-10: 208 rapid-fire 400s as the user retried).

## Changes

- `callout-adapter.ts`: check `outputType === 'response'` before the 204 early-return so raw-response callers always receive the real response. Fixes web, desktop, browser extension, and canvas (shared adapter).
- `callout-adapter.spec.ts`: regression tests for 204 handling (raw response returned for `outputType: 'response'`; `undefined` preserved for body-producing output types). Verified the new test fails against the previous adapter behavior.
- `client-data.ts`: fix `UNKOWN ERROR` → `UNKNOWN ERROR` typo in `deleteReportsById` (the message users saw for these failures) plus a prettier formatting-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)