### PR TITLE
fix: add @inquirer/prompts missing dependency for release process

### DIFF
--- a/package.json
+++ b/package.json
@@ -142,6 +142,7 @@
     "@eslint/compat": "^1.1.1",
     "@eslint/eslintrc": "^2.1.1",
     "@eslint/js": "~8.57.0",
+    "@inquirer/prompts": "8.4.2",
     "@maxim_mazurok/gapi.client.drive-v3": "0.2.20260311",
     "@nx/devkit": "22.7.2",
     "@nx/esbuild": "22.7.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -632,6 +632,9 @@ importers:
       '@eslint/js':
         specifier: ~8.57.0
         version: 8.57.1
+      '@inquirer/prompts':
+        specifier: 8.4.2
+        version: 8.4.2(@types/node@24.1.0)
       '@maxim_mazurok/gapi.client.drive-v3':
         specifier: 0.2.20260311
         version: 0.2.20260311
@@ -4668,11 +4671,14 @@ packages:
       react: ^17.0.2 || ^18.0.0 || ^19.0
       react-dom: ^17.0.2 || ^18.0.0 || ^19.0
 
-  '@maxim_mazurok/gapi.client.discovery-v1@0.5.20200806':
-    resolution: {integrity: sha512-oVq9hnnI5VhAtsx55iJbPz8NRfJtWFpI1kINKeuygzCvsx90b1GQDeN3MDUvhADXiQ7+Izs316cqBnJjoDxCow==}
+  '@maxim_mazurok/gapi.client.discovery-v1@0.6.20200806':
+    resolution: {integrity: sha512-QN6aGmIbLXcJW0SEf8tz9UWCpQTBMy2u4xSuZ04YofzMGknhWwMeUecySLntCZYAEstHzDoSgwxCf5Gb8GqIRQ==}
 
   '@maxim_mazurok/gapi.client.drive-v3@0.2.20260311':
     resolution: {integrity: sha512-2SVn8bIFZB9pq1JjqBNY/Agebv8gjHdr5k+ippSVsz07eWpl7d0Vxj4huX1O60ev0NDqrIx6a7w6MFFUIKlN6w==}
+
+  '@maxim_mazurok/gapi.client.drive-v3@0.2.20260602':
+    resolution: {integrity: sha512-BNDVj7gVop5Q4rx0hvAfHxjhACShaQrYB1Zmd8fJeNAszGpLK3zRoggqPGtehdYW3O72fmsHmEsWV89QObuAgw==}
 
   '@mdn/browser-compat-data@7.3.16':
     resolution: {integrity: sha512-JQ6SGcHeyqSYGVwWe7NzOeXfp/vZgo2yz+fsEbMOyWLyNRVP4RoG8+dqaF/VTx1zPtF4J8XvxiWXH1l2cMZTwQ==}
@@ -22840,12 +22846,17 @@ snapshots:
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
 
-  '@maxim_mazurok/gapi.client.discovery-v1@0.5.20200806':
+  '@maxim_mazurok/gapi.client.discovery-v1@0.6.20200806':
     dependencies:
       '@types/gapi.client': 1.0.8
       '@types/gapi.client.discovery-v1': 0.0.4
 
   '@maxim_mazurok/gapi.client.drive-v3@0.2.20260311':
+    dependencies:
+      '@types/gapi.client': 1.0.8
+      '@types/gapi.client.discovery-v1': 0.0.4
+
+  '@maxim_mazurok/gapi.client.drive-v3@0.2.20260602':
     dependencies:
       '@types/gapi.client': 1.0.8
       '@types/gapi.client.discovery-v1': 0.0.4
@@ -26084,11 +26095,11 @@ snapshots:
 
   '@types/gapi.client.discovery-v1@0.0.4':
     dependencies:
-      '@maxim_mazurok/gapi.client.discovery-v1': 0.5.20200806
+      '@maxim_mazurok/gapi.client.discovery-v1': 0.6.20200806
 
   '@types/gapi.client.drive-v3@0.0.5':
     dependencies:
-      '@maxim_mazurok/gapi.client.drive-v3': 0.2.20260311
+      '@maxim_mazurok/gapi.client.drive-v3': 0.2.20260602
 
   '@types/gapi.client@1.0.8': {}
 


### PR DESCRIPTION
@inquirer/prompts is required for release scripts, but was not included as a direct dependency