### PR TITLE
chore: add workflows for publishing macOS and Windows desktop apps

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+# pnpm 11 writes a multi-document lockfile (a `---`-separated `packageManagerDependencies`
+# document plus the workspace document) when self-managing the package manager version.
+# Nx's lockfile parser splits on the YAML `---` separator but does not normalize CRLF, so a
+# CRLF checkout — Windows CI runners default to `core.autocrlf=true` — hides the separator and
+# fails the project graph with "expected a single document in the stream, but found more".
+# Forcing LF keeps the separator findable on every platform. See https://github.com/nrwl/nx/issues/35828.
+pnpm-lock.yaml text eol=lf

--- a/.github/workflows/publish-desktop-windows.yml
+++ b/.github/workflows/publish-desktop-windows.yml
@@ -62,7 +62,7 @@ jobs:
       # The TrustedSigning PowerShell module that electron-builder installs at
       # sign time runs on .NET 8. Without it, signing fails with SignTool exit 3.
       - name: Setup .NET 8 runtime
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: "8.0.x"
 

--- a/build-resources/.gitignore
+++ b/build-resources/.gitignore
@@ -1,3 +1,5 @@
 # Ignore provisioning profiles
 *.provisionprofile
 *.p8
+*.p12
+*.pem


### PR DESCRIPTION
Lockfile line endings cause the windows build to fail during CI

update outdated dotnet action