### PR TITLE
Release new desktop signing publisher + new update storage

### DIFF
--- a/.github/workflows/publish-desktop-macos.yml
+++ b/.github/workflows/publish-desktop-macos.yml
@@ -14,11 +14,9 @@ on:
         description: "Git ref (tag or branch) to build"
         required: true
         default: "main"
-  # Enable once the manual flow is proven rock solid: the `desktop-v*` tag that
-  # release.yml pushes (via the GitHub App token) will then auto-trigger this.
-  # push:
-  #   tags:
-  #     - "desktop-v*"
+  push:
+    tags:
+      - "desktop-v*"
 
 concurrency:
   group: release-desktop-macos-${{ github.ref }}
@@ -31,7 +29,6 @@ jobs:
   build-macos:
     runs-on: macos-latest
     timeout-minutes: 60
-    environment: production
     env:
       NODE_OPTIONS: "--max_old_space_size=8192"
       # Turns on the mac signing branch in electron-builder.config.js
@@ -43,14 +40,14 @@ jobs:
       # Developer ID cert — electron-builder imports this into a temp keychain
       CSC_LINK: ${{ secrets.APPLE_CERTIFICATE_P12_BASE64 }}
       CSC_KEY_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
-      # S3-compatible release storage creds (Backblaze B2 during the Cloudflare R2 sunset)
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_DESKTOP_UPDATES_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_DESKTOP_UPDATES_SECRET_ACCESS_KEY }}
+      AWS_ENDPOINT_URL: ${{ secrets.AWS_DESKTOP_UPDATES_ENDPOINT_URL }}
 
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ inputs.ref || github.ref }}
+          ref: ${{ github.event.inputs.ref || github.ref }}
           persist-credentials: false
 
       - uses: pnpm/action-setup@v6
@@ -98,7 +95,7 @@ jobs:
         run: pnpm build:desktop
 
       # electron-builder --mac -p always: signs, notarizes, uploads the dmg/zip installers
-      # + update metadata to the Backblaze bucket, and points clients at the release feed subdomain.
+      # + update metadata to the R2 desktop-updates bucket, and points clients at the release feed subdomain.
       - name: Package, sign, notarize, and publish macOS installers
         working-directory: dist/desktop-build
         run: pnpm publish:mac

--- a/.github/workflows/publish-desktop-windows.yml
+++ b/.github/workflows/publish-desktop-windows.yml
@@ -14,11 +14,9 @@ on:
         description: "Git ref (tag or branch) to build"
         required: true
         default: "main"
-  # Enable once the manual flow is proven rock solid: the `desktop-v*` tag that
-  # release.yml pushes (via the GitHub App token) will then auto-trigger this.
-  # push:
-  #   tags:
-  #     - "desktop-v*"
+  push:
+    tags:
+      - "desktop-v*"
 
 concurrency:
   group: release-desktop-windows-${{ github.ref }}
@@ -31,7 +29,6 @@ jobs:
   build-windows:
     runs-on: windows-latest
     timeout-minutes: 60
-    environment: production
     env:
       NODE_OPTIONS: "--max_old_space_size=8192"
       # Turns on the win `azureSignOptions` branch in electron-builder.config.js
@@ -40,14 +37,14 @@ jobs:
       AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
       AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
-      # S3-compatible release storage creds (Backblaze B2 during the Cloudflare R2 sunset)
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_DESKTOP_UPDATES_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_DESKTOP_UPDATES_SECRET_ACCESS_KEY }}
+      AWS_ENDPOINT_URL: ${{ secrets.AWS_DESKTOP_UPDATES_ENDPOINT_URL }}
 
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ inputs.ref || github.ref }}
+          ref: ${{ github.event.inputs.ref || github.ref }}
           persist-credentials: false
 
       - uses: pnpm/action-setup@v6
@@ -83,7 +80,7 @@ jobs:
         run: pnpm build:desktop
 
       # electron-builder --win -p always: signs via Azure Trusted Signing, uploads installers
-      # + update metadata to the Backblaze bucket, and points clients at the release feed subdomain.
+      # + update metadata to the R2 desktop-updates bucket, and points clients at the release feed subdomain.
       - name: Package, sign, and publish Windows installers
         working-directory: dist/desktop-build
         run: pnpm publish:win

--- a/electron-builder.config.js
+++ b/electron-builder.config.js
@@ -10,6 +10,7 @@ const ENV = {
   PROVISIONING_PROFILE_PATH_MAS: process.env.PROVISIONING_PROFILE_PATH_MAS,
   AWS_ACCESS_KEY_ID: process.env.AWS_ACCESS_KEY_ID,
   AWS_SECRET_ACCESS_KEY: process.env.AWS_SECRET_ACCESS_KEY,
+  AWS_ENDPOINT_URL: process.env.AWS_ENDPOINT_URL,
   AZURE_TENANT_ID: process.env.AZURE_TENANT_ID,
   AZURE_CLIENT_ID: process.env.AZURE_CLIENT_ID,
   AZURE_CLIENT_SECRET: process.env.AZURE_CLIENT_SECRET,
@@ -181,23 +182,21 @@ const config = {
   ],
 
   publish:
-    ENV.IS_CODESIGNING_ENABLED && ENV.AWS_ACCESS_KEY_ID && ENV.AWS_SECRET_ACCESS_KEY
+    ENV.IS_CODESIGNING_ENABLED && ENV.AWS_ACCESS_KEY_ID && ENV.AWS_SECRET_ACCESS_KEY && ENV.AWS_ENDPOINT_URL
       ? [
           // Primary feed clients read from — a subdomain we control, decoupled from any
-          // storage vendor. Backed by Backblaze today, Cloudflare R2 after the DNS cutover.
+          // storage vendor. Backed by Cloudflare R2.
           {
             provider: 'generic',
             url: 'https://release-updates.getjetstream.app/jetstream/releases',
           },
-          // Upload target during the sunset: keep publishing to Backblaze so existing clients
-          // (pinned to the raw B2 endpoint in their baked app-update.yml) keep updating.
           {
             provider: 's3',
-            // Local testing with MinIO
-            // endpoint: 'http://localhost:9000',
-            endpoint: 'https://s3.us-east-005.backblazeb2.com',
+            endpoint: ENV.AWS_ENDPOINT_URL,
             bucket: 'desktop-updates',
             path: `jetstream/releases`,
+            region: 'auto',
+            acl: null,
           },
         ]
       : null,

--- a/scripts/build-electron.mjs
+++ b/scripts/build-electron.mjs
@@ -183,6 +183,7 @@ async function build() {
     'AZURE_CLIENT_SECRET',
     'AWS_ACCESS_KEY_ID',
     'AWS_SECRET_ACCESS_KEY',
+    'AWS_ENDPOINT_URL',
   ]) {
     if (process.env[key]) {
       envValues[key] = process.env[key];


### PR DESCRIPTION
Windows users have broken updates since the CN name change on the certificate (it is case-sensitive)

This PR shuold wait to merge for 7-10 days so that dekstop users can reasonably install the latest version where the failed update can include instructions to re-install