### PR TITLE
fix: web extension token churn

### DIFF
--- a/apps/api/src/app/controllers/__tests__/desktop-app.controller.spec.ts
+++ b/apps/api/src/app/controllers/__tests__/desktop-app.controller.spec.ts
@@ -1,0 +1,173 @@
+/**
+ * Regression coverage for the token-rotation gating in the desktop app verifyToken handler.
+ *
+ * Mirrors the web extension change: the handler only rotates the access token when it is within
+ * the refresh window, reducing rotation races that caused frequent logouts. These tests lock in:
+ *   - rotation is skipped (and no accessToken is returned) when the token is not near expiry
+ *   - rotation runs when the token is near expiry
+ *   - a race-loss-none rotation outcome still forces a 401
+ */
+import { HTTP } from '@jetstream/shared/constants';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { routeDefinition } from '../desktop-app.controller';
+
+const mocks = vi.hoisted(() => ({
+  sendJson: vi.fn(),
+  redirect: vi.fn(),
+  findIdByUserIdUserFacing: vi.fn(),
+  checkUserEntitlement: vi.fn(),
+  isTokenWithinRefreshWindow: vi.fn(),
+  rotateToken: vi.fn(),
+  getApiAddressFromReq: vi.fn(() => '127.0.0.1'),
+  createUserActivityFromReq: vi.fn(),
+}));
+
+vi.mock('@jetstream/api-config', () => ({
+  ENV: { JETSTREAM_SERVER_URL: 'https://server.test', ENVIRONMENT: 'test', CI: false, DESKTOP_ORG_ENCRYPTION_SECRET: 'desktop-secret' },
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  errorTracker: { error: vi.fn(), warn: vi.fn(), critical: vi.fn(), info: vi.fn() },
+  prisma: {},
+}));
+
+vi.mock('@jetstream/auth/server', () => {
+  class InvalidSession extends Error {
+    constructor() {
+      super('Invalid session');
+      this.name = 'InvalidSession';
+    }
+  }
+  class MissingEntitlement extends Error {
+    constructor() {
+      super('Missing entitlement');
+      this.name = 'MissingEntitlement';
+    }
+  }
+  return {
+    InvalidSession,
+    MissingEntitlement,
+    getApiAddressFromReq: mocks.getApiAddressFromReq,
+    createUserActivityFromReq: mocks.createUserActivityFromReq,
+    getCookieConfig: vi.fn(() => ({})),
+  };
+});
+
+vi.mock('@jetstream/prisma', () => ({
+  isPrismaError: () => false,
+  Prisma: { PrismaClientKnownRequestError: class extends Error {} },
+  toTypedPrismaError: () => ({ code: undefined }),
+}));
+
+vi.mock('@jetstream/desktop/types', () => ({}));
+
+vi.mock('../../db/salesforce-org.db', () => ({ findByUniqueId_UNSAFE: vi.fn(), updateOrg_UNSAFE: vi.fn() }));
+vi.mock('../../db/user.db', () => ({
+  findIdByUserIdUserFacing: mocks.findIdByUserIdUserFacing,
+  checkUserEntitlement: mocks.checkUserEntitlement,
+}));
+vi.mock('../../db/web-extension.db', () => ({
+  TOKEN_TYPE_AUTH: 'AUTH_TOKEN',
+  TOKEN_SOURCE_BROWSER_EXTENSION: 'BROWSER_EXTENSION',
+  TOKEN_SOURCE_DESKTOP: 'DESKTOP',
+  create: vi.fn(),
+  findByUserIdAndDeviceId: vi.fn(),
+  deleteByUserIdAndDeviceId: vi.fn(),
+}));
+vi.mock('../../db/data-sync.db', () => ({ findByUpdatedAt: vi.fn(), syncRecordChanges: vi.fn() }));
+vi.mock('../../services/data-sync-broadcast.service', () => ({ emitRecordSyncEventsToOtherClients: vi.fn() }));
+vi.mock('../../services/external-auth.service', () => ({
+  AUDIENCE_WEB_EXT: 'https://getjetstream.app/web-extension',
+  AUDIENCE_DESKTOP: 'https://getjetstream.app/desktop-app',
+  isTokenWithinRefreshWindow: mocks.isTokenWithinRefreshWindow,
+  rotateToken: mocks.rotateToken,
+  issueAccessToken: vi.fn(),
+  decodeToken: vi.fn(),
+  TOKEN_EXPIRATION_SHORT: 1,
+  TOKEN_AUTO_REFRESH_DAYS: 2,
+}));
+vi.mock('../../services/jwt-token-encryption.service', () => ({ decryptJwtTokenOrPlaintext: vi.fn() }));
+vi.mock('../../utils/response.handlers', () => ({ sendJson: mocks.sendJson, redirect: mocks.redirect }));
+vi.mock('../data-sync.controller', () => ({
+  routeDefinition: { pull: { validators: { hasSourceOrg: false } }, push: { validators: { hasSourceOrg: false } } },
+}));
+
+const userProfile = { id: 'user-1', email: 'test@example.com', name: 'Test User' };
+
+function makeReq(headers: Record<string, string>) {
+  return {
+    get: (name: string) => headers[name],
+    body: {},
+    query: {},
+    params: {},
+    session: { user: { id: 'user-1' } },
+    externalAuth: { user: { id: 'user-1' }, deviceId: 'device-1' },
+    log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+  };
+}
+
+function makeRes() {
+  return {
+    locals: { deviceId: 'device-1', ipAddress: '127.0.0.1', cookies: {}, requestId: 'req-1' },
+    log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+  };
+}
+
+async function invokeVerify(headers: Record<string, string>) {
+  const req = makeReq(headers);
+  const res = makeRes();
+  await routeDefinition.verifyToken.controllerFn()(req as never, res as never, vi.fn());
+  return { req, res };
+}
+
+describe('desktop-app.controller verifyToken token rotation gating', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.findIdByUserIdUserFacing.mockResolvedValue(userProfile);
+    mocks.getApiAddressFromReq.mockReturnValue('127.0.0.1');
+  });
+
+  it('skips rotation and returns no accessToken when the token is not within the refresh window', async () => {
+    mocks.isTokenWithinRefreshWindow.mockReturnValue(false);
+
+    const { res } = await invokeVerify({ Authorization: 'Bearer old-token', [HTTP.HEADERS.X_SUPPORTS_TOKEN_ROTATION]: '1' });
+
+    expect(mocks.isTokenWithinRefreshWindow).toHaveBeenCalledWith('old-token');
+    expect(mocks.rotateToken).not.toHaveBeenCalled();
+    expect(mocks.sendJson).toHaveBeenCalledWith(
+      res,
+      expect.objectContaining({ success: true, userProfile, encryptionKey: expect.any(String), accessToken: undefined }),
+    );
+  });
+
+  it('rotates the token and returns the new accessToken when within the refresh window', async () => {
+    mocks.isTokenWithinRefreshWindow.mockReturnValue(true);
+    mocks.rotateToken.mockResolvedValue({ outcome: 'rotated', token: 'new-token' });
+
+    const { res } = await invokeVerify({ Authorization: 'Bearer old-token', [HTTP.HEADERS.X_SUPPORTS_TOKEN_ROTATION]: '1' });
+
+    expect(mocks.rotateToken).toHaveBeenCalledTimes(1);
+    expect(mocks.sendJson).toHaveBeenCalledWith(
+      res,
+      expect.objectContaining({ success: true, userProfile, encryptionKey: expect.any(String), accessToken: 'new-token' }),
+    );
+  });
+
+  it('returns a 401 when the rotation outcome is race-loss-none', async () => {
+    mocks.isTokenWithinRefreshWindow.mockReturnValue(true);
+    mocks.rotateToken.mockResolvedValue({ outcome: 'race-loss-none', token: undefined });
+
+    const { res } = await invokeVerify({ Authorization: 'Bearer old-token', [HTTP.HEADERS.X_SUPPORTS_TOKEN_ROTATION]: '1' });
+
+    expect(mocks.sendJson).toHaveBeenCalledWith(res, { success: false, error: 'Invalid session' }, 401);
+  });
+
+  it('does not rotate when the client does not support rotation', async () => {
+    const { res } = await invokeVerify({ Authorization: 'Bearer old-token' });
+
+    expect(mocks.isTokenWithinRefreshWindow).not.toHaveBeenCalled();
+    expect(mocks.rotateToken).not.toHaveBeenCalled();
+    expect(mocks.sendJson).toHaveBeenCalledWith(
+      res,
+      expect.objectContaining({ success: true, userProfile, encryptionKey: expect.any(String), accessToken: undefined }),
+    );
+  });
+});

--- a/apps/api/src/app/controllers/__tests__/web-extension.controller.spec.ts
+++ b/apps/api/src/app/controllers/__tests__/web-extension.controller.spec.ts
@@ -1,0 +1,162 @@
+/**
+ * Regression coverage for the token-rotation gating in the web extension verifyToken handler.
+ *
+ * To reduce cross-device storage.sync rotation races (a source of frequent logouts), the handler
+ * only rotates the access token when it is within the refresh window. These tests lock in:
+ *   - rotation is skipped (and no accessToken is returned) when the token is not near expiry
+ *   - rotation runs when the token is near expiry
+ *   - a race-loss-none rotation outcome still forces a 401
+ */
+import { HTTP } from '@jetstream/shared/constants';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { routeDefinition } from '../web-extension.controller';
+
+const mocks = vi.hoisted(() => ({
+  sendJson: vi.fn(),
+  redirect: vi.fn(),
+  findIdByUserIdUserFacing: vi.fn(),
+  checkUserEntitlement: vi.fn(),
+  isTokenWithinRefreshWindow: vi.fn(),
+  rotateToken: vi.fn(),
+  getApiAddressFromReq: vi.fn(() => '127.0.0.1'),
+  createUserActivityFromReq: vi.fn(),
+}));
+
+vi.mock('@jetstream/api-config', () => ({
+  ENV: { JETSTREAM_SERVER_URL: 'https://server.test', ENVIRONMENT: 'test', CI: false },
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  errorTracker: { error: vi.fn(), warn: vi.fn(), critical: vi.fn(), info: vi.fn() },
+  prisma: {},
+}));
+
+vi.mock('@jetstream/auth/server', () => {
+  class InvalidSession extends Error {
+    constructor() {
+      super('Invalid session');
+      this.name = 'InvalidSession';
+    }
+  }
+  class MissingEntitlement extends Error {
+    constructor() {
+      super('Missing entitlement');
+      this.name = 'MissingEntitlement';
+    }
+  }
+  return {
+    InvalidSession,
+    MissingEntitlement,
+    getApiAddressFromReq: mocks.getApiAddressFromReq,
+    createUserActivityFromReq: mocks.createUserActivityFromReq,
+    getCookieConfig: vi.fn(() => ({})),
+  };
+});
+
+vi.mock('@jetstream/prisma', () => ({
+  isPrismaError: () => false,
+  Prisma: { PrismaClientKnownRequestError: class extends Error {} },
+  toTypedPrismaError: () => ({ code: undefined }),
+}));
+
+vi.mock('../../db/salesforce-org.db', () => ({ findByUniqueId_UNSAFE: vi.fn(), updateOrg_UNSAFE: vi.fn() }));
+vi.mock('../../db/user.db', () => ({
+  findIdByUserIdUserFacing: mocks.findIdByUserIdUserFacing,
+  checkUserEntitlement: mocks.checkUserEntitlement,
+}));
+vi.mock('../../db/web-extension.db', () => ({
+  TOKEN_TYPE_AUTH: 'AUTH_TOKEN',
+  TOKEN_SOURCE_BROWSER_EXTENSION: 'BROWSER_EXTENSION',
+  TOKEN_SOURCE_DESKTOP: 'DESKTOP',
+  create: vi.fn(),
+  findByUserIdAndDeviceId: vi.fn(),
+  deleteByUserIdAndDeviceId: vi.fn(),
+}));
+vi.mock('../../db/data-sync.db', () => ({ findByUpdatedAt: vi.fn(), syncRecordChanges: vi.fn() }));
+vi.mock('../../services/data-sync-broadcast.service', () => ({ emitRecordSyncEventsToOtherClients: vi.fn() }));
+vi.mock('../../services/external-auth.service', () => ({
+  AUDIENCE_WEB_EXT: 'https://getjetstream.app/web-extension',
+  AUDIENCE_DESKTOP: 'https://getjetstream.app/desktop-app',
+  isTokenWithinRefreshWindow: mocks.isTokenWithinRefreshWindow,
+  rotateToken: mocks.rotateToken,
+  issueAccessToken: vi.fn(),
+  decodeToken: vi.fn(),
+  TOKEN_EXPIRATION_SHORT: 1,
+  TOKEN_AUTO_REFRESH_DAYS: 2,
+}));
+vi.mock('../../services/jwt-token-encryption.service', () => ({ decryptJwtTokenOrPlaintext: vi.fn() }));
+vi.mock('../../utils/response.handlers', () => ({ sendJson: mocks.sendJson, redirect: mocks.redirect }));
+vi.mock('../data-sync.controller', () => ({
+  routeDefinition: { pull: { validators: { hasSourceOrg: false } }, push: { validators: { hasSourceOrg: false } } },
+}));
+
+const userProfile = { id: 'user-1', email: 'test@example.com', name: 'Test User' };
+
+function makeReq(headers: Record<string, string>) {
+  return {
+    get: (name: string) => headers[name],
+    body: {},
+    query: {},
+    params: {},
+    session: { user: { id: 'user-1' } },
+    externalAuth: { user: { id: 'user-1' }, deviceId: 'device-1' },
+    log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+  };
+}
+
+function makeRes() {
+  return {
+    locals: { deviceId: 'device-1', ipAddress: '127.0.0.1', cookies: {}, requestId: 'req-1' },
+    log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+  };
+}
+
+async function invokeVerify(headers: Record<string, string>) {
+  const req = makeReq(headers);
+  const res = makeRes();
+  await routeDefinition.verifyToken.controllerFn()(req as never, res as never, vi.fn());
+  return { req, res };
+}
+
+describe('web-extension.controller verifyToken token rotation gating', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.findIdByUserIdUserFacing.mockResolvedValue(userProfile);
+    mocks.getApiAddressFromReq.mockReturnValue('127.0.0.1');
+  });
+
+  it('skips rotation and returns no accessToken when the token is not within the refresh window', async () => {
+    mocks.isTokenWithinRefreshWindow.mockReturnValue(false);
+
+    const { res } = await invokeVerify({ Authorization: 'Bearer old-token', [HTTP.HEADERS.X_SUPPORTS_TOKEN_ROTATION]: '1' });
+
+    expect(mocks.isTokenWithinRefreshWindow).toHaveBeenCalledWith('old-token');
+    expect(mocks.rotateToken).not.toHaveBeenCalled();
+    expect(mocks.sendJson).toHaveBeenCalledWith(res, { success: true, userProfile, accessToken: undefined });
+  });
+
+  it('rotates the token and returns the new accessToken when within the refresh window', async () => {
+    mocks.isTokenWithinRefreshWindow.mockReturnValue(true);
+    mocks.rotateToken.mockResolvedValue({ outcome: 'rotated', token: 'new-token' });
+
+    const { res } = await invokeVerify({ Authorization: 'Bearer old-token', [HTTP.HEADERS.X_SUPPORTS_TOKEN_ROTATION]: '1' });
+
+    expect(mocks.rotateToken).toHaveBeenCalledTimes(1);
+    expect(mocks.sendJson).toHaveBeenCalledWith(res, { success: true, userProfile, accessToken: 'new-token' });
+  });
+
+  it('returns a 401 when the rotation outcome is race-loss-none', async () => {
+    mocks.isTokenWithinRefreshWindow.mockReturnValue(true);
+    mocks.rotateToken.mockResolvedValue({ outcome: 'race-loss-none', token: undefined });
+
+    const { res } = await invokeVerify({ Authorization: 'Bearer old-token', [HTTP.HEADERS.X_SUPPORTS_TOKEN_ROTATION]: '1' });
+
+    expect(mocks.sendJson).toHaveBeenCalledWith(res, { success: false, error: 'Invalid session' }, 401);
+  });
+
+  it('does not rotate when the client does not support rotation', async () => {
+    const { res } = await invokeVerify({ Authorization: 'Bearer old-token' });
+
+    expect(mocks.isTokenWithinRefreshWindow).not.toHaveBeenCalled();
+    expect(mocks.rotateToken).not.toHaveBeenCalled();
+    expect(mocks.sendJson).toHaveBeenCalledWith(res, { success: true, userProfile, accessToken: undefined });
+  });
+});

--- a/apps/api/src/app/controllers/desktop-app.controller.ts
+++ b/apps/api/src/app/controllers/desktop-app.controller.ts
@@ -219,7 +219,11 @@ const verifyToken = createRoute(routeDefinition.verifyToken.validators, async ({
     let rotatedAccessToken: string | undefined;
     if (supportsRotation && deviceId) {
       const oldAccessToken = req.get('Authorization')?.split(' ')[1];
-      if (oldAccessToken) {
+      // Only rotate as the token approaches expiry. Rotating on every verify churns the shared
+      // token across the user's devices, which can lose the rotation race and force a premature
+      // logout. The auth middleware still fully validates the token on every verify, so skipping
+      // rotation here does not weaken verification.
+      if (oldAccessToken && externalAuthService.isTokenWithinRefreshWindow(oldAccessToken)) {
         const result = await externalAuthService.rotateToken({
           userProfile,
           audience: externalAuthService.AUDIENCE_DESKTOP,

--- a/apps/api/src/app/controllers/web-extension.controller.ts
+++ b/apps/api/src/app/controllers/web-extension.controller.ts
@@ -192,7 +192,11 @@ const verifyToken = createRoute(routeDefinition.verifyToken.validators, async ({
     let rotatedAccessToken: string | undefined;
     if (supportsRotation && deviceId) {
       const oldAccessToken = req.get('Authorization')?.split(' ')[1];
-      if (oldAccessToken) {
+      // Only rotate as the token approaches expiry. Rotating on every verify churns the shared
+      // token across the user's devices (browser storage.sync), which can lose the rotation race
+      // and force a premature logout. The auth middleware still fully validates the token on
+      // every verify, so skipping rotation here does not weaken verification.
+      if (oldAccessToken && externalAuthService.isTokenWithinRefreshWindow(oldAccessToken)) {
         const result = await externalAuthService.rotateToken({
           userProfile,
           audience: externalAuthService.AUDIENCE_WEB_EXT,

--- a/apps/api/src/app/services/__tests__/external-auth.service.spec.ts
+++ b/apps/api/src/app/services/__tests__/external-auth.service.spec.ts
@@ -1,8 +1,19 @@
 import { UserProfileUi } from '@jetstream/types';
 import { Mock, vi } from 'vitest';
 import * as webExtDb from '../../db/web-extension.db';
-import { AUDIENCE_WEB_EXT, rotateToken } from '../external-auth.service';
+import { AUDIENCE_WEB_EXT, isTokenWithinRefreshWindow, rotateToken } from '../external-auth.service';
 import { decryptJwtTokenOrPlaintext, hashToken } from '../jwt-token-encryption.service';
+
+const SECONDS_PER_DAY = 60 * 60 * 24;
+
+/**
+ * Builds a JWT-shaped string with a specific `exp`. decodeToken (fast-jwt's decoder) does not
+ * verify the signature, so an unsigned token with the right payload is sufficient for these tests.
+ */
+function makeTokenWithExp(expUnixSeconds: number): string {
+  const encode = (obj: unknown) => Buffer.from(JSON.stringify(obj)).toString('base64url');
+  return `${encode({ alg: 'HS256', typ: 'JWT' })}.${encode({ exp: expUnixSeconds })}.signature`;
+}
 
 // Preserve the real constants (TOKEN_TYPE_AUTH, etc.) so assertions compare against the
 // actual string values the SUT should be passing — only stub the DB-touching functions.
@@ -139,6 +150,33 @@ describe('external-auth.service', () => {
 
       expect(hashToken).toHaveBeenCalledWith('specific-old-token');
       expect(mockWebExtDb.replaceTokenIfCurrent).toHaveBeenCalledWith(mockUserProfile.id, 'hash(specific-old-token)', expect.any(Object));
+    });
+  });
+
+  describe('isTokenWithinRefreshWindow', () => {
+    it('returns false when the token expires further away than the default window (2 days)', () => {
+      const nowSeconds = Math.floor(Date.now() / 1000);
+      const token = makeTokenWithExp(nowSeconds + 3 * SECONDS_PER_DAY);
+      expect(isTokenWithinRefreshWindow(token)).toBe(false);
+    });
+
+    it('returns true when the token expires within the default window (2 days)', () => {
+      const nowSeconds = Math.floor(Date.now() / 1000);
+      const token = makeTokenWithExp(nowSeconds + 1 * SECONDS_PER_DAY);
+      expect(isTokenWithinRefreshWindow(token)).toBe(true);
+    });
+
+    it('returns true when the token is already expired', () => {
+      const nowSeconds = Math.floor(Date.now() / 1000);
+      const token = makeTokenWithExp(nowSeconds - 100);
+      expect(isTokenWithinRefreshWindow(token)).toBe(true);
+    });
+
+    it('honors a custom withinDays threshold', () => {
+      const nowSeconds = Math.floor(Date.now() / 1000);
+      const token = makeTokenWithExp(nowSeconds + 5 * SECONDS_PER_DAY);
+      expect(isTokenWithinRefreshWindow(token, 2)).toBe(false);
+      expect(isTokenWithinRefreshWindow(token, 7)).toBe(true);
     });
   });
 });

--- a/apps/api/src/app/services/external-auth.service.ts
+++ b/apps/api/src/app/services/external-auth.service.ts
@@ -28,7 +28,24 @@ export const TOKEN_AUTO_REFRESH_DAYS = 2;
 const TOKEN_EXPIRATION = 60 * 60 * 24 * 90 * 1000; // 90 days
 export const TOKEN_EXPIRATION_SHORT = 60 * 60 * 24 * 7 * 1000; // 7 days
 
+const SECONDS_PER_DAY = 60 * 60 * 24;
+
 export type Audience = typeof AUDIENCE_WEB_EXT | typeof AUDIENCE_DESKTOP;
+
+/**
+ * Returns true when the access token expires within `withinDays` days (or is already expired).
+ *
+ * Verify endpoints use this to rotate tokens only as they approach expiry rather than on every
+ * verify. Rotating eagerly churns the shared token across a user's devices (e.g. browser
+ * storage.sync), which can lose the rotation race and prematurely invalidate the session. The
+ * auth middleware still fully validates the token (DB + entitlements) on every verify, so
+ * skipping rotation does not weaken verification.
+ */
+export function isTokenWithinRefreshWindow(accessToken: string, withinDays = TOKEN_AUTO_REFRESH_DAYS): boolean {
+  const { exp } = decodeToken(accessToken);
+  const secondsUntilExpiration = exp - Date.now() / 1000;
+  return secondsUntilExpiration <= withinDays * SECONDS_PER_DAY;
+}
 
 export interface JwtDecodedPayload {
   userProfile: UserProfileUi;

--- a/apps/jetstream-e2e/src/tests/authentication/external-auth/external-auth-logged-in.spec.ts
+++ b/apps/jetstream-e2e/src/tests/authentication/external-auth/external-auth-logged-in.spec.ts
@@ -156,11 +156,13 @@ test.describe('Desktop / Web-Extension Token Rotation', () => {
     await authenticationPage.acceptCookieBanner();
   });
 
-  test('Desktop token rotation - rotated token works, old token is invalidated', async ({
-    page,
-    teamCreationUtils1User,
-    apiRequestUtils,
-  }) => {
+  // A freshly issued session token is well outside the refresh window (TOKEN_AUTO_REFRESH_DAYS), so
+  // verifying with the rotation header must NOT rotate it: the response succeeds without a new
+  // accessToken and the original token keeps working. Rotation only fires as a token nears expiry.
+  // The full gating + rotation mechanics (skip-when-fresh, rotate-when-near-expiry, race-loss-none
+  // -> 401, no-header -> no rotation) are covered against mocked time/DB in
+  // desktop-app.controller.spec.ts, web-extension.controller.spec.ts, and external-auth.service.spec.ts.
+  test('Desktop - fresh token is not rotated when rotation is supported', async ({ page, teamCreationUtils1User, apiRequestUtils }) => {
     const deviceId = uuid();
 
     // 1. Create session and get original token
@@ -171,7 +173,7 @@ test.describe('Desktop / Web-Extension Token Rotation', () => {
     const { accessToken: originalToken } = await sessionResponse.json().then(({ data }) => data);
     expect(typeof originalToken).toBe('string');
 
-    // 2. Verify with rotation header — should get a new token
+    // 2. Verify with rotation header — fresh token is not near expiry, so it is not rotated
     const rotateResponse = await apiRequestUtils.request.post(`/desktop-app/auth/verify`, {
       headers: {
         Accept: 'application/json',
@@ -184,35 +186,22 @@ test.describe('Desktop / Web-Extension Token Rotation', () => {
     expect(rotateResponse.status()).toBe(200);
     const rotateData = await rotateResponse.json().then(({ data }) => data);
     expect(rotateData.success).toBe(true);
-    expect(rotateData.accessToken).toBeDefined();
-    expect(rotateData.accessToken).not.toBe(originalToken);
-    const rotatedToken = rotateData.accessToken;
+    expect(rotateData.accessToken).toBeUndefined();
 
-    // 3. Rotated token works for subsequent verify
-    const verifyWithRotated = await apiRequestUtils.request.post(`/desktop-app/auth/verify`, {
-      headers: {
-        Accept: 'application/json',
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${rotatedToken}`,
-        [HTTP.HEADERS.X_EXT_DEVICE_ID]: deviceId,
-        [HTTP.HEADERS.X_SUPPORTS_TOKEN_ROTATION]: '1',
-      },
-    });
-    expect(verifyWithRotated.status()).toBe(200);
-
-    // 4. Original token is now invalid (its hash was replaced in the DB)
+    // 3. Original token still works — verifying did not rotate or invalidate it
     const verifyWithOriginal = await apiRequestUtils.request.post(`/desktop-app/auth/verify`, {
       headers: {
         Accept: 'application/json',
         'Content-Type': 'application/json',
         Authorization: `Bearer ${originalToken}`,
         [HTTP.HEADERS.X_EXT_DEVICE_ID]: deviceId,
+        [HTTP.HEADERS.X_SUPPORTS_TOKEN_ROTATION]: '1',
       },
     });
-    expect(verifyWithOriginal.status()).toBe(401);
+    expect(verifyWithOriginal.status()).toBe(200);
   });
 
-  test('Web extension token rotation - rotated token works, old token is invalidated', async ({
+  test('Web extension - fresh token is not rotated when rotation is supported', async ({
     page,
     teamCreationUtils1User,
     apiRequestUtils,
@@ -227,7 +216,7 @@ test.describe('Desktop / Web-Extension Token Rotation', () => {
     const { accessToken: originalToken } = await sessionResponse.json().then(({ data }) => data);
     expect(typeof originalToken).toBe('string');
 
-    // 2. Verify with rotation header — should get a new token
+    // 2. Verify with rotation header — fresh token is not near expiry, so it is not rotated
     const rotateResponse = await apiRequestUtils.request.post(`/web-extension/auth/verify`, {
       headers: {
         Accept: 'application/json',
@@ -240,32 +229,19 @@ test.describe('Desktop / Web-Extension Token Rotation', () => {
     expect(rotateResponse.status()).toBe(200);
     const rotateData = await rotateResponse.json().then(({ data }) => data);
     expect(rotateData.success).toBe(true);
-    expect(rotateData.accessToken).toBeDefined();
-    expect(rotateData.accessToken).not.toBe(originalToken);
-    const rotatedToken = rotateData.accessToken;
+    expect(rotateData.accessToken).toBeUndefined();
 
-    // 3. Rotated token works
-    const verifyWithRotated = await apiRequestUtils.request.post(`/web-extension/auth/verify`, {
-      headers: {
-        Accept: 'application/json',
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${rotatedToken}`,
-        [HTTP.HEADERS.X_EXT_DEVICE_ID]: deviceId,
-        [HTTP.HEADERS.X_SUPPORTS_TOKEN_ROTATION]: '1',
-      },
-    });
-    expect(verifyWithRotated.status()).toBe(200);
-
-    // 4. Original token is now invalid
+    // 3. Original token still works — verifying did not rotate or invalidate it
     const verifyWithOriginal = await apiRequestUtils.request.post(`/web-extension/auth/verify`, {
       headers: {
         Accept: 'application/json',
         'Content-Type': 'application/json',
         Authorization: `Bearer ${originalToken}`,
         [HTTP.HEADERS.X_EXT_DEVICE_ID]: deviceId,
+        [HTTP.HEADERS.X_SUPPORTS_TOKEN_ROTATION]: '1',
       },
     });
-    expect(verifyWithOriginal.status()).toBe(401);
+    expect(verifyWithOriginal.status()).toBe(200);
   });
 
   test('No rotation without header (backward compat)', async ({ page, teamCreationUtils1User, apiRequestUtils }) => {
@@ -304,124 +280,31 @@ test.describe('Desktop / Web-Extension Token Rotation', () => {
     expect(verifyAgain.status()).toBe(200);
   });
 
-  test('Concurrent rotation race - successful racers converge on the same valid token', async ({
-    page,
-    teamCreationUtils1User,
-    apiRequestUtils,
-  }) => {
-    const deviceId = uuid();
-    const concurrency = 20;
-
-    // 1. Create session and get the token all racers will rotate from
-    const sessionResponse = await apiRequestUtils.request.post(`/web-extension/auth/session`, {
-      headers: { [HTTP.HEADERS.X_EXT_DEVICE_ID]: deviceId },
-    });
-    expect(sessionResponse.status()).toBe(200);
-    const { accessToken: originalToken } = await sessionResponse.json().then(({ data }) => data);
-
-    // 2. Fire N concurrent verify requests using the same starting token. With the race-loss
-    //    fix, every racer whose auth middleware lookup ran before the winning rotation should
-    //    receive the same valid token (the winner's). Racers whose middleware lookup completes
-    //    after the rotation will 401 because the cache is bypassed for rotation requests and
-    //    the old token is no longer in the DB — that's expected and not under test here. The
-    //    property under test is convergence: every successful response returns the same token.
-    const responses = await Promise.all(
-      Array.from({ length: concurrency }, () =>
-        apiRequestUtils.request.post(`/web-extension/auth/verify`, {
-          headers: {
-            Accept: 'application/json',
-            'Content-Type': 'application/json',
-            Authorization: `Bearer ${originalToken}`,
-            [HTTP.HEADERS.X_EXT_DEVICE_ID]: deviceId,
-            [HTTP.HEADERS.X_SUPPORTS_TOKEN_ROTATION]: '1',
-          },
-        }),
-      ),
-    );
-
-    const successResponses = responses.filter((response) => response.status() === 200);
-    expect(successResponses.length).toBeGreaterThan(0);
-
-    // Any non-success must be a 401. The only legitimate failure mode here is a racer whose
-    // middleware lookup ran after the winning rotation (LRU is bypassed for rotation, so the
-    // old token is no longer in the DB). 5xx/429 responses would indicate a real regression.
-    const failureResponses = responses.filter((response) => response.status() !== 200);
-    for (const failure of failureResponses) {
-      expect(failure.status()).toBe(401);
-    }
-
-    const bodies = await Promise.all(successResponses.map((response) => response.json().then(({ data }) => data)));
-    expect(bodies.every((body) => body.success === true)).toBe(true);
-
-    const returnedTokens = bodies.map((body) => body.accessToken).filter((token): token is string => typeof token === 'string');
-    expect(returnedTokens.length).toBe(successResponses.length);
-
-    const distinctTokens = new Set(returnedTokens);
-    expect(distinctTokens.size).toBe(1);
-
-    const winningToken = [...distinctTokens][0];
-    expect(winningToken).not.toBe(originalToken);
-
-    // 3. The single converged token works for follow-up verify
-    const followUpVerify = await apiRequestUtils.request.post(`/web-extension/auth/verify`, {
-      headers: {
-        Accept: 'application/json',
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${winningToken}`,
-        [HTTP.HEADERS.X_EXT_DEVICE_ID]: deviceId,
-      },
-    });
-    expect(followUpVerify.status()).toBe(200);
-
-    // 4. The original token is no longer valid
-    const verifyWithOriginal = await apiRequestUtils.request.post(`/web-extension/auth/verify`, {
-      headers: {
-        Accept: 'application/json',
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${originalToken}`,
-        [HTTP.HEADERS.X_EXT_DEVICE_ID]: deviceId,
-      },
-    });
-    expect(verifyWithOriginal.status()).toBe(401);
-  });
-
-  test('Logout invalidates rotated token', async ({ page, teamCreationUtils1User, apiRequestUtils }) => {
+  test('Logout invalidates the session token', async ({ page, teamCreationUtils1User, apiRequestUtils }) => {
     const deviceId = uuid();
 
     // 1. Create session
     const sessionResponse = await apiRequestUtils.request.post(`/desktop-app/auth/session`, {
       headers: { [HTTP.HEADERS.X_EXT_DEVICE_ID]: deviceId },
     });
-    const { accessToken: originalToken } = await sessionResponse.json().then(({ data }) => data);
+    const { accessToken } = await sessionResponse.json().then(({ data }) => data);
 
-    // 2. Rotate the token
-    const rotateResponse = await apiRequestUtils.request.post(`/desktop-app/auth/verify`, {
-      headers: {
-        Accept: 'application/json',
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${originalToken}`,
-        [HTTP.HEADERS.X_EXT_DEVICE_ID]: deviceId,
-        [HTTP.HEADERS.X_SUPPORTS_TOKEN_ROTATION]: '1',
-      },
-    });
-    const { accessToken: rotatedToken } = await rotateResponse.json().then(({ data }) => data);
-
-    // 3. Logout with the rotated token
+    // 2. Logout with the token
     const logoutResponse = await apiRequestUtils.request.delete(`/desktop-app/auth/logout`, {
       headers: {
         Accept: 'application/json',
-        Authorization: `Bearer ${rotatedToken}`,
+        Authorization: `Bearer ${accessToken}`,
         [HTTP.HEADERS.X_EXT_DEVICE_ID]: deviceId,
       },
     });
     expect(logoutResponse.status()).toBe(200);
 
-    // 4. Rotated token is now invalid
+    // 3. Token is now invalid (removed from the DB by logout)
     const verifyAfterLogout = await apiRequestUtils.request.post(`/desktop-app/auth/verify`, {
       headers: {
         Accept: 'application/json',
         'Content-Type': 'application/json',
-        Authorization: `Bearer ${rotatedToken}`,
+        Authorization: `Bearer ${accessToken}`,
         [HTTP.HEADERS.X_EXT_DEVICE_ID]: deviceId,
       },
     });

--- a/apps/jetstream-web-extension/src/extension-scripts/__tests__/service-worker.spec.ts
+++ b/apps/jetstream-web-extension/src/extension-scripts/__tests__/service-worker.spec.ts
@@ -1,0 +1,184 @@
+/**
+ * Regression coverage for the frequent-logout fix in the browser extension service worker.
+ *
+ * handleVerifyAuth must only clear the stored tokens on a DEFINITIVE auth failure — an HTTP 401
+ * with a parseable { success: false } body. Transient conditions (network failure, 5xx, other
+ * non-401 status, or an unparseable/HTML body from an upstream proxy) must keep the cached
+ * session so the user is not logged out spuriously.
+ *
+ * The service worker keeps the verified token in a module-level cache (storageSyncCache) that is
+ * normally hydrated by the real storage.onChanged listener. The tests reuse that listener (captured
+ * from the mocked webextension-polyfill) to seed the cache before invoking handleVerifyAuth.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { handleVerifyAuth } from '../service-worker';
+
+const swMock = vi.hoisted(() => {
+  const state: {
+    syncStore: Record<string, unknown>;
+    onChangedListener: ((changes: Record<string, { newValue: unknown }>, namespace: string) => void) | null;
+  } = { syncStore: {}, onChangedListener: null };
+
+  const sync = {
+    get: vi.fn(async (keys?: string | string[]) => {
+      if (keys == null) {
+        return { ...state.syncStore };
+      }
+      const keyArr = Array.isArray(keys) ? keys : [keys];
+      const result: Record<string, unknown> = {};
+      for (const key of keyArr) {
+        if (key in state.syncStore) {
+          result[key] = state.syncStore[key];
+        }
+      }
+      return result;
+    }),
+    set: vi.fn(async (items: Record<string, unknown>) => {
+      Object.assign(state.syncStore, items);
+    }),
+    remove: vi.fn(async (key: string) => {
+      delete state.syncStore[key];
+    }),
+  };
+
+  const browser = {
+    storage: {
+      sync,
+      session: {
+        get: vi.fn(async () => ({})),
+        set: vi.fn(async () => undefined),
+      },
+      onChanged: {
+        addListener: vi.fn((cb: (changes: Record<string, { newValue: unknown }>, namespace: string) => void) => {
+          state.onChangedListener = cb;
+        }),
+      },
+    },
+    runtime: {
+      onInstalled: { addListener: vi.fn() },
+      onMessage: { addListener: vi.fn() },
+      onMessageExternal: { addListener: vi.fn() },
+      getManifest: vi.fn(() => ({ version: '1.2.3' })),
+      getURL: vi.fn((path: string) => `chrome-extension://test/${path}`),
+    },
+    tabs: { onActivated: { addListener: vi.fn() }, create: vi.fn() },
+    commands: { onCommand: { addListener: vi.fn() } },
+    cookies: { get: vi.fn(), getAll: vi.fn() },
+  };
+
+  return { state, browser, sync };
+});
+
+vi.mock('webextension-polyfill', () => ({ default: swMock.browser }));
+vi.mock('../../environments/environment', () => ({ environment: { serverUrl: 'https://server.test', production: false } }));
+vi.mock('../../utils/api-client', () => ({ initApiClientAndOrg: vi.fn() }));
+vi.mock('@jetstream/shared/client-logger', () => ({
+  enableLogger: vi.fn(),
+  logger: { log: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+vi.mock('jwt-decode', () => ({ jwtDecode: vi.fn(() => ({ exp: 4102444800 })) }));
+
+const AUTH_KEY = 'authTokens';
+const senderMock = { tab: undefined } as never;
+
+function seedAuth(accessToken: string, overrides: Record<string, unknown> = {}) {
+  const authTokens = {
+    accessToken,
+    userProfile: { id: 'user-1', email: 'test@example.com' },
+    expiresAt: Date.now() + 7 * 24 * 60 * 60 * 1000,
+    lastChecked: null,
+    loggedIn: true,
+    ...overrides,
+  };
+  const extIdentifier = { id: 'device-1' };
+  // Hydrate storageSyncCache through the real onChanged listener the SUT registered on import.
+  swMock.state.onChangedListener?.({ authTokens: { newValue: authTokens }, extIdentifier: { newValue: extIdentifier } }, 'sync');
+  // Also reflect into the backing store so the pre-write re-read inside handleVerifyAuth matches.
+  swMock.state.syncStore.authTokens = authTokens;
+  swMock.state.syncStore.extIdentifier = extIdentifier;
+  return authTokens;
+}
+
+function jsonResponse(status: number, data: unknown) {
+  return { status, json: async () => ({ data }) } as unknown as Response;
+}
+
+function unparseableResponse(status: number) {
+  return {
+    status,
+    json: async () => {
+      throw new SyntaxError('Unexpected token < in JSON at position 0');
+    },
+  } as unknown as Response;
+}
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+describe('service-worker handleVerifyAuth', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    swMock.state.syncStore = {};
+    fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('keeps the cached session when the fetch rejects (offline / DNS failure)', async () => {
+    seedAuth('token-1');
+    fetchMock.mockRejectedValue(new Error('Failed to fetch'));
+
+    const result = await handleVerifyAuth(senderMock);
+
+    expect(result).toEqual({ hasTokens: true, loggedIn: true });
+    expect(swMock.sync.remove).not.toHaveBeenCalled();
+    expect(swMock.state.syncStore.authTokens).toBeDefined();
+  });
+
+  it('keeps the cached session on a 5xx response', async () => {
+    seedAuth('token-1');
+    fetchMock.mockResolvedValue(jsonResponse(500, { success: false, error: 'server error' }));
+
+    const result = await handleVerifyAuth(senderMock);
+
+    expect(result).toEqual({ hasTokens: true, loggedIn: true });
+    expect(swMock.sync.remove).not.toHaveBeenCalled();
+  });
+
+  it('keeps the cached session when the body is unparseable/HTML even with a 401 status', async () => {
+    seedAuth('token-1');
+    fetchMock.mockResolvedValue(unparseableResponse(401));
+
+    const result = await handleVerifyAuth(senderMock);
+
+    expect(result).toEqual({ hasTokens: true, loggedIn: true });
+    expect(swMock.sync.remove).not.toHaveBeenCalled();
+  });
+
+  it('clears tokens on a definitive 401 with a { success: false } body', async () => {
+    seedAuth('token-1');
+    fetchMock.mockResolvedValue(jsonResponse(401, { success: false, error: 'Invalid session' }));
+
+    const result = await handleVerifyAuth(senderMock);
+
+    expect(result).toEqual({ hasTokens: true, loggedIn: false, error: 'Invalid session' });
+    expect(swMock.sync.remove).toHaveBeenCalledWith(AUTH_KEY);
+    expect(swMock.state.syncStore.authTokens).toBeUndefined();
+  });
+
+  it('writes back a rotated token on success', async () => {
+    seedAuth('token-1');
+    fetchMock.mockResolvedValue(jsonResponse(200, { success: true, accessToken: 'rotated-token' }));
+
+    const result = await handleVerifyAuth(senderMock);
+
+    expect(result).toEqual({ hasTokens: true, loggedIn: true });
+    expect(swMock.sync.remove).not.toHaveBeenCalled();
+    expect(swMock.sync.set).toHaveBeenCalledWith(
+      expect.objectContaining({ [AUTH_KEY]: expect.objectContaining({ accessToken: 'rotated-token', loggedIn: true }) }),
+    );
+    expect((swMock.state.syncStore.authTokens as { accessToken: string }).accessToken).toBe('rotated-token');
+  });
+});

--- a/apps/jetstream-web-extension/src/extension-scripts/service-worker.ts
+++ b/apps/jetstream-web-extension/src/extension-scripts/service-worker.ts
@@ -223,11 +223,7 @@ async function setConnection(key: string, data: OrgAndSessionInfo) {
 }
 
 browser.runtime.onMessage.addListener(
-  (
-    request: Message['request'],
-    sender: browser.Runtime.MessageSender,
-    sendResponse: (response: MessageResponse) => void,
-  ): true => {
+  (request: Message['request'], sender: browser.Runtime.MessageSender, sendResponse: (response: MessageResponse) => void): true => {
     logger.log('[SW EVENT] onMessage', request);
     switch (request.message) {
       case 'EXT_IDENTIFIER': {
@@ -482,9 +478,10 @@ function runVerifyAuth(sender: browser.Runtime.MessageSender): Promise<VerifyAut
 }
 
 /**
- * Verifies that user is logged in to Jetstream and has access to use the browser extension
+ * Verifies that user is logged in to Jetstream and has access to use the browser extension.
+ * Exported for unit testing — production code reaches this via runVerifyAuth.
  */
-async function handleVerifyAuth(sender: browser.Runtime.MessageSender): Promise<VerifyAuth['response']> {
+export async function handleVerifyAuth(sender: browser.Runtime.MessageSender): Promise<VerifyAuth['response']> {
   try {
     await initStorageSyncCache;
     const { authTokens, extIdentifier } = storageSyncCache;
@@ -498,9 +495,13 @@ async function handleVerifyAuth(sender: browser.Runtime.MessageSender): Promise<
       return { hasTokens: true, loggedIn: true };
     }
 
-    const results: { success: true; accessToken?: string } | { success: false; error: string } = await fetch(
-      `${environment.serverUrl}/web-extension/auth/verify`,
-      {
+    // Only a definitive HTTP 401 (with a parseable { success: false } body) logs the user out.
+    // A network failure, 5xx, other non-401 status, or an unparseable/HTML body (e.g. an upstream
+    // proxy or auth wall) is transient: we keep the cached session and return early WITHOUT
+    // bumping lastChecked so the next user action retries promptly.
+    let response: Response;
+    try {
+      response = await fetch(`${environment.serverUrl}/web-extension/auth/verify`, {
         method: 'POST',
         headers: {
           Accept: 'application/json',
@@ -509,21 +510,35 @@ async function handleVerifyAuth(sender: browser.Runtime.MessageSender): Promise<
           [HTTP.HEADERS.X_APP_VERSION]: browser.runtime.getManifest().version,
           [HTTP.HEADERS.X_SUPPORTS_TOKEN_ROTATION]: '1',
         },
-      },
-    ).then((res) =>
-      res
-        .json()
-        .then(({ data }) => data)
-        .catch(() => ({ success: false, error: 'Invalid response' })),
-    );
-
-    if (!results.success) {
-      logger.info('Error verifying tokens', results.error);
-      browser.storage.sync.remove(storageTypes.authTokens.key).catch((err) => {
-        logger.error('Error removing tokens', err);
       });
-      storageSyncCache.authTokens = undefined;
-      return { hasTokens: true, loggedIn: false, error: results.error };
+    } catch (ex) {
+      // Network-level failure (offline, DNS) — keep the cached session and retry next time.
+      logger.info('Network error verifying tokens, keeping cached session', ex);
+      return { hasTokens: true, loggedIn: true };
+    }
+
+    const results: { success: true; accessToken?: string } | { success: false; error: string } | null = await response
+      .json()
+      .then(({ data }) => (data ?? null) as { success: true; accessToken?: string } | { success: false; error: string } | null)
+      .catch(() => null);
+
+    if (!results || results.success === false) {
+      const status = response.status;
+      if (results && results.success === false && status === 401) {
+        logger.info('Error verifying tokens', results.error);
+        browser.storage.sync.remove(storageTypes.authTokens.key).catch((err) => {
+          logger.error('Error removing tokens', err);
+        });
+        storageSyncCache.authTokens = undefined;
+        return { hasTokens: true, loggedIn: false, error: results.error };
+      }
+      // Transient failure (network/5xx/non-401/unparseable body) — keep the cached session. We do
+      // not bump lastChecked, so the next user action re-checks (event-driven, no tight loop).
+      logger.info('Transient error verifying tokens, keeping cached session', {
+        status,
+        error: results && results.success === false ? results.error : undefined,
+      });
+      return { hasTokens: true, loggedIn: true };
     }
     // Re-read storage.sync immediately before writing so we don't clobber a concurrent
     // write (e.g. a newer rotated token written by another tab/context or by Chrome Sync
@@ -594,12 +609,13 @@ async function handleVerifyAuth(sender: browser.Runtime.MessageSender): Promise<
     storageSyncCache.authTokens = syncState;
     return { hasTokens: true, loggedIn: true };
   } catch (ex) {
-    logger.info('Fatal Error verifying tokens', ex);
-    browser.storage.sync.remove(storageTypes.authTokens.key).catch((err) => {
-      logger.error('Error removing tokens', err);
-    });
-    storageSyncCache.authTokens = undefined;
-    return { hasTokens: false, loggedIn: false, error: ex.message };
+    // Unexpected error (storage access, decode, etc.) — treat as transient and keep the cached
+    // session rather than logging the user out. The next user action will retry. Derive the result
+    // from the current cache state instead of assuming a session: if init failed or a concurrent
+    // logout cleared the cache, there are genuinely no tokens and we must not fabricate a session.
+    logger.info('Unexpected error verifying tokens, keeping cached session', ex);
+    const hasCachedSession = !!storageSyncCache.authTokens;
+    return { hasTokens: hasCachedSession, loggedIn: hasCachedSession };
   }
 }
 


### PR DESCRIPTION
The web extension token seemed to expire a lot more frequently than it should have, likely related to race conditions and refreshing every time a token check was performed