### PR TITLE
Fix org group state mismatch with loadable state handling

### DIFF
--- a/apps/jetstream-web-extension/src/utils/extension.store.ts
+++ b/apps/jetstream-web-extension/src/utils/extension.store.ts
@@ -1,6 +1,6 @@
 import { SoqlQueryFormatOptionsSchema, UserProfileUi } from '@jetstream/types';
 import { atom, createStore } from 'jotai';
-import { loadable, unwrap } from 'jotai/utils';
+import { unwrap } from 'jotai/utils';
 import browser from 'webextension-polyfill';
 import { ChromeStorageState, DEFAULT_BUTTON_POSITION } from './extension.types';
 
@@ -71,11 +71,8 @@ async function initAuthState(): Promise<ChromeStorageState> {
 }
 
 export const chromeStorageAsyncState = atom<Promise<ChromeStorageState> | ChromeStorageState>(initAuthState());
-export const chromeStorageLoadable = loadable(chromeStorageAsyncState);
-export const chromeStorageLoading = atom((get) => {
-  const storage = get(chromeStorageLoadable);
-  return storage.state === 'loading' || storage.state !== 'hasData';
-});
+const chromeStorageResolvedState = unwrap(chromeStorageAsyncState);
+export const chromeStorageLoading = atom((get) => get(chromeStorageResolvedState) === undefined);
 
 const DEFAULT_STATE: ChromeStorageState = {
   sync: {

--- a/libs/shared/ui-app-state/src/lib/ui-app-state.ts
+++ b/libs/shared/ui-app-state/src/lib/ui-app-state.ts
@@ -269,6 +269,7 @@ export const googleDriveAccessState = atom((get) => {
 export const orgGroupsAsyncState = atom<Promise<OrgGroup[]> | OrgGroup[]>(fetchOrgGroups());
 // Unwrapped value to simplify derived state
 export const orgGroupsState = unwrap(orgGroupsAsyncState, (prev) => prev ?? []);
+export const orgGroupsResolvedState = unwrap(orgGroupsAsyncState);
 
 // Combine orgs with organizations
 export const orgGroupsWithOrgsSelector = atom(

--- a/libs/shared/ui-core/src/orgs/OrgPersistence.tsx
+++ b/libs/shared/ui-core/src/orgs/OrgPersistence.tsx
@@ -1,11 +1,13 @@
 import { logger } from '@jetstream/shared/client-logger';
 import { setItemInLocalStorage, setItemInSessionStorage } from '@jetstream/shared/ui-utils';
-import { selectedOrgIdState, STORAGE_KEYS } from '@jetstream/ui/app-state';
-import { useAtom } from 'jotai';
+import { ActiveOrgGroupState, orgGroupsResolvedState, selectedOrgIdState, STORAGE_KEYS } from '@jetstream/ui/app-state';
+import { useAtom, useAtomValue } from 'jotai';
 import { FunctionComponent, useEffect } from 'react';
 
 export const OrgPersistence: FunctionComponent = () => {
   const [selectedOrgId] = useAtom(selectedOrgIdState);
+  const orgGroups = useAtomValue(orgGroupsResolvedState);
+  const [activeOrgGroupId, setActiveOrgGroup] = useAtom(ActiveOrgGroupState);
 
   useEffect(() => {
     try {
@@ -18,6 +20,24 @@ export const OrgPersistence: FunctionComponent = () => {
       logger.error('Error persisting selected org ID', { error: ex, selectedOrgId });
     }
   }, [selectedOrgId]);
+
+  /**
+   * Recover from a stale org group selection (e.g. the group was deleted in another browser/session).
+   * A persisted group ID that no longer exists filters out every org, leaving the header with no orgs
+   * and no group visibly selected. Once groups have actually loaded, reset the selection to the default
+   * (no group) which also clears the stored value.
+   */
+  useEffect(() => {
+    // `orgGroups` is undefined until the fetch resolves - skip until then so we don't reset during loading
+    if (!orgGroups || !activeOrgGroupId) {
+      return;
+    }
+    const selectedGroupStillExists = orgGroups.some((group) => group.id === activeOrgGroupId);
+    if (!selectedGroupStillExists) {
+      logger.warn('Resetting invalid selected org group', { activeOrgGroupId });
+      setActiveOrgGroup(null);
+    }
+  }, [orgGroups, activeOrgGroupId, setActiveOrgGroup]);
 
   return null;
 };


### PR DESCRIPTION
Implement loadable state handling to resolve mismatches in organization group states. This change ensures that the application correctly handles the loading state and updates the selected organization group when the data is fetched. The adjustments prevent stale selections when groups are deleted in other sessions.