### PR TITLE
feat: add back/forward/submit keyboard shortcuts

### DIFF
--- a/libs/features/anon-apex/src/AnonymousApex.tsx
+++ b/libs/features/anon-apex/src/AnonymousApex.tsx
@@ -11,6 +11,7 @@ import {
   useDebounce,
   useDisposables,
   useNonInitialEffect,
+  usePrimaryActionShortcut,
   useTitle,
 } from '@jetstream/shared/ui-utils';
 import { getErrorMessage } from '@jetstream/shared/utils';
@@ -187,6 +188,12 @@ export const AnonymousApex: FunctionComponent<AnonymousApexProps> = () => {
 
   const onSubmitRef = useRef(onSubmit);
   onSubmitRef.current = onSubmit;
+
+  // Cmd/Ctrl+Enter submits even when the editor is not focused; when it is focused Monaco handles it (see below).
+  const handleSubmitApex = useCallback(() => {
+    onSubmitRef.current(apexRef.current?.getValue() ?? '');
+  }, []);
+  usePrimaryActionShortcut(handleSubmitApex, { disabled: loading });
 
   const handleApexEditorMount: OnMount = (currEditor, monaco) => {
     apexRef.current = currEditor;

--- a/libs/features/automation-control/src/AutomationControlEditor.tsx
+++ b/libs/features/automation-control/src/AutomationControlEditor.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react';
 import { ANALYTICS_KEYS, TITLES } from '@jetstream/shared/constants';
-import { formatNumber, useTitle } from '@jetstream/shared/ui-utils';
+import { formatNumber, useGoBackShortcut, usePrimaryActionShortcut, useTitle } from '@jetstream/shared/ui-utils';
 import { pluralizeFromNumber } from '@jetstream/shared/utils';
 import { FileExtAllTypes, ListMetadataResult, Maybe, MimeType, RetrievePackageFromListMetadataJob } from '@jetstream/types';
 import {
@@ -11,6 +11,7 @@ import {
   FileFauxDownloadModal,
   Grid,
   Icon,
+  KeyboardShortcut,
   SearchInput,
   Spinner,
   Toast,
@@ -18,13 +19,14 @@ import {
   ToolbarItemActions,
   ToolbarItemGroup,
   Tooltip,
+  getModifierKey,
 } from '@jetstream/ui';
 import { RequireMetadataApiBanner, fromAutomationControlState, fromJetstreamEvents, useAmplitude } from '@jetstream/ui-core';
 import { applicationCookieState, googleDriveAccessState, selectSkipFrontdoorAuth, selectedOrgState } from '@jetstream/ui/app-state';
 import classNames from 'classnames';
 import { useAtomValue } from 'jotai';
 import { useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import AutomationControlEditorReviewModal from './AutomationControlEditorReviewModal';
 import AutomationControlEditorTable from './AutomationControlEditorTable';
 import AutomationControlLastRefreshedPopover from './AutomationControlLastRefreshedPopover';
@@ -46,6 +48,7 @@ const HEIGHT_BUFFER = 170;
 export const AutomationControlEditor = () => {
   useTitle(TITLES.AUTOMATION_CONTROL);
   const { trackEvent } = useAmplitude();
+  const navigate = useNavigate();
 
   const selectedOrg = useAtomValue(selectedOrgState);
   const { serverUrl, defaultApiVersion, google_apiKey, google_appId, google_clientId } = useAtomValue(applicationCookieState);
@@ -101,6 +104,9 @@ export const AutomationControlEditor = () => {
     setSaveModalOpen(true);
     trackEvent(ANALYTICS_KEYS.automation_review, { rows: _dirtyRows.length, objects: selectedSObjects.length });
   }
+
+  usePrimaryActionShortcut(handleReviewChanges, { disabled: loading || !dirtyCount });
+  useGoBackShortcut(() => navigate('..'), {});
 
   function handleDeployModalClose(refreshData?: boolean) {
     if (refreshData) {
@@ -272,15 +278,24 @@ export const AutomationControlEditor = () => {
       <RequireMetadataApiBanner />
       <Toolbar>
         <ToolbarItemGroup>
-          <Link
-            className="slds-button slds-button_brand"
-            title="Go back"
-            to=".."
-            // onClick={handleGoBack}
+          <Tooltip
+            openDelay={300}
+            content={
+              <div className="slds-p-bottom_small">
+                <KeyboardShortcut inverse keys={[getModifierKey(), 'shift', 'enter']} />
+              </div>
+            }
           >
-            <Icon type="utility" icon="back" className="slds-button__icon slds-button__icon_left" omitContainer />
-            <span>Go Back</span>
-          </Link>
+            <Link
+              className="slds-button slds-button_brand"
+              title="Go back"
+              to=".."
+              // onClick={handleGoBack}
+            >
+              <Icon type="utility" icon="back" className="slds-button__icon slds-button__icon_left" omitContainer />
+              <span>Go Back</span>
+            </Link>
+          </Tooltip>
           {/* Select all does not work well for flows/process builders since there is a version that needs to be selected */}
           {/* <button className="slds-button slds-button_neutral slds-m-left_small" onClick={handleSelectAll}>
             <Icon type="utility" icon="refresh" className="slds-button__icon slds-button__icon_left" />
@@ -323,10 +338,19 @@ export const AutomationControlEditor = () => {
               <span>Export as Spreadsheet</span>
             </button>
           </ButtonGroupContainer>
-          <button className="slds-button slds-button_brand" disabled={loading || !dirtyCount} onClick={handleReviewChanges}>
-            <Icon type="utility" icon="upload" className="slds-button__icon slds-button__icon_left" />
-            Review Changes
-          </button>
+          <Tooltip
+            openDelay={300}
+            content={
+              <div className="slds-p-bottom_small">
+                <KeyboardShortcut inverse keys={[getModifierKey(), 'enter']} />
+              </div>
+            }
+          >
+            <button className="slds-button slds-button_brand" disabled={loading || !dirtyCount} onClick={handleReviewChanges}>
+              <Icon type="utility" icon="upload" className="slds-button__icon slds-button__icon_left" />
+              Review Changes
+            </button>
+          </Tooltip>
         </ToolbarItemActions>
       </Toolbar>
       <div>

--- a/libs/features/automation-control/src/AutomationControlSelection.tsx
+++ b/libs/features/automation-control/src/AutomationControlSelection.tsx
@@ -1,25 +1,28 @@
 import { css } from '@emotion/react';
 import { TITLES } from '@jetstream/shared/constants';
 import { APP_ROUTES } from '@jetstream/shared/ui-router';
-import { useTitle } from '@jetstream/shared/ui-utils';
+import { usePrimaryActionShortcut, useTitle } from '@jetstream/shared/ui-utils';
 import { SplitWrapper as Split } from '@jetstream/splitjs';
 import { DescribeGlobalSObjectResult, ListItem } from '@jetstream/types';
 import {
   AutoFullHeightContainer,
   ConnectedSobjectListMultiSelect,
   Icon,
+  KeyboardShortcut,
   ListWithFilterMultiSelect,
   Page,
   PageHeader,
   PageHeaderActions,
   PageHeaderRow,
   PageHeaderTitle,
+  Tooltip,
+  getModifierKey,
 } from '@jetstream/ui';
 import { RequireMetadataApiBanner, fromAutomationControlState } from '@jetstream/ui-core';
 import { selectedOrgState } from '@jetstream/ui/app-state';
 import { recentHistoryItemsDb } from '@jetstream/ui/db';
 import { useAtom, useAtomValue } from 'jotai';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { AutomationMetadataType } from './automation-control-types';
 
 const HEIGHT_BUFFER = 170;
@@ -42,6 +45,7 @@ export function filterPermissionsSobjects(sobject: DescribeGlobalSObjectResult |
 export const AutomationControlSelection = () => {
   useTitle(TITLES.AUTOMATION_CONTROL);
 
+  const navigate = useNavigate();
   const selectedOrg = useAtomValue(selectedOrgState);
 
   const hasSelectionsMade = useAtomValue(fromAutomationControlState.hasSelectionsMade);
@@ -65,6 +69,14 @@ export const AutomationControlSelection = () => {
     );
   }
 
+  usePrimaryActionShortcut(
+    () => {
+      handleContinue();
+      navigate('editor');
+    },
+    { disabled: !hasSelectionsMade },
+  );
+
   return (
     <Page testId="automation-control--selection-page">
       <RequireMetadataApiBanner />
@@ -77,10 +89,19 @@ export const AutomationControlSelection = () => {
           />
           <PageHeaderActions colType="actions" buttonType="separate">
             {hasSelectionsMade && (
-              <Link className="slds-button slds-button_brand" to="editor" onClick={handleContinue}>
-                Continue
-                <Icon type="utility" icon="forward" className="slds-button__icon slds-button__icon_right" />
-              </Link>
+              <Tooltip
+                openDelay={300}
+                content={
+                  <div className="slds-p-bottom_small">
+                    <KeyboardShortcut inverse keys={[getModifierKey(), 'enter']} />
+                  </div>
+                }
+              >
+                <Link className="slds-button slds-button_brand" to="editor" onClick={handleContinue}>
+                  Continue
+                  <Icon type="utility" icon="forward" className="slds-button__icon slds-button__icon_right" />
+                </Link>
+              </Tooltip>
             )}
             {!hasSelectionsMade && (
               <button className="slds-button slds-button_brand" disabled>

--- a/libs/features/create-object-and-fields/src/CreateFields.tsx
+++ b/libs/features/create-object-and-fields/src/CreateFields.tsx
@@ -1,5 +1,5 @@
 import { ANALYTICS_KEYS } from '@jetstream/shared/constants';
-import { formatNumber } from '@jetstream/shared/ui-utils';
+import { formatNumber, useGoBackShortcut, usePrimaryActionShortcut } from '@jetstream/shared/ui-utils';
 import { groupByFlat, pluralizeIfMultiple } from '@jetstream/shared/utils';
 import { ListItem } from '@jetstream/types';
 import {
@@ -9,17 +9,19 @@ import {
   ConfirmationModalPromise,
   Grid,
   Icon,
+  KeyboardShortcut,
   Toolbar,
   ToolbarItemActions,
   ToolbarItemGroup,
   Tooltip,
+  getModifierKey,
 } from '@jetstream/ui';
 import { RequireMetadataApiBanner, useAmplitude } from '@jetstream/ui-core';
 import { selectedOrgState } from '@jetstream/ui/app-state';
 import { useAtomValue } from 'jotai';
 import { useResetAtom } from 'jotai/utils';
 import { FunctionComponent, useCallback, useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import CreateFieldsDeployModal from './CreateFieldsDeployModal';
 import CreateFieldsImportExport from './CreateFieldsImportExport';
 import CreateFieldsRow from './CreateFieldsRow';
@@ -73,6 +75,7 @@ function SelectedItemsBadge({
 export interface CreateFieldsProps {}
 
 export const CreateFields: FunctionComponent<CreateFieldsProps> = () => {
+  const navigate = useNavigate();
   const { trackEvent } = useAmplitude();
   const selectedOrg = useAtomValue(selectedOrgState);
 
@@ -153,6 +156,9 @@ export const CreateFields: FunctionComponent<CreateFieldsProps> = () => {
     setDeployModalOpen(false);
   }
 
+  usePrimaryActionShortcut(handleSubmit, { disabled: !allValid });
+  useGoBackShortcut(() => navigate('..'), {});
+
   return (
     <div>
       {deployModalOpen && (
@@ -177,14 +183,23 @@ export const CreateFields: FunctionComponent<CreateFieldsProps> = () => {
       <RequireMetadataApiBanner />
       <Toolbar>
         <ToolbarItemGroup>
-          <Link
-            className="slds-button slds-button_brand slds-m-right_x-small"
-            to=".."
-            title="Going back will keep all of your fields configured as-is, but you can change your selected objects, profiles, and permission sets."
+          <Tooltip
+            openDelay={300}
+            content={
+              <div className="slds-p-bottom_small">
+                <KeyboardShortcut inverse keys={[getModifierKey(), 'shift', 'enter']} />
+              </div>
+            }
           >
-            <Icon type="utility" icon="back" className="slds-button__icon slds-button__icon_left" omitContainer />
-            Go Back
-          </Link>
+            <Link
+              className="slds-button slds-button_brand slds-m-right_x-small"
+              to=".."
+              title="Going back will keep all of your fields configured as-is, but you can change your selected objects, profiles, and permission sets."
+            >
+              <Icon type="utility" icon="back" className="slds-button__icon slds-button__icon_left" omitContainer />
+              Go Back
+            </Link>
+          </Tooltip>
           <button
             className="slds-button slds-button_neutral slds-m-right_x-small collapsible-button collapsible-button-lg"
             onClick={() => handleStartOver()}
@@ -209,7 +224,18 @@ export const CreateFields: FunctionComponent<CreateFieldsProps> = () => {
             <Icon type="utility" icon="refresh" className="slds-button__icon slds-button__icon_left" omitContainer />
             <span>Reset Fields</span>
           </button>
-          <Tooltip content={allValid ? '' : 'All fields must be fully configured'}>
+          <Tooltip
+            openDelay={300}
+            content={
+              allValid ? (
+                <div className="slds-p-bottom_small">
+                  <KeyboardShortcut inverse keys={[getModifierKey(), 'enter']} />
+                </div>
+              ) : (
+                'All fields must be fully configured'
+              )
+            }
+          >
             <button className="slds-button slds-button_brand" onClick={() => handleSubmit()} disabled={!allValid}>
               <Icon type="utility" icon="upload" className="slds-button__icon slds-button__icon_left" omitContainer />
               Upsert Fields

--- a/libs/features/create-object-and-fields/src/CreateFieldsSelection.tsx
+++ b/libs/features/create-object-and-fields/src/CreateFieldsSelection.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react';
 import { APP_ROUTES } from '@jetstream/shared/ui-router';
-import { useNonInitialEffect, useProfilesAndPermSets } from '@jetstream/shared/ui-utils';
+import { useNonInitialEffect, usePrimaryActionShortcut, useProfilesAndPermSets } from '@jetstream/shared/ui-utils';
 import { SplitWrapper as Split } from '@jetstream/splitjs';
 import { DescribeGlobalSObjectResult, ListItem, PermissionSetNoProfileRecord, PermissionSetWithProfileRecord } from '@jetstream/types';
 import {
@@ -8,6 +8,7 @@ import {
   ConnectedSobjectListMultiSelect,
   ConnectedSobjectListMultiSelectRef,
   Icon,
+  KeyboardShortcut,
   ListWithFilterMultiSelect,
   Page,
   PageHeader,
@@ -16,13 +17,15 @@ import {
   PageHeaderTitle,
   ProfileOrPermSetPopover,
   ProfileOrPermSetRecordType,
+  Tooltip,
+  getModifierKey,
 } from '@jetstream/ui';
 import { RequireMetadataApiBanner, filterCreateFieldsSobjects } from '@jetstream/ui-core';
 import { applicationCookieState, selectSkipFrontdoorAuth, selectedOrgState } from '@jetstream/ui/app-state';
 import { recentHistoryItemsDb } from '@jetstream/ui/db';
 import { useAtom, useAtomValue } from 'jotai';
 import { FunctionComponent, useEffect, useRef } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import * as fromCreateFieldsState from './create-fields.state';
 import CreateNewObject from './create-new-object/CreateNewObject';
 
@@ -31,6 +34,7 @@ const HEIGHT_BUFFER = 170;
 export interface CreateFieldsSelectionProps {}
 
 export const CreateFieldsSelection: FunctionComponent<CreateFieldsSelectionProps> = () => {
+  const navigate = useNavigate();
   const sobjectListRef = useRef<ConnectedSobjectListMultiSelectRef>(null);
   const selectedOrg = useAtomValue(selectedOrgState);
   const { serverUrl } = useAtomValue(applicationCookieState);
@@ -89,6 +93,14 @@ export const CreateFieldsSelection: FunctionComponent<CreateFieldsSelectionProps
     );
   }
 
+  usePrimaryActionShortcut(
+    () => {
+      handleContinue();
+      navigate('configurator');
+    },
+    { disabled: !hasSelectionsMade },
+  );
+
   return (
     <Page testId="create-field-selection-page">
       <RequireMetadataApiBanner />
@@ -105,10 +117,19 @@ export const CreateFieldsSelection: FunctionComponent<CreateFieldsSelectionProps
               }}
             />
             {hasSelectionsMade && (
-              <Link className="slds-button slds-button_brand" to="configurator" onClick={handleContinue}>
-                Continue
-                <Icon type="utility" icon="forward" className="slds-button__icon slds-button__icon_right" />
-              </Link>
+              <Tooltip
+                openDelay={300}
+                content={
+                  <div className="slds-p-bottom_small">
+                    <KeyboardShortcut inverse keys={[getModifierKey(), 'enter']} />
+                  </div>
+                }
+              >
+                <Link className="slds-button slds-button_brand" to="configurator" onClick={handleContinue}>
+                  Continue
+                  <Icon type="utility" icon="forward" className="slds-button__icon slds-button__icon_right" />
+                </Link>
+              </Tooltip>
             )}
             {!hasSelectionsMade && (
               <button className="slds-button slds-button_brand" disabled>

--- a/libs/features/deploy/src/DeployMetadataDeployment.tsx
+++ b/libs/features/deploy/src/DeployMetadataDeployment.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/react';
 import { ListMetadataResultItem, useListMetadata } from '@jetstream/connected-ui';
 import { ANALYTICS_KEYS } from '@jetstream/shared/constants';
-import { copyRecordsToClipboard, formatNumber, isBrowserExtension, isCanvasApp } from '@jetstream/shared/ui-utils';
+import { copyRecordsToClipboard, formatNumber, isBrowserExtension, isCanvasApp, useGoBackShortcut } from '@jetstream/shared/ui-utils';
 import { pluralizeIfMultiple } from '@jetstream/shared/utils';
 import { DeployMetadataTableRow, ListMetadataResult, SidePanelType } from '@jetstream/types';
 import {
@@ -9,13 +9,16 @@ import {
   ButtonGroupContainer,
   DropDown,
   FileDownloadModal,
+  getModifierKey,
   Grid,
   Icon,
+  KeyboardShortcut,
   Spinner,
   Toast,
   Toolbar,
   ToolbarItemActions,
   ToolbarItemGroup,
+  Tooltip,
 } from '@jetstream/ui';
 import { fromDeployMetadataState, fromJetstreamEvents, useAmplitude } from '@jetstream/ui-core';
 import { applicationCookieState, googleDriveAccessState, selectedOrgState } from '@jetstream/ui/app-state';
@@ -26,7 +29,7 @@ import { isBefore } from 'date-fns/isBefore';
 import { startOfDay } from 'date-fns/startOfDay';
 import { useAtomValue } from 'jotai';
 import { FunctionComponent, useCallback, useEffect, useMemo, useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import DeployMetadataDeploymentSidePanel from './DeployMetadataDeploymentSidePanel';
 import DeployMetadataDeploymentTable from './DeployMetadataDeploymentTable';
 import DeployMetadataLastRefreshedPopover from './DeployMetadataLastRefreshedPopover';
@@ -51,6 +54,7 @@ export interface DeployMetadataDeploymentProps {}
 
 export const DeployMetadataDeployment: FunctionComponent<DeployMetadataDeploymentProps> = () => {
   const { trackEvent } = useAmplitude();
+  const navigate = useNavigate();
   const { google_apiKey, google_appId, google_clientId } = useAtomValue(applicationCookieState);
   const { hasGoogleDriveAccess, googleShowUpgradeToPro } = useAtomValue(googleDriveAccessState);
   const selectedOrg = useAtomValue(selectedOrgState);
@@ -240,6 +244,8 @@ export const DeployMetadataDeployment: FunctionComponent<DeployMetadataDeploymen
 
   const selectedMetadata = useMemo(() => convertRowsToMapOfListMetadataResults(Array.from(selectedRows)), [selectedRows]);
 
+  useGoBackShortcut(() => navigate('..'), {});
+
   return (
     <div>
       {activeDownloadType && (
@@ -289,10 +295,19 @@ export const DeployMetadataDeployment: FunctionComponent<DeployMetadataDeploymen
 
       <Toolbar>
         <ToolbarItemGroup>
-          <Link className="slds-button slds-button_brand" to="..">
-            <Icon type="utility" icon="back" className="slds-button__icon slds-button__icon_left" omitContainer />
-            Go Back
-          </Link>
+          <Tooltip
+            openDelay={300}
+            content={
+              <div className="slds-p-bottom_small">
+                <KeyboardShortcut inverse keys={[getModifierKey(), 'shift', 'enter']} />
+              </div>
+            }
+          >
+            <Link className="slds-button slds-button_brand" to="..">
+              <Icon type="utility" icon="back" className="slds-button__icon slds-button__icon_left" omitContainer />
+              Go Back
+            </Link>
+          </Tooltip>
         </ToolbarItemGroup>
         <ToolbarItemActions>
           <DeployMetadataHistoryModal className="collapsible-button collapsible-button-xxl" />

--- a/libs/features/deploy/src/DeployMetadataSelection.tsx
+++ b/libs/features/deploy/src/DeployMetadataSelection.tsx
@@ -1,21 +1,25 @@
 import { css } from '@emotion/react';
 import { ANALYTICS_KEYS } from '@jetstream/shared/constants';
+import { usePrimaryActionShortcut } from '@jetstream/shared/ui-utils';
 import { SplitWrapper as Split } from '@jetstream/splitjs';
 import {
   AutoFullHeightContainer,
   ButtonGroupContainer,
+  getModifierKey,
   Icon,
+  KeyboardShortcut,
   Page,
   PageHeader,
   PageHeaderActions,
   PageHeaderRow,
   PageHeaderTitle,
+  Tooltip,
 } from '@jetstream/ui';
 import { fromDeployMetadataState, RequireMetadataApiBanner, useAmplitude } from '@jetstream/ui-core';
 import { selectedOrgState } from '@jetstream/ui/app-state';
 import { useAtomValue } from 'jotai';
 import { FunctionComponent } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import './DeployMetadataSelection.css';
 import DeployMetadataHistoryModal from './deploy-metadata-history/DeployMetadataHistoryModal';
 import DeployMetadataPackage from './deploy-metadata-package/DeployMetadataPackage';
@@ -31,6 +35,7 @@ export interface DeployMetadataSelectionProps {}
 
 export const DeployMetadataSelection: FunctionComponent<DeployMetadataSelectionProps> = () => {
   const { trackEvent } = useAmplitude();
+  const navigate = useNavigate();
   const selectedOrg = useAtomValue(selectedOrgState);
   const amplitudeSubmissionSelector = useAtomValue(fromDeployMetadataState.amplitudeSubmissionSelector);
   const metadataItems = useAtomValue(fromDeployMetadataState.metadataItemsState);
@@ -40,6 +45,14 @@ export const DeployMetadataSelection: FunctionComponent<DeployMetadataSelectionP
   function trackContinue() {
     trackEvent(ANALYTICS_KEYS.deploy_configuration, { page: 'initial-selection', ...amplitudeSubmissionSelector });
   }
+
+  usePrimaryActionShortcut(
+    () => {
+      trackContinue();
+      navigate('deploy');
+    },
+    { disabled: !hasSelectionsMade },
+  );
 
   return (
     <Page testId="deploy-metadata-selection-page">
@@ -58,10 +71,19 @@ export const DeployMetadataSelection: FunctionComponent<DeployMetadataSelectionP
               <DeployMetadataPackage className="collapsible-button collapsible-button-sm" selectedOrg={selectedOrg} />
             </ButtonGroupContainer>
             {hasSelectionsMade && (
-              <Link onClick={trackContinue} className="slds-button slds-button_brand" to="deploy">
-                Continue
-                <Icon type="utility" icon="forward" className="slds-button__icon slds-button__icon_right" />
-              </Link>
+              <Tooltip
+                openDelay={300}
+                content={
+                  <div className="slds-p-bottom_small">
+                    <KeyboardShortcut inverse keys={[getModifierKey(), 'enter']} />
+                  </div>
+                }
+              >
+                <Link onClick={trackContinue} className="slds-button slds-button_brand" to="deploy">
+                  Continue
+                  <Icon type="utility" icon="forward" className="slds-button__icon slds-button__icon_right" />
+                </Link>
+              </Tooltip>
             )}
             {!hasSelectionsMade && (
               <button className="slds-button slds-button_brand" disabled>

--- a/libs/features/formula-evaluator/src/FormulaEvaluator.tsx
+++ b/libs/features/formula-evaluator/src/FormulaEvaluator.tsx
@@ -2,14 +2,7 @@ import { css } from '@emotion/react';
 import { logger } from '@jetstream/shared/client-logger';
 import { ANALYTICS_KEYS, SFDC_BLANK_PICKLIST_VALUE, TITLES } from '@jetstream/shared/constants';
 import { clearCacheForOrg } from '@jetstream/shared/data';
-import {
-  hasModifierKey,
-  isEnterKey,
-  sanitizePastedEditorText,
-  useDisposables,
-  useGlobalEventHandler,
-  useTitle,
-} from '@jetstream/shared/ui-utils';
+import { sanitizePastedEditorText, useDisposables, usePrimaryActionShortcut, useTitle } from '@jetstream/shared/ui-utils';
 import { getErrorMessage, getErrorMessageAndStackObj } from '@jetstream/shared/utils';
 import { SplitWrapper as Split } from '@jetstream/splitjs';
 import { DescribeGlobalSObjectResult, Field } from '@jetstream/types';
@@ -31,7 +24,9 @@ import {
   SobjectFieldCombobox,
   SobjectFieldComboboxRef,
   Spinner,
+  Tooltip,
   ViewDocsLink,
+  getModifierKey,
 } from '@jetstream/ui';
 import {
   FormulaEvaluatorRecordSearch,
@@ -140,6 +135,8 @@ export const FormulaEvaluator: FunctionComponent<FormulaEvaluatorProps> = () => 
     [setSelectedField, setReturnType],
   );
 
+  const sobjectName = selectedSObject?.name || '';
+
   const handleTestFormula = useCallback(
     async (value: string) => {
       try {
@@ -170,7 +167,7 @@ export const FormulaEvaluator: FunctionComponent<FormulaEvaluatorProps> = () => 
             recordId,
             selectedOrg,
             selectedUserId,
-            sobjectName: selectedSObject?.name || '',
+            sobjectName,
           });
           if (response.type === 'error') {
             setFieldErrorMessage(response.message);
@@ -200,22 +197,14 @@ export const FormulaEvaluator: FunctionComponent<FormulaEvaluatorProps> = () => 
         setLoading(false);
       }
     },
-    [testFormulaDisabled, numberNullBehavior, returnType, trackEvent, recordId, selectedOrg, selectedUserId, selectedSObject?.name],
+    [testFormulaDisabled, numberNullBehavior, returnType, trackEvent, recordId, selectedOrg, selectedUserId, sobjectName],
   );
 
-  const onKeydown = useCallback(
-    (event: KeyboardEvent) => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      if (!testFormulaDisabled && hasModifierKey(event as any) && isEnterKey(event as any)) {
-        event.stopPropagation();
-        event.preventDefault();
-        handleTestFormula(formulaValue);
-      }
-    },
-    [formulaValue, handleTestFormula, testFormulaDisabled],
-  );
+  const handleTestFormulaShortcut = useCallback(() => {
+    handleTestFormula(formulaValue);
+  }, [formulaValue, handleTestFormula]);
 
-  useGlobalEventHandler('keydown', onKeydown);
+  usePrimaryActionShortcut(handleTestFormulaShortcut, { disabled: testFormulaDisabled });
 
   const handleFormat = async (value = formulaValue) => {
     try {
@@ -243,9 +232,11 @@ export const FormulaEvaluator: FunctionComponent<FormulaEvaluatorProps> = () => 
   };
 
   const handleTestFormulaRef = useRef(handleTestFormula);
+  // eslint-disable-next-line react-hooks/refs
   handleTestFormulaRef.current = handleTestFormula;
 
   const handleFormatRef = useRef(handleFormat);
+  // eslint-disable-next-line react-hooks/refs
   handleFormatRef.current = handleFormat;
 
   function handleEditorChange(value?: string) {
@@ -468,13 +459,22 @@ export const FormulaEvaluator: FunctionComponent<FormulaEvaluatorProps> = () => 
                   >
                     Deploy
                   </button>
-                  <button
-                    className="slds-button slds-button_brand"
-                    disabled={testFormulaDisabled}
-                    onClick={() => handleTestFormula(formulaValue)}
+                  <Tooltip
+                    openDelay={300}
+                    content={
+                      <div className="slds-p-bottom_small">
+                        <KeyboardShortcut inverse keys={[getModifierKey(), 'enter']} />
+                      </div>
+                    }
                   >
-                    Test
-                  </button>
+                    <button
+                      className="slds-button slds-button_brand slds-button_last"
+                      disabled={testFormulaDisabled}
+                      onClick={() => handleTestFormula(formulaValue)}
+                    >
+                      Test
+                    </button>
+                  </Tooltip>
                 </ButtonGroupContainer>
               }
             >

--- a/libs/features/load-records/src/LoadRecords.tsx
+++ b/libs/features/load-records/src/LoadRecords.tsx
@@ -3,20 +3,23 @@ import { logger } from '@jetstream/shared/client-logger';
 import { ANALYTICS_KEYS, TITLES } from '@jetstream/shared/constants';
 import { clearCacheForOrg } from '@jetstream/shared/data';
 import { APP_ROUTES } from '@jetstream/shared/ui-router';
-import { formatNumber, useTitle } from '@jetstream/shared/ui-utils';
+import { formatNumber, useGoBackShortcut, usePrimaryActionShortcut, useTitle } from '@jetstream/shared/ui-utils';
 import { FieldWithRelatedEntities, LocalOrGoogle, Maybe, Step } from '@jetstream/types';
 import {
   AutoFullHeightContainer,
   fireToast,
+  getModifierKey,
   Grid,
   GridCol,
   Icon,
+  KeyboardShortcut,
   Page,
   PageHeader,
   PageHeaderActions,
   PageHeaderRow,
   PageHeaderTitle,
   Spinner,
+  Tooltip,
 } from '@jetstream/ui';
 import {
   autoMapFields,
@@ -417,6 +420,11 @@ export const LoadRecords = () => {
     }
   }
 
+  // Cmd/Ctrl+Enter advances to the next step; mirrors the next-step button's disabled condition
+  usePrimaryActionShortcut(() => changeStep(1), { disabled: nextStepDisabled || loading });
+  // Cmd/Ctrl+Shift+Enter goes back one step; mirrors the go-back button's disabled condition
+  useGoBackShortcut(handleGoBackToPrev, { disabled: currentStep.idx === 0 || loading });
+
   const handleIsLoading = useCallback((isLoading: boolean) => {
     setLoading(isLoading);
     setDidPerformDataLoad(true);
@@ -464,25 +472,43 @@ export const LoadRecords = () => {
               <Icon type="utility" icon="refresh" className="slds-button__icon slds-button__icon_left" />
               <span>Start Over</span>
             </button>
-            <button
-              data-testid="prev-step-button"
-              className="slds-button slds-button_neutral"
-              disabled={currentStep.idx === 0 || loading}
-              onClick={() => handleGoBackToPrev()}
+            <Tooltip
+              openDelay={300}
+              content={
+                <div className="slds-p-bottom_small">
+                  <KeyboardShortcut inverse keys={[getModifierKey(), 'shift', 'enter']} />
+                </div>
+              }
             >
-              <Icon type="utility" icon="back" className="slds-button__icon slds-button__icon_left" />
-              Go Back To Previous Step
-            </button>
-            <button
-              data-testid="next-step-button"
-              className="slds-button slds-button_brand slds-is-relative"
-              disabled={nextStepDisabled || loading}
-              onClick={() => changeStep(1)}
+              <button
+                data-testid="prev-step-button"
+                className="slds-button slds-button_neutral"
+                disabled={currentStep.idx === 0 || loading}
+                onClick={() => handleGoBackToPrev()}
+              >
+                <Icon type="utility" icon="back" className="slds-button__icon slds-button__icon_left" />
+                Go Back To Previous Step
+              </button>
+            </Tooltip>
+            <Tooltip
+              openDelay={300}
+              content={
+                <div className="slds-p-bottom_small">
+                  <KeyboardShortcut inverse keys={[getModifierKey(), 'enter']} />
+                </div>
+              }
             >
-              {currentStepText}
-              <Icon type="utility" icon="forward" className="slds-button__icon slds-button__icon_right" />
-              {loadingFields && <Spinner size="small" />}
-            </button>
+              <button
+                data-testid="next-step-button"
+                className="slds-button slds-button_brand slds-is-relative"
+                disabled={nextStepDisabled || loading}
+                onClick={() => changeStep(1)}
+              >
+                {currentStepText}
+                <Icon type="utility" icon="forward" className="slds-button__icon slds-button__icon_right" />
+                {loadingFields && <Spinner size="small" />}
+              </button>
+            </Tooltip>
           </PageHeaderActions>
         </PageHeaderRow>
         <PageHeaderRow>

--- a/libs/features/manage-permissions/src/ManagePermissionsEditor.tsx
+++ b/libs/features/manage-permissions/src/ManagePermissionsEditor.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/react';
 import { logger } from '@jetstream/shared/client-logger';
 import { ANALYTICS_KEYS, MIME_TYPES } from '@jetstream/shared/constants';
-import { saveFile, tracker } from '@jetstream/shared/ui-utils';
+import { saveFile, tracker, useGoBackShortcut, usePrimaryActionShortcut } from '@jetstream/shared/ui-utils';
 import { getErrorMessage, groupByFlat, multiWordObjectFilter } from '@jetstream/shared/utils';
 import {
   AsyncJobNew,
@@ -33,6 +33,7 @@ import {
   FileFauxDownloadModal,
   FileFauxDownloadModalProps,
   Icon,
+  KeyboardShortcut,
   ScopedNotification,
   Spinner,
   Tabs,
@@ -42,13 +43,14 @@ import {
   ToolbarItemGroup,
   Tooltip,
   fireToast,
+  getModifierKey,
 } from '@jetstream/ui';
 import { ConfirmPageChange, RequireMetadataApiBanner, fromJetstreamEvents, fromPermissionsState, useAmplitude } from '@jetstream/ui-core';
 import { applicationCookieState, googleDriveAccessState, selectedOrgState } from '@jetstream/ui/app-state';
 import { useAtom, useAtomValue } from 'jotai';
 import { useResetAtom } from 'jotai/utils';
 import { Fragment, FunctionComponent, useCallback, useEffect, useRef, useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import ManagePermissionsEditorFieldTable from './ManagePermissionsEditorFieldTable';
 import ManagePermissionsEditorObjectTable from './ManagePermissionsEditorObjectTable';
 import ManagePermissionsEditorTabVisibilityTable from './ManagePermissionsEditorTabVisibilityTable';
@@ -106,6 +108,7 @@ export function ErrorTooltip({ hasError, id }: { hasError: boolean; id: string }
 export interface ManagePermissionsEditorProps {}
 
 export const ManagePermissionsEditor: FunctionComponent<ManagePermissionsEditorProps> = () => {
+  const navigate = useNavigate();
   const { trackEvent } = useAmplitude();
   const isMounted = useRef(true);
   const { google_apiKey, google_appId, google_clientId } = useAtomValue(applicationCookieState);
@@ -607,6 +610,15 @@ export const ManagePermissionsEditor: FunctionComponent<ManagePermissionsEditorP
     resetTabVisibilityPermissionMap();
   }
 
+  usePrimaryActionShortcut(saveChanges, {
+    disabled: loading || (!dirtyObjectCount && !dirtyFieldCount && !dirtyTabVisibilityCount),
+  });
+
+  useGoBackShortcut(() => {
+    handleGoBack();
+    navigate('..');
+  }, {});
+
   return (
     <div>
       <ConfirmPageChange actionInProgress={loading} />
@@ -630,10 +642,19 @@ export const ManagePermissionsEditor: FunctionComponent<ManagePermissionsEditorP
       <RequireMetadataApiBanner />
       <Toolbar>
         <ToolbarItemGroup>
-          <Link className="slds-button slds-button_brand" to=".." onClick={handleGoBack}>
-            <Icon type="utility" icon="back" className="slds-button__icon slds-button__icon_left" omitContainer />
-            Go Back
-          </Link>
+          <Tooltip
+            openDelay={300}
+            content={
+              <div className="slds-p-bottom_small">
+                <KeyboardShortcut inverse keys={[getModifierKey(), 'shift', 'enter']} />
+              </div>
+            }
+          >
+            <Link className="slds-button slds-button_brand" to=".." onClick={handleGoBack}>
+              <Icon type="utility" icon="back" className="slds-button__icon slds-button__icon_left" omitContainer />
+              Go Back
+            </Link>
+          </Tooltip>
         </ToolbarItemGroup>
         <ToolbarItemActions>
           <button
@@ -669,14 +690,23 @@ export const ManagePermissionsEditor: FunctionComponent<ManagePermissionsEditorP
             <Icon type="utility" icon="download" className="slds-button__icon slds-button__icon_left" />
             <span>Export</span>
           </button>
-          <button
-            className="slds-button slds-button_brand"
-            onClick={saveChanges}
-            disabled={loading || (!dirtyObjectCount && !dirtyFieldCount && !dirtyTabVisibilityCount)}
+          <Tooltip
+            openDelay={300}
+            content={
+              <div className="slds-p-bottom_small">
+                <KeyboardShortcut inverse keys={[getModifierKey(), 'enter']} />
+              </div>
+            }
           >
-            <Icon type="utility" icon="upload" className="slds-button__icon slds-button__icon_left" />
-            Save
-          </button>
+            <button
+              className="slds-button slds-button_brand"
+              onClick={saveChanges}
+              disabled={loading || (!dirtyObjectCount && !dirtyFieldCount && !dirtyTabVisibilityCount)}
+            >
+              <Icon type="utility" icon="upload" className="slds-button__icon slds-button__icon_left" />
+              Save
+            </button>
+          </Tooltip>
         </ToolbarItemActions>
       </Toolbar>
       <AutoFullHeightContainer

--- a/libs/features/manage-permissions/src/ManagePermissionsSelection.tsx
+++ b/libs/features/manage-permissions/src/ManagePermissionsSelection.tsx
@@ -1,12 +1,13 @@
 import { css } from '@emotion/react';
 import { APP_ROUTES } from '@jetstream/shared/ui-router';
-import { useNonInitialEffect, useProfilesAndPermSets } from '@jetstream/shared/ui-utils';
+import { useNonInitialEffect, usePrimaryActionShortcut, useProfilesAndPermSets } from '@jetstream/shared/ui-utils';
 import { SplitWrapper as Split } from '@jetstream/splitjs';
 import { DescribeGlobalSObjectResult, ListItem, PermissionSetNoProfileRecord, PermissionSetWithProfileRecord } from '@jetstream/types';
 import {
   AutoFullHeightContainer,
   ConnectedSobjectListMultiSelect,
   Icon,
+  KeyboardShortcut,
   ListWithFilterMultiSelect,
   Page,
   PageHeader,
@@ -15,6 +16,8 @@ import {
   PageHeaderTitle,
   ProfileOrPermSetPopover,
   ProfileOrPermSetRecordType,
+  Tooltip,
+  getModifierKey,
 } from '@jetstream/ui';
 import { RequireMetadataApiBanner, fromPermissionsState } from '@jetstream/ui-core';
 import { applicationCookieState, selectSkipFrontdoorAuth, selectedOrgState } from '@jetstream/ui/app-state';
@@ -22,7 +25,7 @@ import { recentHistoryItemsDb } from '@jetstream/ui/db';
 import { useAtom, useAtomValue } from 'jotai';
 import { useResetAtom } from 'jotai/utils';
 import { FunctionComponent, useEffect } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { filterPermissionsSobjects } from './utils/permission-manager-utils';
 
 const HEIGHT_BUFFER = 170;
@@ -30,6 +33,7 @@ const HEIGHT_BUFFER = 170;
 export interface ManagePermissionsSelectionProps {}
 
 export const ManagePermissionsSelection: FunctionComponent<ManagePermissionsSelectionProps> = () => {
+  const navigate = useNavigate();
   const selectedOrg = useAtomValue(selectedOrgState);
   const { serverUrl } = useAtomValue(applicationCookieState);
   const skipFrontDoorAuth = useAtomValue(selectSkipFrontdoorAuth);
@@ -101,6 +105,14 @@ export const ManagePermissionsSelection: FunctionComponent<ManagePermissionsSele
     );
   }
 
+  usePrimaryActionShortcut(
+    () => {
+      handleContinue();
+      navigate('editor');
+    },
+    { disabled: !hasSelectionsMade },
+  );
+
   return (
     <Page testId="manage-permissions-page">
       <RequireMetadataApiBanner />
@@ -113,10 +125,19 @@ export const ManagePermissionsSelection: FunctionComponent<ManagePermissionsSele
           />
           <PageHeaderActions colType="actions" buttonType="separate">
             {hasSelectionsMade && (
-              <Link className="slds-button slds-button_brand" to="editor" onClick={handleContinue}>
-                Continue
-                <Icon type="utility" icon="forward" className="slds-button__icon slds-button__icon_right" />
-              </Link>
+              <Tooltip
+                openDelay={300}
+                content={
+                  <div className="slds-p-bottom_small">
+                    <KeyboardShortcut inverse keys={[getModifierKey(), 'enter']} />
+                  </div>
+                }
+              >
+                <Link className="slds-button slds-button_brand" to="editor" onClick={handleContinue}>
+                  Continue
+                  <Icon type="utility" icon="forward" className="slds-button__icon slds-button__icon_right" />
+                </Link>
+              </Tooltip>
             )}
             {!hasSelectionsMade && (
               <button className="slds-button slds-button_brand" disabled>

--- a/libs/features/query/src/QueryBuilder/QueryBuilder.tsx
+++ b/libs/features/query/src/QueryBuilder/QueryBuilder.tsx
@@ -8,12 +8,10 @@ import { APP_ROUTES } from '@jetstream/shared/ui-router';
 import {
   getFlattenedListItemsById,
   getListItemsFromFieldWithRelatedItems,
-  hasModifierKey,
-  isEnterKey,
   sortQueryFields,
   unFlattenedListItemsById,
-  useGlobalEventHandler,
   useNonInitialEffect,
+  usePrimaryActionShortcut,
 } from '@jetstream/shared/ui-utils';
 import { SplitWrapper as Split } from '@jetstream/splitjs';
 import { DescribeGlobalSObjectResult, Field, ListItem, QueryFieldWithPolymorphic, SoqlQueryFormatOptions } from '@jetstream/types';
@@ -118,27 +116,23 @@ export const QueryBuilder = () => {
 
   const [showWalkthrough, setShowWalkthrough] = useState(false);
 
-  const onKeydown = useCallback(
-    (event: KeyboardEvent) => {
-      if (selectedSObject && soql && hasModifierKey(event as any) && isEnterKey(event as any)) {
-        event.stopPropagation();
-        event.preventDefault();
-        navigate('results', {
-          state: {
-            soql,
-            isTooling,
-            sobject: {
-              label: selectedSObject.label,
-              name: selectedSObject.name,
-            },
-          },
-        });
-      }
-    },
-    [isTooling, navigate, selectedSObject, soql],
-  );
+  const handleExecuteQuery = useCallback(() => {
+    if (!selectedSObject || !soql) {
+      return;
+    }
+    navigate('results', {
+      state: {
+        soql,
+        isTooling,
+        sobject: {
+          label: selectedSObject.label,
+          name: selectedSObject.name,
+        },
+      },
+    });
+  }, [isTooling, navigate, selectedSObject, soql]);
 
-  useGlobalEventHandler('keydown', onKeydown);
+  usePrimaryActionShortcut(handleExecuteQuery, { disabled: !selectedSObject || !soql });
 
   useNonInitialEffect(() => {
     if (showWalkthrough) {

--- a/libs/features/query/src/QueryResults/QueryResults.tsx
+++ b/libs/features/query/src/QueryResults/QueryResults.tsx
@@ -14,9 +14,11 @@ import {
   setItemInSessionStorage,
   useBrowserNotifications,
   useGlobalEventHandler,
+  useGoBackShortcut,
   useLocationState,
   useNonInitialEffect,
   useObservable,
+  usePrimaryActionShortcut,
 } from '@jetstream/shared/ui-utils';
 import { getErrorMessage, getRecordIdFromAttributes, getSObjectNameFromAttributes, splitArrayToMaxSize } from '@jetstream/shared/utils';
 import {
@@ -37,11 +39,14 @@ import {
   Grid,
   GridCol,
   Icon,
+  KeyboardShortcut,
   SalesforceRecordDataTable,
   Spinner,
   Toolbar,
   ToolbarItemActions,
   ToolbarItemGroup,
+  Tooltip,
+  getModifierKey,
   useConfirmation,
 } from '@jetstream/ui';
 import {
@@ -194,6 +199,22 @@ export const QueryResults = React.memo(() => {
   );
 
   useGlobalEventHandler('keydown', onKeydown);
+
+  const executeQueryRef = useRef(executeQuery);
+  executeQueryRef.current = executeQuery;
+
+  // Cmd/Ctrl+Enter re-runs the active query when the SOQL panel is closed. When the panel is open the
+  // editor's own Monaco action submits the edited value, so we skip here to avoid submitting a stale query.
+  const handleRerunQuery = useCallback(() => {
+    executeQueryRef.current(soql, SOURCE_MANUAL, { isTooling });
+  }, [soql, isTooling]);
+  usePrimaryActionShortcut(handleRerunQuery, { disabled: loading || soqlPanelOpen });
+
+  // Cmd/Ctrl+Shift+Enter returns to the query builder, carrying the current SOQL back with it.
+  const handleGoBackToQueryBuilder = useCallback(() => {
+    navigate({ pathname: APP_ROUTES.QUERY.ROUTE, search: APP_ROUTES.QUERY.SEARCH_PARAM }, { state: { soql } });
+  }, [navigate, soql]);
+  useGoBackShortcut(handleGoBackToQueryBuilder);
 
   useEffect(() => {
     isMounted.current = true;
@@ -597,14 +618,23 @@ export const QueryResults = React.memo(() => {
       )}
       <Toolbar>
         <ToolbarItemGroup>
-          <Link
-            className="slds-button slds-button_brand"
-            to={{ pathname: APP_ROUTES.QUERY.ROUTE, search: APP_ROUTES.QUERY.SEARCH_PARAM }}
-            state={{ soql }}
+          <Tooltip
+            openDelay={300}
+            content={
+              <div className="slds-p-bottom_small">
+                <KeyboardShortcut inverse keys={[getModifierKey(), 'shift', 'enter']} />
+              </div>
+            }
           >
-            <Icon type="utility" icon="back" className="slds-button__icon slds-button__icon_left" omitContainer />
-            Back
-          </Link>
+            <Link
+              className="slds-button slds-button_brand"
+              to={{ pathname: APP_ROUTES.QUERY.ROUTE, search: APP_ROUTES.QUERY.SEARCH_PARAM }}
+              state={{ soql }}
+            >
+              <Icon type="utility" icon="back" className="slds-button__icon slds-button__icon_left" omitContainer />
+              Back
+            </Link>
+          </Tooltip>
           <ButtonGroupContainer>
             <button
               className={classNames('slds-button collapsible-button collapsible-button-md slds-button_first', {

--- a/libs/features/record-type-manager/src/lib/RecordTypeManagerEditor.tsx
+++ b/libs/features/record-type-manager/src/lib/RecordTypeManagerEditor.tsx
@@ -1,12 +1,13 @@
 import { ANALYTICS_KEYS } from '@jetstream/shared/constants';
 import { APP_ROUTES } from '@jetstream/shared/ui-router';
-import { formatNumber } from '@jetstream/shared/ui-utils';
+import { formatNumber, useGoBackShortcut, usePrimaryActionShortcut } from '@jetstream/shared/ui-utils';
 import { getNameOrNameAndLabel, pluralizeIfMultiple } from '@jetstream/shared/utils';
 import {
   Accordion,
   AutoFullHeightContainer,
   Badge,
   Icon,
+  KeyboardShortcut,
   Page,
   PageHeader,
   PageHeaderActions,
@@ -16,10 +17,12 @@ import {
   RadioGroup,
   ScopedNotification,
   Spinner,
+  Tooltip,
+  getModifierKey,
 } from '@jetstream/ui';
 import { useAmplitude } from '@jetstream/ui-core';
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { DeploymentModal } from './deployment/DeploymentModal';
 import { EditorAccordion } from './editor/EditorAccordion';
 import { DeployButton } from './misc/DeployButton';
@@ -29,6 +32,7 @@ import { useLoadRecordTypeData } from './utils/useLoadRecordTypeData';
 const HEIGHT_BUFFER = 170;
 
 export function RecordTypeManagerEditor() {
+  const navigate = useNavigate();
   const isMounted = useRef(true);
   const { trackEvent } = useAmplitude();
   const [viewMode, setViewMode] = useState<ViewMode>('RECORD_TYPE');
@@ -53,6 +57,9 @@ export function RecordTypeManagerEditor() {
     }
     return configurationErrorsByRecordType;
   }, [viewMode, configurationErrorsByField, configurationErrorsByRecordType]);
+
+  usePrimaryActionShortcut(() => handleDeploy(), { disabled: !!configurationErrors || modifiedValues.length === 0 });
+  useGoBackShortcut(() => navigate('..'), {});
 
   useEffect(() => {
     isMounted.current = true;
@@ -96,11 +103,33 @@ export function RecordTypeManagerEditor() {
               docsPath={APP_ROUTES.RECORD_TYPE_MANAGER.DOCS}
             />
             <PageHeaderActions colType="actions" buttonType="separate">
-              <Link className="slds-button slds-button_neutral" to="..">
-                <Icon type="utility" icon="back" className="slds-button__icon slds-button__icon_left" omitContainer />
-                Go Back
-              </Link>
-              <DeployButton modifiedValues={modifiedValues} configurationErrors={configurationErrors} handleDeploy={handleDeploy} />
+              <Tooltip
+                openDelay={300}
+                content={
+                  <div className="slds-p-bottom_small">
+                    <KeyboardShortcut inverse keys={[getModifierKey(), 'shift', 'enter']} />
+                  </div>
+                }
+              >
+                <Link className="slds-button slds-button_neutral" to="..">
+                  <Icon type="utility" icon="back" className="slds-button__icon slds-button__icon_left" omitContainer />
+                  Go Back
+                </Link>
+              </Tooltip>
+              {!configurationErrors && modifiedValues.length > 0 ? (
+                <Tooltip
+                  openDelay={300}
+                  content={
+                    <div className="slds-p-bottom_small">
+                      <KeyboardShortcut inverse keys={[getModifierKey(), 'enter']} />
+                    </div>
+                  }
+                >
+                  <DeployButton modifiedValues={modifiedValues} configurationErrors={configurationErrors} handleDeploy={handleDeploy} />
+                </Tooltip>
+              ) : (
+                <DeployButton modifiedValues={modifiedValues} configurationErrors={configurationErrors} handleDeploy={handleDeploy} />
+              )}
             </PageHeaderActions>
           </PageHeaderRow>
         </PageHeader>

--- a/libs/features/record-type-manager/src/lib/RecordTypeManagerSelection.tsx
+++ b/libs/features/record-type-manager/src/lib/RecordTypeManagerSelection.tsx
@@ -2,9 +2,11 @@ import { css } from '@emotion/react';
 import { useListMetadata } from '@jetstream/connected-ui';
 import { logger } from '@jetstream/shared/client-logger';
 import { APP_ROUTES } from '@jetstream/shared/ui-router';
+import { usePrimaryActionShortcut } from '@jetstream/shared/ui-utils';
 import {
   AutoFullHeightContainer,
   Icon,
+  KeyboardShortcut,
   ListWithFilterMultiSelect,
   Page,
   PageHeader,
@@ -12,17 +14,20 @@ import {
   PageHeaderRow,
   PageHeaderTitle,
   ScopedNotification,
+  Tooltip,
+  getModifierKey,
 } from '@jetstream/ui';
 import { RequireMetadataApiBanner, fromRecordTypeManagerState } from '@jetstream/ui-core';
 import { selectedOrgState } from '@jetstream/ui/app-state';
 import { useAtom, useAtomValue } from 'jotai';
 import { useEffect } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { getListItemFromRecordTypeMetadata } from './utils/record-types.utils';
 
 const HEIGHT_BUFFER = 170;
 
 export function RecordTypeManagerSelection() {
+  const navigate = useNavigate();
   const selectedOrg = useAtomValue(selectedOrgState);
 
   const [recordTypes, setRecordTypes] = useAtom(fromRecordTypeManagerState.recordTypesState);
@@ -30,6 +35,8 @@ export function RecordTypeManagerSelection() {
   const hasSelectionsMade = useAtomValue(fromRecordTypeManagerState.hasSelectionsMade);
 
   const { loadListMetadata, loading, listMetadataItems, hasError } = useListMetadata(selectedOrg);
+
+  usePrimaryActionShortcut(() => navigate('editor'), { disabled: !hasSelectionsMade });
 
   useEffect(() => {
     loadListMetadata([{ type: 'RecordType' }], { skipRequestCache: true });
@@ -60,10 +67,19 @@ export function RecordTypeManagerSelection() {
           />
           <PageHeaderActions colType="actions" buttonType="separate">
             {hasSelectionsMade && (
-              <Link className="slds-button slds-button_brand" to="editor">
-                Continue
-                <Icon type="utility" icon="forward" className="slds-button__icon slds-button__icon_right" />
-              </Link>
+              <Tooltip
+                openDelay={300}
+                content={
+                  <div className="slds-p-bottom_small">
+                    <KeyboardShortcut inverse keys={[getModifierKey(), 'enter']} />
+                  </div>
+                }
+              >
+                <Link className="slds-button slds-button_brand" to="editor">
+                  Continue
+                  <Icon type="utility" icon="forward" className="slds-button__icon slds-button__icon_right" />
+                </Link>
+              </Tooltip>
             )}
             {!hasSelectionsMade && (
               <button className="slds-button slds-button_brand" disabled>

--- a/libs/features/salesforce-api/src/SalesforceApiRequest.tsx
+++ b/libs/features/salesforce-api/src/SalesforceApiRequest.tsx
@@ -1,6 +1,12 @@
 import { css } from '@emotion/react';
 import { HTTP, MIME_TYPES } from '@jetstream/shared/constants';
-import { sanitizePastedEditorText, useDebounce, useDisposables, useNonInitialEffect } from '@jetstream/shared/ui-utils';
+import {
+  sanitizePastedEditorText,
+  useDebounce,
+  useDisposables,
+  useNonInitialEffect,
+  usePrimaryActionShortcut,
+} from '@jetstream/shared/ui-utils';
 import { getErrorMessage } from '@jetstream/shared/utils';
 import { HttpMethod, SalesforceApiHistoryRequest, SalesforceApiRequest as SalesforceApiReqSample, SalesforceOrgUi } from '@jetstream/types';
 import {
@@ -18,7 +24,7 @@ import {
 import { MonacoEditor } from '@jetstream/ui-core';
 import { OnMount } from '@monaco-editor/react';
 import type { editor } from 'monaco-editor';
-import { FunctionComponent, useReducer, useRef, useState } from 'react';
+import { FunctionComponent, useCallback, useReducer, useRef, useState } from 'react';
 import SalesforceApiExamplesModal from './SalesforceApiExamplesModal';
 import { SalesforceApiHistoryModal } from './SalesforceApiHistoryModal';
 import SalesforceApiUserInput from './SalesforceApiUserInput';
@@ -161,6 +167,10 @@ export const SalesforceApiRequest: FunctionComponent<SalesforceApiRequestProps> 
   // eslint-disable-next-line react-hooks/refs
   handleSubmitRef.current = handleSubmit;
 
+  // Cmd/Ctrl+Enter submits from anywhere on the page; when an editor is focused Monaco handles it (see below).
+  const handleSubmitShortcut = useCallback(() => handleSubmitRef.current(), []);
+  usePrimaryActionShortcut(handleSubmitShortcut, { disabled: loading || !!headersErrorMessage || !!bodyErrorMessage });
+
   const setBodyRef = useRef(setBody);
   // eslint-disable-next-line react-hooks/refs
   setBodyRef.current = setBody;
@@ -228,6 +238,7 @@ export const SalesforceApiRequest: FunctionComponent<SalesforceApiRequestProps> 
               View History
             </button>
             <Tooltip
+              openDelay={300}
               content={
                 <div className="slds-p-bottom_small">
                   <KeyboardShortcut inverse keys={[getModifierKey(), 'enter']} />
@@ -255,7 +266,6 @@ export const SalesforceApiRequest: FunctionComponent<SalesforceApiRequestProps> 
             loading={loading}
             onUrlChange={setUrl}
             onMethodChange={setMethod}
-            onAltEnter={handleSubmit}
           />
           <Grid verticalAlign="end" className="slds-m-top_x-small">
             <h2 className="slds-text-heading_small">Request Headers</h2>

--- a/libs/features/salesforce-api/src/SalesforceApiUserInput.tsx
+++ b/libs/features/salesforce-api/src/SalesforceApiUserInput.tsx
@@ -1,9 +1,8 @@
-import { hasModifierKey, isEnterKey } from '@jetstream/shared/ui-utils';
 import { HttpMethod, ListItem, SalesforceOrgUi } from '@jetstream/types';
 import { ComboboxWithItems, Grid, GridCol, Input } from '@jetstream/ui';
 import { applicationCookieState } from '@jetstream/ui/app-state';
 import { useAtom } from 'jotai';
-import { FunctionComponent, KeyboardEvent } from 'react';
+import { FunctionComponent } from 'react';
 
 function getDefaultUrl(defaultApiVersion: string) {
   return `/services/${defaultApiVersion}`;
@@ -24,7 +23,6 @@ export interface SalesforceApiUserInputProps {
   loading: boolean;
   onUrlChange: (url: string) => void;
   onMethodChange: (method: HttpMethod) => void;
-  onAltEnter: () => void;
 }
 
 export const SalesforceApiUserInput: FunctionComponent<SalesforceApiUserInputProps> = ({
@@ -34,15 +32,8 @@ export const SalesforceApiUserInput: FunctionComponent<SalesforceApiUserInputPro
   loading,
   onUrlChange,
   onMethodChange,
-  onAltEnter,
 }) => {
   const [{ defaultApiVersion }] = useAtom(applicationCookieState);
-
-  function handleKeyUp(event: KeyboardEvent<HTMLElement>) {
-    if (onAltEnter && hasModifierKey(event) && isEnterKey(event)) {
-      onAltEnter();
-    }
-  }
 
   return (
     <Grid guttersDirect>
@@ -70,7 +61,6 @@ export const SalesforceApiUserInput: FunctionComponent<SalesforceApiUserInputPro
             placeholder={getDefaultUrl(defaultApiVersion)}
             value={url}
             disabled={loading}
-            onKeyDown={handleKeyUp}
             onChange={(event) => onUrlChange(event.target.value)}
           />
         </Input>

--- a/libs/features/sobject-export/src/SObjectExport.tsx
+++ b/libs/features/sobject-export/src/SObjectExport.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/react';
 import { logger } from '@jetstream/shared/client-logger';
 import { INDEXED_DB, TITLES } from '@jetstream/shared/constants';
 import { APP_ROUTES } from '@jetstream/shared/ui-router';
-import { tracker, useTitle } from '@jetstream/shared/ui-utils';
+import { tracker, usePrimaryActionShortcut, useTitle } from '@jetstream/shared/ui-utils';
 import { getErrorMessage } from '@jetstream/shared/utils';
 import { SplitWrapper as Split } from '@jetstream/splitjs';
 import { DescribeGlobalSObjectResult, ListItem, Maybe } from '@jetstream/types';
@@ -13,6 +13,7 @@ import {
   FileDownloadModal,
   Grid,
   Icon,
+  KeyboardShortcut,
   ListWithFilterMultiSelect,
   Page,
   PageHeader,
@@ -24,6 +25,7 @@ import {
   ScopedNotification,
   Spinner,
   Tooltip,
+  getModifierKey,
 } from '@jetstream/ui';
 import { fromJetstreamEvents, useAmplitude } from '@jetstream/ui-core';
 import { applicationCookieState, googleDriveAccessState, selectedOrgState } from '@jetstream/ui/app-state';
@@ -211,6 +213,8 @@ export const SObjectExport: FunctionComponent<SObjectExportProps> = () => {
     }
   }
 
+  usePrimaryActionShortcut(() => handleExport(), { disabled: !hasSelectionsMade || loading || exportDataModalOpen });
+
   return (
     <Fragment>
       {exportDataModalOpen && (
@@ -240,9 +244,18 @@ export const SObjectExport: FunctionComponent<SObjectExportProps> = () => {
               docsPath={APP_ROUTES.OBJECT_EXPORT.DOCS}
             />
             <PageHeaderActions colType="actions" buttonType="separate">
-              <button className="slds-button slds-button_brand" disabled={!hasSelectionsMade || loading} onClick={handleExport}>
-                Download
-              </button>
+              <Tooltip
+                openDelay={300}
+                content={
+                  <div className="slds-p-bottom_small">
+                    <KeyboardShortcut inverse keys={[getModifierKey(), 'enter']} />
+                  </div>
+                }
+              >
+                <button className="slds-button slds-button_brand" disabled={!hasSelectionsMade || loading} onClick={handleExport}>
+                  Download
+                </button>
+              </Tooltip>
             </PageHeaderActions>
           </PageHeaderRow>
           <PageHeaderRow>

--- a/libs/features/update-records/src/deployment/MassUpdateRecordsDeployment.tsx
+++ b/libs/features/update-records/src/deployment/MassUpdateRecordsDeployment.tsx
@@ -1,15 +1,19 @@
+import { useGoBackShortcut, usePrimaryActionShortcut } from '@jetstream/shared/ui-utils';
 import { BulkJobBatchInfo, Maybe } from '@jetstream/types';
 import {
   AutoFullHeightContainer,
   Checkbox,
   Icon,
   Input,
+  KeyboardShortcut,
   Page,
   Section,
   Spinner,
   Toolbar,
   ToolbarItemActions,
   ToolbarItemGroup,
+  Tooltip,
+  getModifierKey,
 } from '@jetstream/ui';
 import { DeployResults, MassUpdateRecordsDeploymentRow, MetadataRow, useDeployRecords } from '@jetstream/ui-core';
 import { selectedOrgState } from '@jetstream/ui/app-state';
@@ -17,7 +21,7 @@ import { useAtomValue, useSetAtom } from 'jotai';
 import { useAtomCallback } from 'jotai/utils';
 import isNumber from 'lodash/isNumber';
 import { ChangeEvent, useCallback, useEffect, useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import * as fromMassUpdateState from '../mass-update-records.state';
 
 const HEIGHT_BUFFER = 170;
@@ -42,6 +46,7 @@ const updateDeploymentResultsState =
   };
 
 export const MassUpdateRecordsDeployment = () => {
+  const navigate = useNavigate();
   const selectedOrg = useAtomValue(selectedOrgState);
   const rows = useAtomValue(fromMassUpdateState.rowsState);
   const [loading, setLoading] = useState(false);
@@ -77,6 +82,9 @@ export const MassUpdateRecordsDeployment = () => {
     pollResultsUntilDone(getRows);
   }
 
+  usePrimaryActionShortcut(handleDeploy, { disabled: loading || !!batchSizeError });
+  useGoBackShortcut(() => navigate('..'), { disabled: loading });
+
   useEffect(() => {
     if (!isNumber(batchSize) || batchSize <= 0 || batchSize > MAX_BATCH_SIZE) {
       setBatchSizeError(`The batch size must be between 1 and ${MAX_BATCH_SIZE}`);
@@ -104,17 +112,39 @@ export const MassUpdateRecordsDeployment = () => {
               Go Back
             </button>
           ) : (
-            <Link className="slds-button slds-button_neutral slds-m-right_x-small" to="..">
-              <Icon type="utility" icon="back" className="slds-button__icon slds-button__icon_left" omitContainer />
-              Go Back
-            </Link>
+            <Tooltip
+              openDelay={300}
+              content={
+                <div className="slds-p-bottom_small">
+                  <KeyboardShortcut inverse keys={[getModifierKey(), 'shift', 'enter']} />
+                </div>
+              }
+            >
+              <Link className="slds-button slds-button_neutral slds-m-right_x-small" to="..">
+                <Icon type="utility" icon="back" className="slds-button__icon slds-button__icon_left" omitContainer />
+                Go Back
+              </Link>
+            </Tooltip>
           )}
         </ToolbarItemGroup>
         <ToolbarItemActions>
-          <button className="slds-button slds-button_brand slds-is-relative" onClick={handleDeploy} disabled={loading || !!batchSizeError}>
-            {loading && <Spinner size="small" />}
-            Update Records
-          </button>
+          <Tooltip
+            openDelay={300}
+            content={
+              <div className="slds-p-bottom_small">
+                <KeyboardShortcut inverse keys={[getModifierKey(), 'enter']} />
+              </div>
+            }
+          >
+            <button
+              className="slds-button slds-button_brand slds-is-relative"
+              onClick={handleDeploy}
+              disabled={loading || !!batchSizeError}
+            >
+              {loading && <Spinner size="small" />}
+              Update Records
+            </button>
+          </Tooltip>
         </ToolbarItemActions>
       </Toolbar>
       <AutoFullHeightContainer bottomBuffer={10} className="slds-p-around_small slds-scrollable_none" bufferIfNotRendered={HEIGHT_BUFFER}>

--- a/libs/features/update-records/src/selection/MassUpdateRecordsSelection.tsx
+++ b/libs/features/update-records/src/selection/MassUpdateRecordsSelection.tsx
@@ -1,15 +1,18 @@
 import { css } from '@emotion/react';
 import { APP_ROUTES } from '@jetstream/shared/ui-router';
+import { usePrimaryActionShortcut } from '@jetstream/shared/ui-utils';
 import { SplitWrapper as Split } from '@jetstream/splitjs';
 import {
   AutoFullHeightContainer,
   ConnectedSobjectListMultiSelect,
+  KeyboardShortcut,
   Page,
   PageHeader,
   PageHeaderActions,
   PageHeaderRow,
   PageHeaderTitle,
   Tooltip,
+  getModifierKey,
 } from '@jetstream/ui';
 import { filterMassUpdateSobject } from '@jetstream/ui-core';
 import { selectedOrgState } from '@jetstream/ui/app-state';
@@ -17,7 +20,7 @@ import { recentHistoryItemsDb } from '@jetstream/ui/db';
 import { useAtom, useAtomValue } from 'jotai';
 import { useResetAtom } from 'jotai/utils';
 import { FunctionComponent, useEffect, useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import * as fromMassUpdateState from '../mass-update-records.state';
 import MassUpdateRecordsObjects from './MassUpdateRecordsObjects';
 import { useMassUpdateFieldItems } from './useMassUpdateFieldItems';
@@ -27,6 +30,7 @@ const HEIGHT_BUFFER = 170;
 export interface MassUpdateRecordsSelectionProps {}
 
 export const MassUpdateRecordsSelection: FunctionComponent<MassUpdateRecordsSelectionProps> = () => {
+  const navigate = useNavigate();
   const selectedOrg = useAtomValue(selectedOrgState);
   const [sobjects, setSobjects] = useAtom(fromMassUpdateState.sObjectsState);
   const [selectedSObjects, setSelectedSObjects] = useAtom(fromMassUpdateState.selectedSObjectsState);
@@ -82,6 +86,14 @@ export const MassUpdateRecordsSelection: FunctionComponent<MassUpdateRecordsSele
     );
   }
 
+  usePrimaryActionShortcut(
+    () => {
+      handleContinue();
+      navigate('deployment');
+    },
+    { disabled: !allRowsValidated },
+  );
+
   return (
     <Page testId="mass-update-records-selection-page">
       <PageHeader>
@@ -98,9 +110,18 @@ export const MassUpdateRecordsSelection: FunctionComponent<MassUpdateRecordsSele
               </button>
             )}
             {allRowsValidated ? (
-              <Link className="slds-button slds-button_brand" to="deployment" onClick={handleContinue}>
-                Review Changes
-              </Link>
+              <Tooltip
+                openDelay={300}
+                content={
+                  <div className="slds-p-bottom_small">
+                    <KeyboardShortcut inverse keys={[getModifierKey(), 'enter']} />
+                  </div>
+                }
+              >
+                <Link className="slds-button slds-button_brand" to="deployment" onClick={handleContinue}>
+                  Review Changes
+                </Link>
+              </Tooltip>
             ) : (
               <Tooltip content={allRowsValidated ? '' : 'Validate all objects to ensure configuration is valid before continuing'}>
                 <button className="slds-button slds-button_brand" disabled>

--- a/libs/shared/ui-utils/src/index.ts
+++ b/libs/shared/ui-utils/src/index.ts
@@ -1,3 +1,4 @@
+export * from './lib/errorTracker';
 export * from './lib/google-access-token';
 export * from './lib/hooks/useBrowserNotifications';
 export * from './lib/hooks/useCombinedRefs';
@@ -13,11 +14,11 @@ export * from './lib/hooks/useGoogleApi';
 export * from './lib/hooks/useHover';
 export * from './lib/hooks/useInjectScript';
 export * from './lib/hooks/useInterval';
+export * from './lib/hooks/useKeyboardShortcuts';
 export * from './lib/hooks/useLocationState';
 export * from './lib/hooks/useNonInitialEffect';
 export * from './lib/hooks/useObservable';
 export * from './lib/hooks/useProfilesAndPermSets';
-export * from './lib/errorTracker';
 export * from './lib/hooks/useTitle';
 export * from './lib/queries';
 export * from './lib/shared-browser-extension-helpers';

--- a/libs/shared/ui-utils/src/lib/hooks/__tests__/useKeyboardShortcuts.spec.ts
+++ b/libs/shared/ui-utils/src/lib/hooks/__tests__/useKeyboardShortcuts.spec.ts
@@ -1,0 +1,102 @@
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, test, vi } from 'vitest';
+import { useGoBackShortcut, usePrimaryActionShortcut } from '../useKeyboardShortcuts';
+
+function dispatchKeydown(init: KeyboardEventInit) {
+  act(() => {
+    window.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, cancelable: true, ...init }));
+  });
+}
+
+describe('usePrimaryActionShortcut', () => {
+  test('fires on Ctrl+Enter', () => {
+    const handler = vi.fn();
+    renderHook(() => usePrimaryActionShortcut(handler));
+    dispatchKeydown({ key: 'Enter', ctrlKey: true });
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  test('fires on Meta(Cmd)+Enter', () => {
+    const handler = vi.fn();
+    renderHook(() => usePrimaryActionShortcut(handler));
+    dispatchKeydown({ key: 'Enter', metaKey: true });
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  test('does not fire when Shift is also held (reserved for go-back)', () => {
+    const handler = vi.fn();
+    renderHook(() => usePrimaryActionShortcut(handler));
+    dispatchKeydown({ key: 'Enter', metaKey: true, shiftKey: true });
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  test('does not fire on Enter without a modifier', () => {
+    const handler = vi.fn();
+    renderHook(() => usePrimaryActionShortcut(handler));
+    dispatchKeydown({ key: 'Enter' });
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  test('does not fire on Ctrl + non-Enter key', () => {
+    const handler = vi.fn();
+    renderHook(() => usePrimaryActionShortcut(handler));
+    dispatchKeydown({ key: 'a', ctrlKey: true });
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  test('does not fire when disabled', () => {
+    const handler = vi.fn();
+    renderHook(() => usePrimaryActionShortcut(handler, { disabled: true }));
+    dispatchKeydown({ key: 'Enter', metaKey: true });
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  test('skips events already handled elsewhere (defaultPrevented, e.g. a focused Monaco editor)', () => {
+    const handler = vi.fn();
+    renderHook(() => usePrimaryActionShortcut(handler));
+    const event = new KeyboardEvent('keydown', { key: 'Enter', ctrlKey: true, bubbles: true, cancelable: true });
+    event.preventDefault();
+    act(() => {
+      window.dispatchEvent(event);
+    });
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  test('stops listening after unmount', () => {
+    const handler = vi.fn();
+    const { unmount } = renderHook(() => usePrimaryActionShortcut(handler));
+    unmount();
+    dispatchKeydown({ key: 'Enter', metaKey: true });
+    expect(handler).not.toHaveBeenCalled();
+  });
+});
+
+describe('useGoBackShortcut', () => {
+  test('fires on Ctrl+Shift+Enter', () => {
+    const handler = vi.fn();
+    renderHook(() => useGoBackShortcut(handler));
+    dispatchKeydown({ key: 'Enter', ctrlKey: true, shiftKey: true });
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  test('fires on Meta(Cmd)+Shift+Enter', () => {
+    const handler = vi.fn();
+    renderHook(() => useGoBackShortcut(handler));
+    dispatchKeydown({ key: 'Enter', metaKey: true, shiftKey: true });
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  test('does not fire without Shift (reserved for the primary action)', () => {
+    const handler = vi.fn();
+    renderHook(() => useGoBackShortcut(handler));
+    dispatchKeydown({ key: 'Enter', metaKey: true });
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  test('does not fire when disabled', () => {
+    const handler = vi.fn();
+    renderHook(() => useGoBackShortcut(handler, { disabled: true }));
+    dispatchKeydown({ key: 'Enter', metaKey: true, shiftKey: true });
+    expect(handler).not.toHaveBeenCalled();
+  });
+});

--- a/libs/shared/ui-utils/src/lib/hooks/useKeyboardShortcuts.ts
+++ b/libs/shared/ui-utils/src/lib/hooks/useKeyboardShortcuts.ts
@@ -1,0 +1,52 @@
+import { KeyboardEvent as ReactKeyboardEvent, useCallback } from 'react';
+import { hasCtrlOrMeta, hasShiftModifierKey, isEnterKey } from '../shared-ui-keyboard';
+import { useGlobalEventHandler } from './useGlobalEventHandler';
+
+interface KeyboardActionOptions {
+  /** When true the shortcut is ignored — wire this to the same condition that disables the button */
+  disabled?: boolean;
+}
+
+/**
+ * Cmd+Enter (mac) / Ctrl+Enter — fires the page's primary action (save, continue, execute, etc.).
+ * Ignores Shift so it never collides with the go-back shortcut, and skips events already handled by
+ * a focused Monaco editor (which binds Cmd+Enter itself and stops propagation).
+ */
+export function usePrimaryActionShortcut(handler: () => void, { disabled }: KeyboardActionOptions = {}) {
+  const onKeydown = useCallback(
+    (event: KeyboardEvent) => {
+      if (disabled || event.defaultPrevented) {
+        return;
+      }
+      const keyboardEvent = event as unknown as ReactKeyboardEvent;
+      if (hasCtrlOrMeta(keyboardEvent) && !hasShiftModifierKey(keyboardEvent) && isEnterKey(keyboardEvent)) {
+        event.stopPropagation();
+        event.preventDefault();
+        handler();
+      }
+    },
+    [disabled, handler],
+  );
+  useGlobalEventHandler('keydown', onKeydown);
+}
+
+/**
+ * Cmd+Shift+Enter (mac) / Ctrl+Shift+Enter — navigates back one step in a multi-step (wizard) flow.
+ */
+export function useGoBackShortcut(handler: () => void, { disabled }: KeyboardActionOptions = {}) {
+  const onKeydown = useCallback(
+    (event: KeyboardEvent) => {
+      if (disabled || event.defaultPrevented) {
+        return;
+      }
+      const keyboardEvent = event as unknown as ReactKeyboardEvent;
+      if (hasCtrlOrMeta(keyboardEvent) && hasShiftModifierKey(keyboardEvent) && isEnterKey(keyboardEvent)) {
+        event.stopPropagation();
+        event.preventDefault();
+        handler();
+      }
+    },
+    [disabled, handler],
+  );
+  useGlobalEventHandler('keydown', onKeydown);
+}


### PR DESCRIPTION
Add cmd+enter and cmd+shift+enter to go forward and backward on pages that have multiple steps