### PR TITLE
Increase tooltip open delay and prevent column drag during resize

### DIFF
--- a/libs/features/anon-apex/src/AnonymousApex.tsx
+++ b/libs/features/anon-apex/src/AnonymousApex.tsx
@@ -259,7 +259,7 @@ export const AnonymousApex: FunctionComponent<AnonymousApexProps> = () => {
                   />
                 </div>
                 <Tooltip
-                  openDelay={300}
+                  openDelay={500}
                   content={
                     <div className="slds-p-bottom_small">
                       <KeyboardShortcut inverse keys={[getModifierKey(), 'enter']} />

--- a/libs/features/automation-control/src/AutomationControlEditor.tsx
+++ b/libs/features/automation-control/src/AutomationControlEditor.tsx
@@ -279,7 +279,7 @@ export const AutomationControlEditor = () => {
       <Toolbar>
         <ToolbarItemGroup>
           <Tooltip
-            openDelay={300}
+            openDelay={500}
             content={
               <div className="slds-p-bottom_small">
                 <KeyboardShortcut inverse keys={[getModifierKey(), 'shift', 'enter']} />
@@ -338,7 +338,7 @@ export const AutomationControlEditor = () => {
             </button>
           </ButtonGroupContainer>
           <Tooltip
-            openDelay={300}
+            openDelay={500}
             content={
               <div className="slds-p-bottom_small">
                 <KeyboardShortcut inverse keys={[getModifierKey(), 'enter']} />

--- a/libs/features/automation-control/src/AutomationControlSelection.tsx
+++ b/libs/features/automation-control/src/AutomationControlSelection.tsx
@@ -90,7 +90,7 @@ export const AutomationControlSelection = () => {
           <PageHeaderActions colType="actions" buttonType="separate">
             {hasSelectionsMade && (
               <Tooltip
-                openDelay={300}
+                openDelay={500}
                 content={
                   <div className="slds-p-bottom_small">
                     <KeyboardShortcut inverse keys={[getModifierKey(), 'enter']} />

--- a/libs/features/create-object-and-fields/src/CreateFields.tsx
+++ b/libs/features/create-object-and-fields/src/CreateFields.tsx
@@ -184,7 +184,7 @@ export const CreateFields: FunctionComponent<CreateFieldsProps> = () => {
       <Toolbar>
         <ToolbarItemGroup>
           <Tooltip
-            openDelay={300}
+            openDelay={500}
             content={
               <div className="slds-p-bottom_small">
                 <KeyboardShortcut inverse keys={[getModifierKey(), 'shift', 'enter']} />
@@ -225,7 +225,7 @@ export const CreateFields: FunctionComponent<CreateFieldsProps> = () => {
             <span>Reset Fields</span>
           </button>
           <Tooltip
-            openDelay={300}
+            openDelay={500}
             content={
               allValid ? (
                 <div className="slds-p-bottom_small">

--- a/libs/features/create-object-and-fields/src/CreateFieldsSelection.tsx
+++ b/libs/features/create-object-and-fields/src/CreateFieldsSelection.tsx
@@ -118,7 +118,7 @@ export const CreateFieldsSelection: FunctionComponent<CreateFieldsSelectionProps
             />
             {hasSelectionsMade && (
               <Tooltip
-                openDelay={300}
+                openDelay={500}
                 content={
                   <div className="slds-p-bottom_small">
                     <KeyboardShortcut inverse keys={[getModifierKey(), 'enter']} />

--- a/libs/features/deploy/src/DeployMetadataDeployment.tsx
+++ b/libs/features/deploy/src/DeployMetadataDeployment.tsx
@@ -316,7 +316,7 @@ export const DeployMetadataDeployment: FunctionComponent<DeployMetadataDeploymen
       <Toolbar>
         <ToolbarItemGroup>
           <Tooltip
-            openDelay={300}
+            openDelay={500}
             content={
               <div className="slds-p-bottom_small">
                 <KeyboardShortcut inverse keys={[getModifierKey(), 'shift', 'enter']} />

--- a/libs/features/deploy/src/DeployMetadataSelection.tsx
+++ b/libs/features/deploy/src/DeployMetadataSelection.tsx
@@ -72,7 +72,7 @@ export const DeployMetadataSelection: FunctionComponent<DeployMetadataSelectionP
             </ButtonGroupContainer>
             {hasSelectionsMade && (
               <Tooltip
-                openDelay={300}
+                openDelay={500}
                 content={
                   <div className="slds-p-bottom_small">
                     <KeyboardShortcut inverse keys={[getModifierKey(), 'enter']} />

--- a/libs/features/formula-evaluator/src/FormulaEvaluator.tsx
+++ b/libs/features/formula-evaluator/src/FormulaEvaluator.tsx
@@ -460,7 +460,7 @@ export const FormulaEvaluator: FunctionComponent<FormulaEvaluatorProps> = () => 
                     Deploy
                   </button>
                   <Tooltip
-                    openDelay={300}
+                    openDelay={500}
                     content={
                       <div className="slds-p-bottom_small">
                         <KeyboardShortcut inverse keys={[getModifierKey(), 'enter']} />

--- a/libs/features/load-records/src/LoadRecords.tsx
+++ b/libs/features/load-records/src/LoadRecords.tsx
@@ -473,7 +473,7 @@ export const LoadRecords = () => {
               <span>Start Over</span>
             </button>
             <Tooltip
-              openDelay={300}
+              openDelay={500}
               content={
                 <div className="slds-p-bottom_small">
                   <KeyboardShortcut inverse keys={[getModifierKey(), 'shift', 'enter']} />
@@ -491,7 +491,7 @@ export const LoadRecords = () => {
               </button>
             </Tooltip>
             <Tooltip
-              openDelay={300}
+              openDelay={500}
               content={
                 <div className="slds-p-bottom_small">
                   <KeyboardShortcut inverse keys={[getModifierKey(), 'enter']} />

--- a/libs/features/manage-permissions/src/ManagePermissionsEditor.tsx
+++ b/libs/features/manage-permissions/src/ManagePermissionsEditor.tsx
@@ -643,7 +643,7 @@ export const ManagePermissionsEditor: FunctionComponent<ManagePermissionsEditorP
       <Toolbar>
         <ToolbarItemGroup>
           <Tooltip
-            openDelay={300}
+            openDelay={500}
             content={
               <div className="slds-p-bottom_small">
                 <KeyboardShortcut inverse keys={[getModifierKey(), 'shift', 'enter']} />
@@ -691,7 +691,7 @@ export const ManagePermissionsEditor: FunctionComponent<ManagePermissionsEditorP
             <span>Export</span>
           </button>
           <Tooltip
-            openDelay={300}
+            openDelay={500}
             content={
               <div className="slds-p-bottom_small">
                 <KeyboardShortcut inverse keys={[getModifierKey(), 'enter']} />

--- a/libs/features/manage-permissions/src/ManagePermissionsSelection.tsx
+++ b/libs/features/manage-permissions/src/ManagePermissionsSelection.tsx
@@ -126,7 +126,7 @@ export const ManagePermissionsSelection: FunctionComponent<ManagePermissionsSele
           <PageHeaderActions colType="actions" buttonType="separate">
             {hasSelectionsMade && (
               <Tooltip
-                openDelay={300}
+                openDelay={500}
                 content={
                   <div className="slds-p-bottom_small">
                     <KeyboardShortcut inverse keys={[getModifierKey(), 'enter']} />

--- a/libs/features/query/src/QueryBuilder/ExecuteQueryButton.tsx
+++ b/libs/features/query/src/QueryBuilder/ExecuteQueryButton.tsx
@@ -23,7 +23,7 @@ export const ExecuteQueryButton: FunctionComponent<ExecuteQueryButtonProps> = ({
     <>
       {soql && selectedSObject && (
         <Tooltip
-          openDelay={300}
+          openDelay={500}
           content={
             <div className="slds-p-bottom_small">
               <KeyboardShortcut inverse keys={[getModifierKey(), 'enter']} />

--- a/libs/features/query/src/QueryResults/QueryResults.tsx
+++ b/libs/features/query/src/QueryResults/QueryResults.tsx
@@ -619,7 +619,7 @@ export const QueryResults = React.memo(() => {
       <Toolbar>
         <ToolbarItemGroup>
           <Tooltip
-            openDelay={300}
+            openDelay={500}
             content={
               <div className="slds-p-bottom_small">
                 <KeyboardShortcut inverse keys={[getModifierKey(), 'shift', 'enter']} />
@@ -627,7 +627,7 @@ export const QueryResults = React.memo(() => {
             }
           >
             <Link
-              className="slds-button slds-button_brand"
+              className="slds-button slds-button_brand slds-m-right_x-small"
               to={{ pathname: APP_ROUTES.QUERY.ROUTE, search: APP_ROUTES.QUERY.SEARCH_PARAM }}
               state={{ soql }}
             >

--- a/libs/features/record-type-manager/src/lib/RecordTypeManagerEditor.tsx
+++ b/libs/features/record-type-manager/src/lib/RecordTypeManagerEditor.tsx
@@ -104,7 +104,7 @@ export function RecordTypeManagerEditor() {
             />
             <PageHeaderActions colType="actions" buttonType="separate">
               <Tooltip
-                openDelay={300}
+                openDelay={500}
                 content={
                   <div className="slds-p-bottom_small">
                     <KeyboardShortcut inverse keys={[getModifierKey(), 'shift', 'enter']} />
@@ -118,7 +118,7 @@ export function RecordTypeManagerEditor() {
               </Tooltip>
               {!configurationErrors && modifiedValues.length > 0 ? (
                 <Tooltip
-                  openDelay={300}
+                  openDelay={500}
                   content={
                     <div className="slds-p-bottom_small">
                       <KeyboardShortcut inverse keys={[getModifierKey(), 'enter']} />

--- a/libs/features/record-type-manager/src/lib/RecordTypeManagerSelection.tsx
+++ b/libs/features/record-type-manager/src/lib/RecordTypeManagerSelection.tsx
@@ -68,7 +68,7 @@ export function RecordTypeManagerSelection() {
           <PageHeaderActions colType="actions" buttonType="separate">
             {hasSelectionsMade && (
               <Tooltip
-                openDelay={300}
+                openDelay={500}
                 content={
                   <div className="slds-p-bottom_small">
                     <KeyboardShortcut inverse keys={[getModifierKey(), 'enter']} />

--- a/libs/features/salesforce-api/src/SalesforceApiRequest.tsx
+++ b/libs/features/salesforce-api/src/SalesforceApiRequest.tsx
@@ -238,7 +238,7 @@ export const SalesforceApiRequest: FunctionComponent<SalesforceApiRequestProps> 
               View History
             </button>
             <Tooltip
-              openDelay={300}
+              openDelay={500}
               content={
                 <div className="slds-p-bottom_small">
                   <KeyboardShortcut inverse keys={[getModifierKey(), 'enter']} />

--- a/libs/features/sobject-export/src/SObjectExport.tsx
+++ b/libs/features/sobject-export/src/SObjectExport.tsx
@@ -245,7 +245,7 @@ export const SObjectExport: FunctionComponent<SObjectExportProps> = () => {
             />
             <PageHeaderActions colType="actions" buttonType="separate">
               <Tooltip
-                openDelay={300}
+                openDelay={500}
                 content={
                   <div className="slds-p-bottom_small">
                     <KeyboardShortcut inverse keys={[getModifierKey(), 'enter']} />

--- a/libs/features/update-records/src/deployment/MassUpdateRecordsDeployment.tsx
+++ b/libs/features/update-records/src/deployment/MassUpdateRecordsDeployment.tsx
@@ -113,7 +113,7 @@ export const MassUpdateRecordsDeployment = () => {
             </button>
           ) : (
             <Tooltip
-              openDelay={300}
+              openDelay={500}
               content={
                 <div className="slds-p-bottom_small">
                   <KeyboardShortcut inverse keys={[getModifierKey(), 'shift', 'enter']} />
@@ -129,7 +129,7 @@ export const MassUpdateRecordsDeployment = () => {
         </ToolbarItemGroup>
         <ToolbarItemActions>
           <Tooltip
-            openDelay={300}
+            openDelay={500}
             content={
               <div className="slds-p-bottom_small">
                 <KeyboardShortcut inverse keys={[getModifierKey(), 'enter']} />

--- a/libs/features/update-records/src/selection/MassUpdateRecordsSelection.tsx
+++ b/libs/features/update-records/src/selection/MassUpdateRecordsSelection.tsx
@@ -111,7 +111,7 @@ export const MassUpdateRecordsSelection: FunctionComponent<MassUpdateRecordsSele
             )}
             {allRowsValidated ? (
               <Tooltip
-                openDelay={300}
+                openDelay={500}
                 content={
                   <div className="slds-p-bottom_small">
                     <KeyboardShortcut inverse keys={[getModifierKey(), 'enter']} />

--- a/libs/ui/src/lib/data-table/grid/components/HeaderCell.tsx
+++ b/libs/ui/src/lib/data-table/grid/components/HeaderCell.tsx
@@ -74,8 +74,17 @@ export function HeaderCell<TRow>({
   const canReorder = !!column?.draggable && meta?.cellKind === 'data' && !meta?.frozen && !!onColumnReorder;
   const isDraggingThis = !!draggingColumnId && draggingColumnId === header.column.id;
   const [dropSide, setDropSide] = useState<'left' | 'right' | null>(null);
+  // The resize handle lives inside this (draggable) cell, so a drag gesture starting on the handle would
+  // otherwise pick the cell as the native drag source — initiating a column reorder instead of a resize.
+  // While the pointer is over the handle we drop `draggable` so the mousedown can only start a resize.
+  const [isOverResizeHandle, setIsOverResizeHandle] = useState(false);
 
   const handleDragStart = (event: React.DragEvent<HTMLDivElement>) => {
+    // Belt-and-suspenders: never let an in-progress resize turn into a column drag.
+    if (isOverResizeHandle || header.column.getIsResizing()) {
+      event.preventDefault();
+      return;
+    }
     event.dataTransfer.setData('text/plain', header.column.id);
     event.dataTransfer.effectAllowed = 'move';
     onColumnDragStart?.(header.column.id);
@@ -183,7 +192,7 @@ export function HeaderCell<TRow>({
       })}
       style={style}
       tabIndex={isActive ? 0 : -1}
-      draggable={canReorder}
+      draggable={canReorder && !isOverResizeHandle}
       onDragStart={canReorder ? handleDragStart : undefined}
       onDragEnd={canReorder ? () => onColumnDragEnd?.() : undefined}
       onDragOver={canReorder ? handleDragOver : undefined}
@@ -229,10 +238,13 @@ export function HeaderCell<TRow>({
       {canResize && (
         <span
           role="presentation"
-          // Not draggable so a resize drag never initiates a column reorder.
+          // Not draggable, and while hovered the parent cell drops `draggable` too (see isOverResizeHandle),
+          // so a resize drag can never initiate a column reorder.
           draggable={false}
           className={classNames('jgrid-header-resize-handle', { 'jgrid-resizing': isResizing })}
           style={resizeIndicatorStyle}
+          onMouseEnter={() => setIsOverResizeHandle(true)}
+          onMouseLeave={() => setIsOverResizeHandle(false)}
           onMouseDown={header.getResizeHandler()}
           onTouchStart={header.getResizeHandler()}
           onClick={(event) => event.stopPropagation()}

--- a/libs/ui/src/lib/user-feedback-widget/UserFeedbackWidget.tsx
+++ b/libs/ui/src/lib/user-feedback-widget/UserFeedbackWidget.tsx
@@ -319,7 +319,7 @@ export const UserFeedbackWidget = () => {
       >
         <Tooltip
           content={isOpen || showContextMenu ? undefined : 'Send us your feedback (⌘/Ctrl+Shift+.). Right click for positioning options.'}
-          openDelay={300}
+          openDelay={500}
         >
           <Icon type="standard" icon="feedback" className="" omitContainer />
           <span className="slds-assistive-text">Send Feedback</span>


### PR DESCRIPTION
Adjust the tooltip open delay from 300ms to 500ms for improved user experience. Prevent column drag initiation while resizing to enhance table usability.