### PR TITLE
feat: optimize data table performance

### DIFF
--- a/libs/ui/src/lib/data-table/SalesforceRecordDataTable.tsx
+++ b/libs/ui/src/lib/data-table/SalesforceRecordDataTable.tsx
@@ -6,7 +6,7 @@ import { formatNumber, hasCtrlOrMeta, isEnterKey, tracker, useGlobalEventHandler
 import { flattenRecord, getIdFromRecordUrl, groupByFlat, nullifyEmptyStrings } from '@jetstream/shared/utils';
 import { CloneEditView, ContextMenuItem, Field, Maybe, QueryResults, SalesforceOrgUi, SobjectCollectionResponse } from '@jetstream/types';
 import uniqueId from 'lodash/uniqueId';
-import { Fragment, ReactNode, memo, useCallback, useEffect, useRef, useState } from 'react';
+import { Fragment, ReactNode, memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import SearchInput from '../form/search-input/SearchInput';
 import Grid from '../grid/Grid';
 import AutoFullHeightContainer from '../layout/AutoFullHeightContainer';
@@ -443,6 +443,27 @@ export const SalesforceRecordDataTable = memo<SalesforceRecordDataTableProps>(
       // });
     }
 
+    // Stable context for the grid's generic bag. An inline object here gave the grid a new `context`
+    // identity on every render (search keystroke, selection, dirty-row change), which churned the grid's
+    // record-action context and re-rendered every link/popover cell. Keyed on the callbacks it closes over.
+    const tableContext = useMemo(
+      () => ({
+        org,
+        defaultApiVersion,
+        onRecordAction: (action: CloneEditView, recordId: string, sobjectName: string) => {
+          switch (action) {
+            case 'view':
+              onView({ Id: recordId, attributes: { type: sobjectName } }, 'RELATED_RECORD_POPOVER');
+              break;
+            case 'edit':
+              onEdit({ Id: recordId, attributes: { type: sobjectName } }, 'RELATED_RECORD_POPOVER');
+              break;
+          }
+        },
+      }),
+      [org, defaultApiVersion, onView, onEdit],
+    );
+
     return records ? (
       <Fragment>
         <Grid className="slds-p-around_xx-small" align="spread">
@@ -526,20 +547,7 @@ export const SalesforceRecordDataTable = memo<SalesforceRecordDataTableProps>(
               onSelectedRowsChange={handleSelectedRowsChange}
               onSortedAndFilteredRowsChange={handleSortedAndFilteredRowsChange}
               onRowsChange={(changedRows, data) => handleRowsChange(rows || [], changedRows, data)}
-              context={{
-                org,
-                defaultApiVersion,
-                onRecordAction: (action: CloneEditView, recordId: string, sobjectName: string) => {
-                  switch (action) {
-                    case 'view':
-                      onView({ Id: recordId, attributes: { type: sobjectName } }, 'RELATED_RECORD_POPOVER');
-                      break;
-                    case 'edit':
-                      onEdit({ Id: recordId, attributes: { type: sobjectName } }, 'RELATED_RECORD_POPOVER');
-                      break;
-                  }
-                },
-              }}
+              context={tableContext}
               contextMenuItems={TABLE_CONTEXT_MENU_ITEMS}
               contextMenuAction={handleContextMenuAction}
             />

--- a/libs/ui/src/lib/data-table/grid/DataTableV2.tsx
+++ b/libs/ui/src/lib/data-table/grid/DataTableV2.tsx
@@ -6,7 +6,7 @@ import { RowHeightFn } from './components/GridBody';
 import { GridContainer } from './components/GridContainer';
 import { useJetstreamTable } from './core/useJetstreamTable';
 import './data-table-grid.css';
-import { GridFilterContext, GridGenericContext } from './grid-context';
+import { GridFilterContext, GridGenericContext, GridRecordActionContext } from './grid-context';
 import { getSortedFilteredLeafRows } from './grid-row-utils';
 import {
   ColumnWithFilter,
@@ -147,6 +147,17 @@ function DataTableV2Inner<TRow extends object = RowWithKey>(props: DataTableV2Pr
 
   const filterContextValue = useMemo(() => ({ filterSetValues, filters, updateFilter }), [filterSetValues, filters, updateFilter]);
 
+  // Stable record-action context for the high-cardinality id/name link cells. The generic context bag
+  // below carries a volatile `rows` array (rebuilt on every data/sort/filter change), and because a
+  // cell's `useContext` subscribes its owning GridCell, reading these stable values from there forced
+  // every link/popover cell to re-render on each keystroke. Key the memo on `onRecordAction`'s identity
+  // (not the whole `context` object) so an inline `context={{...}}` at a call site can't churn it.
+  const onRecordAction = (context as Record<string, any> | undefined)?.onRecordAction;
+  const recordActionContextValue = useMemo(
+    () => ({ org, serverUrl, skipFrontdoorLogin, onRecordAction }),
+    [org, serverUrl, skipFrontdoorLogin, onRecordAction],
+  );
+
   // The legacy DataTable exposed the filtered+sorted rows on the generic context; several consumers
   // (e.g. permission-manager's ColumnSearchFilterSummary / BulkActionRenderer) still read `rows`, so
   // keep providing them or those components crash on `rows.filter(...)` of undefined. Uses the
@@ -167,26 +178,28 @@ function DataTableV2Inner<TRow extends object = RowWithKey>(props: DataTableV2Pr
   );
 
   return (
-    <GridGenericContext.Provider value={genericContextValue}>
-      <GridFilterContext.Provider value={filterContextValue}>
-        <GridContainer
-          table={table}
-          gridId={gridId}
-          getRowKey={getRowKey}
-          orderedColumns={orderedColumns}
-          role={role ?? (grouping?.length || getSubRows ? 'treegrid' : 'grid')}
-          ariaLabel={ariaLabel}
-          className={className}
-          rowHeight={rowHeight}
-          rowClass={rowClass}
-          onRowsChange={onRowsChange ? handleRowsChange : undefined}
-          summaryRows={summaryRows}
-          summaryRowHeight={summaryRowHeight}
-          contextMenuItems={contextMenuItems}
-          contextMenuAction={contextMenuAction}
-        />
-      </GridFilterContext.Provider>
-    </GridGenericContext.Provider>
+    <GridRecordActionContext.Provider value={recordActionContextValue}>
+      <GridGenericContext.Provider value={genericContextValue}>
+        <GridFilterContext.Provider value={filterContextValue}>
+          <GridContainer
+            table={table}
+            gridId={gridId}
+            getRowKey={getRowKey}
+            orderedColumns={orderedColumns}
+            role={role ?? (grouping?.length || getSubRows ? 'treegrid' : 'grid')}
+            ariaLabel={ariaLabel}
+            className={className}
+            rowHeight={rowHeight}
+            rowClass={rowClass}
+            onRowsChange={onRowsChange ? handleRowsChange : undefined}
+            summaryRows={summaryRows}
+            summaryRowHeight={summaryRowHeight}
+            contextMenuItems={contextMenuItems}
+            contextMenuAction={contextMenuAction}
+          />
+        </GridFilterContext.Provider>
+      </GridGenericContext.Provider>
+    </GridRecordActionContext.Provider>
   );
 }
 

--- a/libs/ui/src/lib/data-table/grid/components/GridCell.tsx
+++ b/libs/ui/src/lib/data-table/grid/components/GridCell.tsx
@@ -143,4 +143,30 @@ function GridCellComponent<TRow>({
   );
 }
 
-export const GridCell = memo(GridCellComponent) as typeof GridCellComponent;
+// TanStack recreates Cell/Row instances whenever the row model recomputes (filter / sort / data change),
+// so a default shallow memo sees a brand-new `cell` prop and re-renders EVERY visible cell on each
+// keystroke — defeating the point of memoizing. Compare the stable underlying identity + values instead
+// (`cell.id`, the row's `original` data object, the resolved value, depth) plus the display flags. The
+// grid-level callbacks are intentionally NOT compared: they receive row/column ids as arguments and never
+// close over per-cell state, so a skipped re-render can never leave a stale handler. Context-driven
+// updates (e.g. a link cell reading GridRecordActionContext) still re-render through this memo — React
+// context propagation is not blocked by `memo`.
+function gridCellPropsAreEqual(prev: GridCellProps<any>, next: GridCellProps<any>): boolean {
+  return (
+    prev.cell.id === next.cell.id &&
+    prev.cell.row.original === next.cell.row.original &&
+    prev.cell.getValue() === next.cell.getValue() &&
+    prev.cell.row.depth === next.cell.row.depth &&
+    prev.columns === next.columns &&
+    prev.rowIndex === next.rowIndex &&
+    prev.colIndex === next.colIndex &&
+    prev.ariaColIndex === next.ariaColIndex &&
+    prev.colSpan === next.colSpan &&
+    prev.isActive === next.isActive &&
+    prev.isSelected === next.isSelected &&
+    prev.rowIsExpanded === next.rowIsExpanded &&
+    prev.isRangeSelected === next.isRangeSelected
+  );
+}
+
+export const GridCell = memo(GridCellComponent, gridCellPropsAreEqual) as typeof GridCellComponent;

--- a/libs/ui/src/lib/data-table/grid/components/GridRow.tsx
+++ b/libs/ui/src/lib/data-table/grid/components/GridRow.tsx
@@ -148,4 +148,29 @@ function GridRowComponent<TRow>({
   );
 }
 
-export const GridRow = memo(GridRowComponent) as typeof GridRowComponent;
+// Same rationale as GridCell: TanStack hands us a fresh `row` instance every time the row model
+// recomputes, so the default shallow memo re-renders every visible row on each keystroke. Compare the
+// stable row identity + data object + the layout/selection props that actually change what's rendered.
+// Callbacks are omitted (they take ids as args, never stale); the shared layout props (gridTemplateColumns,
+// visibleColumnIndexes, columns) are memoized upstream so comparing identity is correct.
+function gridRowPropsAreEqual(prev: GridRowProps<any>, next: GridRowProps<any>): boolean {
+  return (
+    prev.row.id === next.row.id &&
+    prev.row.original === next.row.original &&
+    prev.columns === next.columns &&
+    prev.gridTemplateColumns === next.gridTemplateColumns &&
+    prev.visibleColumnIndexes === next.visibleColumnIndexes &&
+    prev.ariaRowIndex === next.ariaRowIndex &&
+    prev.rowIndex === next.rowIndex &&
+    prev.virtualStart === next.virtualStart &&
+    prev.height === next.height &&
+    prev.activeCell === next.activeCell &&
+    prev.isSelected === next.isSelected &&
+    prev.isExpanded === next.isExpanded &&
+    prev.isLastRow === next.isLastRow &&
+    prev.selectionColRange === next.selectionColRange &&
+    prev.rowClass === next.rowClass
+  );
+}
+
+export const GridRow = memo(GridRowComponent, gridRowPropsAreEqual) as typeof GridRowComponent;

--- a/libs/ui/src/lib/data-table/grid/grid-column-utils.tsx
+++ b/libs/ui/src/lib/data-table/grid/grid-column-utils.tsx
@@ -12,7 +12,7 @@ import { EditorBoolean, EditorDate, EditorText, editorDropdown, editorRecordLook
 import { ACTION_COLUMN_KEY, SELECT_COLUMN_KEY } from './grid-constants';
 import { ColumnType, ColumnWithFilter, FilterType, RowWithKey, SalesforceQueryColumnDefinition } from './grid-types';
 import {
-  ActionRenderer,
+  ActionRendererMemo,
   BooleanRenderer,
   ComplexDataRenderer,
   GenericRenderer,
@@ -110,7 +110,7 @@ export function getColumnDefinitions(
         width: 116,
         minWidth: 100,
         maxWidth: 150,
-        renderCell: ActionRenderer,
+        renderCell: (props) => <ActionRendererMemo {...props} />,
         frozen: true,
         sortable: false,
       });

--- a/libs/ui/src/lib/data-table/grid/grid-context.tsx
+++ b/libs/ui/src/lib/data-table/grid/grid-context.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { NOOP } from '@jetstream/shared/utils';
+import { CloneEditView, SalesforceOrgUi } from '@jetstream/types';
 import type { Table } from '@tanstack/react-table';
 import { createContext, useContext } from 'react';
 import { ColumnWithFilter, FilterContextProps, RowWithKey, SelectedRowsContext, SubqueryContext } from './grid-types';
@@ -19,6 +20,22 @@ export const GridSelectedContext = createContext<SelectedRowsContext>({ selected
 
 /** Arbitrary data bag passed by the consumer (org, onRecordAction, defaultApiVersion, rows, columns, ...). */
 export const GridGenericContext = createContext<Record<string, any>>({});
+
+/**
+ * Stable record-action context consumed by high-cardinality cell renderers (the id/name link cells).
+ * Kept separate from `GridGenericContext` on purpose: the generic bag carries a volatile `rows` array
+ * that is rebuilt on every data/sort/filter change, and because a cell's `useContext` subscribes its
+ * owning `GridCell`, bundling these stable values there forced every link/popover cell to re-render on
+ * each keystroke. This context only changes when the org/serverUrl/onRecordAction actually change.
+ */
+export interface RecordActionContextValue {
+  org?: SalesforceOrgUi;
+  serverUrl?: string;
+  skipFrontdoorLogin?: boolean;
+  onRecordAction?: (action: CloneEditView, recordId: string, sobjectName: string) => void;
+}
+
+export const GridRecordActionContext = createContext<RecordActionContextValue>({});
 
 /**
  * Shared grid runtime: the TanStack table instance + a few config values renderers/cells need without

--- a/libs/ui/src/lib/data-table/grid/grid-filters.ts
+++ b/libs/ui/src/lib/data-table/grid/grid-filters.ts
@@ -188,32 +188,41 @@ export function computeFilterSetValues<TRow>(
   data: TRow[],
   ignoreRowInSetFilter?: (row: TRow) => boolean,
 ): Record<string, string[]> {
-  const columnsByKey = new Map(columns.map((column) => [column.key, column]));
-  return columns.reduce((acc: Record<string, string[]>, column) => {
+  const result: Record<string, string[]> = {};
+
+  // Resolve the SET columns once. BOOLEAN_SET is the constant True/False pair and needs no data scan.
+  const setColumns: { column: ColumnWithFilter<TRow>; values: Set<string> }[] = [];
+  for (const column of columns) {
     const setFilterType = column.filters?.find((type) => FILTER_SET_TYPES.has(type));
     if (!setFilterType) {
-      return acc;
+      continue;
     }
     if (setFilterType === 'BOOLEAN_SET') {
-      acc[column.key] = ['True', 'False'];
-      return acc;
+      result[column.key] = ['True', 'False'];
+      continue;
     }
-    const resolvedColumn = columnsByKey.get(column.key);
-    if (!resolvedColumn) {
-      return acc;
+    setColumns.push({ column, values: new Set<string>() });
+  }
+  if (setColumns.length === 0) {
+    return result;
+  }
+
+  // Single pass over the data: accumulate every SET column's distinct values together and evaluate
+  // `ignoreRowInSetFilter` once per row. The previous implementation scanned the entire dataset once PER
+  // SET column (filter→map→Set→sort, with two row-length temp arrays each), which dominated the initial
+  // render of wide query results.
+  for (const row of data) {
+    if (ignoreRowInSetFilter && ignoreRowInSetFilter(row)) {
+      continue;
     }
-    acc[column.key] = orderValues(
-      Array.from(
-        new Set(
-          data
-            .filter((row) => (ignoreRowInSetFilter ? !ignoreRowInSetFilter(row) : true))
-            .map((row) => {
-              const rowValue = getFilterValue(resolvedColumn, row);
-              return isNil(rowValue) ? EMPTY_FIELD : String(rowValue);
-            }),
-        ),
-      ),
-    );
-    return acc;
-  }, {});
+    for (const { column, values } of setColumns) {
+      const rowValue = getFilterValue(column, row);
+      values.add(isNil(rowValue) ? EMPTY_FIELD : String(rowValue));
+    }
+  }
+
+  for (const { column, values } of setColumns) {
+    result[column.key] = orderValues(Array.from(values));
+  }
+  return result;
 }

--- a/libs/ui/src/lib/data-table/grid/renderers/CellRenderers.tsx
+++ b/libs/ui/src/lib/data-table/grid/renderers/CellRenderers.tsx
@@ -2,12 +2,12 @@
 import { css } from '@emotion/react';
 import { isValidSalesforceRecordId } from '@jetstream/shared/ui-utils';
 import { getIdFromRecordUrl } from '@jetstream/shared/utils';
-import { CloneEditView, SalesforceOrgUi } from '@jetstream/types';
+import { SalesforceOrgUi } from '@jetstream/types';
 import lodashGet from 'lodash/get';
 import isBoolean from 'lodash/isBoolean';
 import isFunction from 'lodash/isFunction';
 import isString from 'lodash/isString';
-import { Fragment, ReactNode, useContext, useState } from 'react';
+import { Fragment, memo, ReactNode, useContext, useState } from 'react';
 import Checkbox from '../../../form/checkbox/Checkbox';
 import Modal from '../../../modal/Modal';
 import { Popover } from '../../../popover/Popover';
@@ -18,21 +18,15 @@ import Spinner from '../../../widgets/Spinner';
 import Tooltip from '../../../widgets/Tooltip';
 import { dataTableDateFormatter } from '../../data-table-formatters';
 import { ACTION_COLUMN_KEY, SELECT_COLUMN_KEY } from '../grid-constants';
-import { GridGenericContext } from '../grid-context';
+import { GridRecordActionContext } from '../grid-context';
 import { getRowId, getSfdcRetUrl } from '../grid-row-utils';
 import { ColumnWithFilter, DataTableCellProps, DataTableGroupCellProps, RowWithKey } from '../grid-types';
 
 /**
  * Cell renderers ported from the legacy DataTableRenderers to the new `DataTableCellProps` contract.
- * Salesforce org/serverUrl/onRecordAction now come from GridGenericContext instead of module globals.
+ * Salesforce org/serverUrl/onRecordAction come from GridRecordActionContext (kept separate from the
+ * volatile GridGenericContext bag for render stability) instead of module globals.
  */
-
-interface RecordActionContext {
-  org?: SalesforceOrgUi;
-  serverUrl?: string;
-  skipFrontdoorLogin?: boolean;
-  onRecordAction?: (action: CloneEditView, recordId: string, sobjectName: string) => void;
-}
 
 export function GenericRenderer(props: DataTableCellProps<RowWithKey>): ReactNode {
   const { column, row } = props;
@@ -104,7 +98,7 @@ export function ComplexDataRenderer({ column, row }: DataTableCellProps<RowWithK
 }
 
 export function IdLinkRenderer({ column, row }: DataTableCellProps<RowWithKey>): ReactNode {
-  const { org, serverUrl, skipFrontdoorLogin, onRecordAction } = useContext(GridGenericContext) as RecordActionContext;
+  const { org, serverUrl, skipFrontdoorLogin, onRecordAction } = useContext(GridRecordActionContext);
   const recordId = row[column.key];
   const { skipFrontDoorAuth, url } = getSfdcRetUrl(row, recordId, skipFrontdoorLogin);
   return (
@@ -122,7 +116,7 @@ export function IdLinkRenderer({ column, row }: DataTableCellProps<RowWithKey>):
 }
 
 export function NameLinkRenderer({ column, row }: DataTableCellProps<RowWithKey>): ReactNode {
-  const { org, serverUrl, skipFrontdoorLogin, onRecordAction } = useContext(GridGenericContext) as RecordActionContext;
+  const { org, serverUrl, skipFrontdoorLogin, onRecordAction } = useContext(GridRecordActionContext);
   const nameValue = row[column.key];
   const parentPath = column.key.includes('.') ? column.key.split('.').slice(0, -1).join('.') : '';
   const relatedRecord = parentPath ? lodashGet(row._record, parentPath) : row._record;
@@ -150,7 +144,7 @@ export function NameLinkRenderer({ column, row }: DataTableCellProps<RowWithKey>
 
 export function TextOrIdLinkRenderer(props: DataTableCellProps<RowWithKey>): ReactNode {
   const { column, row } = props;
-  const { org } = useContext(GridGenericContext) as RecordActionContext;
+  const { org } = useContext(GridRecordActionContext);
   if (!row) {
     return <div />;
   }
@@ -205,6 +199,15 @@ export function ActionRenderer({ row }: DataTableCellProps<any>): ReactNode {
     </Fragment>
   );
 }
+
+/**
+ * Memoized `ActionRenderer` for use as a column `renderCell`. The action column renders ~5 tooltipped
+ * buttons per row; `ActionRenderer` depends only on `row`, so memoizing on row identity keeps an
+ * unrelated grid commit (which re-renders the cell) from reconciling hundreds of floating-ui tooltips.
+ * Must be rendered as a fiber — `renderCell: (props) => <ActionRendererMemo {...props} />` — for the
+ * memo boundary to take effect (a bare `renderCell: ActionRenderer` is invoked as a plain function).
+ */
+export const ActionRendererMemo = memo(ActionRenderer, (prev, next) => prev.row === next.row);
 
 export function ErrorMessageRenderer({ row }: { row: any }): ReactNode {
   if (!row?._saveError) {

--- a/libs/ui/src/lib/popover/Popover.tsx
+++ b/libs/ui/src/lib/popover/Popover.tsx
@@ -17,7 +17,7 @@ import {
 } from '@floating-ui/react';
 import { FullWidth, sizeXLarge, SmallMediumLarge } from '@jetstream/types';
 import classNames from 'classnames';
-import { createElement, CSSProperties, ReactNode, RefObject, useCallback, useEffect, useImperativeHandle, useState } from 'react';
+import { createElement, CSSProperties, memo, ReactNode, RefObject, useCallback, useEffect, useImperativeHandle, useState } from 'react';
 import { Tooltip, TooltipProps } from '../..';
 import { usePortalContext } from '../modal/PortalContext';
 import { Icon } from '../widgets/Icon';
@@ -62,7 +62,7 @@ export interface PopoverProps {
   onChange?: (isOpen: boolean) => void;
 }
 
-export const Popover = ({
+const PopoverComponent = ({
   ref,
   testId,
   classname,
@@ -325,3 +325,12 @@ export const Popover = ({
     </span>
   );
 };
+
+/**
+ * Memoized so a parent re-render with shallow-equal props doesn't re-run the floating-ui hooks. The
+ * benefit only materializes when props (notably `content`/`children`) are referentially stable —
+ * inline JSX defeats the shallow comparison. In the query-results id/name link cells the real win is
+ * the upstream `GridCell` memo boundary gating re-renders; this wrapper is defensive for callers that
+ * do pass stable props.
+ */
+export const Popover = memo(PopoverComponent);

--- a/libs/ui/src/lib/widgets/Tooltip.tsx
+++ b/libs/ui/src/lib/widgets/Tooltip.tsx
@@ -14,7 +14,7 @@ import {
   useRole,
 } from '@floating-ui/react';
 import { Maybe } from '@jetstream/types';
-import { FunctionComponent, MouseEvent, useEffect, useRef, useState } from 'react';
+import { FunctionComponent, memo, MouseEvent, useEffect, useRef, useState } from 'react';
 import { usePortalContext } from '../modal/PortalContext';
 
 export interface TooltipProps {
@@ -36,7 +36,7 @@ export interface TooltipProps {
   children?: React.ReactNode;
 }
 
-export const Tooltip: FunctionComponent<TooltipProps> = ({
+const TooltipComponent: FunctionComponent<TooltipProps> = ({
   className,
   content,
   openDelay,
@@ -188,5 +188,14 @@ export const Tooltip: FunctionComponent<TooltipProps> = ({
     </>
   );
 };
+
+/**
+ * Memoized so a parent re-render with shallow-equal props doesn't re-run the floating-ui hooks. The
+ * benefit only materializes when `content`/`children` are referentially stable — inline JSX children
+ * defeat the shallow comparison. In the query-results action column the real win is the upstream
+ * `ActionRendererMemo`/`GridCell` memo boundaries gating re-renders; this wrapper is defensive for
+ * callers that do pass stable props.
+ */
+export const Tooltip = memo(TooltipComponent);
 
 export default Tooltip;


### PR DESCRIPTION
Improved set filter performance by iterating once instead of once per column

Improved Tooltip/popover rendering performance by memoizing

Memoized where possible to reduce re-render cycles on initial table load