### PR TITLE
chore: utilize AsyncContext to ensure logs have all request context

### DIFF
--- a/apps/api/eslint.config.js
+++ b/apps/api/eslint.config.js
@@ -1,3 +1,4 @@
+/* eslint-disable @nx/enforce-module-boundaries */
 const baseConfig = require('../../eslint.config.js');
 
 module.exports = [
@@ -13,8 +14,25 @@ module.exports = [
   },
   {
     files: ['**/*.ts', '**/*.tsx'],
+    ignores: ['**/__tests__/**', '**/*.spec.ts'],
     // Override or add rules here
-    rules: {},
+    rules: {
+      // Request-scoped logging flows through `getLogger()` (AsyncLocalStorage) from
+      // '@jetstream/api-config'. Reading `req.log` / `res.log` directly bypasses the request
+      // context (and still typechecks because @types/pino-http augments the base Express types),
+      // so it is banned here to prevent regressions.
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector: "MemberExpression[object.name='req'][property.name='log']",
+          message: "Use getLogger() from '@jetstream/api-config' instead of req.log.",
+        },
+        {
+          selector: "MemberExpression[object.name='res'][property.name='log']",
+          message: "Use getLogger() from '@jetstream/api-config' instead of res.log.",
+        },
+      ],
+    },
   },
   {
     files: ['**/*.js', '**/*.jsx'],

--- a/apps/api/src/app/controllers/__tests__/auth.controller.spec.ts
+++ b/apps/api/src/app/controllers/__tests__/auth.controller.spec.ts
@@ -136,6 +136,7 @@ vi.mock('@jetstream/api-config', () => ({
     CI: false,
   },
   logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  getLogger: () => ({ trace: vi.fn(), debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
   prisma: {},
   errorTracker: { error: vi.fn(), warn: vi.fn(), critical: vi.fn(), info: vi.fn() },
   DbCacheProvider: class {

--- a/apps/api/src/app/controllers/__tests__/desktop-app.controller.spec.ts
+++ b/apps/api/src/app/controllers/__tests__/desktop-app.controller.spec.ts
@@ -25,6 +25,7 @@ const mocks = vi.hoisted(() => ({
 vi.mock('@jetstream/api-config', () => ({
   ENV: { JETSTREAM_SERVER_URL: 'https://server.test', ENVIRONMENT: 'test', CI: false, DESKTOP_ORG_ENCRYPTION_SECRET: 'desktop-secret' },
   logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  getLogger: () => ({ trace: vi.fn(), debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
   errorTracker: { error: vi.fn(), warn: vi.fn(), critical: vi.fn(), info: vi.fn() },
   prisma: {},
 }));

--- a/apps/api/src/app/controllers/__tests__/team.controller.spec.ts
+++ b/apps/api/src/app/controllers/__tests__/team.controller.spec.ts
@@ -32,10 +32,17 @@ const resolveTxtMock = vi.hoisted(() => vi.fn());
 // to load the module. We are exercising maskSsoSecrets and fetchSamlMetadata — nothing
 // else from the controller touches its DB/service layer. vitest hoists these vi.mock
 // calls before the imports above at runtime, so the load-order is correct.
+// Holder so the mocked getLogger() can be pointed at warnMock for checkDomainVerification's
+// warning assertions. Defaults to a no-op logger for every other test.
+const loggerHolder = vi.hoisted(() => ({
+  current: { trace: vi.fn(), debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() } as Record<string, ReturnType<typeof vi.fn>>,
+}));
+
 vi.mock('@jetstream/api-config', () => ({
   ENV: { JETSTREAM_SERVER_URL: 'https://server.test', USE_SECURE_COOKIES: true, JETSTREAM_SAML_ACS_PATH_PREFIX: '/api/auth/sso/saml' },
   getExceptionLog: (error: unknown) => ({ error: error instanceof Error ? error.message : error }),
   logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  getLogger: () => loggerHolder.current,
   prisma: {},
   rollbarServer: { error: vi.fn(), warn: vi.fn() },
 }));
@@ -240,6 +247,7 @@ describe('fetchSamlMetadata', () => {
       ENV: { JETSTREAM_SERVER_URL: 'https://server.test', USE_SECURE_COOKIES: false, JETSTREAM_SAML_ACS_PATH_PREFIX: '/api/auth/sso/saml' },
       getExceptionLog: (error: unknown) => ({ error: error instanceof Error ? error.message : error }),
       logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+      getLogger: () => loggerHolder.current,
       prisma: {},
       rollbarServer: { error: vi.fn(), warn: vi.fn() },
     }));
@@ -263,12 +271,14 @@ describe('checkDomainVerification', () => {
     resolveTxtMock.mockReset();
     fetchWithPinnedPublicIpMock.mockReset();
     warnMock = vi.fn<(obj: Record<string, unknown>, msg: string) => void>();
+    // checkDomainVerification now logs via getLogger(); point its warn at warnMock for assertions.
+    loggerHolder.current = { trace: vi.fn(), debug: vi.fn(), info: vi.fn(), warn: warnMock, error: vi.fn() };
   });
 
   it('verifies via a DNS TXT record on the apex domain without checking files', async () => {
     resolveTxtMock.mockResolvedValueOnce([[CODE]]);
 
-    const result = await checkDomainVerification(DOMAIN, CODE, { warn: warnMock });
+    const result = await checkDomainVerification(DOMAIN, CODE);
 
     expect(result).toEqual({ verified: true, verificationMethod: 'dns', foundNonMatchingValue: false });
     expect(resolveTxtMock).toHaveBeenCalledTimes(1);
@@ -279,7 +289,7 @@ describe('checkDomainVerification', () => {
   it('verifies via the _jetstream. subdomain when the apex has no matching record', async () => {
     resolveTxtMock.mockResolvedValueOnce([['v=spf1 include:_spf.google.com ~all']]).mockResolvedValueOnce([[CODE]]);
 
-    const result = await checkDomainVerification(DOMAIN, CODE, { warn: warnMock });
+    const result = await checkDomainVerification(DOMAIN, CODE);
 
     expect(result).toEqual({ verified: true, verificationMethod: 'dns', foundNonMatchingValue: false });
     expect(resolveTxtMock).toHaveBeenNthCalledWith(2, '_jetstream.example.com');
@@ -289,7 +299,7 @@ describe('checkDomainVerification', () => {
   it('does not report a mismatch when a stale apex record coexists with a matching _jetstream. record', async () => {
     resolveTxtMock.mockResolvedValueOnce([['jetstream-verification=stale']]).mockResolvedValueOnce([[CODE]]);
 
-    const result = await checkDomainVerification(DOMAIN, CODE, { warn: warnMock });
+    const result = await checkDomainVerification(DOMAIN, CODE);
 
     expect(result).toEqual({ verified: true, verificationMethod: 'dns', foundNonMatchingValue: false });
     expect(fetchWithPinnedPublicIpMock).not.toHaveBeenCalled();
@@ -299,7 +309,7 @@ describe('checkDomainVerification', () => {
     resolveTxtMock.mockResolvedValue([['jetstream-verification=stale']]);
     fetchWithPinnedPublicIpMock.mockImplementation(async () => new Response('not found', { status: 404 }));
 
-    const result = await checkDomainVerification(DOMAIN, CODE, { warn: warnMock });
+    const result = await checkDomainVerification(DOMAIN, CODE);
 
     expect(result).toEqual({ verified: false, verificationMethod: null, foundNonMatchingValue: true });
     expect(warnMock).toHaveBeenCalledWith(
@@ -312,7 +322,7 @@ describe('checkDomainVerification', () => {
     resolveTxtMock.mockResolvedValue([['v=spf1 include:_spf.google.com ~all']]);
     fetchWithPinnedPublicIpMock.mockImplementation(async () => new Response('not found', { status: 404 }));
 
-    const result = await checkDomainVerification(DOMAIN, CODE, { warn: warnMock });
+    const result = await checkDomainVerification(DOMAIN, CODE);
 
     expect(result).toEqual({ verified: false, verificationMethod: null, foundNonMatchingValue: false });
   });
@@ -322,7 +332,7 @@ describe('checkDomainVerification', () => {
     // Trailing newline exercises the trim before comparison.
     fetchWithPinnedPublicIpMock.mockResolvedValueOnce(new Response(`${CODE}\n`, { status: 200 }));
 
-    const result = await checkDomainVerification(DOMAIN, CODE, { warn: warnMock });
+    const result = await checkDomainVerification(DOMAIN, CODE);
 
     expect(result).toEqual({ verified: true, verificationMethod: 'file', foundNonMatchingValue: false });
     expect(fetchWithPinnedPublicIpMock).toHaveBeenCalledTimes(1);
@@ -336,7 +346,7 @@ describe('checkDomainVerification', () => {
       .mockResolvedValueOnce(new Response('not found', { status: 404 }))
       .mockResolvedValueOnce(new Response(CODE, { status: 200 }));
 
-    const result = await checkDomainVerification(DOMAIN, CODE, { warn: warnMock });
+    const result = await checkDomainVerification(DOMAIN, CODE);
 
     expect(result).toEqual({ verified: true, verificationMethod: 'file', foundNonMatchingValue: false });
     expect(fetchWithPinnedPublicIpMock.mock.calls[1][0]).toBe('https://www.example.com/.well-known/jetstream-verification.txt');
@@ -346,7 +356,7 @@ describe('checkDomainVerification', () => {
     resolveTxtMock.mockResolvedValue([]);
     fetchWithPinnedPublicIpMock.mockImplementation(async () => new Response('not found', { status: 404 }));
 
-    const result = await checkDomainVerification('www.example.com', CODE, { warn: warnMock });
+    const result = await checkDomainVerification('www.example.com', CODE);
 
     expect(result).toEqual({ verified: false, verificationMethod: null, foundNonMatchingValue: false });
     // Only the stored host is fetched — never `www.www.example.com`.
@@ -358,7 +368,7 @@ describe('checkDomainVerification', () => {
     resolveTxtMock.mockResolvedValue([]);
     fetchWithPinnedPublicIpMock.mockImplementation(async () => new Response('jetstream-verification=stale', { status: 200 }));
 
-    const result = await checkDomainVerification(DOMAIN, CODE, { warn: warnMock });
+    const result = await checkDomainVerification(DOMAIN, CODE);
 
     expect(result).toEqual({ verified: false, verificationMethod: null, foundNonMatchingValue: true });
     expect(warnMock).toHaveBeenCalledWith(
@@ -371,7 +381,7 @@ describe('checkDomainVerification', () => {
     resolveTxtMock.mockResolvedValue([]);
     fetchWithPinnedPublicIpMock.mockImplementation(async () => new Response('<html>404</html>', { status: 404 }));
 
-    const result = await checkDomainVerification(DOMAIN, CODE, { warn: warnMock });
+    const result = await checkDomainVerification(DOMAIN, CODE);
 
     expect(result).toEqual({ verified: false, verificationMethod: null, foundNonMatchingValue: false });
     // Both DNS hosts and both file hosts are tried before giving up.
@@ -383,7 +393,7 @@ describe('checkDomainVerification', () => {
     resolveTxtMock.mockResolvedValue([]);
     fetchWithPinnedPublicIpMock.mockRejectedValue(new Error('Hostname resolves to a private or reserved IP address'));
 
-    const result = await checkDomainVerification(DOMAIN, CODE, { warn: warnMock });
+    const result = await checkDomainVerification(DOMAIN, CODE);
 
     expect(result).toEqual({ verified: false, verificationMethod: null, foundNonMatchingValue: false });
     expect(fetchWithPinnedPublicIpMock).toHaveBeenCalled();

--- a/apps/api/src/app/controllers/__tests__/user.controller.spec.ts
+++ b/apps/api/src/app/controllers/__tests__/user.controller.spec.ts
@@ -69,6 +69,7 @@ vi.mock('@jetstream/api-config', () => ({
     CI: false,
   },
   logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  getLogger: () => ({ trace: vi.fn(), debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
   prisma: {},
   errorTracker: { error: vi.fn(), warn: vi.fn(), critical: vi.fn(), info: vi.fn() },
 }));

--- a/apps/api/src/app/controllers/__tests__/web-extension.controller.spec.ts
+++ b/apps/api/src/app/controllers/__tests__/web-extension.controller.spec.ts
@@ -25,6 +25,7 @@ const mocks = vi.hoisted(() => ({
 vi.mock('@jetstream/api-config', () => ({
   ENV: { JETSTREAM_SERVER_URL: 'https://server.test', ENVIRONMENT: 'test', CI: false },
   logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  getLogger: () => ({ trace: vi.fn(), debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
   errorTracker: { error: vi.fn(), warn: vi.fn(), critical: vi.fn(), info: vi.fn() },
   prisma: {},
 }));

--- a/apps/api/src/app/controllers/auth.controller.ts
+++ b/apps/api/src/app/controllers/auth.controller.ts
@@ -1,4 +1,4 @@
-import { DbCacheProvider, ENV } from '@jetstream/api-config';
+import { DbCacheProvider, ENV, getLogger } from '@jetstream/api-config';
 import {
   acceptTos,
   AuthError,
@@ -303,7 +303,7 @@ export const routeDefinition = {
 const logout = createRoute(routeDefinition.logout.validators, async ({}, req, res) => {
   req.session.destroy((err) => {
     if (err) {
-      res.log.error({ err }, '[AUTH][LOGOUT][ERROR] Error destroying session');
+      getLogger().error({ err }, '[AUTH][LOGOUT][ERROR] Error destroying session');
     }
     redirect(res, ENV.JETSTREAM_SERVER_URL);
   });
@@ -794,7 +794,7 @@ const verification = createRoute(
           if (nextAttempts >= MAX_VERIFICATION_ATTEMPTS) {
             // Capture before destroy so the audit row for the abuse event remains attributable.
             const userIdForAudit = req.session.user?.id;
-            res.log.warn(
+            getLogger().warn(
               {
                 userId: userIdForAudit,
                 email: req.session.user?.email,
@@ -806,7 +806,7 @@ const verification = createRoute(
             await new Promise<void>((resolve) => {
               req.session.destroy((destroyErr) => {
                 if (destroyErr) {
-                  res.log.error({ err: destroyErr }, '[AUTH][TOO_MANY_ATTEMPTS][ERROR] Error destroying session');
+                  getLogger().error({ err: destroyErr }, '[AUTH][TOO_MANY_ATTEMPTS][ERROR] Error destroying session');
                 }
                 resolve();
               });
@@ -820,12 +820,12 @@ const verification = createRoute(
 
       // Redirect back to sign in page
       if (isPlaceholderUser) {
-        res.log.info(
+        getLogger().info(
           '[AUTH][PLACEHOLDER_USER] User registration with placeholder user - destroying session and redirecting to login with error',
         );
         req.session.destroy((err) => {
           if (err) {
-            res.log.error({ err }, '[AUTH][PLACEHOLDER_USER][ERROR] Error destroying session');
+            getLogger().error({ err }, '[AUTH][PLACEHOLDER_USER][ERROR] Error destroying session');
           }
           const searchParams = new URLSearchParams({ error: 'InvalidRegistration' });
           sendJson(res, { error: false, redirect: `/auth/login/?${searchParams.toString()}` });
@@ -954,7 +954,7 @@ const resendVerification = createRoute(routeDefinition.resendVerification.valida
         })();
 
     void resendVerificationEmailPromise.catch((error) => {
-      res.log.error({ err: error, userId: req.session.user?.id, type }, 'Failed to resend verification message');
+      getLogger().error({ err: error, userId: req.session.user?.id, type }, 'Failed to resend verification message');
     });
 
     createUserActivityFromReq(req, res, {
@@ -991,10 +991,10 @@ const requestPasswordReset = createRoute(routeDefinition.requestPasswordReset.va
       // which was an account-enumeration timing oracle. Not awaiting it removes that dominant
       // timing gap (the residual DB-work difference between the two paths is negligible by comparison).
       void sendPasswordReset(email, token, PASSWORD_RESET_DURATION_MINUTES).catch((error) => {
-        res.log.error({ err: error, email }, '[AUTH][PASSWORD_RESET] Failed to send password reset email');
+        getLogger().error({ err: error, email }, '[AUTH][PASSWORD_RESET] Failed to send password reset email');
       });
     } catch (ex) {
-      res.log.warn({ email }, `[AUTH][PASSWORD_RESET] ${getErrorMessage(ex)}`);
+      getLogger().warn({ email }, `[AUTH][PASSWORD_RESET] ${getErrorMessage(ex)}`);
       success = false;
     }
     sendJson(res, { error: false });
@@ -1007,7 +1007,7 @@ const requestPasswordReset = createRoute(routeDefinition.requestPasswordReset.va
       success,
     });
   } catch (ex) {
-    res.log.warn(getErrorMessageAndStackObj(ex), `[AUTH][PASSWORD_RESET] Fatal error when processing password reset`);
+    getLogger().warn(getErrorMessageAndStackObj(ex), `[AUTH][PASSWORD_RESET] Fatal error when processing password reset`);
     createUserActivityFromReqWithError(req, res, ex, {
       action: 'PASSWORD_RESET_REQUEST',
       method: 'UNAUTHENTICATED',
@@ -1227,12 +1227,12 @@ const discoverSso = createRoute(routeDefinition.discoverSso.validators, async ({
     const ssoConfig = await discoverSsoConfigByDomain(domain);
 
     if (!ssoConfig || !ssoConfig.ssoEnabled) {
-      res.log.debug({ email, ssoDiscoverSuccess: false }, '[AUTH][DISCOVER_SSO] No SSO configuration found for email domain');
+      getLogger().debug({ email, ssoDiscoverSuccess: false }, '[AUTH][DISCOVER_SSO] No SSO configuration found for email domain');
       sendJson(res, { available: false });
       return;
     }
 
-    res.log.debug({ email, ssoDiscoverSuccess: true }, '[AUTH][DISCOVER_SSO] SSO configuration found for email domain');
+    getLogger().debug({ email, ssoDiscoverSuccess: true }, '[AUTH][DISCOVER_SSO] SSO configuration found for email domain');
     createUserActivityFromReq(req, res, {
       action: 'SSO_DISCOVER',
       method: ssoConfig.ssoProvider,
@@ -1242,7 +1242,7 @@ const discoverSso = createRoute(routeDefinition.discoverSso.validators, async ({
     });
     sendJson(res, { available: true });
   } catch (ex) {
-    res.log.error(getErrorMessageAndStackObj(ex), '[AUTH][DISCOVER_SSO] Error discovering SSO configuration');
+    getLogger().error(getErrorMessageAndStackObj(ex), '[AUTH][DISCOVER_SSO] Error discovering SSO configuration');
     createUserActivityFromReqWithError(req, res, ex, {
       action: 'SSO_DISCOVER',
       email,
@@ -1320,7 +1320,7 @@ const startSso = createRoute(routeDefinition.startSso.validators, async ({ body,
     }
     throw new InvalidProvider('Unsupported SSO provider');
   } catch (ex) {
-    res.log.error({ email, returnUrl, ...getErrorMessageAndStackObj(ex) }, '[AUTH][START_SSO] Error starting SSO');
+    getLogger().error({ email, returnUrl, ...getErrorMessageAndStackObj(ex) }, '[AUTH][START_SSO] Error starting SSO');
     createUserActivityFromReqWithError(req, res, ex, {
       action: 'SSO_START',
       email,
@@ -1408,7 +1408,7 @@ const handleSamlCallback = createRoute(
         redirect(res, returnUrl);
       }
     } catch (ex) {
-      res.log.error(getErrorMessageAndStackObj(ex), '[AUTH][SAML_CALLBACK] Error processing SAML callback');
+      getLogger().error(getErrorMessageAndStackObj(ex), '[AUTH][SAML_CALLBACK] Error processing SAML callback');
       createUserActivityFromReqWithError(req, res, ex, {
         action: 'SSO_LOGIN',
         method: 'SAML',
@@ -1441,7 +1441,7 @@ const getSamlMetadata = createRoute(routeDefinition.getSamlMetadata.validators, 
     res.set('Content-Type', 'application/xml');
     res.send(metadata);
   } catch (ex) {
-    res.log.error(getErrorMessageAndStackObj(ex), '[AUTH][SAML_METADATA] Error generating SAML metadata');
+    getLogger().error(getErrorMessageAndStackObj(ex), '[AUTH][SAML_METADATA] Error generating SAML metadata');
     res.status(500).send('Error generating SAML metadata');
   }
 });
@@ -1477,7 +1477,7 @@ const initiateOidcLogin = createRoute(routeDefinition.initiateOidcLogin.validato
 
     redirect(res, url);
   } catch (ex) {
-    res.log.error(getErrorMessageAndStackObj(ex), '[AUTH][OIDC_INITIATE] Error initiating OIDC login');
+    getLogger().error(getErrorMessageAndStackObj(ex), '[AUTH][OIDC_INITIATE] Error initiating OIDC login');
     createUserActivityFromReqWithError(req, res, ex, {
       action: 'SSO_START',
       method: 'OIDC',
@@ -1573,7 +1573,7 @@ const handleOidcCallback = createRoute(routeDefinition.handleOidcCallback.valida
       redirect(res, returnUrl);
     }
   } catch (ex) {
-    res.log.error(getErrorMessageAndStackObj(ex), '[AUTH][OIDC_CALLBACK] Error processing OIDC callback');
+    getLogger().error(getErrorMessageAndStackObj(ex), '[AUTH][OIDC_CALLBACK] Error processing OIDC callback');
     createUserActivityFromReqWithError(req, res, ex, {
       action: 'SSO_LOGIN',
       method: 'OIDC',

--- a/apps/api/src/app/controllers/billing.controller.ts
+++ b/apps/api/src/app/controllers/billing.controller.ts
@@ -1,4 +1,4 @@
-import { ENV, logger } from '@jetstream/api-config';
+import { ENV, getLogger } from '@jetstream/api-config';
 import type { Request, Response } from '@jetstream/api-types';
 import { refreshSessionUser } from '@jetstream/auth/server';
 import { STRIPE_PRICE_KEYS, TeamMemberRole, TeamMemberRoleSchema, UserProfileUi } from '@jetstream/types';
@@ -106,7 +106,7 @@ const createCheckoutSessionHandler = createRoute(
 
     const priceId = await stripeService.fetchPrices({ lookupKeys: STRIPE_PRICE_KEYS }).then((prices) => prices[priceLookupKey]?.id);
     if (!priceId) {
-      res.log.error({ priceLookupKey }, 'Price lookup key not found');
+      getLogger().error({ priceLookupKey }, 'Price lookup key not found');
       throw new UserFacingError(`There was a problem initializing your billing session`);
     }
 
@@ -200,7 +200,7 @@ const getSubscriptionsHandler = createRoute(routeDefinition.getSubscriptions.val
     stripeCustomer: internalCustomer,
   } = await stripeService.synchronizeStripeWithJetstreamIfRequiredForTeamOrUser({ userId: user.id, teamId });
   if (!success) {
-    logger.error({ userId: user.id }, `Did not synchronize Stripe with Jetstream: ${reason}`);
+    getLogger().error({ userId: user.id }, `Did not synchronize Stripe with Jetstream: ${reason}`);
     sendJson(res, { customer: null, pricesByLookupKey: null, hasManualBilling: false, didUpdate });
     return;
   }

--- a/apps/api/src/app/controllers/canvas.controller.ts
+++ b/apps/api/src/app/controllers/canvas.controller.ts
@@ -1,4 +1,4 @@
-import { ENV } from '@jetstream/api-config';
+import { ENV, getLogger } from '@jetstream/api-config';
 import { salesforceCanvasOauthCallback, SalesforceCanvasOauthInit } from '@jetstream/salesforce-oauth';
 import { getErrorMessage, urlSearchParamsToJson } from '@jetstream/shared/utils';
 import { Canvas } from '@jetstream/types';
@@ -66,7 +66,7 @@ const callbackHandler = createRoute(routeDefinition.callbackHandler.validators, 
     if (queryParams.error) {
       returnParams.error = queryParams.error;
       returnParams.message = queryParams.error_description || 'There was an error authenticating with Salesforce.';
-      res.log.warn(
+      getLogger().warn(
         {
           hasCode: !!queryParams.code,
           error: queryParams.error,
@@ -92,7 +92,7 @@ const callbackHandler = createRoute(routeDefinition.callbackHandler.validators, 
     );
     returnParams.success = 'true';
   } catch (error) {
-    res.log.warn({ ...returnParams, error: getErrorMessage(error) }, '[CANVAS][AUTH_ERROR]');
+    getLogger().warn({ ...returnParams, error: getErrorMessage(error) }, '[CANVAS][AUTH_ERROR]');
     returnParams.error = 'unknown_error';
     returnParams.message = returnParams.message || getErrorMessage(error) || 'unknown_error';
   }
@@ -134,7 +134,7 @@ const appHandler = createRoute(routeDefinition.appHandler.validators, async ({ b
     } else if (signed_request) {
       // Verify and decode the signed request
       envelope = verifyAndDecodeAsJson(signed_request, clientSecret);
-      res.log.info(
+      getLogger().info(
         {
           authType: envelope?.context?.application?.authType,
           appName: envelope?.context?.application?.name,
@@ -182,7 +182,7 @@ const appHandler = createRoute(routeDefinition.appHandler.validators, async ({ b
 
     res.status(200).send(fileContents);
   } catch (error) {
-    res.log.error({ error: getErrorMessage(error) }, '[CANVAS][VERIFICATION_ERROR]');
+    getLogger().error({ error: getErrorMessage(error) }, '[CANVAS][VERIFICATION_ERROR]');
     res.status(401).send({
       status: 'error',
       message: error instanceof Error ? error.message : 'Failed to verify signed request',

--- a/apps/api/src/app/controllers/desktop-app.controller.ts
+++ b/apps/api/src/app/controllers/desktop-app.controller.ts
@@ -1,4 +1,4 @@
-import { ENV } from '@jetstream/api-config';
+import { ENV, getLogger } from '@jetstream/api-config';
 import {
   createUserActivityFromReq,
   getApiAddressFromReq,
@@ -170,7 +170,7 @@ const initSession = createRoute(routeDefinition.initSession.validators, async ({
       .verifyToken({ token: decryptedToken, deviceId }, externalAuthService.AUDIENCE_DESKTOP)
       .then(() => true)
       .catch((ex) => {
-        res.log.warn(
+        getLogger().warn(
           { userId: user.id, deviceId, ...getErrorMessageAndStackObj(ex) },
           'Stored desktop token failed verification; issuing a new token',
         );
@@ -181,7 +181,7 @@ const initSession = createRoute(routeDefinition.initSession.validators, async ({
       const decoded = externalAuthService.decodeToken(decryptedToken);
       const expiresAt = fromUnixTime(decoded.exp);
 
-      res.log.debug({ userId: user.id, deviceId, expiresAt }, 'Reusing existing desktop token');
+      getLogger().debug({ userId: user.id, deviceId, expiresAt }, 'Reusing existing desktop token');
 
       sendJson(res, { accessToken: decryptedToken });
       createUserActivityFromReq(req, res, {
@@ -210,7 +210,7 @@ const initSession = createRoute(routeDefinition.initSession.validators, async ({
     providerAccountId: req.session.providerAccountId,
   });
 
-  res.log.info({ userId: user.id, deviceId }, 'Issued new desktop token');
+  getLogger().info({ userId: user.id, deviceId }, 'Issued new desktop token');
 
   sendJson(res, { accessToken });
 
@@ -260,17 +260,17 @@ const verifyToken = createRoute(routeDefinition.verifyToken.validators, async ({
           throw new InvalidSession();
         }
         rotatedAccessToken = result.token;
-        res.log.debug({ userId: userProfile.id, deviceId, rotationOutcome: result.outcome }, 'Desktop App token verified');
+        getLogger().debug({ userId: userProfile.id, deviceId, rotationOutcome: result.outcome }, 'Desktop App token verified');
       }
     }
 
     if (!supportsRotation) {
-      res.log.debug({ userId: userProfile.id, deviceId }, 'Desktop App token verified');
+      getLogger().debug({ userId: userProfile.id, deviceId }, 'Desktop App token verified');
     }
 
     sendJson(res, { success: true, userProfile, encryptionKey, accessToken: rotatedAccessToken });
   } catch (ex) {
-    res.log.error({ userId: user?.id, deviceId, ...getErrorMessageAndStackObj(ex) }, 'Error verifying Desktop App token');
+    getLogger().error({ userId: user?.id, deviceId, ...getErrorMessageAndStackObj(ex) }, 'Error verifying Desktop App token');
     sendJson(res, { success: false, error: 'Invalid session' }, 401);
   }
 });
@@ -288,11 +288,11 @@ const logout = createRoute(routeDefinition.logout.validators, async ({ user }, r
     if (accessToken) {
       externalAuthService.invalidateCacheEntry(accessToken, deviceId);
     }
-    res.log.info({ userId: user.id, deviceId }, 'User logged out of desktop app');
+    getLogger().info({ userId: user.id, deviceId }, 'User logged out of desktop app');
 
     sendJson(res, { success: true });
   } catch (ex) {
-    res.log.error({ userId: user?.id, deviceId, ...getErrorMessageAndStackObj(ex) }, 'Error logging out of desktop app');
+    getLogger().error({ userId: user?.id, deviceId, ...getErrorMessageAndStackObj(ex) }, 'Error logging out of desktop app');
     sendJson(res, { success: false, error: 'Invalid session' }, 401);
   }
 });
@@ -339,7 +339,7 @@ const notifications = createRoute(routeDefinition.notifications.validators, asyn
 
   // TODO: potentially message user based on some conditions
 
-  res.log.info({ userId: user?.id, deviceId, os, version }, '[DESKTOP NOTIFICATIONS] User requested notifications');
+  getLogger().info({ userId: user?.id, deviceId, os, version }, '[DESKTOP NOTIFICATIONS] User requested notifications');
 
   const response: NotificationMessageV1Response = {
     success: true,

--- a/apps/api/src/app/controllers/oauth.controller.ts
+++ b/apps/api/src/app/controllers/oauth.controller.ts
@@ -1,4 +1,4 @@
-import { ENV, logger } from '@jetstream/api-config';
+import { ENV, getLogger } from '@jetstream/api-config';
 import { AuditLogAction, AuditLogResource, createTeamAuditLog } from '@jetstream/audit-logs';
 import { getApiAddressFromReq } from '@jetstream/auth/server';
 import { ApiConnection, ApiRequestError, getApiRequestFactoryFn } from '@jetstream/salesforce-api';
@@ -97,7 +97,7 @@ const salesforceOauthCallback = createRoute(
         returnParams.message = queryParams.error_description
           ? (queryParams.error_description as string)
           : 'There was an error authenticating with Salesforce.';
-        res.log.warn(
+        getLogger().warn(
           {
             hasCode: !!queryParams.code,
             error: queryParams.error,
@@ -115,7 +115,7 @@ const salesforceOauthCallback = createRoute(
         returnParams.message = queryParams.error_description
           ? (queryParams.error_description as string)
           : 'There was an error authenticating with Salesforce.';
-        res.log.warn(
+        getLogger().warn(
           {
             hasCode: !!queryParams.code,
             error: queryParams.error,
@@ -155,7 +155,7 @@ const salesforceOauthCallback = createRoute(
         apiVersion: ENV.SFDC_API_VERSION,
         instanceUrl: (userInfo.urls?.custom_domain as string) || loginUrl,
         refreshToken: refresh_token,
-        logger: res.log || req.log || logger,
+        logger: getLogger(),
         enableLogging: ENV.LOG_LEVEL === 'trace',
       });
 
@@ -209,7 +209,7 @@ const salesforceOauthCallback = createRoute(
         };
       }
 
-      res.log.warn(errorLogObj, '[OAUTH][ERROR]');
+      getLogger().warn(errorLogObj, '[OAUTH][ERROR]');
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       return res.redirect(`/oauth-link/?${new URLSearchParams(returnParams as any).toString().replaceAll('+', '%20')}`);
@@ -237,7 +237,7 @@ export async function initConnectionFromOAuthResponse({
       companyInfoRecord = results.records[0];
     }
   } catch (ex) {
-    logger.warn({ userId, err: ex }, 'Error getting org info %o', ex);
+    getLogger().warn({ userId, err: ex }, 'Error getting org info %o', ex);
     if (ex instanceof ApiRequestError && ERROR_MESSAGES.SFDC_REST_API_NOT_ENABLED.test(getErrorMessage(ex))) {
       throw new Error(ERROR_MESSAGES.SFDC_REST_API_NOT_ENABLED_MSG);
     }
@@ -276,7 +276,7 @@ export async function initConnectionFromOAuthResponse({
     try {
       salesforceOrgUi.jetstreamOrganizationId = (await jetstreamOrganizationsDb.findById({ id: orgGroupId, userId })).id;
     } catch (ex) {
-      logger.warn(
+      getLogger().warn(
         { userId, jetstreamOrganizationId: orgGroupId, err: ex },
         'Error getting jetstream org with provided id %s',
         getErrorMessage(ex),

--- a/apps/api/src/app/controllers/orgs.controller.ts
+++ b/apps/api/src/app/controllers/orgs.controller.ts
@@ -1,3 +1,4 @@
+import { getLogger } from '@jetstream/api-config';
 import { AuditLogAction, AuditLogResource, createTeamAuditLog } from '@jetstream/audit-logs';
 import { getApiAddressFromReq } from '@jetstream/auth/server';
 import { ApiRequestError } from '@jetstream/salesforce-api';
@@ -125,10 +126,10 @@ const checkOrgHealth = createRoute(routeDefinition.checkOrgHealth.validators, as
     try {
       await jetstreamConn.org.identity();
       connectionError = null;
-      res.log.debug('[ORG CHECK][VALID ORG][IDENTITY]');
+      getLogger().debug('[ORG CHECK][VALID ORG][IDENTITY]');
     } catch (ex) {
       connectionError = ERROR_MESSAGES.SFDC_EXPIRED_TOKEN;
-      res.log.debug({ err: ex }, '[ORG CHECK][INVALID ORG] %s', getErrorMessage(ex));
+      getLogger().debug({ err: ex }, '[ORG CHECK][INVALID ORG] %s', getErrorMessage(ex));
     }
 
     // Ensure full API access, identity API works even without API access
@@ -137,11 +138,11 @@ const checkOrgHealth = createRoute(routeDefinition.checkOrgHealth.validators, as
       try {
         await jetstreamConn.query.query<SObjectOrganization>(`SELECT Id, TrialExpirationDate FROM Organization`);
         connectionError = null;
-        res.log.debug('[ORG CHECK][VALID ORG][API ACCESS]');
+        getLogger().debug('[ORG CHECK][VALID ORG][API ACCESS]');
       } catch (ex) {
         if (ex instanceof ApiRequestError && ERROR_MESSAGES.SFDC_REST_API_NOT_ENABLED.test(getErrorMessage(ex))) {
           connectionError = ERROR_MESSAGES.SFDC_REST_API_NOT_ENABLED_MSG;
-          res.log.debug({ err: ex }, '[ORG CHECK][INVALID ORG] %s', getErrorMessage(ex));
+          getLogger().debug({ err: ex }, '[ORG CHECK][INVALID ORG] %s', getErrorMessage(ex));
         }
       }
     }
@@ -151,7 +152,7 @@ const checkOrgHealth = createRoute(routeDefinition.checkOrgHealth.validators, as
         await salesforceOrgsDb.updateOrg_UNSAFE(org, { connectionError });
       }
     } catch (ex) {
-      res.log.warn({ orgId: org?.id, err: ex }, '[ERROR UPDATING INVALID ORG] %s', getErrorMessage(ex));
+      getLogger().warn({ orgId: org?.id, err: ex }, '[ERROR UPDATING INVALID ORG] %s', getErrorMessage(ex));
     }
 
     if (connectionError) {

--- a/apps/api/src/app/controllers/sf-bulk-api.controller.ts
+++ b/apps/api/src/app/controllers/sf-bulk-api.controller.ts
@@ -1,3 +1,4 @@
+import { getLogger } from '@jetstream/api-config';
 import { BooleanQueryParamSchema, CreateJobRequestSchema } from '@jetstream/api-types';
 import { HTTP } from '@jetstream/shared/constants';
 import { ensureBoolean, getErrorMessageAndStackObj, toBoolean } from '@jetstream/shared/utils';
@@ -351,7 +352,7 @@ const downloadAllResults = createRoute(
             streamToPipe.on('error', reject);
           });
         } catch (ex) {
-          res.log.error({ requestId, ...getErrorMessageAndStackObj(ex) }, 'Error downloading batch results');
+          getLogger().error({ requestId, ...getErrorMessageAndStackObj(ex) }, 'Error downloading batch results');
         }
       }
       // indicate end of stream - we are done pushing data

--- a/apps/api/src/app/controllers/socket.controller.ts
+++ b/apps/api/src/app/controllers/socket.controller.ts
@@ -1,4 +1,4 @@
-import { ENV, logger } from '@jetstream/api-config';
+import { ENV, getLogger, logger } from '@jetstream/api-config';
 import type { Request, Response } from '@jetstream/api-types';
 import { convertUserProfileToSession_External } from '@jetstream/auth/server';
 import { HTTP, HTTP_SOURCE_DESKTOP } from '@jetstream/shared/constants';
@@ -64,7 +64,7 @@ export function emitSocketEvent({
     }
     broadcastOperator.emit(event, payload);
   } catch (ex) {
-    logger.error({ err: ex, userId, event }, 'Error emitting socket event');
+    getLogger().error({ err: ex, userId, event }, 'Error emitting socket event');
   }
 }
 
@@ -173,11 +173,11 @@ export function initSocketServer(
     const userId = session?.user?.id as string | undefined;
     const deviceId = session?.deviceId as string | undefined;
 
-    logger.debug(
-      { socketId: socket.id, userId: session?.user?.id || 'unknown', sessionId: session?.id },
-      '[SOCKET][CONNECT] %s',
-      socket.id,
-    );
+    // Socket lifecycle is not a single async scope (events fire over time), so bind a
+    // per-connection child logger instead of relying on AsyncLocalStorage here.
+    const socketLogger = logger.child({ socketId: socket.id, userId: userId || 'unknown', sessionId, deviceId });
+
+    socketLogger.debug('[SOCKET][CONNECT] %s', socket.id);
 
     if (userId) {
       socket.join(userId);
@@ -192,11 +192,11 @@ export function initSocketServer(
     }
 
     socket.on('disconnect', (reason) => {
-      logger.debug({ socketId: socket.id, userId: userId || 'unknown' }, '[SOCKET][DISCONNECT] %s', reason);
+      socketLogger.debug('[SOCKET][DISCONNECT] %s', reason);
     });
 
     socket.on('error', (err) => {
-      logger.error({ socketId: socket.id, userId: userId || 'unknown', err }, '[SOCKET][ERROR] %s', err.message);
+      socketLogger.error({ err }, '[SOCKET][ERROR] %s', err.message);
     });
   });
 

--- a/apps/api/src/app/controllers/team.controller.ts
+++ b/apps/api/src/app/controllers/team.controller.ts
@@ -1,4 +1,4 @@
-import { ENV, logger } from '@jetstream/api-config';
+import { ENV, getLogger } from '@jetstream/api-config';
 import { AuditLogAction, AuditLogResource, createTeamAuditLog } from '@jetstream/audit-logs';
 import * as authService from '@jetstream/auth/server';
 import { encryptSecret, oidcService, samlService } from '@jetstream/auth/server';
@@ -464,7 +464,7 @@ const verifyInvitation = createRoute(routeDefinition.verifyInvitation.validators
       sendJson(res, { success: true, inviteVerification });
     })
     .catch((error) => {
-      logger.warn({ error: getErrorMessage(error), teamId, token, userId: user.id }, 'Error verifying team invitation');
+      getLogger().warn({ error: getErrorMessage(error), teamId, token, userId: user.id }, 'Error verifying team invitation');
       sendJson(res, { success: false });
     });
 });
@@ -836,7 +836,7 @@ const parseSamlMetadata = createRoute(routeDefinition.parseSamlMetadata.validato
     const parsed = await samlService.parseIdpMetadata(xml);
     sendJson(res, parsed);
   } catch (ex) {
-    res.log.error(getErrorMessageAndStackObj(ex), 'Failed to parse SAML metadata');
+    getLogger().error(getErrorMessageAndStackObj(ex), 'Failed to parse SAML metadata');
     next(ex);
   }
 });
@@ -933,7 +933,7 @@ const createOrUpdateSamlConfig = createRoute(
         });
       }
     } catch (ex) {
-      res.log.error(getErrorMessageAndStackObj(ex), 'Failed to save SAML configuration');
+      getLogger().error(getErrorMessageAndStackObj(ex), 'Failed to save SAML configuration');
 
       next(ex);
     }
@@ -952,7 +952,7 @@ const discoverOidcConfig = createRoute(routeDefinition.discoverOidcConfig.valida
     const discovered = await oidcService.getDiscoveredConfigForSaving(issuer);
     sendJson(res, discovered);
   } catch (ex) {
-    res.log.error(getErrorMessageAndStackObj(ex), 'Failed to discover OIDC configuration');
+    getLogger().error(getErrorMessageAndStackObj(ex), 'Failed to discover OIDC configuration');
     next(ex);
   }
 });
@@ -1035,7 +1035,7 @@ const createOrUpdateOidcConfig = createRoute(
         });
       }
     } catch (ex) {
-      res.log.error(getErrorMessageAndStackObj(ex), 'Failed to save OIDC configuration');
+      getLogger().error(getErrorMessageAndStackObj(ex), 'Failed to save OIDC configuration');
 
       next(ex);
     }
@@ -1068,7 +1068,7 @@ const updateSsoSettings = createRoute(routeDefinition.updateSsoSettings.validato
       userAgent: req.headers['user-agent'] as string,
     });
   } catch (ex) {
-    res.log.error(getErrorMessageAndStackObj(ex), 'Failed to update SSO settings');
+    getLogger().error(getErrorMessageAndStackObj(ex), 'Failed to update SSO settings');
     next(ex);
   }
 });
@@ -1092,7 +1092,7 @@ const deleteSamlConfig = createRoute(routeDefinition.deleteSamlConfig.validators
       });
     }
   } catch (ex) {
-    res.log.error(getErrorMessageAndStackObj(ex), 'Failed to delete SAML configuration');
+    getLogger().error(getErrorMessageAndStackObj(ex), 'Failed to delete SAML configuration');
     next(ex);
   }
 });
@@ -1116,7 +1116,7 @@ const deleteOidcConfig = createRoute(routeDefinition.deleteOidcConfig.validators
       });
     }
   } catch (ex) {
-    res.log.error(getErrorMessageAndStackObj(ex), 'Failed to delete OIDC configuration');
+    getLogger().error(getErrorMessageAndStackObj(ex), 'Failed to delete OIDC configuration');
     next(ex);
   }
 });
@@ -1127,7 +1127,7 @@ const getDomainVerifications = createRoute(routeDefinition.getDomainVerification
     const verifications = await teamDb.getDomainVerifications(teamId);
     sendJson(res, verifications);
   } catch (ex) {
-    res.log.error(getErrorMessageAndStackObj(ex), 'Failed to get domain verifications');
+    getLogger().error(getErrorMessageAndStackObj(ex), 'Failed to get domain verifications');
     next(ex);
   }
 });
@@ -1161,7 +1161,7 @@ const saveDomainVerification = createRoute(
         userAgent: req.headers['user-agent'] as string,
       });
     } catch (ex) {
-      res.log.error(getErrorMessageAndStackObj(ex), 'Failed to save domain verification');
+      getLogger().error(getErrorMessageAndStackObj(ex), 'Failed to save domain verification');
       next(ex);
     }
   },
@@ -1184,11 +1184,8 @@ export interface DomainVerificationCheckResult {
  * (apex or `_jetstream.` subdomain) or a hosted verification file (apex or `www.`).
  * Exported for tests.
  */
-export async function checkDomainVerification(
-  domain: string,
-  verificationCode: string,
-  log: { warn: (obj: Record<string, unknown>, msg: string) => void },
-): Promise<DomainVerificationCheckResult> {
+export async function checkDomainVerification(domain: string, verificationCode: string): Promise<DomainVerificationCheckResult> {
+  const logger = getLogger();
   let verified = false;
   let verificationMethod: 'dns' | 'file' | null = null;
   let foundNonMatchingValue = false;
@@ -1205,11 +1202,11 @@ export async function checkDomainVerification(
         const otherJetstreamRecords = txtRecords.filter((record) => record.startsWith(VERIFICATION_CODE_PREFIX));
         if (otherJetstreamRecords.length > 0) {
           foundNonMatchingValue = true;
-          log.warn({ domain, dnsHost, found: otherJetstreamRecords }, 'DNS TXT verification record found but value did not match');
+          logger.warn({ domain, dnsHost, found: otherJetstreamRecords }, 'DNS TXT verification record found but value did not match');
         }
       }
     } catch (error) {
-      log.warn({ error: getErrorMessage(error), domain, dnsHost }, 'DNS TXT record lookup failed');
+      logger.warn({ error: getErrorMessage(error), domain, dnsHost }, 'DNS TXT record lookup failed');
     }
   }
 
@@ -1235,11 +1232,11 @@ export async function checkDomainVerification(
             verificationMethod = 'file';
           } else if (text.trim().startsWith(VERIFICATION_CODE_PREFIX)) {
             foundNonMatchingValue = true;
-            log.warn({ domain, fileUrl }, 'Verification file found but contents did not match');
+            logger.warn({ domain, fileUrl }, 'Verification file found but contents did not match');
           }
         }
       } catch (error) {
-        log.warn({ error: getErrorMessage(error), domain, fileUrl }, 'File verification fetch failed');
+        logger.warn({ error: getErrorMessage(error), domain, fileUrl }, 'File verification fetch failed');
       }
     }
   }
@@ -1259,7 +1256,6 @@ const verifyDomain = createRoute(routeDefinition.verifyDomain.validators, async 
     const { verified, verificationMethod, foundNonMatchingValue } = await checkDomainVerification(
       verification.domain,
       verification.verificationCode,
-      res.log,
     );
 
     if (verified) {
@@ -1283,7 +1279,7 @@ const verifyDomain = createRoute(routeDefinition.verifyDomain.validators, async 
       sendJson(res, { success: false, message });
     }
   } catch (ex) {
-    res.log.error(getErrorMessageAndStackObj(ex), 'Failed to verify domain');
+    getLogger().error(getErrorMessageAndStackObj(ex), 'Failed to verify domain');
     next(ex);
   }
 });
@@ -1311,7 +1307,7 @@ const deleteDomainVerification = createRoute(
         userAgent: req.headers['user-agent'] as string,
       });
     } catch (ex) {
-      res.log.error(getErrorMessageAndStackObj(ex), 'Failed to delete domain verification');
+      getLogger().error(getErrorMessageAndStackObj(ex), 'Failed to delete domain verification');
       next(ex);
     }
   },

--- a/apps/api/src/app/controllers/test.controller.ts
+++ b/apps/api/src/app/controllers/test.controller.ts
@@ -1,3 +1,4 @@
+import { getLogger } from '@jetstream/api-config';
 import { z } from 'zod';
 import { UserFacingError } from '../utils/error-handler';
 import { sendJson } from '../utils/response.handlers';
@@ -39,7 +40,7 @@ export const routeDefinition = {
 const deferredResponse = createRoute(routeDefinition.deferredResponse.validators, async ({ query }, _req, res, next) => {
   const { delay, status, errorMessage, responseSize } = query;
 
-  res.log.info({ delay, status, errorMessage, responseSize }, '[TEST][DEFERRED] Test endpoint invoked');
+  getLogger().info({ delay, status, errorMessage, responseSize }, '[TEST][DEFERRED] Test endpoint invoked');
 
   await new Promise((resolve) => setTimeout(resolve, delay));
 

--- a/apps/api/src/app/controllers/user-feedback.controller.ts
+++ b/apps/api/src/app/controllers/user-feedback.controller.ts
@@ -1,4 +1,4 @@
-import { ENV, logger } from '@jetstream/api-config';
+import { ENV, getLogger } from '@jetstream/api-config';
 import { getApiAddressFromReq } from '@jetstream/auth/server';
 import { HTTP } from '@jetstream/shared/constants';
 import express from 'express';
@@ -41,7 +41,7 @@ export const sendUserFeedbackEmail = async (req: express.Request, res: express.R
     res.json({ success: true });
   } catch (error) {
     await cleanupFeedbackAttachments(req, { userEmail: 'unknown', userId: 'unknown', requestId: res.locals?.requestId });
-    (res.log || logger).error({ err: error }, 'Error processing feedback submission');
+    getLogger().error({ err: error }, 'Error processing feedback submission');
     next(error);
   }
 };

--- a/apps/api/src/app/controllers/user.controller.ts
+++ b/apps/api/src/app/controllers/user.controller.ts
@@ -1,4 +1,4 @@
-import { ENV, logger } from '@jetstream/api-config';
+import { ENV, getLogger } from '@jetstream/api-config';
 import {
   AuthError,
   convertBase32ToHex,
@@ -213,7 +213,7 @@ const getUserProfile = createRoute(routeDefinition.getUserProfile.validators, as
     const userProfile = await userDbService.findIdByUserIdUserFacing({ userId: user.id });
     sendJson(res, userProfile);
   } catch (ex) {
-    res.log.error({ err: ex }, 'Error fetching user profile');
+    getLogger().error({ err: ex }, 'Error fetching user profile');
     req.session.destroy(() => {
       next(new AuthenticationError('Unable to get user profile, please log in again'));
     });
@@ -503,14 +503,14 @@ const deleteAccount = createRoute(routeDefinition.deleteAccount.validators, asyn
       const results = await stripeService.cancelAllSubscriptions({ customerId: userWithSubscriptions.billingAccount.customerId });
       billingResultsJson = JSON.stringify(results);
       billingPortalLinkText = `If you need to access any of your billing information or history, you can continue to do so here: ${ENV.STRIPE_BILLING_PORTAL_LINK}`;
-      logger.info({ requestId, results }, '[ACCOUNT DELETE][CANCEL SUBSCRIPTIONS]');
+      getLogger().info({ requestId, results }, '[ACCOUNT DELETE][CANCEL SUBSCRIPTIONS]');
     }
 
     await userDbService.deleteUserAndAllRelatedData(user.id);
     // Destroy session - don't wait for response
     req.session.destroy((error) => {
       if (error) {
-        req.log.error({ requestId, err: error }, '[ACCOUNT DELETE][ERROR DESTROYING SESSION]');
+        getLogger().error({ requestId, err: error }, '[ACCOUNT DELETE][ERROR DESTROYING SESSION]');
       }
     });
 
@@ -518,7 +518,7 @@ const deleteAccount = createRoute(routeDefinition.deleteAccount.validators, asyn
       await sendGoodbyeEmail(user.email, billingPortalLinkText);
       await sendInternalAccountDeletionEmail(user.id, reason, billingResultsJson);
     } catch (ex) {
-      req.log.error('[ACCOUNT DELETE][ERROR SENDING EMAIL SUMMARY] %s', getErrorMessage(ex));
+      getLogger().error('[ACCOUNT DELETE][ERROR SENDING EMAIL SUMMARY] %s', getErrorMessage(ex));
     }
 
     createUserActivityFromReq(req, res, {
@@ -540,9 +540,9 @@ const deleteAccount = createRoute(routeDefinition.deleteAccount.validators, asyn
     if (ex.isAxiosError) {
       const error: AxiosError = ex;
       if (error.response && error.response.data) {
-        req.log.error({ err: ex }, '[ACCOUNT DELETE][FATAL ERROR] %o', error.response.data);
+        getLogger().error({ err: ex }, '[ACCOUNT DELETE][FATAL ERROR] %o', error.response.data);
       } else if (error.request) {
-        req.log.error({ err: ex }, '[ACCOUNT DELETE][FATAL ERROR] %s', error.message || 'An unknown error has occurred.');
+        getLogger().error({ err: ex }, '[ACCOUNT DELETE][FATAL ERROR] %s', error.message || 'An unknown error has occurred.');
       }
     }
     throw new UserFacingError('There was a problem deleting your account, contact support@getjetstream.app for assistance.');

--- a/apps/api/src/app/controllers/web-extension.controller.ts
+++ b/apps/api/src/app/controllers/web-extension.controller.ts
@@ -1,4 +1,4 @@
-import { ENV } from '@jetstream/api-config';
+import { ENV, getLogger } from '@jetstream/api-config';
 import {
   createUserActivityFromReq,
   getApiAddressFromReq,
@@ -150,7 +150,7 @@ const initSession = createRoute(routeDefinition.initSession.validators, async ({
       .verifyToken({ token: decryptedToken, deviceId }, externalAuthService.AUDIENCE_WEB_EXT)
       .then(() => true)
       .catch((ex) => {
-        res.log.warn(
+        getLogger().warn(
           { userId: user.id, deviceId, ...getErrorMessageAndStackObj(ex) },
           'Stored web extension token failed verification; issuing a new token',
         );
@@ -161,7 +161,7 @@ const initSession = createRoute(routeDefinition.initSession.validators, async ({
       const decoded = externalAuthService.decodeToken(decryptedToken);
       const expiresAt = fromUnixTime(decoded.exp);
 
-      res.log.debug({ userId: user.id, deviceId, expiresAt }, 'Reusing existing web extension token');
+      getLogger().debug({ userId: user.id, deviceId, expiresAt }, 'Reusing existing web extension token');
 
       sendJson(res, { accessToken: decryptedToken });
       createUserActivityFromReq(req, res, {
@@ -232,17 +232,17 @@ const verifyToken = createRoute(routeDefinition.verifyToken.validators, async ({
           throw new InvalidSession();
         }
         rotatedAccessToken = result.token;
-        res.log.debug({ userId: userProfile.id, deviceId, rotationOutcome: result.outcome }, 'Web extension token verified');
+        getLogger().debug({ userId: userProfile.id, deviceId, rotationOutcome: result.outcome }, 'Web extension token verified');
       }
     }
 
     if (!supportsRotation) {
-      res.log.debug({ userId: userProfile.id, deviceId }, 'Web extension token verified');
+      getLogger().debug({ userId: userProfile.id, deviceId }, 'Web extension token verified');
     }
 
     sendJson(res, { success: true, userProfile, accessToken: rotatedAccessToken });
   } catch (ex) {
-    res.log.error({ userId: user?.id, deviceId, ...getErrorMessageAndStackObj(ex) }, 'Error verifying web extension token');
+    getLogger().error({ userId: user?.id, deviceId, ...getErrorMessageAndStackObj(ex) }, 'Error verifying web extension token');
     sendJson(res, { success: false, error: 'Invalid session' }, 401);
   }
 });
@@ -261,11 +261,11 @@ const logout = createRoute(routeDefinition.logout.validators, async ({ user }, r
     if (accessToken) {
       externalAuthService.invalidateCacheEntry(accessToken, deviceId);
     }
-    res.log.info({ userId: user.id, deviceId }, 'User logged out of browser extension');
+    getLogger().info({ userId: user.id, deviceId }, 'User logged out of browser extension');
 
     sendJson(res, { success: true });
   } catch (ex) {
-    res.log.error({ userId: user?.id, deviceId, ...getErrorMessageAndStackObj(ex) }, 'Error logging out of browser extension');
+    getLogger().error({ userId: user?.id, deviceId, ...getErrorMessageAndStackObj(ex) }, 'Error logging out of browser extension');
     sendJson(res, { success: false, error: 'Invalid session' }, 401);
   }
 });

--- a/apps/api/src/app/routes/platform-event.routes.ts
+++ b/apps/api/src/app/routes/platform-event.routes.ts
@@ -1,4 +1,4 @@
-import { ENV, logger } from '@jetstream/api-config';
+import { ENV, getLogger } from '@jetstream/api-config';
 import { HTTP } from '@jetstream/shared/constants';
 import express, { Router } from 'express';
 import https from 'https';
@@ -18,7 +18,7 @@ function getAllowedProxyOrigins(): Set<string> {
       origins.add(new URL(url).origin);
     } catch {
       // A malformed URL shrinks the allowlist and every cross-origin request 403s, so make the cause findable.
-      logger.warn({ envVarName, url }, '[PLATFORM-EVENT] Ignoring malformed URL when building the allowed origin list');
+      getLogger().warn({ envVarName, url }, '[PLATFORM-EVENT] Ignoring malformed URL when building the allowed origin list');
     }
   }
   return origins;
@@ -35,7 +35,7 @@ routes.use(checkAuth);
 routes.use((req: express.Request, res: express.Response, next: express.NextFunction) => {
   const origin = req.headers.origin;
   if (origin && !ALLOWED_PROXY_ORIGINS.has(origin)) {
-    res.log.warn({ origin }, '[PLATFORM-EVENT][FORBIDDEN-ORIGIN]');
+    getLogger().warn({ origin }, '[PLATFORM-EVENT][FORBIDDEN-ORIGIN]');
     res.status(403).send('Forbidden');
     return;
   }
@@ -59,7 +59,7 @@ routes.use('/', async (req: express.Request, res: express.Response, next: expres
     const proxyPath = req.originalUrl.replace('/platform-event', `/cometd/${ENV.SFDC_API_VERSION}`);
     const proxyUrl = `${jetstreamConn.sessionInfo.instanceUrl}${proxyPath}`;
 
-    res.log.debug({ proxyUrl }, '[PROXY][REQUEST]');
+    getLogger().debug({ proxyUrl }, '[PROXY][REQUEST]');
 
     const forwardedCookie = stripJetstreamCookies(req.headers.cookie);
     const headers: Record<string, string | string[] | undefined> = {
@@ -103,12 +103,12 @@ routes.use('/', async (req: express.Request, res: express.Response, next: expres
           proxyResponse.pipe(res, { end: true });
         })
         .on('error', (err) => {
-          logger.error({ err }, '[PROXY][EXCEPTION]');
+          getLogger().error({ err }, '[PROXY][EXCEPTION]');
           next(err);
         }),
     );
   } catch (err) {
-    logger.error({ err }, '[PROXY][EXCEPTION]');
+    getLogger().error({ err }, '[PROXY][EXCEPTION]');
     next(err);
   }
 });

--- a/apps/api/src/app/routes/redirect.routes.ts
+++ b/apps/api/src/app/routes/redirect.routes.ts
@@ -1,4 +1,4 @@
-import { ENV } from '@jetstream/api-config';
+import { ENV, getLogger } from '@jetstream/api-config';
 import { getCookieConfig, validateRedirectUrl } from '@jetstream/auth/server';
 import { stringifySetCookie } from 'cookie';
 import * as express from 'express';
@@ -25,7 +25,7 @@ routes.get('/', (req, res, next) => {
 
   // If validation changed the URL, log the attempted redirect
   if (safeRedirectUrl !== redirectUrl) {
-    res.log.warn({ originalUrl: redirectUrl, validatedUrl: safeRedirectUrl }, '[SECURITY] Invalid redirect URL blocked');
+    getLogger().warn({ originalUrl: redirectUrl, validatedUrl: safeRedirectUrl }, '[SECURITY] Invalid redirect URL blocked');
   }
 
   // If the user is logged in, redirect them to desired redirectUrl

--- a/apps/api/src/app/routes/route.middleware.ts
+++ b/apps/api/src/app/routes/route.middleware.ts
@@ -1,5 +1,4 @@
-import { createRateLimit, ENV, logger } from '@jetstream/api-config';
-import { LoggerLike } from '@jetstream/api-types';
+import { createRateLimit, enrichRequestContext, ENV, getLogger } from '@jetstream/api-config';
 import { AuditLogAction, AuditLogResource, createTeamAuditLog } from '@jetstream/audit-logs';
 import {
   AuthError,
@@ -25,7 +24,6 @@ import express, { Request } from 'express';
 import multer from 'multer';
 import { randomBytes } from 'node:crypto';
 import os from 'node:os';
-import pino from 'pino';
 import { v4 as uuid } from 'uuid';
 import * as salesforceOrgsDb from '../db/salesforce-org.db';
 import { checkUserEntitlement } from '../db/user.db';
@@ -37,7 +35,7 @@ export function basicAuthMiddleware(req: express.Request, res: express.Response,
   try {
     const authHeader = req.headers.authorization;
     if (typeof authHeader !== 'string') {
-      (res.log || logger).warn('Missing Authorization header for basic auth protected route');
+      getLogger().warn('Missing Authorization header for basic auth protected route');
       return res.status(401).send('Unauthorized');
     }
     const [type, token] = authHeader.split(' ');
@@ -45,7 +43,7 @@ export function basicAuthMiddleware(req: express.Request, res: express.Response,
       return res.status(401).send('Unauthorized');
     }
     if (!ENV.BASIC_AUTH_USERNAME || !ENV.BASIC_AUTH_PASSWORD) {
-      (res.log || logger).error('BASIC_AUTH_USERNAME/BASIC_AUTH_PASSWORD environment variables are not set');
+      getLogger().error('BASIC_AUTH_USERNAME/BASIC_AUTH_PASSWORD environment variables are not set');
       return res.status(401).send('Unauthorized');
     }
     const [username, password] = Buffer.from(token, 'base64').toString().split(':');
@@ -54,7 +52,7 @@ export function basicAuthMiddleware(req: express.Request, res: express.Response,
     const usernameMatches = timingSafeStringCompare(username, ENV.BASIC_AUTH_USERNAME);
     const passwordMatches = timingSafeStringCompare(password, ENV.BASIC_AUTH_PASSWORD);
     if (!usernameMatches || !passwordMatches) {
-      (res.log || logger).warn('Invalid BASIC_AUTH_USERNAME/BASIC_AUTH_PASSWORD');
+      getLogger().warn('Invalid BASIC_AUTH_USERNAME/BASIC_AUTH_PASSWORD');
       return res.status(401).send('Unauthorized');
     }
     next();
@@ -77,7 +75,7 @@ export function addContextMiddleware(req: express.Request, res: express.Response
 }
 
 export function deprecatedRouteMiddleware(req: express.Request, res: express.Response, next: express.NextFunction) {
-  res.log.warn({ path: req.path, method: req.method }, '[DEPRECATED][ROUTE] This route is deprecated');
+  getLogger().warn({ path: req.path, method: req.method }, '[DEPRECATED][ROUTE] This route is deprecated');
   next();
 }
 
@@ -184,10 +182,10 @@ export async function checkAuth(req: express.Request, res: express.Response, nex
   // guard so scanners that rotate their User-Agent do not self-destruct their session.
   if (req.session.userAgent && req.session.userAgent !== userAgent && !req.session.isScannerSession) {
     if (!checkUserAgentSimilarity(req.session.userAgent, userAgent || '')) {
-      res.log.warn(`[AUTH][UNAUTHORIZED] User-Agent mismatch: ${req.session.userAgent} !== ${userAgent}`);
+      getLogger().warn(`[AUTH][UNAUTHORIZED] User-Agent mismatch: ${req.session.userAgent} !== ${userAgent}`);
       req.session.destroy((err) => {
         if (err) {
-          (res.log || req.log || logger).error({ err }, '[AUTH][UNAUTHORIZED][ERROR] Error destroying session');
+          getLogger().error({ err }, '[AUTH][UNAUTHORIZED][ERROR] Error destroying session');
         }
         // TODO: Send email to user about potential suspicious activity
         next(new AuthenticationError('Unauthorized'));
@@ -197,10 +195,11 @@ export async function checkAuth(req: express.Request, res: express.Response, nex
   }
 
   if (user && user.id !== PLACEHOLDER_USER_ID && !hasPendingVerification && !hasPendingMfaEnrollment && !hasPendingTosAcceptance) {
+    enrichRequestContext({ userId: user.id, sessionId: req.session.id });
     return next();
   }
 
-  res.log.warn(
+  getLogger().warn(
     {
       hasUser: !!user,
       isPlaceholderUser: user?.id === PLACEHOLDER_USER_ID,
@@ -228,6 +227,7 @@ export async function addOrgsToLocal(req: express.Request, res: express.Response
         const { org, jetstreamConn } = results;
         res.locals.org = org;
         res.locals.jetstreamConn = jetstreamConn;
+        enrichRequestContext({ orgId: org.id });
       }
     }
     if (req.get(HTTP.HEADERS.X_SFDC_ID_TARGET) || req.query[HTTP.HEADERS.X_SFDC_ID_TARGET]) {
@@ -248,7 +248,7 @@ export async function addOrgsToLocal(req: express.Request, res: express.Response
       }
     }
   } catch (ex) {
-    res.log.warn({ err: ex }, '[INIT-ORG][ERROR]');
+    getLogger().warn({ err: ex }, '[INIT-ORG][ERROR]');
     if (ex instanceof NotFoundError) {
       return next(ex);
     }
@@ -280,7 +280,7 @@ export const verifyEntitlement =
 
 export function ensureOrgExists(_req: express.Request, res: express.Response, next: express.NextFunction) {
   if (!res.locals?.jetstreamConn) {
-    res.log.warn('[INIT-ORG][ERROR] An org did not exist on locals');
+    getLogger().warn('[INIT-ORG][ERROR] An org did not exist on locals');
     return next(new UserFacingError('An org is required for this action'));
   }
   next();
@@ -288,7 +288,7 @@ export function ensureOrgExists(_req: express.Request, res: express.Response, ne
 
 export function ensureTargetOrgExists(_req: express.Request, res: express.Response, next: express.NextFunction) {
   if (!res.locals?.targetJetstreamConn) {
-    res.log.warn('[INIT-ORG][ERROR] A target org did not exist on locals');
+    getLogger().warn('[INIT-ORG][ERROR] A target org did not exist on locals');
     return next(new UserFacingError('A target org is required for this action'));
   }
   next();
@@ -325,7 +325,7 @@ export async function getOrgFromHeaderOrQuery(
     return;
   }
 
-  return getOrgForRequest(user, uniqueId, res.log || req.log || logger, apiVersion, includeCallOptions, requestId, {
+  return getOrgForRequest(user, uniqueId, apiVersion, includeCallOptions, requestId, {
     ipAddress: res.locals.ipAddress || getApiAddressFromReq(req),
     userAgent: req.get('user-agent'),
   });
@@ -334,7 +334,6 @@ export async function getOrgFromHeaderOrQuery(
 export async function getOrgForRequest(
   user: UserProfileSession,
   uniqueId: string,
-  logger: pino.Logger | LoggerLike = console,
   apiVersion?: string,
   includeCallOptions?: boolean,
   requestId?: string,
@@ -357,14 +356,14 @@ export async function getOrgForRequest(
   // This should be done after decryption so that the org stays expired if decryption failed (we use placeholder decryption token)
   if (org.expirationScheduledFor) {
     salesforceOrgsDb.clearExpiration(org.id, user.id).catch((err) => {
-      logger.error({ orgId: org.id, userId: user.id, err }, '[ORG][UPDATE] Error clearing expirationScheduledFor');
+      getLogger().error({ orgId: org.id, userId: user.id, err }, '[ORG][UPDATE] Error clearing expirationScheduledFor');
     });
   } else {
     // Only update lastActivityAt if it's null or older than 1 day to reduce DB writes
     const oneDayAgo = addDays(new Date(), -1);
     if (!org.lastActivityAt || isBefore(new Date(org.lastActivityAt), oneDayAgo)) {
       salesforceOrgsDb.updateLastActivity(org.id).catch((err) => {
-        logger.error({ orgId: org.id, userId: user.id, err }, '[ORG][UPDATE] Error updating lastActivityAt');
+        getLogger().error({ orgId: org.id, userId: user.id, err }, '[ORG][UPDATE] Error updating lastActivityAt');
       });
     }
   }
@@ -385,7 +384,7 @@ export async function getOrgForRequest(
     try {
       await salesforceOrgsDb.updateAccessToken_UNSAFE({ accessToken, refreshToken, org, userId: user.id });
     } catch (ex) {
-      logger.error({ requestId, orgId: org.id, userId: user.id, err: ex }, '[ORG][REFRESH] Error saving refresh token');
+      getLogger().error({ requestId, orgId: org.id, userId: user.id, err: ex }, '[ORG][REFRESH] Error saving refresh token');
     }
   };
 
@@ -393,7 +392,7 @@ export async function getOrgForRequest(
     try {
       await salesforceOrgsDb.updateOrg_UNSAFE(org, { connectionError: error });
     } catch (ex) {
-      logger.error({ requestId, orgId: org.id, userId: user.id, err: ex }, '[ORG][UPDATE] Error updating connection error on org');
+      getLogger().error({ requestId, orgId: org.id, userId: user.id, err: ex }, '[ORG][UPDATE] Error updating connection error on org');
     }
   };
 
@@ -419,7 +418,7 @@ export async function getOrgForRequest(
           sfdcClientSecret: ENV.SFDC_CONSUMER_SECRET,
         }),
     });
-    logger.info(
+    getLogger().info(
       {
         requestId,
         orgId: org.id,
@@ -472,7 +471,7 @@ export async function getOrgForRequest(
       }
       return { accessToken: freshAccessToken, refreshToken: freshRefreshToken };
     } catch (ex) {
-      logger.error(
+      getLogger().error(
         { requestId, orgId: org.id, userId: user.id, err: ex },
         '[ORG][REFRESH] Error fetching fresh tokens for race condition check',
       );
@@ -491,7 +490,7 @@ export async function getOrgForRequest(
       instanceUrl,
       refreshToken,
       enableLogging: ENV.LOG_LEVEL === 'trace',
-      logger,
+      logger: getLogger(),
       sfdcClientId: ENV.SFDC_CONSUMER_KEY,
       sfdcClientSecret: ENV.SFDC_CONSUMER_SECRET,
       refreshTokens,
@@ -510,7 +509,7 @@ export function verifyCaptcha(req: express.Request, res: express.Response, next:
   }
   const token = req.body?.[ENV.CAPTCHA_PROPERTY];
   if (!token) {
-    (res.log || logger).warn({ token, reason: 'Missing captcha token' }, '[CAPTCHA][FAILED]');
+    getLogger().warn({ token, reason: 'Missing captcha token' }, '[CAPTCHA][FAILED]');
     createUserActivityFromReq(req, res, {
       action: 'CAPTCHA_FAILED',
       method: 'UNAUTHENTICATED',
@@ -542,7 +541,7 @@ export function verifyCaptcha(req: express.Request, res: express.Response, next:
       if (fetchData.success) {
         return next();
       }
-      (res.log || logger).warn({ token, fetchData, reason: 'Captcha verification failed' }, '[CAPTCHA][FAILED]');
+      getLogger().warn({ token, fetchData, reason: 'Captcha verification failed' }, '[CAPTCHA][FAILED]');
       createUserActivityFromReq(req, res, {
         action: 'CAPTCHA_FAILED',
         method: 'UNAUTHENTICATED',
@@ -571,7 +570,7 @@ export function validateDoubleCSRF(req: express.Request, res: express.Response, 
   // Skip if user is not logged in (no session)
   if (!req.session?.user) {
     // Log for monitoring
-    (res.log || logger).warn(
+    getLogger().warn(
       {
         path: req.path,
         method: req.method,
@@ -596,7 +595,7 @@ export function validateDoubleCSRF(req: express.Request, res: express.Response, 
     res.cookie(cookieConfig.doubleCSRFToken.name, cookieToken, cookieConfig.doubleCSRFToken.options);
     isNewTokenGenerated = true;
 
-    (res.log || logger).info(
+    getLogger().info(
       {
         sessionAge: req.session.loginTime ? Date.now() - req.session.loginTime : 'unknown',
       },
@@ -613,7 +612,7 @@ export function validateDoubleCSRF(req: express.Request, res: express.Response, 
 
     if (!isValid) {
       // Log the CSRF violation
-      (res.log || logger).warn(
+      getLogger().warn(
         {
           hasCookieToken: !!cookieToken,
           hasHeaderToken: !!requestToken,
@@ -631,7 +630,7 @@ export function validateDoubleCSRF(req: express.Request, res: express.Response, 
     }
   } catch (error) {
     // Log validation errors
-    (res.log || logger).error(
+    getLogger().error(
       {
         ...getErrorMessageAndStackObj(error),
         path: req.path,

--- a/apps/api/src/app/routes/team.routes.ts
+++ b/apps/api/src/app/routes/team.routes.ts
@@ -1,3 +1,4 @@
+import { getLogger } from '@jetstream/api-config';
 import { Request, Response } from '@jetstream/api-types';
 import { TEAM_MEMBER_ROLE_ADMIN, TEAM_MEMBER_ROLE_BILLING, TeamMemberRole, TeamMemberRoleSchema } from '@jetstream/types';
 import express, { Router } from 'express';
@@ -14,15 +15,15 @@ const routes: express.Router = Router();
 function validateTeamRoleMiddlewareFn(roles: TeamMemberRole[]) {
   return async (req: Request, res: Response, next: express.NextFunction) => {
     if (!req.session.user) {
-      res.log.warn({ path: req.path, method: req.method }, 'Unauthorized access to team route without session user');
+      getLogger().warn({ path: req.path, method: req.method }, 'Unauthorized access to team route without session user');
       return res.status(401).json({ error: 'Unauthorized' });
     }
     if (!req.params.teamId) {
-      res.log.warn({ path: req.path, method: req.method, userId: req.session.user.id }, 'Missing teamId in team route');
+      getLogger().warn({ path: req.path, method: req.method, userId: req.session.user.id }, 'Missing teamId in team route');
       return res.status(400).json({ error: 'Team ID is required' });
     }
     if (!TeamMemberRoleSchema.array().safeParse(roles).success) {
-      res.log.error(
+      getLogger().error(
         { path: req.path, method: req.method, userId: req.session.user.id },
         `Invalid roles provided to validateTeamRoleMiddlewareFn: ${roles}`,
       );
@@ -30,7 +31,7 @@ function validateTeamRoleMiddlewareFn(roles: TeamMemberRole[]) {
     }
     const teamMembership = await findActiveTeamMembershipForRoles({ teamId: req.params.teamId, userId: req.session.user.id, roles });
     if (!teamMembership) {
-      res.log.warn(
+      getLogger().warn(
         { path: req.path, method: req.method, userId: req.session.user.id, teamId: req.params.teamId },
         'User does not have required team role for this route',
       );

--- a/apps/api/src/app/services/__tests__/external-auth.service.spec.ts
+++ b/apps/api/src/app/services/__tests__/external-auth.service.spec.ts
@@ -40,6 +40,8 @@ vi.mock('@jetstream/api-config', () => ({
     JWT_ENCRYPTION_KEY: 'test-jwt-encryption-key',
   },
   logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+  getLogger: () => ({ trace: vi.fn(), debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+  enrichRequestContext: vi.fn(),
   errorTracker: { error: vi.fn(), warn: vi.fn(), critical: vi.fn(), info: vi.fn() },
   DbCacheProvider: vi.fn().mockImplementation(function () {
     this.saveAsync = vi.fn().mockResolvedValue(null);

--- a/apps/api/src/app/services/external-auth.service.ts
+++ b/apps/api/src/app/services/external-auth.service.ts
@@ -1,4 +1,4 @@
-import { ENV, logger } from '@jetstream/api-config';
+import { enrichRequestContext, ENV, getLogger } from '@jetstream/api-config';
 import { convertUserProfileToSession_External, InvalidAccessToken } from '@jetstream/auth/server';
 import { TokenSource, UserProfileSession } from '@jetstream/auth/types';
 import { HTTP } from '@jetstream/shared/constants';
@@ -164,16 +164,16 @@ export async function rotateToken({
       type: webExtDb.TOKEN_TYPE_AUTH,
     });
     if (currentTokenRecord && currentTokenRecord.source === source) {
-      logger.warn({ userId: userProfile.id, deviceId, audience }, 'rotateToken: race lost — returning current DB token to caller');
+      getLogger().warn({ userId: userProfile.id, deviceId, audience }, 'rotateToken: race lost — returning current DB token to caller');
       return { token: decryptJwtTokenOrPlaintext(currentTokenRecord.token), outcome: 'race-loss-current' };
     }
     if (currentTokenRecord) {
-      logger.warn(
+      getLogger().warn(
         { userId: userProfile.id, deviceId, audience, expectedSource: source, foundSource: currentTokenRecord.source },
         'rotateToken: race lost and current DB token has mismatched source — treating as race-loss-none',
       );
     } else {
-      logger.warn({ userId: userProfile.id, deviceId, audience }, 'rotateToken: race lost and no current token found');
+      getLogger().warn({ userId: userProfile.id, deviceId, audience }, 'rotateToken: race lost and no current token found');
     }
     return { token: undefined, outcome: 'race-loss-none' };
   }
@@ -265,7 +265,7 @@ export async function getUserAndDeviceIdForExternalAuth(
     }
     return { user, deviceId };
   } catch (ex) {
-    res.log.warn({ audience, deviceId, ...getErrorMessageAndStackObj(ex) }, '[EXTERNAL-AUTH][AUTH ERROR] Error decoding token');
+    getLogger().warn({ audience, deviceId, ...getErrorMessageAndStackObj(ex) }, '[EXTERNAL-AUTH][AUTH ERROR] Error decoding token');
     return { user: null, deviceId };
   }
 }
@@ -301,9 +301,10 @@ export function getExternalAuthMiddleware(audience: Audience, options?: External
         user,
       };
       res.locals.deviceId = deviceId;
+      enrichRequestContext({ userId: user.id, deviceId });
       next();
     } catch (ex) {
-      res.log.warn(
+      getLogger().warn(
         { audience, deviceId: getDeviceId(req, res), ...getErrorMessageAndStackObj(ex) },
         '[EXTERNAL AUTH ERROR] Error decoding token',
       );

--- a/apps/api/src/app/services/user-feedback.service.ts
+++ b/apps/api/src/app/services/user-feedback.service.ts
@@ -1,4 +1,4 @@
-import { ENV, errorTracker, logger } from '@jetstream/api-config';
+import { ENV, errorTracker, getLogger } from '@jetstream/api-config';
 import { sendUserFeedbackEmail } from '@jetstream/email';
 import { Request } from 'express';
 import fs from 'node:fs/promises';
@@ -94,7 +94,7 @@ export async function handleUserFeedbackEmail(
     userId,
   });
 
-  logger.info({ userId, feedbackType: type, hasAttachments: !!files?.length }, 'User feedback submitted');
+  getLogger().info({ userId, feedbackType: type, hasAttachments: !!files?.length }, 'User feedback submitted');
 }
 
 export async function cleanupFeedbackAttachments(req: Request, loggerInfo: Record<string, unknown>) {
@@ -109,9 +109,9 @@ export async function cleanupFeedbackAttachments(req: Request, loggerInfo: Recor
     if (results.some((result) => result.status === 'rejected')) {
       throw new Error('Error deleting one or more temp feedback attachment files');
     }
-    (req.log || logger).info({ filePaths, ...loggerInfo }, 'Temp feedback attachment files cleaned up');
+    getLogger().info({ filePaths, ...loggerInfo }, 'Temp feedback attachment files cleaned up');
   } catch (ex) {
-    (req.log || logger).error({ err: ex, ...loggerInfo }, 'Error during cleanup of feedback attachments');
+    getLogger().error({ err: ex, ...loggerInfo }, 'Error during cleanup of feedback attachments');
     errorTracker.error('Error during cleanup of feedback attachments', req, ex, {
       context: `user-feedback.service#cleanupFeedbackAttachments`,
       ...loggerInfo,

--- a/apps/api/src/app/utils/__tests__/deferred-response.middleware.spec.ts
+++ b/apps/api/src/app/utils/__tests__/deferred-response.middleware.spec.ts
@@ -1,6 +1,11 @@
+/* eslint-disable @typescript-eslint/no-empty-function */
 import { HTTP } from '@jetstream/shared/constants';
 import { EventEmitter } from 'events';
 import { deferredResponseMiddleware, writeDeferredResponse, type DeferredResponseState } from '../deferred-response.middleware';
+
+// Holder so the mocked getLogger() returns the same per-test logger assigned to res.log
+// (createMockRes refreshes it each test), keeping the existing res.log.* assertions valid.
+const loggerHolder = vi.hoisted(() => ({ current: null as unknown as Record<string, ReturnType<typeof vi.fn>> }));
 
 vi.mock('@jetstream/api-config', () => ({
   ENV: {
@@ -8,6 +13,7 @@ vi.mock('@jetstream/api-config', () => ({
     DEFERRED_RESPONSE_THRESHOLD_MS: 75_000,
     DEFERRED_RESPONSE_KEEPALIVE_MS: 25_000,
   },
+  getLogger: () => loggerHolder.current,
 }));
 
 let mockEnv: Record<string, unknown>;
@@ -36,18 +42,22 @@ function createMockRes() {
 
   // Extend EventEmitter so writeDeferredResponse's res.once('finish'|'close'|'error') listeners work.
   const emitter = new EventEmitter();
+  // Fresh per-test logger, exposed to the code-under-test via the mocked getLogger() holder.
+  const log = {
+    warn: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+    error: vi.fn(),
+    trace: vi.fn(),
+  };
+  loggerHolder.current = log;
   const res = Object.assign(emitter, {
     locals: {
       requestId: 'test-request-id',
     } as Record<string, unknown>,
     headersSent: false,
     writableEnded: false,
-    log: {
-      warn: vi.fn(),
-      info: vi.fn(),
-      debug: vi.fn(),
-      error: vi.fn(),
-    },
+    log,
     writeHead: vi.fn((status: number, headers: Record<string, string>) => {
       headersWritten = true;
       res.headersSent = true;
@@ -124,7 +134,7 @@ describe('deferredResponseMiddleware', () => {
     // First keepalive byte
     expect(res._chunks).toEqual([' ']);
     expect(res.log.warn).toHaveBeenCalledWith(
-      expect.objectContaining({ requestId: 'test-request-id' }),
+      expect.objectContaining({ elapsedMs: expect.any(Number) }),
       expect.stringContaining('[DEFERRED][ACTIVATED]'),
     );
   });
@@ -213,7 +223,7 @@ describe('deferredResponseMiddleware', () => {
     expect(deferred.active).toBe(false);
     expect(res.destroy).toHaveBeenCalled();
     expect(res.log.error).toHaveBeenCalledWith(
-      expect.objectContaining({ requestId: 'test-request-id' }),
+      expect.objectContaining({ elapsedMs: expect.any(Number) }),
       expect.stringContaining('[DEFERRED][WRITE_ERROR] Failed to write initial keepalive'),
     );
   });
@@ -247,7 +257,7 @@ describe('deferredResponseMiddleware', () => {
     expect(deferred.active).toBe(false);
     expect(res.destroy).toHaveBeenCalled();
     expect(res.log.error).toHaveBeenCalledWith(
-      expect.objectContaining({ requestId: 'test-request-id' }),
+      expect.objectContaining({ elapsedMs: expect.any(Number) }),
       expect.stringContaining('destroying stream'),
     );
   });
@@ -272,7 +282,7 @@ describe('deferredResponseMiddleware', () => {
     expect(deferred.timer).toBeNull();
     expect(deferred.keepaliveInterval).toBeNull();
     expect(res.log.warn).toHaveBeenCalledWith(
-      expect.objectContaining({ requestId: 'test-request-id' }),
+      expect.objectContaining({ elapsedMs: expect.any(Number) }),
       expect.stringContaining('[DEFERRED][CLIENT_DISCONNECT]'),
     );
   });
@@ -353,7 +363,7 @@ describe('writeDeferredResponse', () => {
     expect(deferred.active).toBe(false);
     expect(res.end).toHaveBeenCalled();
     expect(res.log.error).toHaveBeenCalledWith(
-      expect.objectContaining({ requestId: 'test-request-id' }),
+      expect.objectContaining({ elapsedMs: expect.any(Number) }),
       expect.stringContaining('[DEFERRED][WRITE_ERROR]'),
     );
   });

--- a/apps/api/src/app/utils/__tests__/response.handlers.spec.ts
+++ b/apps/api/src/app/utils/__tests__/response.handlers.spec.ts
@@ -17,6 +17,10 @@ const prismaMocks = vi.hoisted(() => {
   };
 });
 
+// Holder so the mocked getLogger() returns the same per-test logger assigned to res.log
+// (createMockRes refreshes it each test), keeping the existing res.log.* assertions valid.
+const loggerHolder = vi.hoisted(() => ({ current: null as unknown as Record<string, ReturnType<typeof vi.fn>> }));
+
 vi.mock('@jetstream/api-config', () => ({
   ENV: {
     JETSTREAM_SERVER_URL: 'https://getjetstream.app',
@@ -27,6 +31,7 @@ vi.mock('@jetstream/api-config', () => ({
     info: vi.fn(),
     warn: vi.fn(),
   },
+  getLogger: () => loggerHolder.current,
   prisma: {},
   errorTracker: {
     error: vi.fn(),
@@ -72,18 +77,22 @@ function createMockReq() {
 }
 
 function createMockRes() {
+  // Fresh per-test logger, exposed to the code-under-test via the mocked getLogger() holder.
+  const log = {
+    debug: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    trace: vi.fn(),
+  };
+  loggerHolder.current = log;
   const res = {
     headersSent: false,
     locals: {
       cookies: {},
       requestId: 'request-id',
     },
-    log: {
-      debug: vi.fn(),
-      error: vi.fn(),
-      info: vi.fn(),
-      warn: vi.fn(),
-    },
+    log,
     json: vi.fn(),
     redirect: vi.fn(),
     set: vi.fn(),
@@ -193,16 +202,19 @@ describe('uncaughtErrorHandler logging levels', () => {
 
 function createMockStreamRes() {
   const chunks: string[] = [];
+  const log = {
+    debug: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    trace: vi.fn(),
+  };
+  loggerHolder.current = log;
   const res = {
     locals: {
       requestId: 'request-id',
     },
-    log: {
-      debug: vi.fn(),
-      error: vi.fn(),
-      info: vi.fn(),
-      warn: vi.fn(),
-    },
+    log,
     setHeader: vi.fn(),
     status: vi.fn(),
     json: vi.fn(),

--- a/apps/api/src/app/utils/deferred-response.middleware.ts
+++ b/apps/api/src/app/utils/deferred-response.middleware.ts
@@ -1,7 +1,7 @@
-import { ENV } from '@jetstream/api-config';
+import { ENV, getLogger } from '@jetstream/api-config';
 import type { DeferredResponseState, Response } from '@jetstream/api-types';
 import { HTTP } from '@jetstream/shared/constants';
-import type { NextFunction, Request, Response as ExpressResponse } from 'express';
+import type { Response as ExpressResponse, NextFunction, Request } from 'express';
 import { setCookieHeaders } from './response.handlers';
 
 export type { DeferredResponseState };
@@ -42,8 +42,8 @@ export function deferredResponseMiddleware(req: Request, res: Response, next: Ne
 
       const elapsedMs = Date.now() - deferred.startTime;
 
-      res.log.warn(
-        { requestId: res.locals.requestId, method: req.method, url: req.originalUrl, elapsedMs },
+      getLogger().warn(
+        { method: req.method, url: req.originalUrl, elapsedMs },
         '[DEFERRED][ACTIVATED] Response deferred due to slow upstream',
       );
 
@@ -67,8 +67,8 @@ export function deferredResponseMiddleware(req: Request, res: Response, next: Ne
         res.write(' ');
         deferred.keepaliveCount++;
       } catch (ex) {
-        res.log.error(
-          { requestId: res.locals.requestId, elapsedMs: Date.now() - deferred.startTime, err: ex },
+        getLogger().error(
+          { elapsedMs: Date.now() - deferred.startTime, err: ex },
           '[DEFERRED][WRITE_ERROR] Failed to write initial keepalive',
         );
         cleanupDeferred(deferred);
@@ -90,13 +90,13 @@ export function deferredResponseMiddleware(req: Request, res: Response, next: Ne
           try {
             res.write(' ');
             deferred.keepaliveCount++;
-            res.log.debug(
-              { requestId: res.locals.requestId, keepaliveCount: deferred.keepaliveCount, elapsedMs: Date.now() - deferred.startTime },
+            getLogger().debug(
+              { keepaliveCount: deferred.keepaliveCount, elapsedMs: Date.now() - deferred.startTime },
               '[DEFERRED][KEEPALIVE]',
             );
           } catch (ex) {
-            res.log.error(
-              { requestId: res.locals.requestId, elapsedMs: Date.now() - deferred.startTime, err: ex },
+            getLogger().error(
+              { elapsedMs: Date.now() - deferred.startTime, err: ex },
               '[DEFERRED][WRITE_ERROR] Failed to write keepalive, destroying stream',
             );
             cleanupDeferred(deferred);
@@ -117,8 +117,8 @@ export function deferredResponseMiddleware(req: Request, res: Response, next: Ne
   // Clean up timers if client disconnects
   req.on('close', () => {
     if (deferred.active) {
-      res.log.warn(
-        { requestId: res.locals.requestId, elapsedMs: Date.now() - deferred.startTime },
+      getLogger().warn(
+        { elapsedMs: Date.now() - deferred.startTime },
         '[DEFERRED][CLIENT_DISCONNECT] Client disconnected during deferred response',
       );
     }
@@ -146,9 +146,7 @@ export function writeDeferredResponse(res: Response | ExpressResponse, body: unk
 
   const writeStartedAt = Date.now();
   const elapsedMs = writeStartedAt - deferred.startTime;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const resLog = (res as any).log;
-  const requestId = res.locals?.requestId;
+  const resLog = getLogger();
 
   // Attach lifecycle listeners BEFORE writing, so we can tell whether the body actually flushed.
   // 'finish' = handed off to OS for transmission. 'close' before 'finish' = peer hung up
@@ -157,9 +155,8 @@ export function writeDeferredResponse(res: Response | ExpressResponse, body: unk
   let finished = false;
   res.once('finish', () => {
     finished = true;
-    resLog?.info(
+    resLog.info(
       {
-        requestId,
         elapsedMs: Date.now() - deferred.startTime,
         writeMs: Date.now() - writeStartedAt,
         keepaliveCount: deferred.keepaliveCount,
@@ -171,9 +168,8 @@ export function writeDeferredResponse(res: Response | ExpressResponse, body: unk
     if (finished) {
       return;
     }
-    resLog?.warn(
+    resLog.warn(
       {
-        requestId,
         elapsedMs: Date.now() - deferred.startTime,
         writeMs: Date.now() - writeStartedAt,
         keepaliveCount: deferred.keepaliveCount,
@@ -182,9 +178,8 @@ export function writeDeferredResponse(res: Response | ExpressResponse, body: unk
     );
   });
   res.once('error', (err) => {
-    resLog?.error(
+    resLog.error(
       {
-        requestId,
         elapsedMs: Date.now() - deferred.startTime,
         writeMs: Date.now() - writeStartedAt,
         err,
@@ -202,10 +197,7 @@ export function writeDeferredResponse(res: Response | ExpressResponse, body: unk
     deferred.active = false;
   } catch (ex) {
     deferred.active = false;
-    resLog?.error(
-      { requestId: res.locals?.requestId, elapsedMs, err: ex },
-      '[DEFERRED][WRITE_ERROR] Failed to write deferred response body',
-    );
+    resLog.error({ elapsedMs, err: ex }, '[DEFERRED][WRITE_ERROR] Failed to write deferred response body');
     try {
       // Only write fallback error if JSON.stringify failed (not after a partial res.write)
       // A partial write + fallback would produce unparseable JSON for the client

--- a/apps/api/src/app/utils/response.handlers.ts
+++ b/apps/api/src/app/utils/response.handlers.ts
@@ -1,4 +1,4 @@
-import { ENV, errorTracker, logger, prisma } from '@jetstream/api-config';
+import { ENV, errorTracker, getLogger, prisma } from '@jetstream/api-config';
 import type { Response } from '@jetstream/api-types';
 import { AuthError, createCSRFToken, getCookieConfig } from '@jetstream/auth/server';
 import { isPrismaError, Prisma, SalesforceOrg, toTypedPrismaError } from '@jetstream/prisma';
@@ -56,11 +56,11 @@ export function setCookieHeaders(res: Response) {
         }
         res.appendHeader('Set-Cookie', stringifySetCookie(name, value, options));
       } catch (ex) {
-        logger.error({ err: ex }, 'Error setting cookie: %s', name);
+        getLogger().error({ err: ex }, 'Error setting cookie: %s', name);
       }
     });
   } catch (ex) {
-    logger.error({ err: ex }, 'Error setting cookies');
+    getLogger().error({ err: ex }, 'Error setting cookies');
   }
 }
 
@@ -81,10 +81,7 @@ export function sendJson<ResponseType = unknown>(res: Response, content?: Respon
   // Deferred response mode: write body to the existing chunked stream
   if (deferred?.active) {
     const elapsedMs = Date.now() - deferred.startTime;
-    res.log.info(
-      { requestId: res.locals.requestId, elapsedMs },
-      '[DEFERRED][BODY_READY] Controller produced response body, writing to deferred stream',
-    );
+    getLogger().info({ elapsedMs }, '[DEFERRED][BODY_READY] Controller produced response body, writing to deferred stream');
     writeDeferredResponse(res, { data: content || {} });
     return;
   }
@@ -95,7 +92,7 @@ export function sendJson<ResponseType = unknown>(res: Response, content?: Respon
   }
 
   if (res.headersSent) {
-    res.log.warn('Response headers already sent');
+    getLogger().warn('Response headers already sent');
     try {
       errorTracker.warn('Response not handled by sendJson, headers already sent', new Error('headers already sent'), {
         context: `route#sendJson`,
@@ -103,7 +100,7 @@ export function sendJson<ResponseType = unknown>(res: Response, content?: Respon
         status,
       });
     } catch (ex) {
-      res.log.error({ err: ex }, 'Error sending to error tracker');
+      getLogger().error({ err: ex }, 'Error sending to error tracker');
     }
     return;
   }
@@ -117,7 +114,7 @@ export function sendJson<ResponseType = unknown>(res: Response, content?: Respon
  */
 export function streamParsedCsvAsJson(res: express.Response, csvParseStream: Duplex) {
   let isFirstChunk = true;
-  const _logger = res.log || logger;
+  const _logger = getLogger();
 
   res.setHeader('Content-Type', 'application/json; charset=utf-8');
 
@@ -135,11 +132,11 @@ export function streamParsedCsvAsJson(res: express.Response, csvParseStream: Dup
   csvParseStream.on('finish', () => {
     res.write(isFirstChunk ? '{"data":[]}' : ']}');
     res.end();
-    _logger.debug({ requestId: res.locals.requestId }, 'Finished streaming CSV');
+    _logger.debug('Finished streaming CSV');
   });
 
   csvParseStream.on('error', (err) => {
-    _logger.warn({ requestId: res.locals.requestId, err }, 'Error streaming CSV.');
+    _logger.warn({ err }, 'Error streaming CSV.');
     if (!res.headersSent) {
       res.status(400).json({ error: true, success: false, message: 'Error streaming CSV' });
     } else {
@@ -157,7 +154,7 @@ export async function uncaughtErrorHandler(err: any, req: express.Request, res: 
       setCookieHeaders(res as any);
     }
     // Logger is not added to the response object in all cases depending on where error is encountered
-    const responseLogger = res.log || logger;
+    const responseLogger = getLogger();
 
     // If org had a connection error, ensure that the database is updated
     // This runs before the headersSent/deferred checks so the DB side effect always happens
@@ -198,7 +195,6 @@ export async function uncaughtErrorHandler(err: any, req: express.Request, res: 
       const errorMessage = err.message || 'An unknown error has occurred';
       responseLogger.error(
         {
-          requestId: res.locals.requestId,
           method: req.method,
           url: req.originalUrl,
           elapsedMs,
@@ -397,9 +393,9 @@ export async function uncaughtErrorHandler(err: any, req: express.Request, res: 
         requestId: res.locals.requestId,
       });
     } catch (trackerEx) {
-      logger.error({ err: trackerEx }, 'Error sending to error tracker');
+      getLogger().error({ err: trackerEx }, 'Error sending to error tracker');
     }
-    logger.error({ err: ex }, 'Error in uncaughtErrorHandler');
+    getLogger().error({ err: ex }, 'Error in uncaughtErrorHandler');
     res.status(500).json({ error: true, success: false, message: 'Internal Server Error' });
   }
 }
@@ -409,7 +405,7 @@ function getPrismaErrorMessage(
 ) {
   if (error instanceof Prisma.PrismaClientKnownRequestError) {
     const prismaError = toTypedPrismaError(error);
-    logger.warn({ error: error.message, code: error.code }, '[DB][PRISMA][WARN]');
+    getLogger().warn({ error: error.message, code: error.code }, '[DB][PRISMA][WARN]');
     if (prismaError.code === 'P2002') {
       return `A record with the same unique field already exists.`;
     } else if (prismaError.code === 'P2022') {

--- a/apps/api/src/app/utils/route.utils.ts
+++ b/apps/api/src/app/utils/route.utils.ts
@@ -1,4 +1,4 @@
-import { ENV, errorTracker } from '@jetstream/api-config';
+import { ENV, errorTracker, getLogger } from '@jetstream/api-config';
 import { Request, Response } from '@jetstream/api-types';
 import { getApiAddressFromReq } from '@jetstream/auth/server';
 import { AuthenticatedUser, CookieOptions, UserProfileSession } from '@jetstream/auth/types';
@@ -99,7 +99,6 @@ export function createRoute<TParamsSchema extends z.ZodTypeAny, TBodySchema exte
   onErrorHandler?: (error: unknown, req: Request<unknown, unknown, unknown>, res: Response, next: NextFunction) => void,
 ) {
   return async (req: Request<unknown, unknown, unknown>, res: Response, next: NextFunction) => {
-    const logger = res.log || req.log;
     try {
       res.locals.ipAddress = getApiAddressFromReq(req);
       res.locals.cookies = res.locals.cookies || {};
@@ -131,11 +130,11 @@ export function createRoute<TParamsSchema extends z.ZodTypeAny, TBodySchema exte
         },
       };
       if (hasSourceOrg && !data.jetstreamConn) {
-        logger.warn('[INIT-ORG][ERROR] A source org did not exist on locals');
+        getLogger().warn('[INIT-ORG][ERROR] A source org did not exist on locals');
         return next(new UserFacingError('An org is required for this action'));
       }
       if (hasTargetOrg && !data.targetJetstreamConn) {
-        logger.warn('[INIT-ORG][ERROR] A target org did not exist on locals');
+        getLogger().warn('[INIT-ORG][ERROR] A target org did not exist on locals');
         return next(new UserFacingError('A source and target org are required for this action'));
       }
       try {
@@ -143,7 +142,7 @@ export function createRoute<TParamsSchema extends z.ZodTypeAny, TBodySchema exte
         await controllerFn(data as any, req, res, next);
       } catch (ex) {
         if (logErrorToBugTracker) {
-          logger.error({ err: ex }, 'Logging error to bug tracker');
+          getLogger().error({ err: ex }, 'Logging error to bug tracker');
           errorTracker.error(ex, req, {
             url: req.url,
             params: req.params,
@@ -160,7 +159,7 @@ export function createRoute<TParamsSchema extends z.ZodTypeAny, TBodySchema exte
         next(new UserFacingError(ex));
       }
     } catch (ex) {
-      logger.warn({ err: ex }, '[ROUTE][VALIDATION ERROR]');
+      getLogger().warn({ err: ex }, '[ROUTE][VALIDATION ERROR]');
       if (logErrorToBugTracker) {
         errorTracker.error(ex, req, {
           url: req.url,

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -2,7 +2,15 @@
 import '@jetstream/api-config';
 
 import { ClusterMemoryStorePrimary } from '@express-rate-limit/cluster-memory-store';
-import { createRateLimit, ENV, httpLogger, logger, pgPool, sentryRequestContextMiddleware } from '@jetstream/api-config';
+import {
+  createRateLimit,
+  ENV,
+  httpLogger,
+  logger,
+  pgPool,
+  requestContextMiddleware,
+  sentryRequestContextMiddleware,
+} from '@jetstream/api-config';
 import { getSessionCookieName } from '@jetstream/auth/server';
 import '@jetstream/auth/types';
 import { HTTP, SESSION_EXP_DAYS } from '@jetstream/shared/constants';
@@ -183,6 +191,7 @@ if (ENV.NODE_ENV === 'production' && !ENV.CI && cluster.isPrimary) {
   }
 
   app.use(httpLogger);
+  app.use(requestContextMiddleware);
 
   // Handle CORS for web extension routes
   const allowedHeaders = [

--- a/apps/cron-tasks/eslint.config.js
+++ b/apps/cron-tasks/eslint.config.js
@@ -1,3 +1,4 @@
+/* eslint-disable @nx/enforce-module-boundaries */
 const baseConfig = require('../../eslint.config.js');
 
 module.exports = [

--- a/apps/cron-tasks/src/__tests__/salesforce-org-expiration.spec.ts
+++ b/apps/cron-tasks/src/__tests__/salesforce-org-expiration.spec.ts
@@ -1,3 +1,4 @@
+import { sendEmail } from '@jetstream/api-config';
 import { createAuditLog } from '@jetstream/audit-logs';
 import { sendOrgExpirationWarningEmail } from '@jetstream/email';
 import { PrismaClient } from '@jetstream/prisma';
@@ -57,9 +58,6 @@ vi.mock('@jetstream/audit-logs', () => {
     },
   };
 });
-
-// Import the mocked functions after mock calls
-import { sendEmail } from '@jetstream/api-config';
 
 let orgCounter = 0;
 // Ensure this runs against a test database

--- a/apps/geo-ip-api/eslint.config.js
+++ b/apps/geo-ip-api/eslint.config.js
@@ -1,3 +1,4 @@
+/* eslint-disable @nx/enforce-module-boundaries */
 const baseConfig = require('../../eslint.config.js');
 
 module.exports = [

--- a/apps/geo-ip-api/src/main.ts
+++ b/apps/geo-ip-api/src/main.ts
@@ -1,4 +1,4 @@
-import { ENV, httpLogger, logger } from '@jetstream/api-config';
+import { ENV, getLogger, httpLogger, logger, requestContextMiddleware } from '@jetstream/api-config';
 import { GeoIpLookupResult } from '@jetstream/types';
 import { json, urlencoded } from 'body-parser';
 import express from 'express';
@@ -17,8 +17,8 @@ const app = express();
 
 app.use(json({ limit: '20mb' }));
 app.use(urlencoded({ extended: true }));
-
 app.use(httpLogger);
+app.use(requestContextMiddleware);
 
 app.use('/healthz', (_, res) => {
   res.status(200).json({
@@ -65,7 +65,7 @@ app.post(
         timeTaken,
       });
     } catch (ex) {
-      res.log.error({ err: ex }, 'Failed to download MaxMind database');
+      getLogger().error({ err: ex }, 'Failed to download MaxMind database');
       next(ex);
     }
   }),
@@ -90,7 +90,7 @@ app.get(
         : { ipAddress, isValid: false as const };
       res.status(200).json({ success: true, results: [result] });
     } catch (ex) {
-      res.log.error({ err: ex }, 'Failed to lookup IP address');
+      getLogger().error({ err: ex }, 'Failed to lookup IP address');
       next(ex);
     }
   }),
@@ -119,7 +119,7 @@ app.post(
 
       res.status(200).json({ success: true, results });
     } catch (ex) {
-      res.log.error({ err: ex }, 'Failed to lookup IP address');
+      getLogger().error({ err: ex }, 'Failed to lookup IP address');
       next(ex);
     }
   }),
@@ -133,7 +133,7 @@ app.use((_, res) => {
 });
 
 app.use((err: Error | ZodError, _: express.Request, res: express.Response, _next: express.NextFunction) => {
-  res.log.error({ err }, 'Unhandled error');
+  getLogger().error({ err }, 'Unhandled error');
 
   if (err instanceof ZodError) {
     res.status(400);

--- a/apps/geo-ip-api/src/route.utils.ts
+++ b/apps/geo-ip-api/src/route.utils.ts
@@ -1,15 +1,15 @@
+import { getLogger } from '@jetstream/api-config';
 import type { Request as ExpressRequest, Response as ExpressResponse } from 'express';
 import { NextFunction } from 'express';
-import type pino from 'pino';
 import { z } from 'zod';
 
 export type Request<
   Params extends Record<string, string> | unknown = Record<string, string>,
   ReqBody = unknown,
   Query extends Record<string, string | undefined> | unknown = Record<string, string | undefined>,
-> = ExpressRequest<Params, unknown, ReqBody, Query> & { log: pino.Logger };
+> = ExpressRequest<Params, unknown, ReqBody, Query>;
 
-export type Response<ResBody = unknown> = ExpressResponse<ResBody> & { log: pino.Logger };
+export type Response<ResBody = unknown> = ExpressResponse<ResBody>;
 
 export type ControllerFunction<TParamsSchema extends z.ZodTypeAny, TBodySchema extends z.ZodTypeAny, TQuerySchema extends z.ZodTypeAny> = (
   data: {
@@ -48,7 +48,7 @@ export function createRoute<TParamsSchema extends z.ZodTypeAny, TBodySchema exte
         next(ex);
       }
     } catch (ex) {
-      req.log.error({ err: ex }, '[ROUTE][VALIDATION ERROR]');
+      getLogger().error({ err: ex }, '[ROUTE][VALIDATION ERROR]');
       res.status(400);
       next(ex);
     }

--- a/apps/jetstream-e2e/eslint.config.js
+++ b/apps/jetstream-e2e/eslint.config.js
@@ -1,3 +1,4 @@
+/* eslint-disable @nx/enforce-module-boundaries */
 const { FlatCompat } = require('@eslint/eslintrc');
 const js = require('@eslint/js');
 const baseConfig = require('../../eslint.config.js');

--- a/apps/jetstream-web-extension-e2e/eslint.config.js
+++ b/apps/jetstream-web-extension-e2e/eslint.config.js
@@ -1,3 +1,4 @@
+/* eslint-disable @nx/enforce-module-boundaries */
 const { FlatCompat } = require('@eslint/eslintrc');
 const js = require('@eslint/js');
 const baseConfig = require('../../eslint.config.js');

--- a/apps/jetstream-web-extension/eslint.config.js
+++ b/apps/jetstream-web-extension/eslint.config.js
@@ -1,3 +1,4 @@
+/* eslint-disable @nx/enforce-module-boundaries */
 const baseConfig = require('../../eslint.config.js');
 
 module.exports = [

--- a/libs/api-config/eslint.config.js
+++ b/libs/api-config/eslint.config.js
@@ -1,3 +1,4 @@
+/* eslint-disable @nx/enforce-module-boundaries */
 const baseConfig = require('../../eslint.config.js');
 
 module.exports = [

--- a/libs/api-config/src/index.ts
+++ b/libs/api-config/src/index.ts
@@ -1,5 +1,6 @@
 // Sentry must initialize before any other module that should be auto-instrumented (db, http).
 import './lib/api-sentry-config';
+
 import './lib/api-db-config';
 import './lib/env-config';
 
@@ -10,5 +11,6 @@ export * from './lib/api-rate-limit.config';
 export * from './lib/api-sentry-config';
 export * from './lib/db-cache-provider.config';
 export * from './lib/email.config';
-export * from './lib/pg-rate-limit-store';
 export * from './lib/env-config';
+export * from './lib/pg-rate-limit-store';
+export * from './lib/request-context';

--- a/libs/api-config/src/lib/__tests__/db-cache-provider.config.spec.ts
+++ b/libs/api-config/src/lib/__tests__/db-cache-provider.config.spec.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { DbCacheProvider } from '../db-cache-provider.config';
 
 const prismaMock = vi.hoisted(() => {
   const mock: any = {
@@ -35,8 +36,6 @@ vi.mock('@jetstream/prisma', () => ({
     PrismaClientKnownRequestError: PrismaClientKnownRequestErrorMock,
   },
 }));
-
-import { DbCacheProvider } from '../db-cache-provider.config';
 
 describe('DbCacheProvider.consumeOnceAsync', () => {
   beforeEach(() => {

--- a/libs/api-config/src/lib/__tests__/logging-policy.spec.ts
+++ b/libs/api-config/src/lib/__tests__/logging-policy.spec.ts
@@ -27,9 +27,9 @@ describe('logging policy', () => {
       expect(getHttpLogLevel({}, { statusCode: 404 })).toBe('info');
     });
 
-    it('silences 5xx responses to avoid duplicating app-level error logs', () => {
-      expect(getHttpLogLevel({}, { statusCode: 500 })).toBe('silent');
-      expect(getHttpLogLevel({}, { statusCode: 503 })).toBe('silent');
+    it('logs 5xx responses at error so the access line is not lost for server errors', () => {
+      expect(getHttpLogLevel({}, { statusCode: 500 })).toBe('error');
+      expect(getHttpLogLevel({}, { statusCode: 503 })).toBe('error');
     });
 
     it('logs non-5xx request errors at error', () => {

--- a/libs/api-config/src/lib/__tests__/request-context.spec.ts
+++ b/libs/api-config/src/lib/__tests__/request-context.spec.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it, vi } from 'vitest';
+import { enrichRequestContext, getLogger, getRequestContext, runWithRequestContext } from '../request-context';
+
+// Mock the base logger so the test does not pull in pino/env-config. The fake logger records the
+// accumulated bindings on each `child()` so we can assert what the request-scoped logger carries.
+vi.mock('../api-logger', () => {
+  const makeLogger = (bindings: Record<string, unknown> = {}): Record<string, unknown> => ({
+    bindings,
+    child: (extra: Record<string, unknown>) => makeLogger({ ...bindings, ...extra }),
+    trace: vi.fn(),
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  });
+  return { logger: makeLogger() };
+});
+
+function bindingsOf(logger: unknown): Record<string, unknown> {
+  return (logger as { bindings: Record<string, unknown> }).bindings;
+}
+
+describe('request-context', () => {
+  it('returns the base logger (no request bindings) outside of a request scope', () => {
+    expect(bindingsOf(getLogger())).toEqual({});
+    expect(getRequestContext()).toBeUndefined();
+  });
+
+  it('binds requestId to the logger inside a request scope', () => {
+    runWithRequestContext({ requestId: 'req-1' }, () => {
+      expect(bindingsOf(getLogger())).toEqual({ requestId: 'req-1' });
+      expect(getRequestContext()?.requestId).toBe('req-1');
+    });
+  });
+
+  it('folds late-bound context into the logger and subsequent getLogger() calls observe it', () => {
+    runWithRequestContext({ requestId: 'req-2' }, () => {
+      enrichRequestContext({ userId: 'user-1' });
+      enrichRequestContext({ orgId: 42 });
+      expect(bindingsOf(getLogger())).toEqual({ requestId: 'req-2', userId: 'user-1', orgId: 42 });
+      const context = getRequestContext();
+      expect(context?.userId).toBe('user-1');
+      expect(context?.orgId).toBe(42);
+    });
+  });
+
+  it('ignores null/undefined enrichment values', () => {
+    runWithRequestContext({ requestId: 'req-3' }, () => {
+      enrichRequestContext({ userId: undefined, sessionId: null as unknown as string });
+      expect(bindingsOf(getLogger())).toEqual({ requestId: 'req-3' });
+    });
+  });
+
+  it('isolates context between concurrent scopes', async () => {
+    const seen: Record<string, unknown>[] = [];
+    await Promise.all([
+      new Promise<void>((resolve) =>
+        runWithRequestContext({ requestId: 'a' }, async () => {
+          enrichRequestContext({ userId: 'user-a' });
+          await Promise.resolve();
+          seen.push(bindingsOf(getLogger()));
+          resolve();
+        }),
+      ),
+      new Promise<void>((resolve) =>
+        runWithRequestContext({ requestId: 'b' }, async () => {
+          enrichRequestContext({ userId: 'user-b' });
+          await Promise.resolve();
+          seen.push(bindingsOf(getLogger()));
+          resolve();
+        }),
+      ),
+    ]);
+    expect(seen).toContainEqual({ requestId: 'a', userId: 'user-a' });
+    expect(seen).toContainEqual({ requestId: 'b', userId: 'user-b' });
+  });
+
+  it('enrichRequestContext is a no-op outside a request scope', () => {
+    expect(() => enrichRequestContext({ userId: 'nobody' })).not.toThrow();
+    expect(bindingsOf(getLogger())).toEqual({});
+  });
+});

--- a/libs/api-config/src/lib/logging-policy.ts
+++ b/libs/api-config/src/lib/logging-policy.ts
@@ -24,7 +24,11 @@ export function resolveLogLevel({
 
 export function getHttpLogLevel(_: unknown, res: { statusCode?: number }, error?: Error): pino.LevelWithSilent {
   if ((res.statusCode ?? 0) >= 500) {
-    return 'silent';
+    // Emit the access-log line at error level for server errors. Previously this returned
+    // 'silent', which suppressed the line entirely and lost request timing/url for exactly
+    // the responses most worth inspecting (the error body is still logged separately by the
+    // uncaught error handler).
+    return 'error';
   }
   if (error) {
     return 'error';

--- a/libs/api-config/src/lib/request-context.ts
+++ b/libs/api-config/src/lib/request-context.ts
@@ -1,0 +1,100 @@
+import type { Maybe } from '@jetstream/types';
+import type express from 'express';
+import { AsyncLocalStorage } from 'node:async_hooks';
+import type pino from 'pino';
+import { v4 as uuid } from 'uuid';
+import { logger as baseLogger } from './api-logger';
+
+/**
+ * Per-request logging context propagated via AsyncLocalStorage.
+ *
+ * The store holds a re-bindable child logger so that context discovered late in the request
+ * lifecycle (userId after auth, orgId after org resolution) can be folded into the logger
+ * without having to thread `req`/`res`/`logger` through every function. Any code — however
+ * deep — can call `getLogger()` to obtain the request-scoped logger.
+ */
+export interface RequestContextStore {
+  requestId: string;
+  /** Re-bindable child logger; always carries at least `requestId`. */
+  logger: pino.Logger;
+  /** Accumulated bindings so each enrichment is additive rather than lossy. */
+  bindings: Record<string, unknown>;
+  userId?: Maybe<string>;
+  sessionId?: Maybe<string>;
+  orgId?: string | number;
+  deviceId?: Maybe<string>;
+}
+
+const asyncLocalStorage = new AsyncLocalStorage<RequestContextStore>();
+
+/**
+ * The logger for the current request, or the base logger when called outside of a request
+ * scope (socket handlers, cron tasks, startup, etc.).
+ */
+export function getLogger(): pino.Logger {
+  return asyncLocalStorage.getStore()?.logger ?? baseLogger;
+}
+
+export function getRequestContext(): RequestContextStore | undefined {
+  return asyncLocalStorage.getStore();
+}
+
+/**
+ * Entry point for a request scope. The callback (and every async continuation it spawns)
+ * runs with access to the store. `next()` MUST be invoked inside the callback so the rest of
+ * the middleware chain inherits the context.
+ */
+export function runWithRequestContext<T>(seed: { requestId: string; bindings?: Record<string, unknown> }, callback: () => T): T {
+  const bindings = { requestId: seed.requestId, ...(seed.bindings ?? {}) };
+  const store: RequestContextStore = {
+    requestId: seed.requestId,
+    bindings,
+    logger: baseLogger.child(bindings),
+  };
+  return asyncLocalStorage.run(store, callback);
+}
+
+type EnrichableContext = Partial<Pick<RequestContextStore, 'userId' | 'sessionId' | 'orgId' | 'deviceId'>> & Record<string, unknown>;
+
+/**
+ * Fold additional context into the current request's logger. No-op when called outside a
+ * request scope. Re-childs from the base logger using the accumulated bindings so repeated
+ * enrichment stays idempotent and the binding set remains flat.
+ */
+export function enrichRequestContext(extra: EnrichableContext): void {
+  const store = asyncLocalStorage.getStore();
+  if (!store) {
+    return;
+  }
+  const defined = Object.fromEntries(Object.entries(extra).filter(([, value]) => value != null));
+  if (Object.keys(defined).length === 0) {
+    return;
+  }
+  Object.assign(store.bindings, defined);
+  store.logger = baseLogger.child(store.bindings);
+  if (typeof defined.userId === 'string') {
+    store.userId = defined.userId;
+  }
+  if (typeof defined.sessionId === 'string') {
+    store.sessionId = defined.sessionId;
+  }
+  if (typeof defined.orgId === 'string' || typeof defined.orgId === 'number') {
+    store.orgId = defined.orgId;
+  }
+  if (typeof defined.deviceId === 'string') {
+    store.deviceId = defined.deviceId;
+  }
+}
+
+/**
+ * Opens an AsyncLocalStorage scope for the request so `getLogger()` resolves a request-scoped
+ * logger anywhere downstream. Mount right after `httpLogger` so the access log is wired and
+ * `res.locals.requestId` is finalized; self-sufficient (falls back to `req.id`/uuid) so it also
+ * works for apps without a dedicated request-id middleware (e.g. geo-ip-api). `next()` runs
+ * inside the scope so the entire chain, including the terminal error handler, inherits context.
+ */
+export function requestContextMiddleware(req: express.Request, res: express.Response, next: express.NextFunction) {
+  const requestId = res.locals.requestId || (req as express.Request & { id?: string }).id || uuid();
+  res.locals.requestId = requestId;
+  runWithRequestContext({ requestId }, () => next());
+}

--- a/libs/api-types/eslint.config.js
+++ b/libs/api-types/eslint.config.js
@@ -1,3 +1,4 @@
+/* eslint-disable @nx/enforce-module-boundaries */
 const baseConfig = require('../../eslint.config.js');
 
 module.exports = [

--- a/libs/api-types/src/lib/api-route.types.ts
+++ b/libs/api-types/src/lib/api-route.types.ts
@@ -3,11 +3,14 @@ import type { SalesforceOrg } from '@jetstream/prisma';
 // eslint-disable-next-line @nx/enforce-module-boundaries
 import type { ApiConnection } from '@jetstream/salesforce-api';
 import type { Request as ExpressRequest, Response as ExpressResponse } from 'express';
-import type pino from 'pino';
 
 // Only declare route-specific locals here. Globally populated fields (requestId, cspNonce)
 // live on the Express.Locals augmentation in custom-express-typings/index.d.ts and are
 // merged in via intersection — do not duplicate them here.
+//
+// NOTE: `req.log` / `res.log` are intentionally NOT declared. Request-scoped logging now flows
+// through `getLogger()` from `@jetstream/api-config` (AsyncLocalStorage). Reading `req.log` /
+// `res.log` is disallowed — see the ESLint `no-restricted-syntax` guard in apps/api/eslint.config.js
 
 export type Request<
   Params extends Record<string, string> | unknown = Record<string, string>,
@@ -22,7 +25,7 @@ export type Request<
     jetstreamConn: ApiConnection;
     targetJetstreamConn?: ApiConnection;
   }
-> & { log: pino.Logger };
+>;
 
 /**
  * Deferred response state for Cloudflare timeout prevention.
@@ -57,4 +60,4 @@ export type Response<ResBody = unknown> = ExpressResponse<
     deviceId?: string;
     _deferred?: DeferredResponseState;
   }
-> & { log: pino.Logger };
+>;

--- a/libs/auth/server/eslint.config.js
+++ b/libs/auth/server/eslint.config.js
@@ -1,3 +1,4 @@
+/* eslint-disable @nx/enforce-module-boundaries */
 const baseConfig = require('../../../eslint.config.js');
 
 module.exports = [

--- a/libs/auth/server/src/lib/auth.service.ts
+++ b/libs/auth/server/src/lib/auth.service.ts
@@ -1,4 +1,4 @@
-import { ENV, logger } from '@jetstream/api-config';
+import { ENV, enrichRequestContext, getLogger } from '@jetstream/api-config';
 import type { Request, Response } from '@jetstream/api-types';
 import { OauthProviderType, Providers, ResponseLocalsCookies, SessionIpData } from '@jetstream/auth/types';
 import { GeoIpLookupResponse } from '@jetstream/types';
@@ -186,7 +186,7 @@ export async function verifyCSRFFromRequestOrThrow(csrfToken: string, cookieStri
       throw new InvalidCsrfToken();
     }
   } catch (ex) {
-    logger.error({ err: ex }, '[ERROR] verifyCSRFFromRequestOrThrow');
+    getLogger().error({ err: ex }, '[ERROR] verifyCSRFFromRequestOrThrow');
     throw new InvalidCsrfToken();
   }
 }
@@ -327,7 +327,7 @@ export async function lookupGeoLocationFromIpAddresses(
       };
     });
   } catch (ex) {
-    logger.warn({ err: ex }, 'Geo-IP lookup failed');
+    getLogger().warn({ err: ex }, 'Geo-IP lookup failed');
     return ipAddresses.map((ipAddress) => ({ ipAddress, location: null }));
   }
 }
@@ -349,7 +349,7 @@ export function initSession(
     req.session.regenerate((error) => {
       try {
         if (error) {
-          logger.error({ err: error }, '[AUTH][INIT_SESSION][ERROR] Error regenerating session');
+          getLogger().error({ err: error }, '[AUTH][INIT_SESSION][ERROR] Error regenerating session');
           reject(new AuthError('Error initializing session'));
           return;
         }
@@ -371,6 +371,7 @@ export function initSession(
         req.session.provider = provider;
         req.session.providerAccountId = providerAccountId;
         req.session.user = user;
+        enrichRequestContext({ userId: user.id, sessionId: req.session.id });
         req.session.pendingMfaEnrollment = undefined;
         req.session.pendingVerification = undefined;
         req.session.pendingVerificationAttempts = 0;
@@ -416,7 +417,7 @@ export function initSession(
 
         resolve();
       } catch (ex) {
-        logger.error({ err: ex }, '[AUTH][INIT_SESSION][ERROR] Error initializing session');
+        getLogger().error({ err: ex }, '[AUTH][INIT_SESSION][ERROR] Error initializing session');
         reject(new AuthError('Error initializing session'));
       }
     });
@@ -433,4 +434,5 @@ export async function refreshSessionUser(req: Request<unknown, unknown, unknown>
 
   const user = await findUserById_UNSAFE(req.session.user.id);
   req.session.user = user;
+  enrichRequestContext({ userId: user?.id, sessionId: req.session.id });
 }

--- a/libs/email/eslint.config.js
+++ b/libs/email/eslint.config.js
@@ -1,3 +1,4 @@
+/* eslint-disable @nx/enforce-module-boundaries */
 const baseConfig = require('../../eslint.config.js');
 
 module.exports = [

--- a/libs/salesforce-api/eslint.config.js
+++ b/libs/salesforce-api/eslint.config.js
@@ -1,3 +1,4 @@
+/* eslint-disable @nx/enforce-module-boundaries */
 const baseConfig = require('../../eslint.config.js');
 
 module.exports = [

--- a/libs/shared/node-utils/eslint.config.js
+++ b/libs/shared/node-utils/eslint.config.js
@@ -1,3 +1,4 @@
+/* eslint-disable @nx/enforce-module-boundaries */
 const baseConfig = require('../../../eslint.config.js');
 
 module.exports = [...baseConfig];


### PR DESCRIPTION
Logs were sometimes hard to know which were associated to a give n transaction, this PR uses AsyncContext to store the logger so that the same logger instance with context is used across entire request lifecycle

This will make debugging errors and performing research much easier