### PR TITLE
chore: move log redaction in-app

### DIFF
--- a/libs/api-config/src/lib/__tests__/api-logger.spec.ts
+++ b/libs/api-config/src/lib/__tests__/api-logger.spec.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest';
+import { extractOrgUniqueId, hashSessionId, sanitizeReferer, sanitizeUrl } from '../api-logger';
+
+describe('sanitizeReferer', () => {
+  it('strips the query string while preserving origin + path', () => {
+    const referer = 'https://getjetstream.app/oauth-link/?type=salesforce&data=%7B%22email%22%3A%22person%40frs.net%22%7D';
+    expect(sanitizeReferer(referer)).toBe('https://getjetstream.app/oauth-link/');
+  });
+
+  it('returns the referer unchanged when there is no query string', () => {
+    expect(sanitizeReferer('https://getjetstream.app/oauth-link/')).toBe('https://getjetstream.app/oauth-link/');
+  });
+
+  it('passes through nullish/empty values without throwing', () => {
+    expect(sanitizeReferer(undefined)).toBeUndefined();
+    expect(sanitizeReferer('')).toBe('');
+  });
+
+  it('cuts at the first `?` even for non-URL strings', () => {
+    expect(sanitizeReferer('not-a-url?leak=1&also=2')).toBe('not-a-url');
+  });
+});
+
+describe('sanitizeUrl', () => {
+  it('redacts the OAuth code while preserving the path and other params', () => {
+    expect(sanitizeUrl('/api/auth/callback?code=secret-auth-code&provider=salesforce')).toBe(
+      '/api/auth/callback?code=REDACTED&provider=salesforce',
+    );
+  });
+
+  it('redacts the oauth-link data payload', () => {
+    const url = '/oauth-link/?type=salesforce&data=%7B%22email%22%3A%22person%40frs.net%22%7D';
+    expect(sanitizeUrl(url)).toBe('/oauth-link/?type=salesforce&data=REDACTED');
+  });
+
+  it('redacts every sensitive param present in one pass', () => {
+    const sanitized = sanitizeUrl('/cb?state=abc&token=t&access_token=at&keep=1');
+    expect(sanitized).toBe('/cb?state=REDACTED&token=REDACTED&access_token=REDACTED&keep=1');
+  });
+
+  it('returns the URL byte-for-byte when nothing sensitive is present', () => {
+    // no re-encoding of untouched URLs — the original string is returned as-is
+    const url = '/api/records?q=Account&fields=Id%2CName';
+    expect(sanitizeUrl(url)).toBe(url);
+  });
+
+  it('returns the URL unchanged when there is no query string', () => {
+    expect(sanitizeUrl('/api/auth/session')).toBe('/api/auth/session');
+  });
+
+  it('passes through nullish/empty values without throwing', () => {
+    expect(sanitizeUrl(undefined)).toBeUndefined();
+    expect(sanitizeUrl('')).toBe('');
+  });
+});
+
+describe('hashSessionId', () => {
+  it('returns a stable, irreversible 16-char hash that is not the raw id', () => {
+    const sessionId = 'AdrCGLHhS9zNNlqcjHMVJlm9dFI5inn2';
+    const hashed = hashSessionId(sessionId);
+    expect(hashed).toMatch(/^[0-9a-f]{16}$/);
+    expect(hashed).not.toBe(sessionId);
+    // deterministic so requests within one session still correlate
+    expect(hashSessionId(sessionId)).toBe(hashed);
+  });
+
+  it('produces different hashes for different session ids', () => {
+    expect(hashSessionId('session-a')).not.toBe(hashSessionId('session-b'));
+  });
+
+  it('passes through nullish/empty values without throwing', () => {
+    expect(hashSessionId(undefined)).toBeUndefined();
+    expect(hashSessionId('')).toBe('');
+  });
+});
+
+describe('extractOrgUniqueId', () => {
+  const orgUniqueId = '00DWC00000DRiVJ2A1-0053a00000Qp8LVAAZ';
+  const buildOauthLinkUrl = (data: unknown) =>
+    `/oauth-link/?type=salesforce&data=${encodeURIComponent(typeof data === 'string' ? data : JSON.stringify(data))}`;
+
+  it('extracts the uniqueId from a valid oauth-link data payload', () => {
+    expect(extractOrgUniqueId(buildOauthLinkUrl({ uniqueId: orgUniqueId, label: 'x' }))).toBe(orgUniqueId);
+  });
+
+  it('returns undefined for non-oauth-link URLs even if they carry a data param', () => {
+    expect(extractOrgUniqueId(buildOauthLinkUrl({ uniqueId: orgUniqueId }).replace('/oauth-link/', '/api/session'))).toBeUndefined();
+  });
+
+  it('returns undefined when the data param is absent', () => {
+    expect(extractOrgUniqueId('/oauth-link/?type=salesforce')).toBeUndefined();
+  });
+
+  it('returns undefined when uniqueId is missing from the payload', () => {
+    expect(extractOrgUniqueId(buildOauthLinkUrl({ label: 'x' }))).toBeUndefined();
+  });
+
+  it('returns undefined (does not throw) on a malformed JSON payload', () => {
+    expect(extractOrgUniqueId(buildOauthLinkUrl('{not-valid-json'))).toBeUndefined();
+  });
+
+  it('returns undefined after the data param has been redacted by sanitizeUrl', () => {
+    // post-deploy reality: sanitizeUrl rewrites data to REDACTED, which is not valid JSON
+    expect(extractOrgUniqueId('/oauth-link/?type=salesforce&data=REDACTED')).toBeUndefined();
+  });
+
+  it('passes through nullish/empty values without throwing', () => {
+    expect(extractOrgUniqueId(undefined)).toBeUndefined();
+    expect(extractOrgUniqueId('')).toBeUndefined();
+  });
+});

--- a/libs/api-config/src/lib/api-logger.ts
+++ b/libs/api-config/src/lib/api-logger.ts
@@ -1,5 +1,6 @@
 import { HTTP } from '@jetstream/shared/constants';
 import type express from 'express';
+import { createHash } from 'node:crypto';
 import pino from 'pino';
 import pinoHttp from 'pino-http';
 import { v4 as uuid } from 'uuid';
@@ -10,6 +11,21 @@ const isLocalDevelopment = ENV.ENVIRONMENT === 'development' && !ENV.IS_LOCAL_DO
 
 export const logger = pino({
   level: ENV.LOG_LEVEL,
+  // Secret keys are listed twice on purpose: a bare path (`token`) censors a top-level field, while
+  // `*.token` censors the same key one level deep (fast-redact wildcards match a single level only).
+  redact: [
+    'req.headers.cookie',
+    'req.headers.authorization',
+    'res.headers["set-cookie"]',
+    'token',
+    'accessToken',
+    'refreshToken',
+    'password',
+    '*.token',
+    '*.accessToken',
+    '*.refreshToken',
+    '*.password',
+  ],
   transport: isLocalDevelopment
     ? {
         targets: [
@@ -41,6 +57,95 @@ export const logger = pino({
 
 const ignoreLogsFileExtensions = /.*\.(js|map|css|png|jpg|jpeg|gif|svg|ico|woff|woff2|ttf|eot|otf|json|xml|txt)$/;
 
+/**
+ * Strip the query string from a referer before logging. The path (e.g. `/oauth-link/`) keeps its
+ * debugging value, while the query can carry encoded payloads with customer PII (name, email,
+ * Salesforce org/instance URLs). Browsers never send the fragment in `referer`, so cutting at the
+ * first `?` leaves exactly origin + path. Cheaper than `new URL()` and cannot throw.
+ */
+export function sanitizeReferer(referer?: string): string | undefined {
+  if (!referer) {
+    return referer;
+  }
+  const queryIndex = referer.indexOf('?');
+  return queryIndex === -1 ? referer : referer.slice(0, queryIndex);
+}
+
+/**
+ * Query-string parameters whose VALUES are redacted from a logged `req.url`. These carry OAuth
+ * credentials (`code` is a single-use authorization code), CSRF/session state, or PII payloads
+ * (`data` on the oauth-link flow). Unlike the referer we keep the rest of the URL — path and
+ * non-sensitive params stay intact for debugging.
+ */
+const REDACTED_URL_PARAMS = ['code', 'state', 'token', 'data', 'access_token', 'refresh_token', 'id_token', 'client_secret'];
+
+/**
+ * Redact known-sensitive query parameter values from a URL while preserving the path and any other
+ * params. Returns the input byte-for-byte when there is nothing to redact, so untouched URLs are
+ * never re-encoded; only mutated URLs are re-serialized.
+ */
+export function sanitizeUrl(url?: string): string | undefined {
+  if (!url) {
+    return url;
+  }
+  const queryIndex = url.indexOf('?');
+  if (queryIndex === -1) {
+    return url;
+  }
+  const params = new URLSearchParams(url.slice(queryIndex + 1));
+  let mutated = false;
+  for (const param of REDACTED_URL_PARAMS) {
+    if (params.has(param)) {
+      params.set(param, 'REDACTED');
+      mutated = true;
+    }
+  }
+  return mutated ? `${url.slice(0, queryIndex)}?${params.toString()}` : url;
+}
+
+/**
+ * Defensive upper bound on the oauth-link `data` payload we'll `JSON.parse`. URL length is already
+ * bounded upstream (proxy/Express limits) and legit payloads are a few hundred bytes, so this only
+ * guards against an oversized value ever turning the request-logger parse into a CPU/memory hotspot.
+ */
+const MAX_ORG_DATA_LENGTH = 10_000;
+
+/**
+ * Pull the Salesforce org unique id out of the oauth-link `data` payload so it survives as a
+ * structured `orgUniqueId` log field after `sanitizeUrl` redacts the raw `data` param (the source is
+ * the only place that payload still exists). Scoped to the oauth-link path so every other request
+ * skips the JSON parse. Never throws — returns undefined on any absent/malformed payload.
+ */
+export function extractOrgUniqueId(url?: string): string | undefined {
+  if (!url || !url.includes('/oauth-link/')) {
+    return undefined;
+  }
+  const queryIndex = url.indexOf('?');
+  if (queryIndex === -1) {
+    return undefined;
+  }
+  const data = new URLSearchParams(url.slice(queryIndex + 1)).get('data');
+  if (!data || data.length > MAX_ORG_DATA_LENGTH) {
+    return undefined;
+  }
+  try {
+    const parsed = JSON.parse(data);
+    return typeof parsed?.uniqueId === 'string' ? parsed.uniqueId : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * The raw session id is the session store's primary key and one half of the session credential
+ * (the browser presents it inside a secret-signed cookie). Logging it would copy that key into
+ * lower-trust log sinks, so we log a stable SHA-256 prefix instead: irreversible, but still lets us
+ * correlate all requests within a single session for debugging.
+ */
+export function hashSessionId(sessionId?: string): string | undefined {
+  return sessionId ? createHash('sha256').update(sessionId).digest('hex').slice(0, 16) : sessionId;
+}
+
 export const httpLogger = pinoHttp<express.Request, express.Response>({
   logger,
   genReqId: (_, res) => res.locals.requestId || uuid(),
@@ -52,31 +157,40 @@ export const httpLogger = pinoHttp<express.Request, express.Response>({
   },
   customSuccessMessage(req, res) {
     if (res.statusCode === 404) {
-      return `[404] [${req.method}] ${req.url}`;
+      // 404s log the full URL (incl. query) rather than `req.path`, so sanitize it here too
+      return `[404] [${req.method}] ${sanitizeUrl(req.url)}`;
     }
     return `${req.method} ${req.path}`;
   },
   serializers: {
     req: pino.stdSerializers.wrapRequestSerializer((req) => {
-      return {
-        id: req.raw.id,
-        method: req.raw.method,
-        url: req.raw.url,
-        headers: {
-          host: req.raw.headers.host,
-          'user-agent': req.raw.headers['user-agent'],
-          referer: req.raw.headers.referer,
-          'cf-ray': req.raw.headers['cf-ray'],
-          'rndr-id': req.raw.headers['rndr-id'],
-          'x-sfdc-id': req.raw.headers[HTTP.HEADERS.X_SFDC_ID.toLowerCase()],
-          'x-client-request-id': req.raw.headers[HTTP.HEADERS.X_CLIENT_REQUEST_ID.toLowerCase()],
-          'x-retry': req.raw.headers[HTTP.HEADERS.X_RETRY.toLowerCase()],
-          'x-ext-id': req.raw.headers[HTTP.HEADERS.X_EXT_DEVICE_ID.toLowerCase()],
-          'x-app-version': req.raw.headers[HTTP.HEADERS.X_APP_VERSION.toLowerCase()],
-          ip: req.raw.headers['cf-connecting-ip'] || req.raw.headers['x-forwarded-for'] || req.raw.socket.remoteAddress,
-          country: req.headers['cf-ipcountry'],
-        },
-      };
+      try {
+        return {
+          id: req.raw.id,
+          method: req.raw.method,
+          url: sanitizeUrl(req.raw.url),
+          orgUniqueId: extractOrgUniqueId(req.raw.url),
+          headers: {
+            host: req.raw.headers.host,
+            'user-agent': req.raw.headers['user-agent'],
+            referer: sanitizeReferer(req.raw.headers.referer),
+            'cf-ray': req.raw.headers['cf-ray'],
+            'rndr-id': req.raw.headers['rndr-id'],
+            'x-sfdc-id': req.raw.headers[HTTP.HEADERS.X_SFDC_ID.toLowerCase()],
+            'x-client-request-id': req.raw.headers[HTTP.HEADERS.X_CLIENT_REQUEST_ID.toLowerCase()],
+            'x-retry': req.raw.headers[HTTP.HEADERS.X_RETRY.toLowerCase()],
+            'x-ext-id': req.raw.headers[HTTP.HEADERS.X_EXT_DEVICE_ID.toLowerCase()],
+            'x-app-version': req.raw.headers[HTTP.HEADERS.X_APP_VERSION.toLowerCase()],
+            ip: req.raw.headers['cf-connecting-ip'] || req.raw.headers['x-forwarded-for'] || req.raw.socket.remoteAddress,
+            country: req.headers['cf-ipcountry'],
+          },
+        };
+      } catch {
+        // A serializer that throws escapes as a 500 (see res serializer note below). None of the
+        // current helpers throw, but this keeps a future field from crashing request logging:
+        // degrade to the essentials (still redacting the url, which can't throw) and flag for alerting.
+        return { id: req.raw?.id, method: req.raw?.method, url: sanitizeUrl(req.raw?.url), serializerError: true };
+      }
     }),
     res: pino.stdSerializers.wrapResponseSerializer((res) => {
       // `wrapResponseSerializer` wraps to `{ statusCode, headers, raw }` where `raw` is the
@@ -100,7 +214,7 @@ export const httpLogger = pinoHttp<express.Request, express.Response>({
   customProps(req) {
     return {
       userId: (req as any).session?.user?.id,
-      sessionId: (req as any).session?.id,
+      sessionIdHash: hashSessionId((req as any).session?.id),
     };
   },
 });


### PR DESCRIPTION
We were redacting logs on BetterStack, which his great, but it makes sense to redact at the source so the redaction does not exist prior to getting piped to BetterStack