### PR TITLE
Add bulk update preview functionality

### DIFF
--- a/apps/jetstream-e2e/src/tests/load-without-file/load-without-file.spec.ts
+++ b/apps/jetstream-e2e/src/tests/load-without-file/load-without-file.spec.ts
@@ -72,8 +72,11 @@ test.describe('LOAD WITHOUT FILE', () => {
     await page.getByTestId('dropdown-Which records should be updated?').getByPlaceholder('Select an Option').click();
     await page.getByRole('option', { name: 'Only if not blank' }).click();
 
+    await page.getByRole('button', { name: 'Preview Proposed Changes' }).click();
+
     await page.getByRole('button', { name: /Update [0-9]+ Records?/g }).click();
-    await expect(page.getByRole('button', { name: /Update [0-9]+ Records?/g })).toBeDisabled();
+    // Committing sets didDeploy, which unmounts the Update button (removed, not just disabled)
+    await expect(page.getByRole('button', { name: /Update [0-9]+ Records?/g })).toBeHidden();
 
     await expect(page.getByText(/(In Progress)|(Finished)/)).toBeVisible();
   });

--- a/apps/jetstream-e2e/src/tests/query/query-results.spec.ts
+++ b/apps/jetstream-e2e/src/tests/query/query-results.spec.ts
@@ -118,6 +118,8 @@ test.describe('QUERY RESULTS', () => {
     await bulkUpdateModal.getByTestId('dropdown-Field to Update').getByText('Account Fax').click();
     await bulkUpdateModal.getByPlaceholder('Value to set on each record').fill(value);
 
+    await bulkUpdateModal.getByRole('button', { name: 'Preview Proposed Changes' }).click();
+
     await bulkUpdateModal.getByRole('button', { name: /Update [0-9]+ Record(s)?/ }).click();
 
     // TODO: add mock API response to speed test up and ensure it is not flaky

--- a/libs/features/query/src/QueryResults/BulkUpdateFromQuery/BulkUpdateFromQueryModal.tsx
+++ b/libs/features/query/src/QueryResults/BulkUpdateFromQuery/BulkUpdateFromQueryModal.tsx
@@ -9,6 +9,7 @@ import {
   Input,
   Modal,
   NotSeeingRecentMetadataPopover,
+  ProgressIndicator,
   RADIO_ALL_BROWSER,
   RADIO_ALL_SERVER,
   RADIO_FILTERED,
@@ -21,18 +22,20 @@ import {
 import {
   DEFAULT_FIELD_CONFIGURATION,
   DeployResults,
+  fetchRecordsWithRequiredFields,
   MassUpdateRecordsDeploymentRow,
   MassUpdateRecordsObjectRow,
   MetadataRowConfiguration,
-  fetchRecordsWithRequiredFields,
   useDeployRecords,
 } from '@jetstream/ui-core';
 import { Query } from '@jetstreamapp/soql-parser-js';
 import { useAtom } from 'jotai';
 import { atomWithReset, useAtomCallback, useResetAtom } from 'jotai/utils';
 import isNumber from 'lodash/isNumber';
-import { ChangeEvent, FunctionComponent, useCallback, useEffect, useMemo, useState } from 'react';
+import { ChangeEvent, FunctionComponent, useCallback, useEffect, useRef, useState } from 'react';
+import { buildProposedChanges, ProposedChangesResult } from './bulk-update-preview.utils';
 import BulkUpdateFromQueryRecordSelection from './BulkUpdateFromQueryRecordSelection';
+import BulkUpdateProposedChangesPreview from './BulkUpdateProposedChangesPreview';
 
 const MAX_BATCH_SIZE = 10000;
 const IN_PROGRESS_STATUSES = new Set<DeployResults['status']>(['In Progress - Preparing', 'In Progress - Uploading', 'In Progress']);
@@ -99,16 +102,15 @@ export const BulkUpdateFromQueryModal: FunctionComponent<BulkUpdateFromQueryModa
   const [deployResults, setDeployResults] = useAtom(deployResultsState);
   const [didDeploy, setDidDeploy] = useState(false);
   const resetDeployResults = useResetAtom(deployResultsState);
+  const [mode, setMode] = useState<'configure' | 'preview'>('configure');
+  const [recordsToLoad, setRecordsToLoad] = useState<SalesforceRecord[]>([]);
+  const [proposedChanges, setProposedChanges] = useState<ProposedChangesResult | null>(null);
+  // Tracks the in-flight preview fetch so it can be cancelled (modal close, Back, unmount, or Cancel button)
+  const previewFetchAbortRef = useRef<AbortController | null>(null);
+  const [isFetchingPreview, setIsFetchingPreview] = useState(false);
+  const [fetchProgress, setFetchProgress] = useState<{ fetched: number; total: number } | null>(null);
 
-  const targetedRecordCount = useMemo(() => {
-    if (downloadRecordsValue === RADIO_ALL_BROWSER || downloadRecordsValue === RADIO_ALL_SERVER) {
-      return totalRecordCount;
-    }
-    if (downloadRecordsValue === RADIO_FILTERED) {
-      return filteredRecords.length;
-    }
-    return selectedRecords.length;
-  }, [downloadRecordsValue, filteredRecords.length, selectedRecords.length, totalRecordCount]);
+  const impactedRecordCount = proposedChanges?.impactedRecordIds.length ?? 0;
 
   // this allows the pollResults to have a stable data source for updated data
   const getDeploymentResults = useAtomCallback(useCallback((get) => [{ deployResults: get(deployResultsState), sobject }], [sobject]));
@@ -150,6 +152,11 @@ export const BulkUpdateFromQueryModal: FunctionComponent<BulkUpdateFromQueryModa
     }
   }, [batchSize, batchSizeError]);
 
+  // Cancel any in-flight preview fetch when the modal unmounts
+  useEffect(() => () => previewFetchAbortRef.current?.abort(), []);
+
+  const handleCancelPreviewFetch = () => previewFetchAbortRef.current?.abort();
+
   async function init() {
     resetDeployResults();
     setLoading(true);
@@ -179,8 +186,71 @@ export const BulkUpdateFromQueryModal: FunctionComponent<BulkUpdateFromQueryModa
     }
   }
 
-  const handleLoadRecords = async () => {
+  const handlePreview = async () => {
     if (batchSizeError || !isValid || !selectedConfig || selectedConfig.some(({ selectedField }) => !selectedField)) {
+      return;
+    }
+
+    // Abort any in-flight preview fetch so a slower prior request can't finish last and overwrite newer results with stale data
+    previewFetchAbortRef.current?.abort();
+
+    const abortController = new AbortController();
+    previewFetchAbortRef.current = abortController;
+
+    try {
+      setErrorMessage(null);
+      setLoading(true);
+      setIsFetchingPreview(true);
+      setFetchProgress(null);
+
+      // if records need to be re-fetched from the server, ensure that we only keep records that user wants to work with
+      let idsToInclude: Set<string> | undefined;
+      if (downloadRecordsValue === RADIO_ALL_BROWSER && hasMoreRecords) {
+        idsToInclude = new Set(records.map((record) => record.Id || getRecordIdFromAttributes(record)));
+      } else if (downloadRecordsValue === RADIO_FILTERED) {
+        idsToInclude = new Set(filteredRecords.map((record) => record.Id || getRecordIdFromAttributes(record)));
+      } else if (downloadRecordsValue === RADIO_SELECTED) {
+        idsToInclude = new Set(selectedRecords.map((record) => record.Id || getRecordIdFromAttributes(record)));
+      }
+
+      const fetchedRecords = await fetchRecordsWithRequiredFields({
+        selectedOrg,
+        parsedQuery,
+        idsToInclude,
+        configuration: selectedConfig,
+        signal: abortController.signal,
+        onProgress: (fetched, total) => setFetchProgress({ fetched, total }),
+      });
+
+      const changes = buildProposedChanges(fetchedRecords, selectedConfig);
+
+      if (changes.impactedRecordIds.length === 0) {
+        setErrorMessage('No records match the criteria, so there are no changes to preview.');
+        return;
+      }
+
+      setRecordsToLoad(fetchedRecords);
+      setProposedChanges(changes);
+      setMode('preview');
+    } catch (ex) {
+      // User cancelled the fetch (modal close, Back, or Cancel button) - not an error
+      if (abortController.signal.aborted) {
+        return;
+      }
+      setFatalError('There was a problem loading records. Please try again.');
+      tracker.error('Error previewing bulk update records', ex);
+    } finally {
+      if (previewFetchAbortRef.current === abortController) {
+        previewFetchAbortRef.current = null;
+      }
+      setIsFetchingPreview(false);
+      setFetchProgress(null);
+      setLoading(false);
+    }
+  };
+
+  const handleCommit = async () => {
+    if (!proposedChanges || proposedChanges.impactedRecordIds.length === 0) {
       return;
     }
 
@@ -196,28 +266,14 @@ export const BulkUpdateFromQueryModal: FunctionComponent<BulkUpdateFromQueryModa
         status: 'In Progress - Preparing',
       });
 
-      // if records need to be re-fetched from the server, ensure that we only keep records that user wants to work with
-      let idsToInclude: Set<string> | undefined;
-      if (downloadRecordsValue === RADIO_ALL_BROWSER && hasMoreRecords) {
-        idsToInclude = new Set(records.map((record) => record.Id || getRecordIdFromAttributes(record)));
-      } else if (downloadRecordsValue === RADIO_FILTERED) {
-        idsToInclude = new Set(filteredRecords.map((record) => record.Id || getRecordIdFromAttributes(record)));
-      } else if (downloadRecordsValue === RADIO_SELECTED) {
-        idsToInclude = new Set(selectedRecords.map((record) => record.Id || getRecordIdFromAttributes(record)));
-      }
-
-      const recordsToLoad = await fetchRecordsWithRequiredFields({
-        selectedOrg,
-        records,
-        parsedQuery,
-        idsToInclude,
-        configuration: selectedConfig,
-      });
+      // Only commit the records shown in the preview (those that actually meet the criteria)
+      const impactedRecordIds = new Set(proposedChanges.impactedRecordIds);
+      const recordsToCommit = recordsToLoad.filter((record) => impactedRecordIds.has(record.Id || getRecordIdFromAttributes(record)));
 
       setLoading(true);
 
       await loadDataForProvidedRecords({
-        records: recordsToLoad,
+        records: recordsToCommit,
         sobject,
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         fields: ['Id', ...selectedConfig.map(({ selectedField }) => selectedField!).filter(Boolean)],
@@ -232,6 +288,19 @@ export const BulkUpdateFromQueryModal: FunctionComponent<BulkUpdateFromQueryModa
     } finally {
       setLoading(false);
     }
+  };
+
+  const handleBackToEdit = () => {
+    previewFetchAbortRef.current?.abort();
+    setMode('configure');
+    setProposedChanges(null);
+    setRecordsToLoad([]);
+    setErrorMessage(null);
+  };
+
+  const handleClose = () => {
+    previewFetchAbortRef.current?.abort();
+    onModalClose(didDeploy);
   };
 
   function handleBatchSize(event: ChangeEvent<HTMLInputElement>) {
@@ -263,28 +332,48 @@ export const BulkUpdateFromQueryModal: FunctionComponent<BulkUpdateFromQueryModa
       closeDisabled={deployInProgress}
       footer={
         <Grid align="spread">
-          <NotSeeingRecentMetadataPopover
-            org={selectedOrg}
-            loading={refreshLoading}
-            disabled={deployInProgress}
-            onReload={handleRefreshMetadata}
-          />
+          {mode === 'configure' ? (
+            <NotSeeingRecentMetadataPopover
+              org={selectedOrg}
+              loading={refreshLoading}
+              disabled={deployInProgress}
+              onReload={handleRefreshMetadata}
+            />
+          ) : (
+            <span />
+          )}
           <div>
-            <button className="slds-button slds-button_neutral" disabled={deployInProgress} onClick={() => onModalClose(didDeploy)}>
+            {mode === 'preview' && !didDeploy && (
+              <button className="slds-button slds-button_neutral" disabled={loading || deployInProgress} onClick={handleBackToEdit}>
+                Back
+              </button>
+            )}
+            <button className="slds-button slds-button_neutral" disabled={deployInProgress} onClick={handleClose}>
               Close
             </button>
-            <button
-              className="slds-button slds-button_brand"
-              onClick={handleLoadRecords}
-              disabled={!isValid || loading || !!batchSizeError || deployInProgress || !!fatalError}
-            >
-              Update {formatNumber(targetedRecordCount)} {pluralizeFromNumber('Record', targetedRecordCount)}
-            </button>
+            {mode === 'configure' && (
+              <button
+                className="slds-button slds-button_brand"
+                onClick={handlePreview}
+                disabled={!isValid || loading || !!batchSizeError || deployInProgress || !!fatalError}
+              >
+                Preview Proposed Changes
+              </button>
+            )}
+            {mode === 'preview' && !didDeploy && (
+              <button
+                className="slds-button slds-button_brand"
+                onClick={handleCommit}
+                disabled={loading || deployInProgress || !!fatalError}
+              >
+                Update {formatNumber(impactedRecordCount)} {pluralizeFromNumber('Record', impactedRecordCount)}
+              </button>
+            )}
           </div>
         </Grid>
       }
       overrideZIndex={1001}
-      onClose={() => onModalClose(didDeploy)}
+      onClose={handleClose}
     >
       <div
         className="slds-is-relative"
@@ -292,91 +381,144 @@ export const BulkUpdateFromQueryModal: FunctionComponent<BulkUpdateFromQueryModa
           min-height: 50vh;
         `}
       >
-        {loading && <Spinner />}
+        {isFetchingPreview ? (
+          <div
+            css={css`
+              position: absolute;
+              inset: 0;
+              z-index: 2;
+              display: flex;
+              flex-direction: column;
+              align-items: center;
+              justify-content: center;
+              gap: 0.75rem;
+              background: rgba(255, 255, 255, 0.85);
+            `}
+          >
+            <div
+              css={css`
+                width: 60%;
+                min-width: 300px;
+              `}
+            >
+              <ProgressIndicator
+                currentValue={fetchProgress && fetchProgress.total ? (fetchProgress.fetched / fetchProgress.total) * 100 : 0}
+                isIndeterminate={!fetchProgress}
+              />
+            </div>
+            <p className="slds-text-body_small">
+              {fetchProgress
+                ? `Fetching ${formatNumber(fetchProgress.fetched)} of ${formatNumber(fetchProgress.total)} ${pluralizeFromNumber(
+                    'record',
+                    fetchProgress.total,
+                  )}`
+                : 'Fetching records…'}
+            </p>
+            <button className="slds-button slds-button_neutral" onClick={handleCancelPreviewFetch}>
+              Cancel
+            </button>
+          </div>
+        ) : (
+          loading && <Spinner />
+        )}
         {(errorMessage || fatalError) && (
           <ScopedNotification theme="error" className="slds-m-around_small">
             {errorMessage || fatalError}
           </ScopedNotification>
         )}
 
-        <BulkUpdateFromQueryRecordSelection
-          disabled={deployInProgress || !!fatalError}
-          hasMoreRecords={hasMoreRecords}
-          downloadRecordsValue={downloadRecordsValue}
-          parsedQuery={parsedQuery}
-          records={records}
-          filteredRecords={filteredRecords}
-          selectedRecords={selectedRecords}
-          totalRecordCount={totalRecordCount}
-          onChange={setDownloadRecordsValue}
-        />
-
-        <MassUpdateRecordsObjectRow
-          org={selectedOrg}
-          className={'slds-is-relative slds-item read-only'}
-          sobject={sobject}
-          loading={false}
-          fields={fields}
-          valueFields={valueFields}
-          fieldConfigurations={selectedConfig}
-          hasExternalWhereClause={!!parsedQuery.where}
-          disabled={loading || deployInProgress || !!fatalError}
-          onFieldChange={(index, field, metadata) => {
-            setSelectedConfig((prev) => {
-              const newConfig = [...prev];
-              let transformationOptions = newConfig[index].transformationOptions;
-              if (transformationOptions.staticValue) {
-                transformationOptions = { ...transformationOptions, staticValue: '' };
-              }
-              newConfig[index] = { selectedField: field, selectedFieldMetadata: metadata, transformationOptions };
-              return newConfig;
-            });
-          }}
-          onOptionsChange={(index, _, transformationOptions) => {
-            setSelectedConfig((prev) => {
-              const newConfig = [...prev];
-              newConfig[index] = { ...newConfig[index], transformationOptions };
-              return newConfig;
-            });
-          }}
-          onLoadChildFields={loadChildFields}
-          filterCriteriaFn={(field) => field.value !== 'custom'}
-          onAddField={() => setSelectedConfig((prev) => [...prev, { ...DEFAULT_FIELD_CONFIGURATION }])}
-          onRemoveField={(_, index) => setSelectedConfig((prev) => prev.toSpliced(index, 1))}
-        />
-
-        <Section id="mass-update-deploy-options" label="Advanced Options" initialExpanded={false}>
-          <div className="slds-p-around_xx-small slds-text-body_small">
-            You may need to adjust these options if you are experiencing governor limits.
-          </div>
-          <Checkbox
-            id={'serial-mode'}
-            checked={serialMode}
-            label={'Serial Mode'}
-            labelHelp="Serial mode processes the batches one-by-one instead of parallel."
-            disabled={loading || deployInProgress}
-            onChange={setSerialMode}
-          />
-          <Input
-            id="batch-size"
-            label="Batch Size"
-            isRequired={true}
-            hasError={!!batchSizeError}
-            errorMessageId="batch-size-error"
-            errorMessage={batchSizeError}
-            labelHelp="The batch size determines how many records will be modified at a time. Only change this if you are experiencing issues with Salesforce governor limits."
-          >
-            <input
-              id="batch-size"
-              className="slds-input"
-              placeholder="Set batch size"
-              value={batchSize || ''}
-              aria-describedby={batchSizeError ? 'batch-size-error' : undefined}
-              disabled={loading || deployInProgress}
-              onChange={handleBatchSize}
+        {mode === 'configure' && (
+          <>
+            <BulkUpdateFromQueryRecordSelection
+              disabled={deployInProgress || !!fatalError}
+              hasMoreRecords={hasMoreRecords}
+              downloadRecordsValue={downloadRecordsValue}
+              parsedQuery={parsedQuery}
+              records={records}
+              filteredRecords={filteredRecords}
+              selectedRecords={selectedRecords}
+              totalRecordCount={totalRecordCount}
+              onChange={setDownloadRecordsValue}
             />
-          </Input>
-        </Section>
+
+            <MassUpdateRecordsObjectRow
+              org={selectedOrg}
+              className={'slds-is-relative slds-item read-only'}
+              sobject={sobject}
+              loading={false}
+              fields={fields}
+              valueFields={valueFields}
+              fieldConfigurations={selectedConfig}
+              hasExternalWhereClause={!!parsedQuery.where}
+              disabled={loading || deployInProgress || !!fatalError}
+              onFieldChange={(index, field, metadata) => {
+                setSelectedConfig((prev) => {
+                  const newConfig = [...prev];
+                  let transformationOptions = newConfig[index].transformationOptions;
+                  if (transformationOptions.staticValue) {
+                    transformationOptions = { ...transformationOptions, staticValue: '' };
+                  }
+                  newConfig[index] = { selectedField: field, selectedFieldMetadata: metadata, transformationOptions };
+                  return newConfig;
+                });
+              }}
+              onOptionsChange={(index, _, transformationOptions) => {
+                setSelectedConfig((prev) => {
+                  const newConfig = [...prev];
+                  newConfig[index] = { ...newConfig[index], transformationOptions };
+                  return newConfig;
+                });
+              }}
+              onLoadChildFields={loadChildFields}
+              filterCriteriaFn={(field) => field.value !== 'custom'}
+              onAddField={() => setSelectedConfig((prev) => [...prev, { ...DEFAULT_FIELD_CONFIGURATION }])}
+              onRemoveField={(_, index) => setSelectedConfig((prev) => prev.toSpliced(index, 1))}
+            />
+
+            <Section id="mass-update-deploy-options" label="Advanced Options" initialExpanded={false}>
+              <div className="slds-p-around_xx-small slds-text-body_small">
+                You may need to adjust these options if you are experiencing governor limits.
+              </div>
+              <Checkbox
+                id={'serial-mode'}
+                checked={serialMode}
+                label={'Serial Mode'}
+                labelHelp="Serial mode processes the batches one-by-one instead of parallel."
+                disabled={loading || deployInProgress}
+                onChange={setSerialMode}
+              />
+              <Input
+                id="batch-size"
+                label="Batch Size"
+                isRequired={true}
+                hasError={!!batchSizeError}
+                errorMessageId="batch-size-error"
+                errorMessage={batchSizeError}
+                labelHelp="The batch size determines how many records will be modified at a time. Only change this if you are experiencing issues with Salesforce governor limits."
+              >
+                <input
+                  id="batch-size"
+                  className="slds-input"
+                  placeholder="Set batch size"
+                  value={batchSize || ''}
+                  aria-describedby={batchSizeError ? 'batch-size-error' : undefined}
+                  disabled={loading || deployInProgress}
+                  onChange={handleBatchSize}
+                />
+              </Input>
+            </Section>
+          </>
+        )}
+
+        {mode === 'preview' && !didDeploy && proposedChanges && (
+          <BulkUpdateProposedChangesPreview
+            org={selectedOrg}
+            sobject={sobject}
+            proposedChanges={proposedChanges}
+            configuration={selectedConfig}
+            totalFetched={recordsToLoad.length}
+          />
+        )}
 
         {deployResults.status !== 'Not Started' && (
           <MassUpdateRecordsDeploymentRow

--- a/libs/features/query/src/QueryResults/BulkUpdateFromQuery/BulkUpdateProposedChangesPreview.tsx
+++ b/libs/features/query/src/QueryResults/BulkUpdateFromQuery/BulkUpdateProposedChangesPreview.tsx
@@ -1,0 +1,187 @@
+import { ANALYTICS_KEYS } from '@jetstream/shared/constants';
+import { formatNumber } from '@jetstream/shared/ui-utils';
+import { pluralizeFromNumber } from '@jetstream/shared/utils';
+import { SalesforceOrgUi } from '@jetstream/types';
+import {
+  AutoFullHeightContainer,
+  ColumnWithFilter,
+  DataTable,
+  FileDownloadModal,
+  Grid,
+  Icon,
+  RowWithKey,
+  setColumnFromType,
+} from '@jetstream/ui';
+import { fromJetstreamEvents, MetadataRowConfiguration, useAmplitude } from '@jetstream/ui-core';
+import { applicationCookieState, googleDriveAccessState, selectSkipFrontdoorAuth } from '@jetstream/ui/app-state';
+import { useAtomValue } from 'jotai';
+import { Fragment, FunctionComponent, useCallback, useMemo, useState } from 'react';
+import { formatProposedValue, ProposedChangesResult } from './bulk-update-preview.utils';
+
+interface DownloadModalState {
+  open: boolean;
+  data: Record<string, unknown>[];
+  header: string[];
+  fileNameParts: string[];
+}
+
+export interface BulkUpdateProposedChangesPreviewProps {
+  org: SalesforceOrgUi;
+  sobject: string;
+  proposedChanges: ProposedChangesResult;
+  configuration: MetadataRowConfiguration[];
+  /** Total number of records that were fetched/targeted (impacted + unaffected) */
+  totalFetched: number;
+}
+
+/**
+ * Renders the "current vs proposed" preview table for the impacted records, plus the ability to
+ * download a backup of the current values or the proposed values (Id + impacted fields only).
+ */
+export const BulkUpdateProposedChangesPreview: FunctionComponent<BulkUpdateProposedChangesPreviewProps> = ({
+  org,
+  sobject,
+  proposedChanges,
+  configuration,
+  totalFetched,
+}) => {
+  const { trackEvent } = useAmplitude();
+  const { serverUrl, defaultApiVersion, google_apiKey, google_appId, google_clientId } = useAtomValue(applicationCookieState);
+  const { hasGoogleDriveAccess, googleShowUpgradeToPro } = useAtomValue(googleDriveAccessState);
+  const skipFrontdoorLogin = useAtomValue(selectSkipFrontdoorAuth);
+  const [downloadModal, setDownloadModal] = useState<DownloadModalState>({ open: false, data: [], header: [], fileNameParts: [] });
+
+  const { fields, records, impactedRecordIds } = proposedChanges;
+
+  const columns = useMemo<ColumnWithFilter<RowWithKey>[]>(() => {
+    const baseColumns: ColumnWithFilter<RowWithKey>[] = [
+      {
+        ...setColumnFromType('Id', 'salesforceId'),
+        key: 'Id',
+        name: 'Record Id',
+        resizable: true,
+        width: 175,
+      } as ColumnWithFilter<RowWithKey>,
+    ];
+    fields.forEach((field) => {
+      baseColumns.push({
+        key: `${field}__current`,
+        name: `${field} (Current)`,
+        resizable: true,
+        sortable: true,
+        width: 200,
+        cellClass: 'slds-truncate slds-text-color_weak',
+        renderCell: ({ row }) => row[`${field}__current`],
+      } as ColumnWithFilter<RowWithKey>);
+      baseColumns.push({
+        key: `${field}__new`,
+        name: `${field} (New)`,
+        resizable: true,
+        sortable: true,
+        width: 200,
+        cellClass: (row: RowWithKey) => (row[`${field}__changed`] ? 'slds-is-edited slds-truncate' : 'slds-truncate'),
+        renderCell: ({ row }) => row[`${field}__new`],
+      } as ColumnWithFilter<RowWithKey>);
+    });
+    return baseColumns;
+  }, [fields]);
+
+  const rows = useMemo<RowWithKey[]>(
+    () =>
+      records.map((record) => {
+        const row: RowWithKey = { _key: record.recordId, Id: record.recordId };
+        record.changes.forEach((change) => {
+          row[`${change.field}__current`] = formatProposedValue(change.currentValue);
+          row[`${change.field}__new`] = formatProposedValue(change.newValue);
+          row[`${change.field}__changed`] = change.willChange;
+        });
+        return row;
+      }),
+    [records],
+  );
+
+  const getRowKey = useCallback((row: RowWithKey) => row._key, []);
+
+  function handleDownloadBackup(variant: 'before' | 'after') {
+    const header = ['Id', ...fields];
+    const data = records.map((record) => {
+      const output: Record<string, unknown> = { Id: record.recordId };
+      record.changes.forEach((change) => {
+        output[change.field] = variant === 'before' ? change.currentValue : change.newValue;
+      });
+      return output;
+    });
+    setDownloadModal({
+      open: true,
+      data,
+      header,
+      fileNameParts: [sobject.toLowerCase(), variant === 'before' ? 'backup-before' : 'backup-after'],
+    });
+    trackEvent(ANALYTICS_KEYS.mass_update_DownloadRecords, {
+      type: variant === 'before' ? 'preview-backup-before' : 'preview-backup-after',
+      numRows: data.length,
+      transformationOptions: configuration.map(({ transformationOptions }) => transformationOptions.option),
+    });
+  }
+
+  function handleDownloadClose() {
+    setDownloadModal((prev) => ({ ...prev, open: false }));
+  }
+
+  return (
+    <Fragment>
+      {downloadModal.open && (
+        <FileDownloadModal
+          org={org}
+          googleIntegrationEnabled={hasGoogleDriveAccess}
+          googleShowUpgradeToPro={googleShowUpgradeToPro}
+          google_apiKey={google_apiKey}
+          google_appId={google_appId}
+          google_clientId={google_clientId}
+          modalHeader="Download Backup"
+          data={downloadModal.data}
+          header={downloadModal.header}
+          fileNameParts={downloadModal.fileNameParts}
+          onModalClose={handleDownloadClose}
+          emitUploadToGoogleEvent={fromJetstreamEvents.emit}
+          source="bulk_update_query_preview"
+          trackEvent={trackEvent}
+        />
+      )}
+
+      <Grid align="spread" verticalAlign="center" wrap className="slds-m-vertical_x-small slds-m-horizontal_xx-small">
+        <p className="slds-text-body_small">
+          <strong>{formatNumber(impactedRecordIds.length)}</strong> of {formatNumber(totalFetched)}{' '}
+          {pluralizeFromNumber('record', totalFetched)} will be updated. Review the proposed changes before saving.
+        </p>
+        <div>
+          <button className="slds-button slds-button_neutral" onClick={() => handleDownloadBackup('before')}>
+            <Icon type="utility" icon="download" className="slds-button__icon slds-button__icon_left" omitContainer />
+            Download current values
+          </button>
+          <button className="slds-button slds-button_neutral" onClick={() => handleDownloadBackup('after')}>
+            <Icon type="utility" icon="download" className="slds-button__icon slds-button__icon_left" omitContainer />
+            Download proposed values
+          </button>
+        </div>
+      </Grid>
+
+      <div className="slds-is-relative slds-scrollable_x">
+        <AutoFullHeightContainer fillHeight setHeightAttr bottomBuffer={200}>
+          <DataTable
+            org={org}
+            serverUrl={serverUrl}
+            skipFrontdoorLogin={skipFrontdoorLogin}
+            columns={columns}
+            data={rows}
+            getRowKey={getRowKey}
+            rowHeight={25}
+            context={{ defaultApiVersion }}
+          />
+        </AutoFullHeightContainer>
+      </div>
+    </Fragment>
+  );
+};
+
+export default BulkUpdateProposedChangesPreview;

--- a/libs/features/query/src/QueryResults/BulkUpdateFromQuery/__tests__/bulk-update-preview.utils.spec.ts
+++ b/libs/features/query/src/QueryResults/BulkUpdateFromQuery/__tests__/bulk-update-preview.utils.spec.ts
@@ -1,0 +1,175 @@
+import { SFDC_BULK_API_NULL_VALUE } from '@jetstream/shared/constants';
+import { MetadataRowConfiguration } from '@jetstream/ui-core';
+import { describe, expect, test } from 'vitest';
+import { buildProposedChanges, formatProposedValue } from '../bulk-update-preview.utils';
+
+type ConfigInput = {
+  selectedField: string;
+  type?: string;
+  option?: MetadataRowConfiguration['transformationOptions']['option'];
+  staticValue?: string;
+  alternateField?: string;
+  criteria?: MetadataRowConfiguration['transformationOptions']['criteria'];
+};
+
+function buildConfig(input: ConfigInput): MetadataRowConfiguration {
+  return {
+    selectedField: input.selectedField,
+    selectedFieldMetadata: { type: input.type ?? 'string' } as any,
+    transformationOptions: {
+      option: input.option ?? 'staticValue',
+      staticValue: input.staticValue ?? '',
+      alternateField: input.alternateField,
+      criteria: input.criteria ?? 'all',
+      whereClause: '',
+    },
+  };
+}
+
+function findChange(record: { changes: any[] }, field: string) {
+  return record.changes.find((change) => change.field === field);
+}
+
+describe('buildProposedChanges', () => {
+  test('criteria "all" marks every record as impacted with the new value', () => {
+    const records = [
+      { Id: '1', Name: 'A' },
+      { Id: '2', Name: 'B' },
+    ];
+    const result = buildProposedChanges(records, [buildConfig({ selectedField: 'Name', staticValue: 'New' })]);
+
+    expect(result.fields).toEqual(['Name']);
+    expect(result.impactedRecordIds).toEqual(['1', '2']);
+    expect(findChange(result.records[0], 'Name')).toEqual({ field: 'Name', currentValue: 'A', newValue: 'New', willChange: true });
+    expect(findChange(result.records[1], 'Name')).toEqual({ field: 'Name', currentValue: 'B', newValue: 'New', willChange: true });
+  });
+
+  test('criteria "onlyIfBlank" only impacts records whose field is blank', () => {
+    const records = [
+      { Id: '1', Name: null },
+      { Id: '2', Name: 'B' },
+    ];
+    const result = buildProposedChanges(records, [buildConfig({ selectedField: 'Name', staticValue: 'New', criteria: 'onlyIfBlank' })]);
+
+    expect(result.impactedRecordIds).toEqual(['1']);
+    expect(findChange(result.records[0], 'Name')).toEqual({ field: 'Name', currentValue: null, newValue: 'New', willChange: true });
+  });
+
+  test('criteria "onlyIfNotBlank" only impacts records whose field has a value', () => {
+    const records = [
+      { Id: '1', Name: null },
+      { Id: '2', Name: 'B' },
+    ];
+    const result = buildProposedChanges(records, [buildConfig({ selectedField: 'Name', staticValue: 'New', criteria: 'onlyIfNotBlank' })]);
+
+    expect(result.impactedRecordIds).toEqual(['2']);
+    expect(findChange(result.records[0], 'Name')?.currentValue).toBe('B');
+  });
+
+  test('"Clear field value" sets the new value to the Bulk API null token', () => {
+    const records = [{ Id: '1', Description: 'has text' }];
+    const result = buildProposedChanges(records, [buildConfig({ selectedField: 'Description', option: 'null' })]);
+
+    expect(result.impactedRecordIds).toEqual(['1']);
+    expect(findChange(result.records[0], 'Description')).toEqual({
+      field: 'Description',
+      currentValue: 'has text',
+      newValue: SFDC_BULK_API_NULL_VALUE,
+      willChange: true,
+    });
+  });
+
+  test('"Value from different field" copies the alternate field value', () => {
+    const records = [{ Id: '1', Name: 'A', Nickname: 'Al' }];
+    const result = buildProposedChanges(records, [
+      buildConfig({ selectedField: 'Name', option: 'anotherField', alternateField: 'Nickname' }),
+    ]);
+
+    expect(findChange(result.records[0], 'Name')).toEqual({ field: 'Name', currentValue: 'A', newValue: 'Al', willChange: true });
+  });
+
+  test('multi-field config with mixed criteria represents every configured field', () => {
+    const records = [
+      { Id: '1', Stage: 'Open', Amount: null },
+      { Id: '2', Stage: 'Open', Amount: 5 },
+    ];
+    const result = buildProposedChanges(records, [
+      buildConfig({ selectedField: 'Stage', staticValue: 'Closed', criteria: 'all' }),
+      buildConfig({ selectedField: 'Amount', type: 'currency', staticValue: '10', criteria: 'onlyIfBlank' }),
+    ]);
+
+    expect(result.fields).toEqual(['Stage', 'Amount']);
+    expect(result.impactedRecordIds).toEqual(['1', '2']);
+
+    // Record 1: both fields change (Stage via "all", Amount because it is blank)
+    expect(findChange(result.records[0], 'Stage')?.willChange).toBe(true);
+    expect(findChange(result.records[0], 'Amount')).toEqual({ field: 'Amount', currentValue: null, newValue: '10', willChange: true });
+
+    // Record 2: impacted via Stage; Amount is not blank so it is unchanged but still represented
+    expect(findChange(result.records[1], 'Stage')?.willChange).toBe(true);
+    expect(findChange(result.records[1], 'Amount')).toEqual({ field: 'Amount', currentValue: 5, newValue: 5, willChange: false });
+  });
+
+  test('"Update record without changes" touches a record even when the field is null and nothing changes', () => {
+    const records = [{ Id: '1', Status: null }];
+    const result = buildProposedChanges(records, [buildConfig({ selectedField: 'Status', option: 'update' })]);
+
+    expect(result.impactedRecordIds).toEqual(['1']);
+    expect(findChange(result.records[0], 'Status')).toEqual({ field: 'Status', currentValue: null, newValue: null, willChange: false });
+  });
+
+  test('records that match no criteria are excluded entirely', () => {
+    const records = [{ Id: '1', Name: 'B' }];
+    const result = buildProposedChanges(records, [buildConfig({ selectedField: 'Name', staticValue: 'New', criteria: 'onlyIfBlank' })]);
+
+    expect(result.records).toHaveLength(0);
+    expect(result.impactedRecordIds).toEqual([]);
+  });
+
+  // The same field can be configured in more than one row. prepareRecords applies configs in order and
+  // the LAST config wins, so the preview must follow the same last-config-wins ordering to stay accurate.
+  test('duplicated field: a later not-met config un-touches the field (matches prepareRecords last-config-wins)', () => {
+    const records = [{ Id: '1', Name: 'A' }];
+    // First config would set Name, but the second config's criteria is not met (Name is not blank), so
+    // prepareRecords nulls it back out and the record is not committed — the preview must agree.
+    const result = buildProposedChanges(records, [
+      buildConfig({ selectedField: 'Name', staticValue: 'New', criteria: 'all' }),
+      buildConfig({ selectedField: 'Name', staticValue: 'New', criteria: 'onlyIfBlank' }),
+    ]);
+
+    expect(result.records).toHaveLength(0);
+    expect(result.impactedRecordIds).toEqual([]);
+  });
+
+  test('duplicated field: a later met config wins over an earlier not-met config', () => {
+    const records = [{ Id: '1', Name: 'A' }];
+    // First config is not met (Name is not blank), but the second config applies to all records, so the
+    // last config wins and the field changes.
+    const result = buildProposedChanges(records, [
+      buildConfig({ selectedField: 'Name', staticValue: 'New', criteria: 'onlyIfBlank' }),
+      buildConfig({ selectedField: 'Name', staticValue: 'New', criteria: 'all' }),
+    ]);
+
+    expect(result.impactedRecordIds).toEqual(['1']);
+    expect(findChange(result.records[0], 'Name')).toEqual({ field: 'Name', currentValue: 'A', newValue: 'New', willChange: true });
+  });
+});
+
+describe('formatProposedValue', () => {
+  test('formats the Bulk API null token as "(cleared)"', () => {
+    expect(formatProposedValue(SFDC_BULK_API_NULL_VALUE)).toBe('(cleared)');
+  });
+
+  test('formats nil and empty values as an empty string', () => {
+    expect(formatProposedValue(null)).toBe('');
+    expect(formatProposedValue(undefined)).toBe('');
+    expect(formatProposedValue('')).toBe('');
+  });
+
+  test('formats booleans and primitives as readable text', () => {
+    expect(formatProposedValue(true)).toBe('true');
+    expect(formatProposedValue(false)).toBe('false');
+    expect(formatProposedValue(5)).toBe('5');
+    expect(formatProposedValue('hello')).toBe('hello');
+  });
+});

--- a/libs/features/query/src/QueryResults/BulkUpdateFromQuery/bulk-update-preview.utils.ts
+++ b/libs/features/query/src/QueryResults/BulkUpdateFromQuery/bulk-update-preview.utils.ts
@@ -1,0 +1,121 @@
+import { SFDC_BULK_API_NULL_VALUE } from '@jetstream/shared/constants';
+import { getRecordIdFromAttributes } from '@jetstream/shared/utils';
+import { SalesforceRecord } from '@jetstream/types';
+import { MetadataRowConfiguration, prepareRecords } from '@jetstream/ui-core';
+import isNil from 'lodash/isNil';
+
+export interface ProposedFieldChange {
+  field: string;
+  /** Original value on the record (normalized so `undefined` becomes `null`) */
+  currentValue: unknown;
+  /** Value that will be written. Equals `currentValue` when this field is not changing for this record. */
+  newValue: unknown;
+  /** True when the cell value actually changes (used to highlight the cell in the preview) */
+  willChange: boolean;
+}
+
+export interface ProposedChangeRecord {
+  recordId: string;
+  changes: ProposedFieldChange[];
+}
+
+export interface ProposedChangesResult {
+  /** Configured fields, de-duplicated and in configuration order */
+  fields: string[];
+  /** Only records that will be updated (at least one configured field meets its criteria) */
+  records: ProposedChangeRecord[];
+  impactedRecordIds: string[];
+}
+
+/**
+ * Re-implements the criteria gate that {@link prepareRecords} applies, so we can tell whether a record
+ * is "touched" independently of the value. This matters for the `update` ("update without changes")
+ * option, where the value does not change but the record is still submitted. `custom` criteria is not
+ * available in the query-results flow, so it is treated as `all`.
+ */
+function isCriteriaMet(record: SalesforceRecord, field: string, criteria: MetadataRowConfiguration['transformationOptions']['criteria']) {
+  if (criteria === 'onlyIfBlank') {
+    return isNil(record[field]);
+  }
+  if (criteria === 'onlyIfNotBlank') {
+    return !isNil(record[field]);
+  }
+  return true;
+}
+
+/**
+ * Computes the proposed changes for a set of already-fetched records using the exact same transform
+ * ({@link prepareRecords}) that the commit will use, guaranteeing the preview matches what is saved.
+ *
+ * Returns only the impacted records (those that will be updated). For each impacted record, every
+ * configured field is represented, with `willChange` flagging the cells whose value actually changes.
+ */
+export function buildProposedChanges(records: SalesforceRecord[], configuration: MetadataRowConfiguration[]): ProposedChangesResult {
+  const fieldConfigs = configuration.filter((config) => config.selectedField);
+  const fields = Array.from(new Set(fieldConfigs.map((config) => config.selectedField as string)));
+  const preparedRecords = prepareRecords(records, configuration);
+
+  const impactedRecords: ProposedChangeRecord[] = [];
+
+  records.forEach((record, index) => {
+    const preparedRecord = preparedRecords[index];
+    const changeByField = new Map<string, ProposedFieldChange>();
+    const touchedFields = new Set<string>();
+
+    fieldConfigs.forEach(({ selectedField, transformationOptions }) => {
+      const field = selectedField as string;
+      const currentValue = record[field] ?? null;
+      const criteriaMet = isCriteriaMet(record, field, transformationOptions.criteria);
+
+      if (!criteriaMet) {
+        // Mirror prepareRecords' last-config-wins semantics: a later config whose criteria is not met
+        // resets the field to unchanged and un-touches it (prepareRecords would null it out), so the
+        // preview/impact detection matches what is actually committed.
+        changeByField.set(field, { field, currentValue, newValue: currentValue, willChange: false });
+        touchedFields.delete(field);
+        return;
+      }
+
+      touchedFields.add(field);
+      if (transformationOptions.option === 'update') {
+        // The record is touched but the value does not change
+        changeByField.set(field, { field, currentValue, newValue: currentValue, willChange: false });
+      } else {
+        const newValue = preparedRecord[field];
+        changeByField.set(field, { field, currentValue, newValue, willChange: newValue !== currentValue });
+      }
+    });
+
+    if (touchedFields.size > 0) {
+      const recordId = record.Id ?? getRecordIdFromAttributes(record);
+      impactedRecords.push({
+        recordId,
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        changes: fields.map((field) => changeByField.get(field)!),
+      });
+    }
+  });
+
+  return {
+    fields,
+    records: impactedRecords,
+    impactedRecordIds: impactedRecords.map((record) => record.recordId),
+  };
+}
+
+/** Formats a raw record value for display in the preview grid. */
+export function formatProposedValue(value: unknown): string {
+  if (value === SFDC_BULK_API_NULL_VALUE) {
+    return '(cleared)';
+  }
+  if (isNil(value) || value === '') {
+    return '';
+  }
+  if (typeof value === 'boolean') {
+    return value ? 'true' : 'false';
+  }
+  if (typeof value === 'object') {
+    return JSON.stringify(value);
+  }
+  return String(value);
+}

--- a/libs/shared/data/src/lib/client-data.ts
+++ b/libs/shared/data/src/lib/client-data.ts
@@ -672,12 +672,13 @@ export async function query<T = any>(
   query: string,
   isTooling = false,
   includeDeletedRecords = false,
+  signal?: AbortSignal,
 ): Promise<QueryResults<T>> {
   if (!query) {
     throw new Error('Query cannot be empty');
   }
   return handleRequest(
-    { method: 'POST', url: `/api/query`, params: { isTooling, includeDeletedRecords }, data: { query } },
+    { method: 'POST', url: `/api/query`, params: { isTooling, includeDeletedRecords }, data: { query }, signal },
     { org, useQueryParamsInCacheKey: true, useBodyInCacheKey: true },
   ).then(unwrapResponseIgnoreCache);
 }
@@ -698,8 +699,13 @@ export async function queryWithCache<T = any>(
   );
 }
 
-export async function queryMore<T = any>(org: SalesforceOrgUi, nextRecordsUrl: string, isTooling = false): Promise<QueryResults<T>> {
-  return handleRequest({ method: 'GET', url: `/api/query-more`, params: { nextRecordsUrl, isTooling } }, { org }).then(
+export async function queryMore<T = any>(
+  org: SalesforceOrgUi,
+  nextRecordsUrl: string,
+  isTooling = false,
+  signal?: AbortSignal,
+): Promise<QueryResults<T>> {
+  return handleRequest({ method: 'GET', url: `/api/query-more`, params: { nextRecordsUrl, isTooling }, signal }, { org }).then(
     unwrapResponseIgnoreCache,
   );
 }
@@ -729,20 +735,34 @@ export async function queryAllFromList<T = any>(
   soqlQueries: string[],
   isTooling = false,
   includeDeletedRecords = false,
+  onProgress?: (fetched: number, total: number) => void,
+  signal?: AbortSignal,
 ): Promise<QueryResults<T>> {
-  if (soqlQueries.length === 0) {
-    throw new Error('queryAllFromList requires at least one SOQL query');
-  }
   let results: QueryResults<T> | undefined;
+  let fetched = 0;
+  let total = 0;
   for (const soqlQuery of soqlQueries) {
-    const _results = await queryAll(org, soqlQuery, isTooling, includeDeletedRecords);
+    // queryAll's onProgress is per-query; report a cumulative count across all chunks so a single progress bar advances continuously
+    const _results = await queryAll<T>(org, soqlQuery, isTooling, includeDeletedRecords, undefined, signal);
+    fetched += _results.queryResults.records.length;
+    // Each chunk has its own totalSize; accumulate so the reported total reflects all chunks and never falls below fetched
+    total += _results.queryResults.totalSize;
     if (!results) {
       results = _results;
     } else {
       results.queryResults.records = results.queryResults.records.concat(_results.queryResults.records);
     }
+    if (isFunction(onProgress)) {
+      onProgress(fetched, total || fetched);
+    }
   }
-  return results as QueryResults<T>;
+  // No queries provided: return an empty result set so callers can always read `queryResults` instead of crashing on undefined
+  if (!results) {
+    return { queryResults: { done: true, totalSize: 0, records: [] } };
+  }
+  // Records were merged across every chunk, so align totalSize with the combined set rather than leaving it at the first chunk's value
+  results.queryResults.totalSize = total;
+  return results;
 }
 
 /**
@@ -758,10 +778,10 @@ export async function queryAll<T = any>(
   soqlQuery: string,
   isTooling = false,
   includeDeletedRecords = false,
-  // Ended up not using onProgress - if used, need to test
   onProgress?: (fetched: number, total: number) => void,
+  signal?: AbortSignal,
 ): Promise<QueryResults<T>> {
-  const results = await query(org, soqlQuery, isTooling, includeDeletedRecords);
+  const results = await query<T>(org, soqlQuery, isTooling, includeDeletedRecords, signal);
   if (!results.queryResults.done && results.queryResults.nextRecordsUrl) {
     let progress: { initialFetched: number; onProgress?: (fetched: number, total: number) => void } | undefined = undefined;
     if (isFunction(onProgress)) {
@@ -771,7 +791,7 @@ export async function queryAll<T = any>(
         onProgress,
       };
     }
-    const currentResults = await queryRemaining(org, results.queryResults.nextRecordsUrl, isTooling, progress);
+    const currentResults = await queryRemaining(org, results.queryResults.nextRecordsUrl, isTooling, progress, signal);
     results.queryResults.records = results.queryResults.records.concat(currentResults.queryResults.records);
     results.queryResults.nextRecordsUrl = undefined;
     results.queryResults.done = true;
@@ -795,13 +815,14 @@ export async function queryRemaining<T = any>(
     initialFetched: number;
     onProgress?: (fetched: number, total: number) => void;
   },
+  signal?: AbortSignal,
 ): Promise<QueryResults<T>> {
-  const results = await queryMore(org, nextRecordsUrl, isTooling);
+  const results = await queryMore<T>(org, nextRecordsUrl, isTooling, signal);
   while (!results.queryResults.done && results.queryResults.nextRecordsUrl) {
     if (progress && isFunction(progress.onProgress)) {
       progress.onProgress(results.queryResults.records.length + progress.initialFetched, results.queryResults.totalSize);
     }
-    const currentResults = await queryMore(org, results.queryResults.nextRecordsUrl, isTooling);
+    const currentResults = await queryMore<T>(org, results.queryResults.nextRecordsUrl, isTooling, signal);
     // update initial object with current results
     results.queryResults.records = results.queryResults.records.concat(currentResults.queryResults.records);
     results.queryResults.nextRecordsUrl = currentResults.queryResults.nextRecordsUrl;

--- a/libs/shared/ui-core/src/mass-update-records/__tests__/mass-update-records.utils.spec.ts
+++ b/libs/shared/ui-core/src/mass-update-records/__tests__/mass-update-records.utils.spec.ts
@@ -1,10 +1,16 @@
+import * as clientData from '@jetstream/shared/data';
+import { parseQuery } from '@jetstreamapp/soql-parser-js';
+import { beforeEach, vi } from 'vitest';
 import {
   composeSoqlQueryCustomWhereClause,
   composeSoqlQueryOptionalCustomWhereClause,
+  fetchRecordsWithRequiredFields,
   getFieldsToQuery,
   isValidRow,
   prepareRecords,
 } from '../mass-update-records.utils';
+
+vi.mock('@jetstream/shared/data');
 
 describe('mass-update-records.utils#isValidRow', () => {
   test('Should return true if all are valid', () => {
@@ -546,5 +552,129 @@ describe('mass-update-records.utils#prepareRecords', () => {
     expect(record1.Name).toBe('Jenny Jenny');
     expect(record2.Name).toBe(null);
     expect(record3.Name).toBe('Jenny Jenny');
+  });
+});
+
+describe('mass-update-records.utils#fetchRecordsWithRequiredFields', () => {
+  const selectedOrg = { uniqueId: 'org1' } as any;
+  const configuration = [
+    {
+      selectedField: 'Industry',
+      transformationOptions: {
+        criteria: 'onlyIfNotBlank',
+        option: 'staticValue',
+        staticValue: 'Tech',
+        alternateField: null,
+        whereClause: '',
+      },
+    },
+  ] as any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('Should query only the chosen records by Id when idsToInclude is provided', async () => {
+    const fetchedRecords = [
+      { Id: '001a', Industry: 'Finance' },
+      { Id: '001b', Industry: null },
+    ];
+    vi.mocked(clientData.queryAllFromList).mockResolvedValue({
+      queryResults: { records: fetchedRecords, totalSize: 2, done: true },
+    } as any);
+
+    const result = await fetchRecordsWithRequiredFields({
+      selectedOrg,
+      parsedQuery: parseQuery('SELECT Id FROM Account'),
+      idsToInclude: new Set(['001a', '001b']),
+      configuration,
+    });
+
+    expect(clientData.queryAll).not.toHaveBeenCalled();
+    expect(clientData.queryAllFromList).toHaveBeenCalledTimes(1);
+    const [org, soqlQueries] = vi.mocked(clientData.queryAllFromList).mock.calls[0];
+    expect(org).toBe(selectedOrg);
+    expect(soqlQueries).toEqual([`SELECT Id, Industry FROM Account WHERE Id IN ('001a','001b')`]);
+    expect(result).toBe(fetchedRecords);
+  });
+
+  it('Should split large id sets into multiple chunked queries', async () => {
+    vi.mocked(clientData.queryAllFromList).mockResolvedValue({ queryResults: { records: [], totalSize: 0, done: true } } as any);
+
+    const ids = Array.from({ length: 1001 }, (_, index) => `id${index}`);
+    await fetchRecordsWithRequiredFields({
+      selectedOrg,
+      parsedQuery: parseQuery('SELECT Id FROM Account'),
+      idsToInclude: new Set(ids),
+      configuration,
+    });
+
+    const [, soqlQueries] = vi.mocked(clientData.queryAllFromList).mock.calls[0];
+    // 1001 ids / 500 per chunk => 3 queries
+    expect(soqlQueries).toHaveLength(3);
+  });
+
+  it('Should return an empty array without querying when idsToInclude is empty', async () => {
+    const result = await fetchRecordsWithRequiredFields({
+      selectedOrg,
+      parsedQuery: parseQuery('SELECT Id FROM Account'),
+      idsToInclude: new Set(),
+      configuration,
+    });
+
+    expect(result).toEqual([]);
+    expect(clientData.queryAllFromList).not.toHaveBeenCalled();
+    expect(clientData.queryAll).not.toHaveBeenCalled();
+  });
+
+  it('Should re-run the full query (preserving WHERE) when idsToInclude is omitted', async () => {
+    const fetchedRecords = [{ Id: '001a', Industry: 'Finance' }];
+    vi.mocked(clientData.queryAll).mockResolvedValue({ queryResults: { records: fetchedRecords, totalSize: 1, done: true } } as any);
+
+    const result = await fetchRecordsWithRequiredFields({
+      selectedOrg,
+      parsedQuery: parseQuery(`SELECT Id FROM Account WHERE Name != null`),
+      configuration,
+    });
+
+    expect(clientData.queryAllFromList).not.toHaveBeenCalled();
+    expect(clientData.queryAll).toHaveBeenCalledTimes(1);
+    const [, soql] = vi.mocked(clientData.queryAll).mock.calls[0];
+    // composeQuery normalizes the `null` literal to `NULL`; the WHERE clause is preserved
+    expect(soql).toBe(`SELECT Id, Industry FROM Account WHERE Name != NULL`);
+    expect(result).toBe(fetchedRecords);
+  });
+
+  it('Should report cumulative progress against the requested id count', async () => {
+    vi.mocked(clientData.queryAllFromList).mockResolvedValue({ queryResults: { records: [], totalSize: 0, done: true } } as any);
+    const onProgress = vi.fn();
+
+    await fetchRecordsWithRequiredFields({
+      selectedOrg,
+      parsedQuery: parseQuery('SELECT Id FROM Account'),
+      idsToInclude: new Set(['001a', '001b']),
+      configuration,
+      onProgress,
+    });
+
+    // grab the progress callback handed to queryAllFromList and simulate a chunk completing
+    const progressCallback = vi.mocked(clientData.queryAllFromList).mock.calls[0][4] as (fetched: number, total: number) => void;
+    progressCallback(2, 999);
+    expect(onProgress).toHaveBeenCalledWith(2, 2);
+  });
+
+  it('Should pass the abort signal through to the query layer', async () => {
+    vi.mocked(clientData.queryAllFromList).mockResolvedValue({ queryResults: { records: [], totalSize: 0, done: true } } as any);
+    const signal = new AbortController().signal;
+
+    await fetchRecordsWithRequiredFields({
+      selectedOrg,
+      parsedQuery: parseQuery('SELECT Id FROM Account'),
+      idsToInclude: new Set(['001a']),
+      configuration,
+      signal,
+    });
+
+    expect(vi.mocked(clientData.queryAllFromList).mock.calls[0][5]).toBe(signal);
   });
 });

--- a/libs/shared/ui-core/src/mass-update-records/mass-update-records.utils.tsx
+++ b/libs/shared/ui-core/src/mass-update-records/mass-update-records.utils.tsx
@@ -1,11 +1,20 @@
 import { logger } from '@jetstream/shared/client-logger';
 import { SFDC_BULK_API_NULL_VALUE } from '@jetstream/shared/constants';
-import { queryAll } from '@jetstream/shared/data';
+import { queryAll, queryAllFromList } from '@jetstream/shared/data';
+import { escapeSoqlString } from '@jetstream/shared/ui-utils';
+import { splitArrayToMaxSize } from '@jetstream/shared/utils';
 import { DescribeGlobalSObjectResult, ListItem, Maybe, SalesforceOrgUi, SalesforceRecord } from '@jetstream/types';
 import { Query, composeQuery, getField, isQueryValid } from '@jetstreamapp/soql-parser-js';
 import lodashGet from 'lodash/get';
 import isNil from 'lodash/isNil';
 import { MetadataRow, MetadataRowConfiguration } from './mass-update-records.types';
+
+/**
+ * Max number of record Ids to include in a single `WHERE Id IN (...)` query when re-fetching a
+ * specific set of records (selected / filtered). 18-char Ids quoted ≈ 21 chars each, so 500 keeps
+ * each query well under Salesforce's 100k character SOQL limit.
+ */
+const ID_CHUNK_SIZE = 500;
 
 export const startsWithWhereRgx = /^( )*WHERE( )*/i;
 
@@ -185,20 +194,27 @@ export function composeSoqlQueryCustomWhereClause(row: MetadataRow, fields: stri
 }
 
 /**
- * Used from places where records are already fetched (query results)
+ * Used from places where records are already fetched (query results).
+ *
+ * When `idsToInclude` is provided (the user chose a specific set of records — selected, filtered, or the
+ * first browser set), only those records are re-fetched via chunked `WHERE Id IN (...)` queries instead of
+ * downloading the entire result set and filtering client-side. When omitted (All records), the full query
+ * is re-run. Pass `signal` to allow cancellation and `onProgress` to report fetch progress.
  */
 export async function fetchRecordsWithRequiredFields({
   selectedOrg,
-  records: existingRecords,
   parsedQuery,
   idsToInclude,
   configuration,
+  signal,
+  onProgress,
 }: {
   selectedOrg: SalesforceOrgUi;
-  records: SalesforceRecord[];
   parsedQuery: Query;
   idsToInclude?: Set<string>;
   configuration: MetadataRowConfiguration[];
+  signal?: AbortSignal;
+  onProgress?: (fetched: number, total: number) => void;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
 }): Promise<any[]> {
   // selectedField is required so that transformationOptions.criteria can be applied to records
@@ -218,17 +234,33 @@ export async function fetchRecordsWithRequiredFields({
     }
   });
 
-  // Re-fetch records - this may not always be required, but for consistency this will happen every time
-  parsedQuery = { ...parsedQuery, fields: Array.from(fieldsRequiredInRecords).map((field) => getField(field)) };
-  const { queryResults } = await queryAll(selectedOrg, composeQuery(parsedQuery));
-  let { records } = queryResults;
+  const fields = Array.from(fieldsRequiredInRecords).map((field) => getField(field));
 
-  // if user has filtered/selected records, only include those
+  // Re-fetch only the specific records the user chose, querying by Id instead of the full result set.
   if (idsToInclude) {
-    records = records.filter((record) => idsToInclude.has(record.Id));
+    const idsToFetch = Array.from(idsToInclude);
+    if (idsToFetch.length === 0) {
+      return [];
+    }
+    // Build a minimal query (drop the original WHERE/LIMIT/ORDER BY); the Id list is already the exact set.
+    const baseSoql = composeQuery({ sObject: parsedQuery.sObject, fields });
+    const soqlQueries = splitArrayToMaxSize(idsToFetch, ID_CHUNK_SIZE).map(
+      (idChunk) => `${baseSoql} WHERE Id IN (${idChunk.map((id) => `'${escapeSoqlString(id)}'`).join(',')})`,
+    );
+    const { queryResults } = await queryAllFromList(
+      selectedOrg,
+      soqlQueries,
+      false,
+      false,
+      (fetched) => onProgress?.(fetched, idsToFetch.length),
+      signal,
+    );
+    return queryResults.records;
   }
 
-  return records;
+  // All records - re-run the original query (criteria is applied client-side downstream)
+  const { queryResults } = await queryAll(selectedOrg, composeQuery({ ...parsedQuery, fields }), false, false, onProgress, signal);
+  return queryResults.records;
 }
 
 export function prepareRecords(


### PR DESCRIPTION
Introduce functionality to preview proposed changes for bulk updates, displaying the original and new values for impacted records. This enhancement allows users to see which records will be updated and how, improving the overall user experience during bulk operations.

* [ ] Test End-to-End