### PR TITLE
feat: add brand colors and structure to allow theming

### DIFF
--- a/apps/jetstream-canvas/src/main.tsx
+++ b/apps/jetstream-canvas/src/main.tsx
@@ -10,6 +10,11 @@ import App from './app/app';
 import { Login } from './app/core/Login';
 import { canvasAppAxiosAdapter } from './utils/canvas-axios-adapter';
 
+// DO NOT CHANGE ORDER OF IMPORTS
+// Brand theming: must load AFTER slds2.cosmos.css so the :root brand-ramp override wins (equal specificity → last wins)
+import '@jetstream/ui-styles/brand-theme.css';
+// DO NOT CHANGE ORDER OF IMPORTS
+
 globalThis.__IS_CANVAS_APP__ = true;
 
 AxiosAdapterConfig.adapter = canvasAppAxiosAdapter;

--- a/apps/jetstream-desktop-client/src/main.tsx
+++ b/apps/jetstream-desktop-client/src/main.tsx
@@ -9,6 +9,11 @@ import { createRoot } from 'react-dom/client';
 import App from './app/app';
 import './main.css';
 
+// DO NOT CHANGE ORDER OF IMPORTS
+// Brand theming: must load AFTER slds2.cosmos.css so the :root brand-ramp override wins (equal specificity → last wins)
+import '@jetstream/ui-styles/brand-theme.css';
+// DO NOT CHANGE ORDER OF IMPORTS
+
 // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 const container = document.getElementById('root')!;
 

--- a/apps/jetstream-web-extension/src/core/AppWrapper.tsx
+++ b/apps/jetstream-web-extension/src/core/AppWrapper.tsx
@@ -15,6 +15,11 @@ import '../utils/monaco-loader';
 import AppInitializer from './AppInitializer';
 import { ExtensionThemeApplier } from './ExtensionThemeApplier';
 
+// DO NOT CHANGE ORDER OF IMPORTS
+// Brand theming: must load AFTER slds2.cosmos.css so the :root brand-ramp override wins (equal specificity → last wins)
+import '@jetstream/ui-styles/brand-theme.css';
+// DO NOT CHANGE ORDER OF IMPORTS
+
 if (!environment.production) {
   enableLogger(true);
 }

--- a/apps/jetstream/src/main.tsx
+++ b/apps/jetstream/src/main.tsx
@@ -11,6 +11,11 @@ import '@salesforce-ux/design-system-2/dist/css/bundled/slds2.cosmos.css';
 import { createRoot } from 'react-dom/client';
 import App from './app/app';
 
+// DO NOT CHANGE ORDER OF IMPORTS
+// Brand POC: must load AFTER slds2.cosmos.css so the :root brand-ramp override wins (equal specificity → last wins)
+import '@jetstream/ui-styles/brand-theme.css';
+// DO NOT CHANGE ORDER OF IMPORTS
+
 // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 const container = document.getElementById('root')!;
 const cspNonce = document.querySelector<HTMLScriptElement>('script[nonce]')?.nonce;

--- a/libs/shared/ui-styles/src/brand-theme.css
+++ b/libs/shared/ui-styles/src/brand-theme.css
@@ -1,0 +1,47 @@
+/* Jetstream brand POC — overrides the SLDS 2 reference brand ramp.
+   Must be imported AFTER slds2.cosmos.css so this :root wins (equal specificity → last wins).
+   Covers light AND dark mode automatically: SLDS does not redefine this ramp per scheme.
+
+   SWAP BRANDS: keep exactly ONE :root block below uncommented — the last uncommented one wins. */
+
+/* ===== Option A — TEAL primary (anchor 50 = #0d9488, teal-600) ===== */
+/* :root {
+  --slds-r-color-brand-5: #021a18;
+  --slds-r-color-brand-10: #042f2e;
+  --slds-r-color-brand-15: #07423d;
+  --slds-r-color-brand-20: #134e4a;
+  --slds-r-color-brand-30: #115e59;
+  --slds-r-color-brand-35: #0f766e;
+  --slds-r-color-brand-40: #0b8074;
+  --slds-r-color-brand-45: #0c8a7e;
+  --slds-r-color-brand-50: #0d9488;
+  --slds-r-color-brand-55: #14b8a6;
+  --slds-r-color-brand-60: #1ac4b3;
+  --slds-r-color-brand-65: #2dd4bf;
+  --slds-r-color-brand-70: #4ee0d2;
+  --slds-r-color-brand-80: #99f6e4;
+  --slds-r-color-brand-85: #b6f7ec;
+  --slds-r-color-brand-90: #cffafe;
+  --slds-r-color-brand-95: #ecfeff;
+} */
+
+/* ===== Option B — CYAN primary (anchor 50 = #0891b2, cyan-600) ===== */
+/* :root {
+  --slds-r-color-brand-5: #04222d;
+  --slds-r-color-brand-10: #083344;
+  --slds-r-color-brand-15: #0c4255;
+  --slds-r-color-brand-20: #164e63;
+  --slds-r-color-brand-30: #155e75;
+  --slds-r-color-brand-35: #0e7490;
+  --slds-r-color-brand-40: #0a82a0;
+  --slds-r-color-brand-45: #078aab;
+  --slds-r-color-brand-50: #0891b2;
+  --slds-r-color-brand-55: #06b6d4;
+  --slds-r-color-brand-60: #11c2dd;
+  --slds-r-color-brand-65: #22d3ee;
+  --slds-r-color-brand-70: #4bddf2;
+  --slds-r-color-brand-80: #a5f3fc;
+  --slds-r-color-brand-85: #c2f7fd;
+  --slds-r-color-brand-90: #cffafe;
+  --slds-r-color-brand-95: #ecfeff;
+} */

--- a/libs/shared/ui-styles/src/main.css
+++ b/libs/shared/ui-styles/src/main.css
@@ -1,10 +1,9 @@
-/* Make react data grid checkbox look sort of like SLDS checkbox */
-@layer rdg.rdg-checkbox-input {
-  .rdg-checkbox-input {
-    inline-size: 14px;
-    block-size: 14px;
-    accent-color: var(--slds-g-color-brand-base-50);
-  }
+/* Brand the OS-native form controls (e.g. the manage-permissions table renders a
+   bare <input type="checkbox"> for perf instead of an SLDS faux checkbox) so they
+   follow the brand accent rather than the OS default blue. */
+input[type='checkbox'],
+input[type='radio'] {
+  accent-color: var(--slds-g-color-brand-base-50, #0176d3);
 }
 
 html {

--- a/libs/ui/src/lib/data-table/grid/data-table-grid.css
+++ b/libs/ui/src/lib/data-table/grid/data-table-grid.css
@@ -14,7 +14,7 @@
   --jgrid-surface-alt: var(--slds-g-color-surface-container-2, #f3f3f3);
   --jgrid-on-surface: var(--slds-g-color-on-surface-1, #181818);
   --jgrid-row-hover: var(--slds-g-color-surface-container-2, #f3f3f3);
-  --jgrid-row-selected: var(--slds-g-color-palette-blue-95, #eef4ff);
+  --jgrid-row-selected: var(--slds-g-color-brand-base-95, #eef4ff);
   color: var(--jgrid-on-surface);
   font-size: 0.8125rem;
 }
@@ -226,7 +226,7 @@
 
 /* Rectangular cell-range selection highlight */
 .jgrid-cell-range {
-  background-color: var(--slds-g-color-palette-blue-90, #d8e6fe);
+  background-color: var(--slds-g-color-brand-base-90, #d8e6fe);
 }
 
 /*
@@ -310,10 +310,11 @@
   padding-inline: 0.25rem;
 }
 
-/* Blue, link-like group label so it's obviously clickable (matches the deploy/compare toggle). */
+/* Brand-colored, link-like group label so it's obviously clickable (matches the deploy/compare toggle).
+   Uses the brand token (not the raw blue palette) so it follows the brand accent. */
 .jgrid-group-toggle-label {
   font-weight: 700;
-  color: var(--slds-g-color-palette-blue-50, #0176d3);
+  color: var(--slds-g-color-brand-base-50, #0176d3);
 }
 .jgrid-group-toggle:hover .jgrid-group-toggle-label {
   text-decoration: underline;

--- a/libs/ui/src/lib/sobject-field-list/sobject-field-list-utils.tsx
+++ b/libs/ui/src/lib/sobject-field-list/sobject-field-list-utils.tsx
@@ -4,25 +4,25 @@ import { FilterTypes } from './SobjectFieldListFilter';
 
 /**
  * Background for each nesting level of related-object fields.
- * Palette tokens resolve via light-dark(), so the ramp inverts in dark mode
+ * Brand tokens resolve via light-dark(), so the ramp inverts in dark mode
  * (the old hardcoded blues stayed light and made dark-mode text unreadable).
  */
 export function getBgColor(level: number): string | undefined {
   switch (level) {
     case 1: {
-      return 'var(--slds-g-color-palette-blue-95, #eef1f6)';
+      return 'var(--slds-g-color-brand-base-95, #eef1f6)';
     }
     case 2: {
-      return 'var(--slds-g-color-palette-blue-90, #c5d5ea)';
+      return 'var(--slds-g-color-brand-base-90, #c5d5ea)';
     }
     case 3: {
-      return 'var(--slds-g-color-palette-blue-80, #a9d3ff)';
+      return 'var(--slds-g-color-brand-base-80, #a9d3ff)';
     }
     case 4: {
-      return 'var(--slds-g-color-palette-blue-70, #96c5f7)';
+      return 'var(--slds-g-color-brand-base-70, #96c5f7)';
     }
     case 5: {
-      return 'var(--slds-g-color-palette-blue-65, #758ecd)';
+      return 'var(--slds-g-color-brand-base-65, #758ecd)';
     }
   }
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -68,7 +68,8 @@
       "@jetstream/ui/cookie-consent-banner": ["./libs/shared/cookie-consent-banner/src/index.ts"],
       "@jetstream/ui/db": ["./libs/shared/ui-db/src/index.ts"],
       "@jetstream/salesforce-oauth": ["./libs/auth/salesforce-oauth/src/index.ts"],
-      "@jetstream/ui-styles/main.css": ["./libs/shared/ui-styles/src/main.css"]
+      "@jetstream/ui-styles/main.css": ["./libs/shared/ui-styles/src/main.css"],
+      "@jetstream/ui-styles/brand-theme.css": ["./libs/shared/ui-styles/src/brand-theme.css"]
     }
   },
   "exclude": ["node_modules", "tmp"]


### PR DESCRIPTION
For new we are keeping sfdc blue, but we can/will probably adjust to our own brand colors (cyan looks line) for brand differentiation.

To do this, uncomment the bran-theme.css root.

We could give users the option to choose or just apply globally

(I think I like Cyan a bit better than Teal)

# TEAL

<img width="1405" height="1229" alt="image" src="https://github.com/user-attachments/assets/2d3e58f3-fd71-45bc-b94d-55007c1ecfaa" />

<img width="1407" height="1224" alt="image" src="https://github.com/user-attachments/assets/4236c7fe-2321-44ce-9485-9c4c8d5ed39d" />

# CYAN

<img width="1408" height="1224" alt="image" src="https://github.com/user-attachments/assets/4bfdd17d-e009-4da6-8dd0-23729b2065b8" />


<img width="1402" height="1230" alt="image" src="https://github.com/user-attachments/assets/5a08bb26-78fd-4798-9cfd-772652398d13" />
