### PR TITLE
Add FieldMetadataModal for enhanced field metadata viewing

### DIFF
--- a/libs/features/query/src/QueryResults/QueryResults.tsx
+++ b/libs/features/query/src/QueryResults/QueryResults.tsx
@@ -831,6 +831,7 @@ export const QueryResults = React.memo(() => {
                 handleGetAsApex(record);
               }}
               onReloadQuery={() => executeQuery(soql, RECORD_BULK_ACTION, { isTooling })}
+              trackEvent={trackEvent}
             />
           )}
         </AutoFullHeightContainer>

--- a/libs/shared/constants/src/lib/shared-constants.ts
+++ b/libs/shared/constants/src/lib/shared-constants.ts
@@ -233,6 +233,8 @@ export const ANALYTICS_KEYS = {
   query_UpdateRecordsInline: 'query_UpdateRecordsInline',
   query_ResetPage: 'query_ResetPage',
   query_InlineEditSave: 'query_InlineEditSave',
+  query_FieldMetadataViewed: 'query_FieldMetadataViewed',
+  query_FieldMetadataDownloaded: 'query_FieldMetadataDownloaded',
   /** QUICK QUERY */
   quick_query_Open: 'quick_query_Open',
   quick_query_Execute: 'quick_query_Execute',

--- a/libs/types/src/lib/ui/types.ts
+++ b/libs/types/src/lib/ui/types.ts
@@ -396,6 +396,7 @@ export interface ContextMenuItem<T = any> {
     icon: string;
     description?: string;
   }; // FIXME: unable to import cross module boundaries
+  leadingDivider?: boolean;
   trailingDivider?: boolean;
   disabled?: boolean;
   title?: string;

--- a/libs/ui/src/index.ts
+++ b/libs/ui/src/index.ts
@@ -22,8 +22,9 @@ export {
 export * from './lib/data-table/DataTable';
 export * from './lib/data-table/DataTableRenderers';
 export * from './lib/data-table/DataTree';
-export * from './lib/data-table/SalesforceRecordDataTable';
+export * from './lib/data-table/FieldMetadataModal';
 export * from './lib/data-table/grid/rdg-compat';
+export * from './lib/data-table/SalesforceRecordDataTable';
 export * from './lib/docked-composer/DockedComposer';
 export * from './lib/expression-group/expression-utils';
 export * from './lib/expression-group/ExpressionContainer';

--- a/libs/ui/src/lib/data-table/DataTable.tsx
+++ b/libs/ui/src/lib/data-table/DataTable.tsx
@@ -31,6 +31,8 @@ export interface DataTableProps<T = RowWithKey, TContext = Record<string, any>> 
   contextMenuItems?: ContextMenuItems<T>;
   // `any` so call sites may type their handler against a narrower row type without variance errors.
   contextMenuAction?: (item: ContextMenuItem, data: ContextMenuActionData<any>) => void;
+  /** Consumer-supplied builder for extra per-column header menu items (must be stable). */
+  getColumnHeaderMenuItems?: (columnId: string) => ContextMenuItem[];
   initialSortColumns?: SortColumn[];
   rowAlwaysVisible?: (row: T) => boolean;
   ignoreRowInSetFilter?: (row: T) => boolean;

--- a/libs/ui/src/lib/data-table/FieldMetadataModal.tsx
+++ b/libs/ui/src/lib/data-table/FieldMetadataModal.tsx
@@ -1,0 +1,158 @@
+import { css } from '@emotion/react';
+import { MIME_TYPES } from '@jetstream/shared/constants';
+import { saveFile } from '@jetstream/shared/ui-utils';
+import { Field } from '@jetstream/types';
+import { FunctionComponent } from 'react';
+import Badge from '../badge/Badge';
+import { ReadOnlyFormElement } from '../form/readonly-form-element/ReadOnlyFormElement';
+import Grid from '../grid/Grid';
+import GridCol from '../grid/GridCol';
+import Modal from '../modal/Modal';
+import Icon from '../widgets/Icon';
+
+/** Field types where the `length` property is meaningful (string-like). */
+const STRING_LIKE_TYPES = new Set<Field['type']>(['string', 'textarea', 'email', 'phone', 'url', 'encryptedstring']);
+/** Field types where `precision`/`scale` are meaningful (numeric). */
+const NUMERIC_TYPES = new Set<Field['type']>(['int', 'double', 'currency', 'percent']);
+
+export interface FieldMetadataRow {
+  id: string;
+  label: string;
+  value: string | number | boolean | null;
+  labelHelp?: string;
+}
+
+/**
+ * Build the flat label/value rows shown in the modal grid. Type/label/help/references/picklist are
+ * rendered as dedicated sections elsewhere; this returns the API name, type-relevant sizing
+ * (length for string-like, precision/scale for numeric), and the key boolean flags.
+ */
+export function buildFieldMetadataRows(field: Field): FieldMetadataRow[] {
+  const rows: FieldMetadataRow[] = [{ id: 'fm-name', label: 'API Name', value: field.name }];
+
+  if (STRING_LIKE_TYPES.has(field.type)) {
+    rows.push({ id: 'fm-length', label: 'Length', value: field.length });
+  }
+  if (NUMERIC_TYPES.has(field.type)) {
+    rows.push({ id: 'fm-precision', label: 'Precision', value: field.precision ?? null });
+    rows.push({ id: 'fm-scale', label: 'Scale', value: field.scale });
+  }
+
+  rows.push(
+    { id: 'fm-custom', label: 'Custom', value: field.custom },
+    { id: 'fm-calculated', label: 'Calculated', value: field.calculated },
+    { id: 'fm-nillable', label: 'Nillable', value: field.nillable },
+    { id: 'fm-createable', label: 'Createable', value: field.createable },
+    { id: 'fm-updateable', label: 'Updateable', value: field.updateable },
+  );
+
+  return rows;
+}
+
+const scrollContainerStyles = css`
+  max-height: 12rem;
+  overflow: auto;
+`;
+
+export interface FieldMetadataModalProps {
+  field: Field;
+  columnName?: string;
+  onClose: () => void;
+  /** Fired after the raw field JSON is downloaded (e.g. for analytics). */
+  onDownload?: () => void;
+}
+
+export const FieldMetadataModal: FunctionComponent<FieldMetadataModalProps> = ({ field, columnName, onClose, onDownload }) => {
+  const handleDownloadJson = () => {
+    saveFile(JSON.stringify(field, null, 2), `field-metadata-${field.name}.json`, MIME_TYPES.JSON);
+    onDownload?.();
+  };
+
+  return (
+    <Modal
+      header={`Field Metadata${columnName ? `: ${columnName}` : ''}`}
+      size="md"
+      onClose={onClose}
+      footer={
+        <Grid align="spread">
+          <button className="slds-button slds-button_neutral" onClick={handleDownloadJson}>
+            <Icon type="utility" icon="download" className="slds-button__icon slds-button__icon_left" omitContainer />
+            Download JSON
+          </button>
+          <button className="slds-button slds-button_neutral" onClick={onClose}>
+            Close
+          </button>
+        </Grid>
+      }
+    >
+      <Grid wrap>
+        <GridCol size={6}>
+          <ReadOnlyFormElement id="fm-label" label="Label" value={field.label} labelHelp={field.inlineHelpText ?? undefined} bottomBorder />
+        </GridCol>
+        <GridCol size={6}>
+          <div className="slds-form-element">
+            <span className="slds-form-element__label">Type</span>
+            <div className="slds-form-element__control slds-border_bottom">
+              <div className="slds-form-element__static">
+                {field.type}
+                {field.calculated && (
+                  <Badge className="slds-m-left_xx-small" type="light">
+                    Calculated
+                  </Badge>
+                )}
+              </div>
+            </div>
+          </div>
+        </GridCol>
+        {buildFieldMetadataRows(field).map((row) => (
+          <GridCol key={row.id} size={6}>
+            <ReadOnlyFormElement id={row.id} label={row.label} value={row.value} labelHelp={row.labelHelp} bottomBorder />
+          </GridCol>
+        ))}
+      </Grid>
+
+      {field.inlineHelpText && (
+        <div className="slds-m-top_small">
+          <ReadOnlyFormElement id="fm-help" label="Help Text" value={field.inlineHelpText} bottomBorder />
+        </div>
+      )}
+
+      {!!field.referenceTo?.length && (
+        <div className="slds-m-top_small">
+          <span className="slds-form-element__label">References</span>
+          <div>
+            {field.referenceTo.map((sobject) => (
+              <Badge key={sobject} className="slds-m-right_xx-small slds-m-bottom_xx-small">
+                {sobject}
+              </Badge>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {!!field.picklistValues?.length && (
+        <div className="slds-m-top_small">
+          <span className="slds-form-element__label">Picklist Values ({field.picklistValues.length})</span>
+          <ul css={scrollContainerStyles} className="slds-has-dividers_bottom-space slds-dropdown_length-with-icon-10">
+            {field.picklistValues.map((picklist, index) => (
+              <li key={`${picklist.value}-${index}`} className="slds-item read-only">
+                <Grid align="spread" verticalAlign="center">
+                  <span className="slds-truncate" title={picklist.label ?? picklist.value}>
+                    {picklist.label && picklist.label !== picklist.value ? `${picklist.label} (${picklist.value})` : picklist.value}
+                  </span>
+                  {!picklist.active && (
+                    <Badge className="slds-m-left_x-small" type="warning">
+                      Inactive
+                    </Badge>
+                  )}
+                </Grid>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </Modal>
+  );
+};
+
+export default FieldMetadataModal;

--- a/libs/ui/src/lib/data-table/SalesforceRecordDataTable.tsx
+++ b/libs/ui/src/lib/data-table/SalesforceRecordDataTable.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { css } from '@emotion/react';
 import { logger } from '@jetstream/shared/client-logger';
+import { ANALYTICS_KEYS } from '@jetstream/shared/constants';
 import { queryRemaining } from '@jetstream/shared/data';
 import { formatNumber, hasCtrlOrMeta, isEnterKey, tracker, useGlobalEventHandler } from '@jetstream/shared/ui-utils';
 import { flattenRecord, getIdFromRecordUrl, groupByFlat, nullifyEmptyStrings } from '@jetstream/shared/utils';
@@ -15,6 +16,7 @@ import { PopoverErrorButton } from '../popover/PopoverErrorButton';
 import { fireToast } from '../toast/AppToast';
 import Spinner from '../widgets/Spinner';
 import { DataTable } from './DataTable';
+import { FieldMetadataModal } from './FieldMetadataModal';
 import { DataTableSubqueryContext } from './data-table-context';
 import { ColumnWithFilter, ContextAction, ContextMenuActionData, RowSalesforceRecordWithKey, RowWithKey } from './data-table-types';
 import {
@@ -86,6 +88,7 @@ export interface SalesforceRecordDataTableProps {
   onGetAsApex: (record: any) => void;
   onSavedRecords: (results: { recordCount: number; failureCount: number }) => void;
   onReloadQuery: () => void;
+  trackEvent?: (key: string, value?: Record<string, any>) => void;
 }
 
 export const SalesforceRecordDataTable = memo<SalesforceRecordDataTableProps>(
@@ -118,6 +121,7 @@ export const SalesforceRecordDataTable = memo<SalesforceRecordDataTableProps>(
     onGetAsApex,
     onSavedRecords,
     onReloadQuery,
+    trackEvent,
   }: SalesforceRecordDataTableProps) => {
     const isMounted = useRef(true);
     const [columns, setColumns] = useState<ColumnWithFilter<RowSalesforceRecordWithKey>[]>();
@@ -135,6 +139,7 @@ export const SalesforceRecordDataTable = memo<SalesforceRecordDataTableProps>(
     const [hasMoreRecords, setHasMoreRecords] = useState(false);
     const [nextRecordsUrl, setNextRecordsUrl] = useState<Maybe<string>>(null);
     const [globalFilter, setGlobalFilter] = useState<string | null>(null);
+    const [fieldMetaModal, setFieldMetaModal] = useState<{ field: Field; columnName: string } | null>(null);
     const [selectedRows, setSelectedRows] = useState<ReadonlySet<string>>(() => new Set());
     const [visibleRecordCount, setVisibleRecordCount] = useState(records?.length);
 
@@ -234,9 +239,35 @@ export const SalesforceRecordDataTable = memo<SalesforceRecordDataTableProps>(
 
     const handleContextMenuAction = useCallback(
       (item: ContextMenuItem<ContextAction>, data: ContextMenuActionData<RowWithKey>) => {
+        if (item.value === 'VIEW_FIELD_METADATA') {
+          const field = data.column.meta?.field as Field | undefined;
+          if (field) {
+            setFieldMetaModal({ field, columnName: String(data.column.name) });
+            trackEvent?.(ANALYTICS_KEYS.query_FieldMetadataViewed, { type: field.type, isCustom: field.custom });
+          }
+          return;
+        }
         copySalesforceRecordTableDataToClipboard(item.value, fields, data);
       },
-      [fields],
+      [fields, trackEvent],
+    );
+
+    // Offer "View field metadata" on a column header only when we have that field's describe stashed on
+    const getColumnHeaderMenuItems = useCallback(
+      (columnId: string): ContextMenuItem<ContextAction>[] => {
+        const column = columns?.find((col) => col.key === columnId);
+        const field = column?.meta?.field as Field | undefined;
+        return field
+          ? [
+              {
+                label: 'View field metadata',
+                value: 'VIEW_FIELD_METADATA',
+                leadingDivider: true,
+              },
+            ]
+          : [];
+      },
+      [columns],
     );
 
     useEffect(() => {
@@ -550,9 +581,18 @@ export const SalesforceRecordDataTable = memo<SalesforceRecordDataTableProps>(
               context={tableContext}
               contextMenuItems={TABLE_CONTEXT_MENU_ITEMS}
               contextMenuAction={handleContextMenuAction}
+              getColumnHeaderMenuItems={getColumnHeaderMenuItems}
             />
           </DataTableSubqueryContext.Provider>
         </AutoFullHeightContainer>
+        {fieldMetaModal && (
+          <FieldMetadataModal
+            field={fieldMetaModal.field}
+            columnName={fieldMetaModal.columnName}
+            onClose={() => setFieldMetaModal(null)}
+            onDownload={() => trackEvent?.(ANALYTICS_KEYS.query_FieldMetadataDownloaded, { type: fieldMetaModal.field.type })}
+          />
+        )}
       </Fragment>
     ) : null;
   },

--- a/libs/ui/src/lib/data-table/__tests__/FieldMetadataModal.spec.ts
+++ b/libs/ui/src/lib/data-table/__tests__/FieldMetadataModal.spec.ts
@@ -1,0 +1,71 @@
+import { Field } from '@jetstream/types';
+import { describe, expect, test } from 'vitest';
+import { buildFieldMetadataRows } from '../FieldMetadataModal';
+
+function makeField(overrides: Partial<Field>): Field {
+  return {
+    name: 'TestField__c',
+    label: 'Test Field',
+    type: 'string',
+    length: 0,
+    precision: 0,
+    scale: 0,
+    custom: false,
+    calculated: false,
+    nillable: false,
+    createable: false,
+    updateable: false,
+    ...overrides,
+  } as Field;
+}
+
+function rowById(rows: ReturnType<typeof buildFieldMetadataRows>, id: string) {
+  return rows.find((row) => row.id === id);
+}
+
+describe('buildFieldMetadataRows', () => {
+  test('includes the API name row and all boolean flag rows', () => {
+    const rows = buildFieldMetadataRows(
+      makeField({ name: 'Account.Name', custom: true, calculated: false, nillable: true, createable: false, updateable: true }),
+    );
+
+    expect(rowById(rows, 'fm-name')?.value).toBe('Account.Name');
+    expect(rowById(rows, 'fm-custom')?.value).toBe(true);
+    expect(rowById(rows, 'fm-calculated')?.value).toBe(false);
+    expect(rowById(rows, 'fm-nillable')?.value).toBe(true);
+    expect(rowById(rows, 'fm-createable')?.value).toBe(false);
+    expect(rowById(rows, 'fm-updateable')?.value).toBe(true);
+  });
+
+  test('includes length for string and textarea types', () => {
+    const stringRows = buildFieldMetadataRows(makeField({ type: 'string', length: 255 }));
+    expect(rowById(stringRows, 'fm-length')?.value).toBe(255);
+
+    const textareaRows = buildFieldMetadataRows(makeField({ type: 'textarea', length: 32768 }));
+    expect(rowById(textareaRows, 'fm-length')?.value).toBe(32768);
+
+    // string-like fields are not numeric, so precision/scale are omitted
+    expect(rowById(stringRows, 'fm-precision')).toBeUndefined();
+    expect(rowById(stringRows, 'fm-scale')).toBeUndefined();
+  });
+
+  test('includes precision and scale for numeric types', () => {
+    const rows = buildFieldMetadataRows(makeField({ type: 'currency', precision: 18, scale: 2 }));
+    expect(rowById(rows, 'fm-precision')?.value).toBe(18);
+    expect(rowById(rows, 'fm-scale')?.value).toBe(2);
+    // numeric fields are not string-like, so length is omitted
+    expect(rowById(rows, 'fm-length')).toBeUndefined();
+  });
+
+  test('omits length/precision/scale for an unrelated type (boolean)', () => {
+    const rows = buildFieldMetadataRows(makeField({ type: 'boolean' }));
+    expect(rowById(rows, 'fm-length')).toBeUndefined();
+    expect(rowById(rows, 'fm-precision')).toBeUndefined();
+    expect(rowById(rows, 'fm-scale')).toBeUndefined();
+  });
+
+  test('does not attach inlineHelpText to the API name row (shown via the Label tooltip and Help Text section instead)', () => {
+    const withHelp = buildFieldMetadataRows(makeField({ inlineHelpText: 'Helpful description' }));
+    expect(rowById(withHelp, 'fm-name')?.labelHelp).toBeUndefined();
+  });
+});

--- a/libs/ui/src/lib/data-table/grid/DataTableV2.tsx
+++ b/libs/ui/src/lib/data-table/grid/DataTableV2.tsx
@@ -66,6 +66,8 @@ export interface DataTableV2Props<TRow = RowWithKey, TContext = Record<string, a
   contextMenuItems?: ContextMenuItems<TRow>;
   /** Right-click context menu action handler (must be stable). */
   contextMenuAction?: (item: ContextMenuItem, data: ContextMenuActionData<TRow>) => void;
+  /** Consumer-supplied builder for extra per-column header menu items (must be stable). */
+  getColumnHeaderMenuItems?: (columnId: string) => ContextMenuItem[];
 }
 
 function DataTableV2Inner<TRow extends object = RowWithKey>(props: DataTableV2Props<TRow>, ref: React.Ref<DataTableRef<TRow>>) {
@@ -105,6 +107,7 @@ function DataTableV2Inner<TRow extends object = RowWithKey>(props: DataTableV2Pr
     summaryRowHeight,
     contextMenuItems,
     contextMenuAction,
+    getColumnHeaderMenuItems,
   } = props;
 
   const { table, gridId, orderedColumns, filters, filterSetValues, updateFilter, registerEditedValues } = useJetstreamTable<TRow>({
@@ -196,6 +199,7 @@ function DataTableV2Inner<TRow extends object = RowWithKey>(props: DataTableV2Pr
             summaryRowHeight={summaryRowHeight}
             contextMenuItems={contextMenuItems}
             contextMenuAction={contextMenuAction}
+            getColumnHeaderMenuItems={getColumnHeaderMenuItems}
           />
         </GridFilterContext.Provider>
       </GridGenericContext.Provider>

--- a/libs/ui/src/lib/data-table/grid/components/GridContainer.tsx
+++ b/libs/ui/src/lib/data-table/grid/components/GridContainer.tsx
@@ -68,6 +68,9 @@ export interface GridContainerProps<TRow> {
   contextMenuItems?: ContextMenuItems<TRow>;
   /** Right-click context menu action handler (must be stable). */
   contextMenuAction?: (item: ContextMenuItem, data: ContextMenuActionData<TRow>) => void;
+  /** Consumer-supplied builder for extra per-column header menu items, appended to the static header
+   * items. Routed through `contextMenuAction` on selection (with `actionData.column`). Must be stable. */
+  getColumnHeaderMenuItems?: (columnId: string) => ContextMenuItem[];
   /** Slot for editor popovers / context menu portals rendered as siblings of the grid. */
   children?: ReactNode;
 }
@@ -89,6 +92,7 @@ export function GridContainer<TRow = RowWithKey>({
   summaryRowHeight,
   contextMenuItems,
   contextMenuAction,
+  getColumnHeaderMenuItems,
   children,
 }: GridContainerProps<TRow>) {
   const scrollRef = useRef<HTMLDivElement>(null);
@@ -396,17 +400,35 @@ export function GridContainer<TRow = RowWithKey>({
   );
   const handleHeaderContextMenu = useCallback(
     (event: React.MouseEvent, columnId: string) => {
-      if (event.ctrlKey || event.metaKey || !headerContextMenuItems.length || NON_DATA_COLUMN_KEYS.has(columnId)) {
+      // Append any consumer-supplied per-column items (e.g. "View field metadata") to the static
+      // column-scoped copy actions.
+      const extraItems = getColumnHeaderMenuItems?.(columnId) ?? [];
+      const items = [...headerContextMenuItems, ...extraItems];
+      // Every header item is dispatched through `contextMenuAction` on selection — without it the menu
+      // would open but be unusable (selections become no-ops), so don't present it.
+      if (event.ctrlKey || event.metaKey || !contextMenuAction || !items.length || NON_DATA_COLUMN_KEYS.has(columnId)) {
         return;
       }
       event.preventDefault();
       const element = event.currentTarget as HTMLElement;
-      // Column/table copy operates over the whole column — anchor the action data on the first leaf row.
-      const actionData = buildCellActionData(getSortedFilteredLeafRows(table)[0]?.id ?? '', columnId);
+      // Column/table actions operate over the whole column — anchor on the first leaf row when present.
+      // Build the payload directly (rather than via buildCellActionData) so header-only actions like
+      // "View field metadata", which read just the column, still fire when the table has no rows.
+      const leafRows = getSortedFilteredLeafRows(table);
+      const column = table.getColumn(columnId)?.columnDef.meta?.jetstream?.column;
+      const actionData: ContextMenuActionData<TRow> | null = column
+        ? {
+            row: leafRows[0]?.original as TRow,
+            rows: leafRows.map((modelRow) => modelRow.original),
+            rowIdx: leafRows.length ? 0 : -1,
+            column,
+            columns: orderedColumns,
+          }
+        : null;
       setContextMenu(null);
-      setTimeout(() => setContextMenu({ area: 'header', columnId, element, items: headerContextMenuItems, actionData }));
+      setTimeout(() => setContextMenu({ area: 'header', columnId, element, items, actionData }));
     },
-    [headerContextMenuItems, table, buildCellActionData],
+    [headerContextMenuItems, table, orderedColumns, getColumnHeaderMenuItems, contextMenuAction],
   );
 
   // Closing the menu can strand DOM focus on <body> (the menu auto-focuses its items and unmounts on

--- a/libs/ui/src/lib/data-table/grid/grid-column-utils.tsx
+++ b/libs/ui/src/lib/data-table/grid/grid-column-utils.tsx
@@ -200,6 +200,15 @@ function getQueryResultColumn({
   if (!subqueryRelationshipName && !queryResultColumn?.aggregate && resolvedType === 'text' && isNameField) {
     updateColumnFromType(column, 'salesforceName');
   }
+
+  // Stash the Salesforce Field describe (when available) on the column's opaque meta bag so consumers
+  // (e.g. the "View field metadata" header menu) can reach it. Looks up by the resolved column key with
+  // a fallback to the bare field name — mirrors how `updateColumnWithEditMode` / the name-field check
+  // resolve metadata. Subquery columns pass their relationship-scoped map as `fieldMetadata`.
+  const fieldDescribe = fieldMetadata?.[column.key.toLowerCase()] ?? fieldMetadata?.[field.toLowerCase()];
+  if (fieldDescribe) {
+    column.meta = { field: fieldDescribe };
+  }
   return column;
 }
 

--- a/libs/ui/src/lib/data-table/grid/grid-types.ts
+++ b/libs/ui/src/lib/data-table/grid/grid-types.ts
@@ -226,6 +226,9 @@ export interface ColumnWithFilter<TRow = RowWithKey, TSummaryRow = unknown> {
   editable?: boolean | ((row: TRow) => boolean);
   renderEditCell?: (props: DataTableEditorProps<TRow, TSummaryRow>) => ReactNode;
   editorOptions?: ColumnEditorOptions;
+
+  /** Opaque per-column bag for consumers (e.g. Salesforce Field describe). The grid never reads this. */
+  meta?: Record<string, unknown>;
 }
 
 export type DefaultColumnOptions<TRow = RowWithKey, TSummaryRow = unknown> = Partial<
@@ -310,7 +313,8 @@ export type ContextAction =
   | 'COPY_COL_NO_HEADER'
   | 'COPY_TABLE'
   | 'COPY_TABLE_JSON'
-  | 'COPY_TABLE_CSV';
+  | 'COPY_TABLE_CSV'
+  | 'VIEW_FIELD_METADATA';
 
 export type ContextMenuActionData<T> = {
   row: T;

--- a/libs/ui/src/lib/form/context-menu/ContextMenu.tsx
+++ b/libs/ui/src/lib/form/context-menu/ContextMenu.tsx
@@ -211,6 +211,7 @@ export const ContextMenu: FunctionComponent<ContextMenuProps> = ({ parentElement
         <ul className="slds-dropdown__list" role="menu" aria-label={actionText} ref={ulContainerEl}>
           {items.map((item, i) => (
             <Fragment key={item.value}>
+              {item.leadingDivider && <li className="slds-has-divider_top-space" role="separator"></li>}
               {item.subheader && (
                 <li className="slds-dropdown__header slds-truncate" title={item.subheader} role="separator">
                   <span>{item.subheader}</span>


### PR DESCRIPTION
Right click on a field column header in query results and get access to view field metadata

Introduce a new FieldMetadataModal and integrate it with SalesforceRecordDataTable to allow users to view detailed field metadata directly from the data table. This enhancement improves the user experience by providing quick access to field information.