### PR TITLE
Fix secondaryType validation and add tests for convertFormulaSecondaryTypeToEvaluatorType

### DIFF
--- a/libs/features/create-object-and-fields/src/CreateFieldsFormulaEditor.tsx
+++ b/libs/features/create-object-and-fields/src/CreateFieldsFormulaEditor.tsx
@@ -75,7 +75,8 @@ export const CreateFieldsFormulaEditor = forwardRef<unknown, CreateFieldsFormula
 
     const monaco = useMonaco();
 
-    const formulaReturnType = convertFormulaSecondaryTypeToEvaluatorType(allValues.secondaryType.value as SalesforceFieldType);
+    const secondaryType = allValues.secondaryType.value;
+    const formulaReturnType = convertFormulaSecondaryTypeToEvaluatorType(typeof secondaryType === 'string' ? secondaryType : null);
 
     useEffect(() => {
       isMounted.current = true;

--- a/libs/features/create-object-and-fields/src/CreateFieldsImportExport.tsx
+++ b/libs/features/create-object-and-fields/src/CreateFieldsImportExport.tsx
@@ -104,7 +104,7 @@ export const CreateFieldsImportExport = ({ selectedOrg, rows, onImportRows, onLo
             if (field === 'deleteConstraint' && value) {
               value = ['SetNull', 'Cascade', 'Restrict'].includes(value) ? value : 'SetNull';
             }
-            if (field === 'secondaryType' && value) {
+            if (field === 'secondaryType') {
               value = ensureValidSecondaryType(value);
             }
             if (field === 'writeRequiresMasterRead' && value) {

--- a/libs/shared/ui-core/src/create-fields/__tests__/create-fields-utils.spec.ts
+++ b/libs/shared/ui-core/src/create-fields/__tests__/create-fields-utils.spec.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from 'vitest';
+import { convertFormulaSecondaryTypeToEvaluatorType, ensureValidSecondaryType } from '../create-fields-utils';
+
+describe('create-fields-utils#convertFormulaSecondaryTypeToEvaluatorType', () => {
+  test.each([
+    ['Checkbox', 'boolean'],
+    ['Currency', 'number'],
+    ['Date', 'date'],
+    ['DateTime', 'datetime'],
+    ['Number', 'number'],
+    ['Percent', 'number'],
+    ['Time', 'time'],
+    ['Text', 'string'],
+  ])('maps secondary type %s to %s', (input, expected) => {
+    expect(convertFormulaSecondaryTypeToEvaluatorType(input)).toBe(expected);
+  });
+
+  // Imported fields can omit the secondaryType column, leaving the value undefined - it must not throw
+  test.each([undefined, null])('returns string for missing secondary type (%s)', (input) => {
+    expect(convertFormulaSecondaryTypeToEvaluatorType(input)).toBe('string');
+  });
+
+  test('returns string for an unknown secondary type', () => {
+    expect(convertFormulaSecondaryTypeToEvaluatorType('SomethingElse')).toBe('string');
+  });
+});
+
+describe('create-fields-utils#ensureValidSecondaryType', () => {
+  test.each(['Checkbox', 'Currency', 'Date', 'DateTime', 'Number', 'Percent', 'Text', 'Time'])(
+    'passes through the canonical value %s',
+    (input) => {
+      expect(ensureValidSecondaryType(input)).toBe(input);
+    },
+  );
+
+  // Imported values only have their keys lowercased, so differently-cased values must still normalize to the canonical type
+  test.each([
+    ['checkbox', 'Checkbox'],
+    ['currency', 'Currency'],
+    ['DATETIME', 'DateTime'],
+    ['  number  ', 'Number'],
+  ])('normalizes %s to %s', (input, expected) => {
+    expect(ensureValidSecondaryType(input)).toBe(expected);
+  });
+
+  test.each(['', 'SomethingElse'])('falls back to Text for an unknown value (%s)', (input) => {
+    expect(ensureValidSecondaryType(input)).toBe('Text');
+  });
+
+  // XLSX parsing can yield non-string cell values - they must fall back to Text instead of throwing
+  test.each([123, true, false, new Date(0), {}, [], undefined, null])('falls back to Text for a non-string value (%s)', (input) => {
+    expect(ensureValidSecondaryType(input)).toBe('Text');
+  });
+});

--- a/libs/shared/ui-core/src/create-fields/create-fields-utils.tsx
+++ b/libs/shared/ui-core/src/create-fields/create-fields-utils.tsx
@@ -68,15 +68,21 @@ export function ensureValidType(type: string): SalesforceFieldType {
   );
 }
 
-export function ensureValidSecondaryType(type: string): string {
-  const validOptions = new Set(['Checkbox', 'Currency', 'Date', 'DateTime', 'Number', 'Percent', 'Text', 'Time']);
-  if (validOptions.has(type)) {
-    return type as SalesforceFieldType;
+export function ensureValidSecondaryType(type: unknown): string {
+  // Imported cell values are not guaranteed to be strings (e.g. XLSX parsing can yield numbers/booleans/dates)
+  if (typeof type !== 'string') {
+    return 'Text';
   }
-  return 'Text';
+  const validOptions = ['Checkbox', 'Currency', 'Date', 'DateTime', 'Number', 'Percent', 'Text', 'Time'];
+  const normalized = type.trim().toLowerCase();
+  // Match case-insensitively (consistent with ensureValidType) and return the canonical-cased value
+  return validOptions.find((option) => option.toLowerCase() === normalized) || 'Text';
 }
 
-export function convertFormulaSecondaryTypeToEvaluatorType(type: SalesforceFieldType): FormulaReturnType {
+export function convertFormulaSecondaryTypeToEvaluatorType(type: Maybe<string>): FormulaReturnType {
+  if (!type) {
+    return 'string';
+  }
   return ({
     checkbox: 'boolean',
     currency: 'number',


### PR DESCRIPTION
Update the validation for secondaryType to ensure it correctly handles various inputs. Add tests to verify the mapping of secondary types to evaluator types, including cases for undefined and unknown types. This resolves a BetterStack error related to secondaryType handling.