### PR TITLE
refactor: extract shared UI component changes ahead of analysis-tools feature

### DIFF
--- a/libs/icon-factory/src/lib/icon-factory.tsx
+++ b/libs/icon-factory/src/lib/icon-factory.tsx
@@ -23,7 +23,10 @@ import StandardIcon_Apex from './icons/standard/Apex';
 import StandardIcon_AssetRelationship from './icons/standard/AssetRelationship';
 import StandardIcon_Billing from './icons/standard/Billing';
 import StandardIcon_BundleConfig from './icons/standard/BundleConfig';
+import StandardIcon_Chart from './icons/standard/Chart';
 import StandardIcon_ConnectedApps from './icons/standard/ConnectedApps';
+import StandardIcon_Customers from './icons/standard/Customers';
+import StandardIcon_CustomerPortalUsers from './icons/standard/CustomerPortalUsers';
 import StandardIcon_DataStreams from './icons/standard/DataStreams';
 import StandardIcon_EmployeeOrganization from './icons/standard/EmployeeOrganization';
 import StandardIcon_Entity from './icons/standard/Entity';
@@ -32,6 +35,8 @@ import StandardIcon_Feed from './icons/standard/Feed';
 import StandardIcon_Feedback from './icons/standard/Feedback';
 import StandardIcon_Form from './icons/standard/Form';
 import StandardIcon_Formula from './icons/standard/Formula';
+import StandardIcon_Groups from './icons/standard/Groups';
+import StandardIcon_Incident from './icons/standard/Incident';
 import StandardIcon_MultiPicklist from './icons/standard/MultiPicklist';
 import StandardIcon_Opportunity from './icons/standard/Opportunity';
 import StandardIcon_Outcome from './icons/standard/Outcome';
@@ -56,6 +61,8 @@ import UtilityIcon_Announcement from './icons/utility/Announcement';
 import UtilityIcon_Apex from './icons/utility/Apex';
 import UtilityIcon_ApexPlugin from './icons/utility/ApexPlugin';
 import UtilityIcon_Archive from './icons/utility/Archive';
+import UtilityIcon_ArrowLeft from './icons/utility/ArrowLeft';
+import UtilityIcon_ArrowRight from './icons/utility/ArrowRight';
 import UtilityIcon_Arrowdown from './icons/utility/Arrowdown';
 import UtilityIcon_Arrowup from './icons/utility/Arrowup';
 import UtilityIcon_Back from './icons/utility/Back';
@@ -90,6 +97,7 @@ import UtilityIcon_ExpandAll from './icons/utility/ExpandAll';
 import UtilityIcon_ExpandAlt from './icons/utility/ExpandAlt';
 import UtilityIcon_Fallback from './icons/utility/Fallback';
 import UtilityIcon_Favorite from './icons/utility/Favorite';
+import UtilityIcon_Feed from './icons/utility/Feed';
 import UtilityIcon_File from './icons/utility/File';
 import UtilityIcon_Filter from './icons/utility/Filter';
 import UtilityIcon_FilterList from './icons/utility/FilterList';
@@ -203,7 +211,10 @@ const standardIcons = {
   asset_relationship: StandardIcon_AssetRelationship,
   billing: StandardIcon_Billing,
   bundle_config: StandardIcon_BundleConfig,
+  chart: StandardIcon_Chart,
   connected_apps: StandardIcon_ConnectedApps,
+  customers: StandardIcon_Customers,
+  customer_portal_users: StandardIcon_CustomerPortalUsers,
   data_streams: StandardIcon_DataStreams,
   employee_organization: StandardIcon_EmployeeOrganization,
   entity: StandardIcon_Entity,
@@ -212,6 +223,8 @@ const standardIcons = {
   feedback: StandardIcon_Feedback,
   form: StandardIcon_Form,
   formula: StandardIcon_Formula,
+  groups: StandardIcon_Groups,
+  incident: StandardIcon_Incident,
   multi_picklist: StandardIcon_MultiPicklist,
   opportunity: StandardIcon_Opportunity,
   outcome: StandardIcon_Outcome,
@@ -254,6 +267,8 @@ const utilityIcons = {
   apex_plugin: UtilityIcon_ApexPlugin,
   apex: UtilityIcon_Apex,
   archive: UtilityIcon_Archive,
+  arrow_left: UtilityIcon_ArrowLeft,
+  arrow_right: UtilityIcon_ArrowRight,
   arrowdown: UtilityIcon_Arrowdown,
   arrowup: UtilityIcon_Arrowup,
   back: UtilityIcon_Back,
@@ -288,6 +303,7 @@ const utilityIcons = {
   expand_alt: UtilityIcon_ExpandAlt,
   fallback: UtilityIcon_Fallback,
   favorite: UtilityIcon_Favorite,
+  feed: UtilityIcon_Feed,
   file: UtilityIcon_File,
   filter: UtilityIcon_Filter,
   filterList: UtilityIcon_FilterList,

--- a/libs/shared/ui-core/src/app/HeaderNavbar.tsx
+++ b/libs/shared/ui-core/src/app/HeaderNavbar.tsx
@@ -26,8 +26,8 @@ import { RecordSearchPopover } from '../record/RecordSearchPopover';
 import { UserSearchPopover } from '../record/UserSearchPopover';
 import HeaderDonatePopover from './HeaderDonatePopover';
 import HeaderHelpPopover from './HeaderHelpPopover';
-import { HeaderNavbarItems } from './HeaderNavbarItems';
-import { HeaderNavbarBillingUserItems } from './HeaderNavbarReadOnlyUserItems';
+import { useHeaderNavbarItems } from './HeaderNavbarItems';
+import { headerNavbarBillingUserItems } from './HeaderNavbarReadOnlyUserItems';
 import HeaderUpdateNotification from './HeaderUpdateNotification';
 import LogoPro from './jetstream-logo-pro-200w.png';
 import Logo from './jetstream-logo-v1-200w.png';
@@ -149,6 +149,7 @@ export const HeaderNavbar = ({
   const colorScheme: ColorScheme = userPreferences?.colorScheme ?? 'light';
   const [enableNotifications, setEnableNotifications] = useState(false);
   const [userMenuItems, setUserMenuItems] = useState<DropDownItem[]>([]);
+  const navbarItems = useHeaderNavbarItems();
 
   function handleUserMenuSelection(id: string) {
     switch (id) {
@@ -311,10 +312,7 @@ export const HeaderNavbar = ({
         isEmbeddedApp={isEmbeddedApp}
         onUserMenuItemSelected={handleUserMenuSelection}
       >
-        <Navbar>
-          {isReadOnlyUser && <HeaderNavbarBillingUserItems />}
-          {!isReadOnlyUser && <HeaderNavbarItems />}
-        </Navbar>
+        <Navbar items={isReadOnlyUser ? headerNavbarBillingUserItems : navbarItems} />
       </Header>
     </Fragment>
   );

--- a/libs/shared/ui-core/src/app/HeaderNavbarItems.tsx
+++ b/libs/shared/ui-core/src/app/HeaderNavbarItems.tsx
@@ -1,20 +1,31 @@
 import { APP_ROUTES } from '@jetstream/shared/ui-router';
-import { NavbarItem, NavbarItemWaffle, NavbarMenuItems } from '@jetstream/ui';
+import type { NavbarItemConfig } from '@jetstream/ui';
+import { useMemo } from 'react';
 
-export const HeaderNavbarItems = () => {
-  return (
-    <>
-      <NavbarItemWaffle path={APP_ROUTES.HOME.ROUTE} search={APP_ROUTES.HOME.SEARCH_PARAM} title="Home" assistiveText="Home Page" />
-      <NavbarItem
-        path={APP_ROUTES.QUERY.ROUTE}
-        search={APP_ROUTES.QUERY.SEARCH_PARAM}
-        title={APP_ROUTES.QUERY.DESCRIPTION}
-        label={APP_ROUTES.QUERY.TITLE}
-      />
-
-      <NavbarMenuItems
-        label="Load Records"
-        items={[
+export function useHeaderNavbarItems(): NavbarItemConfig[] {
+  return useMemo<NavbarItemConfig[]>(
+    () => [
+      {
+        id: 'home',
+        type: 'waffle',
+        path: APP_ROUTES.HOME.ROUTE,
+        search: APP_ROUTES.HOME.SEARCH_PARAM,
+        title: 'Home',
+        assistiveText: 'Home Page',
+      },
+      {
+        id: 'query',
+        type: 'item',
+        path: APP_ROUTES.QUERY.ROUTE,
+        search: APP_ROUTES.QUERY.SEARCH_PARAM,
+        title: APP_ROUTES.QUERY.DESCRIPTION,
+        label: APP_ROUTES.QUERY.TITLE,
+      },
+      {
+        id: 'load-records',
+        type: 'menu',
+        label: 'Load Records',
+        items: [
           {
             id: 'load',
             path: APP_ROUTES.LOAD.ROUTE,
@@ -43,25 +54,29 @@ export const HeaderNavbarItems = () => {
             title: APP_ROUTES.LOAD_CREATE_RECORD.DESCRIPTION,
             label: APP_ROUTES.LOAD_CREATE_RECORD.TITLE,
           },
-        ]}
-      />
-
-      <NavbarItem
-        path={APP_ROUTES.AUTOMATION_CONTROL.ROUTE}
-        search={APP_ROUTES.AUTOMATION_CONTROL.SEARCH_PARAM}
-        title={APP_ROUTES.AUTOMATION_CONTROL.DESCRIPTION}
-        label={APP_ROUTES.AUTOMATION_CONTROL.TITLE}
-      />
-      <NavbarItem
-        path={APP_ROUTES.PERMISSION_MANAGER.ROUTE}
-        search={APP_ROUTES.PERMISSION_MANAGER.SEARCH_PARAM}
-        title={APP_ROUTES.PERMISSION_MANAGER.DESCRIPTION}
-        label={APP_ROUTES.PERMISSION_MANAGER.TITLE}
-      />
-
-      <NavbarMenuItems
-        label="Deploy Metadata"
-        items={[
+        ],
+      },
+      {
+        id: 'automation-control',
+        type: 'item',
+        path: APP_ROUTES.AUTOMATION_CONTROL.ROUTE,
+        search: APP_ROUTES.AUTOMATION_CONTROL.SEARCH_PARAM,
+        title: APP_ROUTES.AUTOMATION_CONTROL.DESCRIPTION,
+        label: APP_ROUTES.AUTOMATION_CONTROL.TITLE,
+      },
+      {
+        id: 'permission-manager',
+        type: 'item',
+        path: APP_ROUTES.PERMISSION_MANAGER.ROUTE,
+        search: APP_ROUTES.PERMISSION_MANAGER.SEARCH_PARAM,
+        title: APP_ROUTES.PERMISSION_MANAGER.DESCRIPTION,
+        label: APP_ROUTES.PERMISSION_MANAGER.TITLE,
+      },
+      {
+        id: 'deploy-metadata',
+        type: 'menu',
+        label: 'Deploy Metadata',
+        items: [
           {
             id: 'deploy-metadata',
             path: APP_ROUTES.DEPLOY_METADATA.ROUTE,
@@ -90,12 +105,13 @@ export const HeaderNavbarItems = () => {
             title: APP_ROUTES.FORMULA_EVALUATOR.DESCRIPTION,
             label: APP_ROUTES.FORMULA_EVALUATOR.TITLE,
           },
-        ]}
-      />
-
-      <NavbarMenuItems
-        label="Developer Tools"
-        items={[
+        ],
+      },
+      {
+        id: 'developer-tools',
+        type: 'menu',
+        label: 'Developer Tools',
+        items: [
           {
             id: 'apex',
             path: APP_ROUTES.ANON_APEX.ROUTE,
@@ -131,11 +147,13 @@ export const HeaderNavbarItems = () => {
             title: APP_ROUTES.PLATFORM_EVENT_MONITOR.DESCRIPTION,
             label: APP_ROUTES.PLATFORM_EVENT_MONITOR.TITLE,
           },
-        ]}
-      />
-      <NavbarMenuItems
-        label="Documentation &amp; Support"
-        items={[
+        ],
+      },
+      {
+        id: 'documentation-support',
+        type: 'menu',
+        label: 'Documentation & Support',
+        items: [
           {
             id: 'feedback',
             path: APP_ROUTES.FEEDBACK_SUPPORT.ROUTE,
@@ -150,8 +168,9 @@ export const HeaderNavbarItems = () => {
             title: 'Documentation',
             label: 'Documentation',
           },
-        ]}
-      />
-    </>
+        ],
+      },
+    ],
+    [],
   );
-};
+}

--- a/libs/shared/ui-core/src/app/HeaderNavbarReadOnlyUserItems.tsx
+++ b/libs/shared/ui-core/src/app/HeaderNavbarReadOnlyUserItems.tsx
@@ -1,30 +1,37 @@
 import { APP_ROUTES } from '@jetstream/shared/ui-router';
-import { NavbarItem, NavbarItemWaffle } from '@jetstream/ui';
+import type { NavbarItemConfig } from '@jetstream/ui';
 
-export const HeaderNavbarBillingUserItems = () => {
-  return (
-    <>
-      <NavbarItemWaffle path={APP_ROUTES.HOME.ROUTE} search={APP_ROUTES.HOME.SEARCH_PARAM} title="Home" assistiveText="Home Page" />
-      <NavbarItem
-        path={APP_ROUTES.PROFILE.ROUTE}
-        search={APP_ROUTES.PROFILE.SEARCH_PARAM}
-        title={APP_ROUTES.PROFILE.DESCRIPTION}
-        label={APP_ROUTES.PROFILE.TITLE}
-      />
-
-      <NavbarItem
-        path={APP_ROUTES.BILLING.ROUTE}
-        search={APP_ROUTES.BILLING.SEARCH_PARAM}
-        title={APP_ROUTES.BILLING.DESCRIPTION}
-        label={APP_ROUTES.BILLING.TITLE}
-      />
-
-      <NavbarItem
-        path={APP_ROUTES.TEAM_DASHBOARD.ROUTE}
-        search={APP_ROUTES.TEAM_DASHBOARD.SEARCH_PARAM}
-        title={APP_ROUTES.TEAM_DASHBOARD.DESCRIPTION}
-        label={APP_ROUTES.TEAM_DASHBOARD.TITLE}
-      />
-    </>
-  );
-};
+export const headerNavbarBillingUserItems: NavbarItemConfig[] = [
+  {
+    id: 'home',
+    type: 'waffle',
+    path: APP_ROUTES.HOME.ROUTE,
+    search: APP_ROUTES.HOME.SEARCH_PARAM,
+    title: 'Home',
+    assistiveText: 'Home Page',
+  },
+  {
+    id: 'profile',
+    type: 'item',
+    path: APP_ROUTES.PROFILE.ROUTE,
+    search: APP_ROUTES.PROFILE.SEARCH_PARAM,
+    title: APP_ROUTES.PROFILE.DESCRIPTION,
+    label: APP_ROUTES.PROFILE.TITLE,
+  },
+  {
+    id: 'billing',
+    type: 'item',
+    path: APP_ROUTES.BILLING.ROUTE,
+    search: APP_ROUTES.BILLING.SEARCH_PARAM,
+    title: APP_ROUTES.BILLING.DESCRIPTION,
+    label: APP_ROUTES.BILLING.TITLE,
+  },
+  {
+    id: 'team-dashboard',
+    type: 'item',
+    path: APP_ROUTES.TEAM_DASHBOARD.ROUTE,
+    search: APP_ROUTES.TEAM_DASHBOARD.SEARCH_PARAM,
+    title: APP_ROUTES.TEAM_DASHBOARD.DESCRIPTION,
+    label: APP_ROUTES.TEAM_DASHBOARD.TITLE,
+  },
+];

--- a/libs/shared/ui-core/src/create-fields/create-fields-load-utils.ts
+++ b/libs/shared/ui-core/src/create-fields/create-fields-load-utils.ts
@@ -1,3 +1,4 @@
+import { parseCustomFieldApiNameForTooling } from '@jetstream/shared/utils';
 import { Field } from '@jetstream/types';
 import { CustomFieldMetadata, FieldValues, SalesforceFieldType } from './create-fields-types';
 import { getInitialValues } from './create-fields-utils';
@@ -338,11 +339,11 @@ export interface ExistingFieldRow {
 
 /**
  * Returns the namespace prefix from a custom field API name, or null if non-namespaced.
- * e.g. "ns__MyField__c" => "ns", "MyField__c" => null
+ * Uses {@link parseCustomFieldApiNameForTooling} so unmanaged names like `My_Field__c` are not mistaken for packaged fields.
  */
 function getFieldNamespacePrefix(fieldName: string): string | null {
-  const match = /^([A-Za-z0-9]+)__.+__c$/.exec(fieldName);
-  return match ? match[1] : null;
+  const parsed = parseCustomFieldApiNameForTooling(fieldName);
+  return parsed?.namespacePrefix ?? null;
 }
 
 /**

--- a/libs/shared/ui-core/src/load/LoadRecordsResultsModal.tsx
+++ b/libs/shared/ui-core/src/load/LoadRecordsResultsModal.tsx
@@ -13,6 +13,7 @@ import {
   CopyToClipboardWithToolTip,
   DataTable,
   getRowTypeFromValue,
+  getWrappedTextRowHeight,
   Grid,
   Icon,
   Modal,
@@ -33,7 +34,9 @@ const COL_WIDTH_MAP = {
   _errors: 450,
 };
 
-const getRowHeight = ({ row }: { type: 'ROW' | 'GROUP'; row: any }) => (row?._errors ? 75 : 25);
+// Grow rows to fit their wrapped error message, tracking the live width of the _errors column on resize.
+const getRowHeight = ({ row, columnWidths }: { type: 'ROW' | 'GROUP'; row: any; columnWidths: Record<string, number> }) =>
+  getWrappedTextRowHeight(row?._errors, columnWidths?.['_errors'] ?? COL_WIDTH_MAP._errors);
 
 const getDefaultSelectedRows = (rows: any[], selectable: boolean): ReadonlySet<Key> =>
   selectable ? new Set(rows.map((_row, i) => `id-${i}`)) : new Set();
@@ -84,9 +87,12 @@ export const LoadRecordsResultsModal: FunctionComponent<LoadRecordsResultsModalP
           item === '_errors'
             ? ({ row }) => (
                 <p
+                  title={row?._errors}
                   css={css`
                     white-space: pre-wrap;
+                    overflow-wrap: anywhere;
                     line-height: normal;
+                    overflow: hidden;
                   `}
                 >
                   {row._errors && (

--- a/libs/shared/ui-utils/src/lib/shared-ui-utils.ts
+++ b/libs/shared/ui-utils/src/lib/shared-ui-utils.ts
@@ -237,10 +237,10 @@ export function polyfillFieldDefinition(field: Field): string {
   let value = '';
 
   if (calculated && calculatedFormula) {
-    prefix = 'Formula(';
+    prefix = 'Formula (';
     suffix = ')';
   } else if (calculated) {
-    prefix = 'Roll-Up Summary(';
+    prefix = 'Roll-Up Summary (';
     suffix = ')';
   } else if (externalId) {
     suffix = ' (External Id)';
@@ -253,36 +253,36 @@ export function polyfillFieldDefinition(field: Field): string {
   } else if (nameField) {
     value = 'Name';
   } else if (type === 'textarea' && extraTypeInfo === 'plaintextarea') {
-    value = `${length > 255 ? 'Long ' : ''}Text Area(${length})`;
+    value = `${length > 255 ? 'Long ' : ''}Text Area (${length})`;
   } else if (type === 'textarea' && extraTypeInfo === 'richtextarea') {
-    value = `Rich Text Area(${length})`;
+    value = `Rich Text Area (${length})`;
   } else if (isRelationshipField(field)) {
     // includes text/reference if referenceTo has data
-    value = `Lookup(${(referenceTo || []).join(',')})`;
+    value = `Lookup (${(referenceTo || []).join(',')})`;
   } else if (type === 'string') {
-    value = `Text(${length})`;
+    value = `Text (${length})`;
   } else if (type === 'boolean') {
     value = 'Checkbox';
   } else if (type === 'datetime') {
     value = 'Date/Time';
   } else if (type === 'currency') {
-    value = `Currency(${precision}, ${scale})`;
+    value = `Currency (${precision}, ${scale})`;
   } else if (calculated && !calculatedFormula && !autoNumber) {
     value = `Number`;
   } else if (type === 'double' || type === 'int') {
     if (calculated) {
       value = `Number`;
     } else {
-      value = `Number(${precision}, ${scale})`;
+      value = `Number (${precision}, ${scale})`;
     }
   } else if (type === 'encryptedstring') {
-    value = `Text (Encrypted)(${length})`;
+    value = `Text (Encrypted) (${length})`;
   } else if (type === 'location') {
     value = 'Geolocation';
   } else if (type === 'percent') {
-    value = `Percent(${precision}, ${scale})`;
+    value = `Percent (${precision}, ${scale})`;
   } else if (type === 'url') {
-    value = `URL(${length})`;
+    value = `URL (${length})`;
   } else {
     // Address, Email, Date, Time, picklist, phone
     value = `${type[0].toUpperCase()}${type.substring(1)}`;

--- a/libs/shared/utils/src/index.ts
+++ b/libs/shared/utils/src/index.ts
@@ -1,3 +1,4 @@
+export * from './lib/custom-field-tooling-names';
+export * from './lib/password-validation';
 export * from './lib/regex';
 export * from './lib/utils';
-export * from './lib/password-validation';

--- a/libs/shared/utils/src/lib/__tests__/custom-field-tooling-names.spec.ts
+++ b/libs/shared/utils/src/lib/__tests__/custom-field-tooling-names.spec.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+import {
+  customFieldApiNameHasNamespacePrefix,
+  isCustomFieldApiName,
+  isUnmanagedCustomFieldApiName,
+  parseCustomFieldApiNameForTooling,
+} from '../custom-field-tooling-names';
+
+describe('parseCustomFieldApiNameForTooling', () => {
+  it('parses unmanaged custom fields (DeveloperName is API name without __c)', () => {
+    expect(parseCustomFieldApiNameForTooling('Amount__c')).toEqual({
+      namespacePrefix: null,
+      developerName: 'Amount',
+    });
+    expect(parseCustomFieldApiNameForTooling('Custom_Field__c')).toEqual({
+      namespacePrefix: null,
+      developerName: 'Custom_Field',
+    });
+  });
+
+  it('parses namespaced packaged fields into NamespacePrefix + DeveloperName', () => {
+    expect(parseCustomFieldApiNameForTooling('acme__Amount__c')).toEqual({
+      namespacePrefix: 'acme',
+      developerName: 'Amount',
+    });
+    expect(parseCustomFieldApiNameForTooling('ns__My_Custom_Field__c')).toEqual({
+      namespacePrefix: 'ns',
+      developerName: 'My_Custom_Field',
+    });
+  });
+
+  it('returns null for non-custom API names', () => {
+    expect(parseCustomFieldApiNameForTooling('Name')).toBeNull();
+    expect(parseCustomFieldApiNameForTooling('Lookup__r')).toBeNull();
+  });
+
+  it('returns null for malformed names with an empty namespace prefix or developer name', () => {
+    expect(parseCustomFieldApiNameForTooling('__Field__c')).toBeNull();
+    expect(parseCustomFieldApiNameForTooling('acme____c')).toBeNull();
+    expect(parseCustomFieldApiNameForTooling('__c')).toBeNull();
+  });
+});
+
+describe('isCustomFieldApiName', () => {
+  it('is true for custom field API names parseable for Tooling', () => {
+    expect(isCustomFieldApiName('Amount__c')).toBe(true);
+    expect(isCustomFieldApiName('acme__Amount__c')).toBe(true);
+  });
+
+  it('is false for standard and relationship suffixes', () => {
+    expect(isCustomFieldApiName('Name')).toBe(false);
+    expect(isCustomFieldApiName('Lookup__r')).toBe(false);
+  });
+});
+
+describe('isUnmanagedCustomFieldApiName', () => {
+  it('is true only when there is no namespace prefix', () => {
+    expect(isUnmanagedCustomFieldApiName('Amount__c')).toBe(true);
+    expect(isUnmanagedCustomFieldApiName('My_Field__c')).toBe(true);
+    expect(isUnmanagedCustomFieldApiName('acme__Amount__c')).toBe(false);
+    expect(isUnmanagedCustomFieldApiName('Name')).toBe(false);
+  });
+});
+
+describe('customFieldApiNameHasNamespacePrefix', () => {
+  it('is false for unmanaged custom fields', () => {
+    expect(customFieldApiNameHasNamespacePrefix('Amount__c')).toBe(false);
+    expect(customFieldApiNameHasNamespacePrefix('My_Field__c')).toBe(false);
+  });
+
+  it('is true for namespaced packaged custom fields', () => {
+    expect(customFieldApiNameHasNamespacePrefix('acme__Amount__c')).toBe(true);
+    expect(customFieldApiNameHasNamespacePrefix('ns__My_Custom_Field__c')).toBe(true);
+  });
+
+  it('is false for non-custom API names', () => {
+    expect(customFieldApiNameHasNamespacePrefix('Name')).toBe(false);
+  });
+});

--- a/libs/shared/utils/src/lib/__tests__/utils.spec.ts
+++ b/libs/shared/utils/src/lib/__tests__/utils.spec.ts
@@ -255,7 +255,7 @@ describe('utils.getErrorMessage', () => {
 describe('utils.dateFromTimestamp', () => {
   it('should return the correct date from a timestamp', () => {
     const timestamp = 1640995200; // January 1, 2022 00:00:00 UTC
-    const expectedDate = new Date(2022, 0, 1, 0, 0, 0);
+    const expectedDate = new Date(Date.UTC(2022, 0, 1, 0, 0, 0));
     expect(dateFromTimestamp(timestamp)).toEqual(expectedDate);
   });
 });

--- a/libs/shared/utils/src/lib/custom-field-tooling-names.ts
+++ b/libs/shared/utils/src/lib/custom-field-tooling-names.ts
@@ -1,0 +1,61 @@
+/**
+ * Tooling CustomField uses DeveloperName (no trailing __c) and optional NamespacePrefix.
+ *
+ * @see https://developer.salesforce.com/docs/atlas.en-us.api_tooling.meta/api_tooling/tooling_api_objects_customfield.htm
+ */
+export interface CustomFieldToolingNameParts {
+  namespacePrefix: string | null;
+  developerName: string;
+}
+
+/**
+ * Maps a custom field API name to Tooling CustomField query filters.
+ * Unmanaged: Amount__c → DeveloperName Amount, NamespacePrefix null.
+ * Managed: acme__Amount__c → DeveloperName Amount, NamespacePrefix acme.
+ */
+export function parseCustomFieldApiNameForTooling(fieldApiName: string): CustomFieldToolingNameParts | null {
+  const trimmed = fieldApiName.trim();
+  if (!trimmed.endsWith('__c')) {
+    return null;
+  }
+  const withoutSuffix = trimmed.slice(0, -3);
+  if (!withoutSuffix) {
+    return null;
+  }
+  const separatorIndex = withoutSuffix.indexOf('__');
+  if (separatorIndex === -1) {
+    return { namespacePrefix: null, developerName: withoutSuffix };
+  }
+  const namespacePrefix = withoutSuffix.slice(0, separatorIndex);
+  const developerName = withoutSuffix.slice(separatorIndex + 2);
+  // A `__` separator with an empty prefix or name (e.g. `__Field__c`, `acme____c`) is malformed
+  if (!namespacePrefix || !developerName) {
+    return null;
+  }
+  return { namespacePrefix, developerName };
+}
+
+/**
+ * True when the API name parses as a custom field (trailing `__c` with a usable developer name).
+ * False for standard fields, `__r` relationship suffixes, and malformed names.
+ */
+export function isCustomFieldApiName(fieldApiName: string): boolean {
+  return parseCustomFieldApiNameForTooling(fieldApiName) != null;
+}
+
+/**
+ * True for unmanaged custom fields (`Amount__c`). False for packaged (`acme__Amount__c`) and non-custom names.
+ */
+export function isUnmanagedCustomFieldApiName(fieldApiName: string): boolean {
+  const parsed = parseCustomFieldApiNameForTooling(fieldApiName);
+  return parsed != null && parsed.namespacePrefix == null;
+}
+
+/**
+ * True when the field API name includes a namespace prefix (e.g. packaged `acme__Amount__c`).
+ * Unmanaged custom fields (`Amount__c`) return false. Non-custom API names return false.
+ */
+export function customFieldApiNameHasNamespacePrefix(fieldApiName: string): boolean {
+  const parsed = parseCustomFieldApiNameForTooling(fieldApiName);
+  return parsed != null && parsed.namespacePrefix != null;
+}

--- a/libs/shared/utils/src/lib/regex.ts
+++ b/libs/shared/utils/src/lib/regex.ts
@@ -28,6 +28,6 @@ export const REGEX = {
   ENDS_WITH_NON_ALPHANUMERIC: /[^0-9a-zA-Z]+$/,
   CONSECUTIVE_UNDERSCORES: /_+/g,
   STARTS_WITH_NUMBER: /^[0-9]/,
-  SFDC_ID: /^([0-9a-zA-Z]{16}|[0-9a-zA-Z]{18})$/,
+  SFDC_ID: /^([0-9a-zA-Z]{15}|[0-9a-zA-Z]{18})$/,
   FILE_EXTENSION: /\.[a-z0-9]+$/i,
 };

--- a/libs/test-utils/src/test-setup-dom.ts
+++ b/libs/test-utils/src/test-setup-dom.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-empty-function */
+/* eslint-disable @typescript-eslint/no-useless-constructor */
 /**
  * Vitest setup for jsdom test environments that load `@dnd-kit/dom` (via `@dnd-kit/react`).
  *
@@ -8,6 +10,7 @@
  */
 if (typeof globalThis.ResizeObserver === 'undefined') {
   class ResizeObserverShim {
+    constructor(_callback: ResizeObserverCallback) {}
     observe(): void {}
     unobserve(): void {}
     disconnect(): void {}

--- a/libs/ui/src/lib/card/Card.tsx
+++ b/libs/ui/src/lib/card/Card.tsx
@@ -51,10 +51,17 @@ export const Card = forwardRef<HTMLElement, CardProps>(
               <div
                 className="slds-media__body"
                 css={css`
-                  min-width: fit-content;
+                  min-width: 0;
                 `}
               >
-                <h2 className="slds-card__header-title">{titleContent}</h2>
+                <h2
+                  className="slds-card__header-title"
+                  css={css`
+                    min-width: 0;
+                  `}
+                >
+                  {titleContent}
+                </h2>
               </div>
               {actions && (
                 <Grid

--- a/libs/ui/src/lib/data-table/DataTable.tsx
+++ b/libs/ui/src/lib/data-table/DataTable.tsx
@@ -76,6 +76,9 @@ export interface DataTableProps<T = RowWithKey, TContext = Record<string, any>> 
   defaultColumnOptions?: DefaultColumnOptions<T>;
   className?: string;
   'aria-label'?: string;
+  /** Opt-in: rows wrap and grow to fit their content (DOM-measured, virtualization preserved). Disables
+   * column virtualization, so use only for grids whose columns fit without horizontal scrolling. */
+  autoRowHeight?: boolean;
 }
 
 /** Map the legacy DataTable/DataTree prop surface onto DataTableV2 props (selection Set↔Record, etc.). */

--- a/libs/ui/src/lib/data-table/DataTableRenderers.tsx
+++ b/libs/ui/src/lib/data-table/DataTableRenderers.tsx
@@ -17,6 +17,7 @@ export {
   ValueOrLoadingRenderer,
   getRecordErrorColumn,
   getRecordErrorRowHeight,
+  getWrappedTextRowHeight,
 } from './grid/renderers/CellRenderers';
 export type { RowWithRecordError } from './grid/renderers/CellRenderers';
 export { SubqueryRenderer } from './grid/renderers/SubqueryRenderer';

--- a/libs/ui/src/lib/data-table/grid/DataTableV2.tsx
+++ b/libs/ui/src/lib/data-table/grid/DataTableV2.tsx
@@ -80,6 +80,9 @@ export interface DataTableV2Props<TRow = RowWithKey, TContext = Record<string, a
   contextMenuAction?: (item: ContextMenuItem, data: ContextMenuActionData<TRow>) => void;
   /** Consumer-supplied builder for extra per-column header menu items (must be stable). */
   getColumnHeaderMenuItems?: (columnId: string) => ContextMenuItem[];
+  /** Opt-in: rows wrap and size to their content (DOM-measured); disables column virtualization so every
+   * row's height accounts for all cells. Use only for grids whose columns fit without horizontal scroll. */
+  autoRowHeight?: boolean;
 }
 
 function DataTableV2Inner<TRow extends object = RowWithKey>(props: DataTableV2Props<TRow>, ref: React.Ref<DataTableRef<TRow>>) {
@@ -125,6 +128,7 @@ function DataTableV2Inner<TRow extends object = RowWithKey>(props: DataTableV2Pr
     contextMenuItems,
     contextMenuAction,
     getColumnHeaderMenuItems,
+    autoRowHeight,
   } = props;
 
   const { table, gridId, orderedColumns, filters, filterSetValues, updateFilter, registerEditedValues } = useJetstreamTable<TRow>({
@@ -222,6 +226,7 @@ function DataTableV2Inner<TRow extends object = RowWithKey>(props: DataTableV2Pr
             contextMenuItems={contextMenuItems}
             contextMenuAction={contextMenuAction}
             getColumnHeaderMenuItems={getColumnHeaderMenuItems}
+            autoRowHeight={autoRowHeight}
           />
         </GridFilterContext.Provider>
       </GridGenericContext.Provider>

--- a/libs/ui/src/lib/data-table/grid/components/GridBody.tsx
+++ b/libs/ui/src/lib/data-table/grid/components/GridBody.tsx
@@ -44,6 +44,10 @@ export interface GridBodyProps<TRow> {
   rowClass?: (row: TRow) => string | undefined;
   onStartEdit?: (rowId: string, columnId: string) => void;
   onCommitRow?: (updatedRow: TRow, rowId: string, columnId: string) => void;
+  /** When true, rows size to their content (cells wrap) and are DOM-measured by the virtualizer instead of
+   * pinned to `rowHeight`. The caller must also render every column (no horizontal virtualization) so a
+   * row's measured height reflects all its cells — `GridContainer` does this when `autoRowHeight` is set. */
+  autoRowHeight?: boolean;
 }
 
 // In-cell controls are removed from the page tab order (tabindex="-1") so the grid is a single tab stop.
@@ -77,6 +81,7 @@ export function GridBody<TRow>({
   rowClass,
   onStartEdit,
   onCommitRow,
+  autoRowHeight,
 }: GridBodyProps<TRow>) {
   const { rows } = table.getRowModel();
   const leafColumns = table.getVisibleLeafColumns();
@@ -117,7 +122,11 @@ export function GridBody<TRow>({
     },
     overscan,
     getItemKey: (index) => rows[index].id,
+    // In auto-height mode the estimate above is only the initial guess; the virtualizer measures each
+    // rendered row's real height (rows wrap to content) and corrects the offsets, keeping virtualization.
+    ...(autoRowHeight ? { measureElement: (el: Element | null) => el?.getBoundingClientRect().height ?? DEFAULT_ROW_HEIGHT } : {}),
   });
+  const measureRowRef = autoRowHeight ? rowVirtualizer.measureElement : undefined;
 
   // Resolve the active cell to a DOM node: scroll its row into view, then focus the cell (navigation)
   // or the first focusable inside it (actionable). Runs only when the coordinate/mode changes — NOT on
@@ -254,6 +263,8 @@ export function GridBody<TRow>({
               height={virtualRow.size}
               activeCell={rowActiveCell}
               onCellMouseDown={onCellMouseDown}
+              autoHeight={autoRowHeight}
+              measureRef={measureRowRef}
             />
           );
         }
@@ -280,6 +291,8 @@ export function GridBody<TRow>({
             onCellContextMenu={onCellContextMenu}
             onStartEdit={onStartEdit}
             onCommitRow={onCommitRow}
+            autoHeight={autoRowHeight}
+            measureRef={measureRowRef}
           />
         );
       })}

--- a/libs/ui/src/lib/data-table/grid/components/GridContainer.tsx
+++ b/libs/ui/src/lib/data-table/grid/components/GridContainer.tsx
@@ -98,6 +98,9 @@ export interface GridContainerProps<TRow> {
   getColumnHeaderMenuItems?: (columnId: string) => ContextMenuItem[];
   /** Slot for editor popovers / context menu portals rendered as siblings of the grid. */
   children?: ReactNode;
+  /** When true, rows size to their content (cells wrap, DOM-measured) and ALL columns render (horizontal
+   * virtualization off) so each row's measured height accounts for every cell. Opt-in per grid. */
+  autoRowHeight?: boolean;
 }
 
 export function GridContainer<TRow = RowWithKey>({
@@ -124,6 +127,7 @@ export function GridContainer<TRow = RowWithKey>({
   contextMenuAction,
   getColumnHeaderMenuItems,
   children,
+  autoRowHeight,
 }: GridContainerProps<TRow>) {
   const scrollRef = useRef<HTMLDivElement>(null);
   const gridRef = useRef<HTMLDivElement>(null);
@@ -312,13 +316,17 @@ export function GridContainer<TRow = RowWithKey>({
     });
     return indexes;
   }, [leafColumns]);
-  const visibleColumnIndexes = useMemo(() => {
+  const windowedColumnIndexes = useMemo(() => {
     const indexes = new Set<number>(frozenColumnIndexes);
     for (const virtualColumn of virtualColumns) {
       indexes.add(virtualColumn.index);
     }
     return Array.from(indexes).sort((a, b) => a - b);
   }, [virtualColumns, frozenColumnIndexes]);
+  const allColumnIndexes = useMemo(() => leafColumns.map((_, index) => index), [leafColumns]);
+  // Auto-height rows are DOM-measured, so every column must render (otherwise a row's measured height
+  // would miss cells outside the horizontal window). Trade horizontal virtualization for correct heights.
+  const visibleColumnIndexes = autoRowHeight ? allColumnIndexes : windowedColumnIndexes;
 
   // Scroll the active column into view (mirrors the active-row logic in GridBody) so keyboard
   // navigation to off-screen columns brings them into the window before focus resolves.
@@ -795,6 +803,7 @@ export function GridContainer<TRow = RowWithKey>({
               rowClass={rowClass}
               onStartEdit={handleStartEdit}
               onCommitRow={handleCellCommit}
+              autoRowHeight={autoRowHeight}
             />
           </div>
         </div>

--- a/libs/ui/src/lib/data-table/grid/components/GridGroupRow.tsx
+++ b/libs/ui/src/lib/data-table/grid/components/GridGroupRow.tsx
@@ -19,6 +19,10 @@ export interface GridGroupRowProps<TRow> {
   height: number;
   activeCell?: ActiveCell | null;
   onCellMouseDown?: (rowId: string, columnId: string, shiftKey: boolean, button?: number) => void;
+  /** When true the group row sizes to its content instead of being pinned to `height`. */
+  autoHeight?: boolean;
+  /** Virtualizer `measureElement` ref; attached in auto-height mode so the row's real height is measured. */
+  measureRef?: (el: HTMLElement | null) => void;
 }
 
 // `row.getLeafRows()` walks + maps the entire group on every call; cache per TanStack row instance
@@ -51,6 +55,8 @@ export function GridGroupRow<TRow>({
   height,
   activeCell,
   onCellMouseDown,
+  autoHeight,
+  measureRef,
 }: GridGroupRowProps<TRow>) {
   const isExpanded = row.getIsExpanded();
   const firstColumnId = columns[0]?.id;
@@ -66,17 +72,20 @@ export function GridGroupRow<TRow>({
     />
   );
 
-  const rowStyle: CSSProperties = { transform: `translateY(${virtualStart}px)`, blockSize: height, gridTemplateColumns };
+  const rowStyle: CSSProperties = autoHeight
+    ? { transform: `translateY(${virtualStart}px)`, gridTemplateColumns }
+    : { transform: `translateY(${virtualStart}px)`, blockSize: height, gridTemplateColumns };
   const anyGroupCell = columns.some((column) => column.columnDef.meta?.jetstream?.renderGroupCell);
 
   const baseRowProps = {
+    ref: autoHeight ? measureRef : undefined,
     role: 'row' as const,
     'aria-rowindex': ariaRowIndex,
     'aria-level': (row.depth ?? 0) + 1,
     'aria-expanded': isExpanded,
     'data-row-id': row.id,
     'data-index': rowIndex,
-    className: 'jgrid-group-row',
+    className: autoHeight ? 'jgrid-group-row jgrid-row-auto-height' : 'jgrid-group-row',
   };
 
   // Fallback: single full-width group header.
@@ -119,7 +128,7 @@ export function GridGroupRow<TRow>({
     // Group rows resolve span via the GROUP discriminant so a column can span the header (e.g. the
     // grouping column owning the toggle + label) without widening that column on data rows. Clamp to the
     // remaining tracks so an over-large span can't overrun the row.
-    const requestedSpan = meta?.colSpan?.({ type: 'GROUP', row: representativeRow }) ?? 1;
+    const requestedSpan = meta?.colSpan?.({ type: 'GROUP', row: representativeRow, groupingColumnId: row.groupingColumnId }) ?? 1;
     const span = Math.max(1, Math.min(requestedSpan, columns.length - index));
     // A spanning cell is visible when any of the tracks it covers is in the visible window.
     let cellIsVisible = false;

--- a/libs/ui/src/lib/data-table/grid/components/GridRow.tsx
+++ b/libs/ui/src/lib/data-table/grid/components/GridRow.tsx
@@ -41,6 +41,10 @@ export interface GridRowProps<TRow> {
   onCellContextMenu?: (event: React.MouseEvent, rowId: string, columnId: string) => void;
   onStartEdit?: (rowId: string, columnId: string) => void;
   onCommitRow?: (updatedRow: TRow, rowId: string, columnId: string) => void;
+  /** When true the row sizes to its content (cells wrap) instead of being pinned to `height`. */
+  autoHeight?: boolean;
+  /** Virtualizer `measureElement` ref; attached to the row in auto-height mode so its real height is measured. */
+  measureRef?: (el: HTMLElement | null) => void;
 }
 
 function GridRowComponent<TRow>({
@@ -63,16 +67,17 @@ function GridRowComponent<TRow>({
   onCellContextMenu,
   onStartEdit,
   onCommitRow,
+  autoHeight,
+  measureRef,
 }: GridRowProps<TRow>) {
   const original = row.original as TRow & Partial<RowWithKey>;
   const consumerRowClass = rowClass?.(row.original);
   const cells = row.getVisibleCells();
 
-  const style: CSSProperties = {
-    gridTemplateColumns,
-    blockSize: height,
-    transform: `translateY(${virtualStart}px)`,
-  };
+  // Auto-height: let the row grow to its (wrapping) content and be DOM-measured; don't pin `blockSize`.
+  const style: CSSProperties = autoHeight
+    ? { gridTemplateColumns, transform: `translateY(${virtualStart}px)` }
+    : { gridTemplateColumns, blockSize: height, transform: `translateY(${virtualStart}px)` };
 
   // ROW colSpan support (e.g. deploy's "No metadata found" message spanning several tracks). Resolve
   // span ownership across ALL columns so it stays stable as the horizontal window moves, then render
@@ -131,6 +136,7 @@ function GridRowComponent<TRow>({
 
   return (
     <div
+      ref={autoHeight ? measureRef : undefined}
       role="row"
       aria-rowindex={ariaRowIndex}
       aria-level={row.depth > 0 ? row.depth + 1 : undefined}
@@ -138,9 +144,14 @@ function GridRowComponent<TRow>({
       aria-selected={row.getCanSelect() ? isSelected : undefined}
       data-row-id={row.id}
       data-index={rowIndex}
-      className={classNames('jgrid-row', { 'jgrid-row-selected': isSelected, 'jgrid-row-last': isLastRow }, consumerRowClass, {
-        'save-error': !!(original as Partial<RowWithKey>)?._saveError,
-      })}
+      className={classNames(
+        'jgrid-row',
+        { 'jgrid-row-selected': isSelected, 'jgrid-row-last': isLastRow, 'jgrid-row-auto-height': autoHeight },
+        consumerRowClass,
+        {
+          'save-error': !!(original as Partial<RowWithKey>)?._saveError,
+        },
+      )}
       style={style}
     >
       {renderedCells}
@@ -169,7 +180,8 @@ function gridRowPropsAreEqual(prev: GridRowProps<any>, next: GridRowProps<any>):
     prev.isExpanded === next.isExpanded &&
     prev.isLastRow === next.isLastRow &&
     prev.selectionColRange === next.selectionColRange &&
-    prev.rowClass === next.rowClass
+    prev.rowClass === next.rowClass &&
+    prev.autoHeight === next.autoHeight
   );
 }
 

--- a/libs/ui/src/lib/data-table/grid/data-table-grid.css
+++ b/libs/ui/src/lib/data-table/grid/data-table-grid.css
@@ -198,6 +198,21 @@
   background-color: var(--jgrid-row-hover);
 }
 
+/* Auto-height rows (opt-in `autoRowHeight`): the virtualizer measures each row, so it grows to fit wrapped
+   cell content instead of being pinned. Cells wrap, top-align, and don't clip. */
+.jgrid-row-auto-height {
+  grid-auto-rows: auto;
+  min-block-size: 1.875rem;
+}
+.jgrid-row-auto-height .jgrid-cell {
+  white-space: normal;
+  overflow: visible;
+  text-overflow: clip;
+  align-items: flex-start;
+  overflow-wrap: anywhere;
+  padding-block: 0.25rem;
+}
+
 .jgrid-row-selected,
 .jgrid-row-selected:hover {
   background-color: var(--jgrid-row-selected);

--- a/libs/ui/src/lib/data-table/grid/grid-types.ts
+++ b/libs/ui/src/lib/data-table/grid/grid-types.ts
@@ -198,7 +198,9 @@ export type ColSpanArgs<TRow = RowWithKey> =
   | { type: 'HEADER'; row?: undefined }
   | { type: 'ROW'; row: TRow }
   | { type: 'SUMMARY'; row: TRow }
-  | { type: 'GROUP'; row?: TRow };
+  // `groupingColumnId` is the column that grouped THIS header's level — lets a column span the header only
+  // at its own level (e.g. multi-level grouping where each level's grouping column spans the full row).
+  | { type: 'GROUP'; row?: TRow; groupingColumnId?: string };
 
 // ─────────────────────────────────────────────────────────────────────────────
 // The public, author-facing column definition (detached from react-data-grid `Column`)

--- a/libs/ui/src/lib/data-table/grid/renderers/CellRenderers.tsx
+++ b/libs/ui/src/lib/data-table/grid/renderers/CellRenderers.tsx
@@ -309,11 +309,29 @@ export function RecordErrorMessageRenderer({ row }: DataTableCellProps<RowWithKe
 }
 
 /**
- * Estimate the row height needed to show a row's full (wrapped) record-error message. Grid rows are
- * pinned to a fixed height (never DOM-measured), so approximate the wrapped line count from the message
- * length and the error column's current width, then clamp. Pass the grid's live `columnWidths` map so the
- * estimate tracks resizes; falls back to the default width when omitted. Returns `defaultRowHeight` for
- * rows without a message.
+ * Estimate the row height needed to show a full wrapped message in a column of the given width. Grid rows
+ * are pinned to a fixed height (never DOM-measured), so approximate the wrapped line count from the
+ * message length and the column width, then clamp to {@link RECORD_ERROR_MAX_LINES}. Returns
+ * `defaultRowHeight` for empty messages. Pair with a cell that wraps (`white-space: pre-wrap`) and hides
+ * overflow, keeping the full text available via a title tooltip.
+ */
+export function getWrappedTextRowHeight(
+  message: string | null | undefined,
+  columnWidth = RECORD_ERROR_COLUMN_WIDTH,
+  defaultRowHeight = DEFAULT_ROW_HEIGHT,
+): number {
+  if (!message) {
+    return defaultRowHeight;
+  }
+  const charsPerLine = Math.max(1, Math.floor((columnWidth - RECORD_ERROR_CELL_PADDING) / RECORD_ERROR_CHAR_WIDTH));
+  const lineCount = message.split('\n').reduce((total, segment) => total + Math.max(1, Math.ceil(segment.length / charsPerLine)), 0);
+  return Math.max(defaultRowHeight, Math.min(lineCount, RECORD_ERROR_MAX_LINES) * RECORD_ERROR_LINE_HEIGHT);
+}
+
+/**
+ * Estimate the row height needed to show a row's full (wrapped) record-error message in the standalone
+ * "Error" column. Pass the grid's live `columnWidths` map so the estimate tracks resizes; falls back to
+ * the default width when omitted. Returns `defaultRowHeight` for rows without a message.
  */
 export function getRecordErrorRowHeight(
   row: RowWithKey,
@@ -321,13 +339,7 @@ export function getRecordErrorRowHeight(
   defaultRowHeight = DEFAULT_ROW_HEIGHT,
 ): number {
   const { status } = row as RowWithRecordError;
-  if (!status) {
-    return defaultRowHeight;
-  }
-  const columnWidth = columnWidths?.[INLINE_ERROR_COLUMN_KEY] ?? RECORD_ERROR_COLUMN_WIDTH;
-  const charsPerLine = Math.max(1, Math.floor((columnWidth - RECORD_ERROR_CELL_PADDING) / RECORD_ERROR_CHAR_WIDTH));
-  const lineCount = status.split('\n').reduce((total, segment) => total + Math.max(1, Math.ceil(segment.length / charsPerLine)), 0);
-  return Math.max(defaultRowHeight, Math.min(lineCount, RECORD_ERROR_MAX_LINES) * RECORD_ERROR_LINE_HEIGHT);
+  return getWrappedTextRowHeight(status, columnWidths?.[INLINE_ERROR_COLUMN_KEY] ?? RECORD_ERROR_COLUMN_WIDTH, defaultRowHeight);
 }
 
 /** Build the standalone, non-sortable/non-filterable "Error" column backed by {@link RecordErrorMessageRenderer}. */

--- a/libs/ui/src/lib/nav/Navbar.tsx
+++ b/libs/ui/src/lib/nav/Navbar.tsx
@@ -1,14 +1,166 @@
-import { FunctionComponent } from 'react';
+import { css } from '@emotion/react';
+import { FunctionComponent, useLayoutEffect, useRef, useState } from 'react';
+import { NavbarItem, NavbarItemProps } from './NavbarItem';
+import { NavbarItemWaffle, NavbarItemWaffleProps } from './NavbarItemWaffle';
+import { NavbarMenuItem, NavbarMenuItems, NavbarMenuItemsProps } from './NavbarMenuItems';
+
+export type NavbarItemConfig =
+  | ({ id: string; type: 'waffle' } & NavbarItemWaffleProps)
+  | ({ id: string; type: 'item' } & NavbarItemProps)
+  | ({ id: string; type: 'menu' } & NavbarMenuItemsProps);
 
 export interface NavbarProps {
-  children?: React.ReactNode;
+  items: NavbarItemConfig[];
 }
 
-export const Navbar: FunctionComponent<NavbarProps> = ({ children }) => {
+function renderNavbarItem(config: NavbarItemConfig) {
+  switch (config.type) {
+    case 'waffle':
+      return <NavbarItemWaffle key={config.id} {...config} />;
+    case 'item':
+      return <NavbarItem key={config.id} {...config} />;
+    case 'menu':
+      return <NavbarMenuItems key={config.id} {...config} />;
+    default:
+      return null;
+  }
+}
+
+/**
+ * Flatten the items that no longer fit into a single list for the "More" dropdown. Dropdown menus
+ * keep their label as a section heading, while plain items become standalone links - matching the
+ * Salesforce overflow pattern where nested menus are flattened into headed sections.
+ */
+function buildOverflowMenuItems(overflowConfigs: NavbarItemConfig[]): NavbarMenuItem[] {
+  const overflowMenuItems: NavbarMenuItem[] = [];
+  overflowConfigs.forEach((config) => {
+    switch (config.type) {
+      case 'menu':
+        config.items.forEach((item, index) => {
+          overflowMenuItems.push(index === 0 ? { ...item, heading: config.label } : item);
+        });
+        break;
+      case 'item':
+        overflowMenuItems.push({
+          id: config.id,
+          path: config.path,
+          search: config.search,
+          title: config.title,
+          label: config.label,
+        });
+        break;
+      // 'waffle' is always kept visible, so it never reaches the overflow menu
+    }
+  });
+  return overflowMenuItems;
+}
+
+function computeVisibleCount(itemWidths: number[], moreWidth: number, availableWidth: number): number {
+  const totalWidth = itemWidths.reduce((total, width) => total + width, 0);
+  if (totalWidth <= availableWidth) {
+    return itemWidths.length;
+  }
+  // Everything no longer fits, so reserve room for the "More" trigger and fit as many leading items as possible
+  let usedWidth = moreWidth;
+  let visibleCount = 0;
+  for (const width of itemWidths) {
+    if (usedWidth + width > availableWidth) {
+      break;
+    }
+    usedWidth += width;
+    visibleCount += 1;
+  }
+  // Always keep at least the first item (the Home/waffle) visible
+  return Math.max(1, visibleCount);
+}
+
+/**
+ * Responsive navigation bar that mirrors the Salesforce context bar: items render inline until they no
+ * longer fit the available width, at which point the overflow collapses into a "More" dropdown.
+ *
+ * Widths are read from a hidden, inert copy of the full item list so that each item's natural width is
+ * always known - even while it is collapsed into the overflow menu - which keeps the calculation stable
+ * and avoids the layout feedback loop of measuring the same elements we are adding/removing.
+ */
+export const Navbar: FunctionComponent<NavbarProps> = ({ items }) => {
+  const containerRef = useRef<HTMLUListElement>(null);
+  const measureRef = useRef<HTMLUListElement>(null);
+  const [visibleCount, setVisibleCount] = useState(items.length);
+
+  useLayoutEffect(() => {
+    const container = containerRef.current;
+    const measure = measureRef.current;
+    if (!container || !measure) {
+      return;
+    }
+
+    const recompute = () => {
+      // The measurement row renders every item followed by the "More" trigger, so the trailing child is "More"
+      const measuredChildren = Array.from(measure.children) as HTMLElement[];
+      if (measuredChildren.length === 0) {
+        return;
+      }
+      const moreWidth = measuredChildren[measuredChildren.length - 1].offsetWidth;
+      const itemWidths = measuredChildren.slice(0, items.length).map((element) => element.offsetWidth);
+      setVisibleCount(computeVisibleCount(itemWidths, moreWidth, container.clientWidth));
+    };
+
+    const resizeObserver = new ResizeObserver(recompute);
+    resizeObserver.observe(container);
+    recompute();
+    return () => resizeObserver.disconnect();
+  }, [items]);
+
+  const hasOverflow = visibleCount < items.length;
+  const visibleItems = hasOverflow ? items.slice(0, visibleCount) : items;
+  const overflowMenuItems = hasOverflow ? buildOverflowMenuItems(items.slice(visibleCount)) : [];
+
   return (
     <div className="slds-context-bar">
-      <nav className="slds-context-bar__secondary" role="navigation">
-        <ul className="slds-grid">{children}</ul>
+      <nav
+        className="slds-context-bar__secondary"
+        role="navigation"
+        css={css`
+          position: relative;
+        `}
+      >
+        <ul
+          className="slds-grid"
+          ref={containerRef}
+          css={css`
+            flex: 1 1 auto;
+            min-width: 0;
+          `}
+        >
+          {visibleItems.map(renderNavbarItem)}
+          {hasOverflow && <NavbarMenuItems label="More" items={overflowMenuItems} />}
+        </ul>
+
+        {/* Hidden, inert copy of the full list used only to measure each item's natural width */}
+        <div
+          aria-hidden
+          css={css`
+            position: absolute;
+            inset: 0;
+            overflow: hidden;
+            visibility: hidden;
+            pointer-events: none;
+          `}
+        >
+          <ul
+            className="slds-grid"
+            ref={measureRef}
+            inert
+            css={css`
+              position: absolute;
+              top: 0;
+              left: 0;
+            `}
+          >
+            {items.map(renderNavbarItem)}
+            <NavbarMenuItems label="More" items={[]} />
+          </ul>
+        </div>
       </nav>
     </div>
   );

--- a/libs/ui/src/lib/nav/NavbarMenuItems.tsx
+++ b/libs/ui/src/lib/nav/NavbarMenuItems.tsx
@@ -247,7 +247,8 @@ export const NavbarMenuItems: FunctionComponent<NavbarMenuItemsProps> = ({ label
               return (
                 <Fragment key={item.id}>
                   {item.heading && (
-                    <li className="slds-dropdown__header slds-has-divider_top-space" role="separator">
+                    // Skip the top divider/spacing on the first row so a leading heading doesn't render a stray border
+                    <li className={classNames('slds-dropdown__header', { 'slds-has-divider_top-space': i > 0 })} role="separator">
                       {item.heading}
                     </li>
                   )}

--- a/libs/ui/src/lib/popover/Popover.tsx
+++ b/libs/ui/src/lib/popover/Popover.tsx
@@ -170,7 +170,7 @@ const PopoverComponent = ({
     };
   }, [isOpen, refs.floating, refs.domReference, isInPortal]);
 
-  const { as: TriggerElement = 'button', ...restButtonProps } = buttonProps || {};
+  const { as: TriggerElement = 'button', style: triggerStyleFromButtonProps, ...restButtonProps } = buttonProps || {};
 
   const mergedButtonProps = {
     ...getReferenceProps(),
@@ -183,7 +183,7 @@ const PopoverComponent = ({
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       'onClick' in restButtonProps && typeof restButtonProps.onClick === 'function' && restButtonProps.onClick?.(ev as any);
     },
-    style: buttonStyle,
+    style: { ...triggerStyleFromButtonProps, ...buttonStyle },
   };
 
   const triggerProps = TriggerElement === 'button' ? { ...mergedButtonProps, type: 'button' as const } : mergedButtonProps;

--- a/libs/ui/src/lib/sobject-field-list/WhereIsThisFieldUsed.tsx
+++ b/libs/ui/src/lib/sobject-field-list/WhereIsThisFieldUsed.tsx
@@ -1,5 +1,6 @@
 import { css } from '@emotion/react';
 import { copyRecordsToClipboard, useNonInitialEffect } from '@jetstream/shared/ui-utils';
+import { isCustomFieldApiName } from '@jetstream/shared/utils';
 import { ListItem, SalesforceOrgUi } from '@jetstream/types';
 import { applicationCookieState, googleDriveAccessState } from '@jetstream/ui/app-state';
 import { useAtomValue } from 'jotai';
@@ -19,18 +20,16 @@ interface QueryWhereIsThisUsedProps {
   field: string;
 }
 
-const CUSTOM_FIELD_SUFFIX = /__c/;
-
 export const QueryWhereIsThisUsed = ({ org, sobject, field }: QueryWhereIsThisUsedProps) => {
   const [isOpen, setIsOpen] = useState(false);
   const [exportModalOpen, setExportModalOpen] = useState(false);
-  const [fieldName] = useState(() => field.replace(CUSTOM_FIELD_SUFFIX, ''));
-  const [isFieldEligible] = useState(() => CUSTOM_FIELD_SUFFIX.test(field));
+  const [isFieldEligible] = useState(() => isCustomFieldApiName(field));
   const [exportData, setExportData] = useState<{ 'Reference Type': string; 'Reference Label': string; Namespace: string }[]>([]);
   const { google_apiKey, google_appId, google_clientId } = useAtomValue(applicationCookieState);
   const { hasGoogleDriveAccess, googleShowUpgradeToPro } = useAtomValue(googleDriveAccessState);
 
-  const { loadDependencies, loading, items, hasLoaded, hasError, errorMessage } = useWhereIsThisUsed(org, sobject, fieldName);
+  // The hook expects the full field API name (e.g. `Amount__c`, `acme__Amount__c`) and handles namespace/suffix parsing
+  const { loadDependencies, loading, items, hasLoaded, hasError, errorMessage } = useWhereIsThisUsed(org, sobject, field);
 
   useNonInitialEffect(() => {
     if (isFieldEligible && isOpen && !hasLoaded) {
@@ -80,7 +79,7 @@ export const QueryWhereIsThisUsed = ({ org, sobject, field }: QueryWhereIsThisUs
           google_clientId={google_clientId}
           data={exportData}
           header={['Reference Type', 'Reference Label', 'Namespace']}
-          fileNameParts={['dependencies', `${sobject}.${fieldName}`]}
+          fileNameParts={['dependencies', `${sobject}.${field}`]}
           onModalClose={() => setExportModalOpen(false)}
           source="where_is_this_used"
           // This one is too much trouble to pass down amplitude dependency

--- a/libs/ui/src/lib/sobject-field-list/__tests__/useWhereIsThisUsed.spec.ts
+++ b/libs/ui/src/lib/sobject-field-list/__tests__/useWhereIsThisUsed.spec.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { getEntityDefinitionQuery } from '../useWhereIsThisUsed';
+
+describe('getEntityDefinitionQuery', () => {
+  it('queries by DeveloperName with a null namespace for unmanaged custom fields', () => {
+    const soql = getEntityDefinitionQuery('Account', 'Amount__c');
+    expect(soql).toContain(`EntityDefinition.QualifiedApiName = 'Account'`);
+    expect(soql).toContain(`DeveloperName = 'Amount'`);
+    expect(soql).toContain(`NamespacePrefix = null`);
+  });
+
+  it('queries by DeveloperName and NamespacePrefix for managed package fields', () => {
+    const soql = getEntityDefinitionQuery('Account', 'acme__Amount__c');
+    expect(soql).toContain(`DeveloperName = 'Amount'`);
+    expect(soql).toContain(`NamespacePrefix = 'acme'`);
+  });
+
+  it('returns a no-result query for non-custom field API names', () => {
+    expect(getEntityDefinitionQuery('Account', 'Name')).toContain('WHERE Id = NULL');
+    // Guards against callers passing a pre-stripped DeveloperName instead of the full API name
+    expect(getEntityDefinitionQuery('Account', 'Amount')).toContain('WHERE Id = NULL');
+  });
+});

--- a/libs/ui/src/lib/sobject-field-list/useWhereIsThisUsed.tsx
+++ b/libs/ui/src/lib/sobject-field-list/useWhereIsThisUsed.tsx
@@ -1,7 +1,7 @@
 import { logger } from '@jetstream/shared/client-logger';
 import { clearCacheForOrg, queryWithCache } from '@jetstream/shared/data';
 import { useReducerFetchFn } from '@jetstream/shared/ui-utils';
-import { getErrorMessage } from '@jetstream/shared/utils';
+import { getErrorMessage, parseCustomFieldApiNameForTooling } from '@jetstream/shared/utils';
 import { ListItem, SalesforceOrgUi } from '@jetstream/types';
 import orderBy from 'lodash/orderBy';
 import { useCallback, useEffect, useReducer, useRef } from 'react';
@@ -20,18 +20,20 @@ export interface MetadataDependency {
   MetadataComponentType: string;
 }
 
-function getEntityDefinitionQuery(sobject: string, field: string) {
-  let namespace: string | undefined = undefined;
-  if (field.includes('__')) {
-    const [_namespace, fieldWithoutNamespace] = field.split('__');
-    namespace = _namespace;
-    field = fieldWithoutNamespace;
+/** Expects the full field API name including the `__c` suffix; non-custom names produce a query with no results. */
+export function getEntityDefinitionQuery(sobject: string, fieldApiName: string) {
+  const parsed = parseCustomFieldApiNameForTooling(fieldApiName);
+  if (!parsed) {
+    return `SELECT Id, DeveloperName, EntityDefinitionId, TableEnumOrId FROM CustomField WHERE Id = NULL LIMIT 1`;
   }
+  const nsClause =
+    parsed.namespacePrefix != null && parsed.namespacePrefix.length > 0
+      ? ` AND NamespacePrefix = '${parsed.namespacePrefix}'`
+      : ' AND NamespacePrefix = null';
   return `SELECT Id, DeveloperName, EntityDefinitionId, TableEnumOrId
   FROM CustomField
   WHERE EntityDefinition.QualifiedApiName = '${sobject}'
-  AND DeveloperName = '${field}'
-  ${namespace ? `AND NamespacePrefix = '${namespace}'` : ''}
+  AND DeveloperName = '${parsed.developerName}'${nsClause}
   LIMIT 1`;
 }
 
@@ -42,7 +44,7 @@ function getDependencyQuery(RefMetadataComponentId: string) {
   ORDER BY MetadataComponentType`;
 }
 
-export function useWhereIsThisUsed(org: SalesforceOrgUi, sobject: string, field: string) {
+export function useWhereIsThisUsed(org: SalesforceOrgUi, sobject: string, fieldApiName: string) {
   const isMounted = useRef(true);
 
   const [{ hasLoaded, loading, data, hasError, errorMessage }, dispatch] = useReducer(
@@ -70,7 +72,7 @@ export function useWhereIsThisUsed(org: SalesforceOrgUi, sobject: string, field:
           clearCacheForOrg(org);
         }
         const entityDefinition = (
-          await queryWithCache<MetadataDependencyEntityDefinition>(org, getEntityDefinitionQuery(sobject, field), true)
+          await queryWithCache<MetadataDependencyEntityDefinition>(org, getEntityDefinitionQuery(sobject, fieldApiName), true)
         ).data.queryResults.records[0];
         if (!entityDefinition) {
           if (isMounted.current) {
@@ -91,7 +93,7 @@ export function useWhereIsThisUsed(org: SalesforceOrgUi, sobject: string, field:
         }
       }
     },
-    [org, sobject, field],
+    [org, sobject, fieldApiName],
   );
 
   return { loadDependencies: load, loading, items: data, hasLoaded, hasError, errorMessage };

--- a/libs/ui/src/lib/sobject-list/ConnectedSobjectListMultiSelect.tsx
+++ b/libs/ui/src/lib/sobject-list/ConnectedSobjectListMultiSelect.tsx
@@ -44,6 +44,8 @@ export interface ConnectedSobjectListMultiSelectProps {
   onSobjects: (sobjects: DescribeGlobalSObjectResult[] | null) => void;
   onSelectedSObjects: (selectedSObjects: string[]) => void;
   onRefresh?: () => void;
+  /** When true, object list is read-only (selection and refresh disabled). */
+  disabled?: boolean;
 }
 
 export const ConnectedSobjectListMultiSelect = forwardRef<any, ConnectedSobjectListMultiSelectProps>(
@@ -61,6 +63,7 @@ export const ConnectedSobjectListMultiSelect = forwardRef<any, ConnectedSobjectL
       onSobjects,
       onSelectedSObjects,
       onRefresh,
+      disabled = false,
     },
     ref,
   ) => {
@@ -131,6 +134,8 @@ export const ConnectedSobjectListMultiSelect = forwardRef<any, ConnectedSobjectL
       setLoading(false);
     }, [filterFn, onSobjects, selectedOrg]);
 
+    // Auto-load is independent of `disabled`: a read-only list should still populate its data (the
+    // `!sobjects` guard skips the fetch when a caller pre-supplies objects); `disabled` only gates interaction.
     useEffect(() => {
       if (selectedOrg && !loading && !errorMessage && !sobjects) {
         loadObjects().then(NOOP);
@@ -162,7 +167,11 @@ export const ConnectedSobjectListMultiSelect = forwardRef<any, ConnectedSobjectL
           </h2>
           <div>
             <Tooltip id={`sobject-list-refresh-tooltip`} content={lastRefreshed}>
-              <button className="slds-button slds-button_icon slds-button_icon-container" disabled={loading} onClick={handleRefresh}>
+              <button
+                className="slds-button slds-button_icon slds-button_icon-container"
+                disabled={disabled || loading}
+                onClick={handleRefresh}
+              >
                 <Icon type="utility" icon="refresh" description={`Reload objects`} className="slds-button__icon" omitContainer />
               </button>
             </Tooltip>
@@ -174,6 +183,7 @@ export const ConnectedSobjectListMultiSelect = forwardRef<any, ConnectedSobjectL
           loading={loading}
           errorMessage={errorMessage}
           allowSelectAll={allowSelectAll}
+          disabled={disabled}
           recentItemsEnabled={recentItemsEnabled}
           recentItems={recentItemsFiltered}
           onSelected={onSelectedSObjects}

--- a/libs/ui/src/lib/sobject-list/SobjectListMultiSelect.tsx
+++ b/libs/ui/src/lib/sobject-list/SobjectListMultiSelect.tsx
@@ -29,7 +29,7 @@ export const SobjectListMultiSelect: FunctionComponent<SobjectListMultiSelectPro
   sobjects: allSobjects,
   selectedSObjects = [],
   allowSelectAll = true,
-  disabled = false, // TODO:
+  disabled = false,
   loading,
   errorMessage,
   recentItemsEnabled,
@@ -50,7 +50,7 @@ export const SobjectListMultiSelect: FunctionComponent<SobjectListMultiSelectPro
     }
   });
   const [selectedSObjectSet, setSelectedSObjectSet] = useState<Set<string>>(new Set<string>(selectedSObjects || []));
-  const [searchInputId] = useState(`object-filter-${Date.now()}`);
+  const [searchInputId] = useState(() => `object-filter-${Date.now()}`);
   const ulRef = createRef<HTMLUListElement>();
 
   useEffect(() => {
@@ -72,6 +72,9 @@ export const SobjectListMultiSelect: FunctionComponent<SobjectListMultiSelectPro
   }
 
   function handleSelection(sobjectName: string) {
+    if (disabled) {
+      return;
+    }
     if (selectedSObjectSet.has(sobjectName)) {
       selectedSObjectSet.delete(sobjectName);
       onSelected(Array.from(selectedSObjectSet));
@@ -81,6 +84,9 @@ export const SobjectListMultiSelect: FunctionComponent<SobjectListMultiSelectPro
   }
 
   function handleSelectAll(value: boolean) {
+    if (disabled) {
+      return;
+    }
     filteredSobjects?.forEach((item) => {
       if (value) {
         selectedSObjectSet.add(item.name);
@@ -135,10 +141,11 @@ export const SobjectListMultiSelect: FunctionComponent<SobjectListMultiSelectPro
                     }
                     label="Select All"
                     onChange={handleSelectAll}
-                    disabled={filteredSobjects.length === 0}
+                    disabled={disabled || filteredSobjects.length === 0}
                   />
                   <ItemSelectionSummary
                     label="object"
+                    disabled={disabled}
                     items={Array.from(selectedSObjectSet).map((item) => ({ label: item, value: item }))}
                     onClearAll={() => onSelected([])}
                     onClearItem={handleSelection}
@@ -158,6 +165,7 @@ export const SobjectListMultiSelect: FunctionComponent<SobjectListMultiSelectPro
                     content: (
                       <AutoFullHeightContainer bottomBuffer={25}>
                         <SobjectListContent
+                          disabled={disabled}
                           selectedSObjectSet={selectedSObjectSet}
                           filteredSobjects={filteredSobjects}
                           searchTerm={searchTerm}
@@ -173,6 +181,7 @@ export const SobjectListMultiSelect: FunctionComponent<SobjectListMultiSelectPro
                     content: (
                       <AutoFullHeightContainer bottomBuffer={25}>
                         <SobjectListContent
+                          disabled={disabled}
                           selectedSObjectSet={selectedSObjectSet}
                           filteredSobjects={filteredSobjects}
                           searchTerm={searchTerm}
@@ -186,6 +195,7 @@ export const SobjectListMultiSelect: FunctionComponent<SobjectListMultiSelectPro
             ) : (
               <AutoFullHeightContainer bottomBuffer={25}>
                 <SobjectListContent
+                  disabled={disabled}
                   selectedSObjectSet={selectedSObjectSet}
                   filteredSobjects={filteredSobjects}
                   searchTerm={searchTerm}
@@ -201,6 +211,7 @@ export const SobjectListMultiSelect: FunctionComponent<SobjectListMultiSelectPro
 };
 
 interface SobjectListContentProps {
+  disabled?: boolean;
   selectedSObjectSet: Set<string>;
   filteredSobjects: DescribeGlobalSObjectResult[];
   searchTerm: string;
@@ -208,13 +219,17 @@ interface SobjectListContentProps {
 }
 
 const SobjectListContent = forwardRef(
-  ({ selectedSObjectSet, filteredSobjects, searchTerm, onSelected }: SobjectListContentProps, ref: ForwardedRef<HTMLUListElement>) => {
+  (
+    { disabled = false, selectedSObjectSet, filteredSobjects, searchTerm, onSelected }: SobjectListContentProps,
+    ref: ForwardedRef<HTMLUListElement>,
+  ) => {
     return (
       <>
         <List
           ref={ref}
           items={filteredSobjects}
           isMultiSelect
+          disabled={disabled}
           isActive={(item: DescribeGlobalSObjectResult) => selectedSObjectSet.has(item.name)}
           onSelected={onSelected}
           getContent={(item: DescribeGlobalSObjectResult) => ({

--- a/libs/ui/src/lib/widgets/ItemSelectionSummary.tsx
+++ b/libs/ui/src/lib/widgets/ItemSelectionSummary.tsx
@@ -28,6 +28,9 @@ export const ItemSelectionSummary: FunctionComponent<ItemSelectionSummaryProps> 
   }
 
   function handleClearItem(item: string) {
+    if (disabled) {
+      return;
+    }
     onClearItem(item);
     if (items.length === 1) {
       popoverRef.current?.close();
@@ -52,10 +55,14 @@ export const ItemSelectionSummary: FunctionComponent<ItemSelectionSummaryProps> 
         }
         content={
           <div>
-            <p className="slds-text-color_weak">Click on an item to de-select</p>
+            <p className="slds-text-color_weak">{disabled ? 'Selected items' : 'Click on an item to de-select'}</p>
             <ul className="slds-has-dividers_top-space slds-dropdown_length-5">
               {items.map((item, i) => (
-                <li key={`${item.value}-${i}`} className="slds-item slds-text-link" onClick={() => handleClearItem(item.value)}>
+                <li
+                  key={`${item.value}-${i}`}
+                  className={disabled ? 'slds-item' : 'slds-item slds-text-link'}
+                  onClick={disabled ? undefined : () => handleClearItem(item.value)}
+                >
                   <div className="slds-truncate" title={item.label}>
                     {item.label}
                   </div>


### PR DESCRIPTION
## Why

Precursor to the analysis-tools feature PR (#1732). That PR modifies a number of **shared UI-library components that render/run for every user regardless of the `analysis-tools` feature flag**. A feature flag protects users from the *feature's* code, but not from regressions in shared components. This PR pulls those unflagged shared changes out so they can be reviewed and shipped independently — and so the feature flag becomes a true safety boundary for the feature itself.

Every file here is byte-identical to #1732 except `HeaderNavbarItems.tsx` (the analysis-tools nav menu is omitted and re-added, flag-gated, in the feature PR) and the `@jetstream/shared/utils` barrel (only the shared tooling-name util is exported here).

## What's included (all ship to all users, not behind the flag)

- **Navbar** — responsive overflow "More" menu + a config-driven items API (`Navbar`, `NavbarMenuItems`, `HeaderNavbar`, `useHeaderNavbarItems` hook, `headerNavbarBillingUserItems`). This is the largest universal change — the top nav is reworked for everyone.
- **DataTable** — opt-in `autoRowHeight` prop; the default render path is unchanged (verified byte-for-byte when the prop is off).
- **Card, Popover, ItemSelectionSummary** — small backward-compatible tweaks; `sobject-list` gains an additive `disabled` prop; `ProfileOrPermSetPopover` adds setup-URL helpers.
- **useWhereIsThisUsed + Create Fields** — shared custom-field tooling-name parsing (`custom-field-tooling-names` util + tests). Changes the "Where is this used?" SOQL (adds explicit `NamespacePrefix = null`) and Create Fields namespace detection.
- **regex** — `SFDC_ID` 15/18-char fix; `polyfillFieldDefinition` label tweaks; additive icon registrations.

## Verification

- ESLint on the changed files: no new problems (pre-existing `react-hooks/*` baseline errors already exist on `main`).
- `custom-field-tooling-names` unit tests pass (9/9).

## Follow-up

Once this merges, #1732 rebases onto `main` and its diff shrinks to gated feature code + additive new files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)