### PR TITLE
Normalize Salesforce connection errors to appropriate HTTP status codes

### DIFF
--- a/apps/api/src/app/utils/__tests__/response.handlers.spec.ts
+++ b/apps/api/src/app/utils/__tests__/response.handlers.spec.ts
@@ -1,5 +1,8 @@
+import { ApiRequestError } from '@jetstream/salesforce-api';
+import { ERROR_MESSAGES, HTTP } from '@jetstream/shared/constants';
 import { PassThrough } from 'node:stream';
 import { describe, expect, it, vi } from 'vitest';
+import * as salesforceOrgsDb from '../../db/salesforce-org.db';
 import { AuthenticationError, NotFoundError, UserFacingError } from '../error-handler';
 import { streamParsedCsvAsJson, uncaughtErrorHandler } from '../response.handlers';
 
@@ -106,9 +109,12 @@ function createMockRes() {
   return res;
 }
 
-async function handleError(error: unknown) {
+async function handleError(error: unknown, locals?: Record<string, unknown>) {
   const req = createMockReq();
   const res = createMockRes();
+  if (locals) {
+    Object.assign(res.locals, locals);
+  }
   await uncaughtErrorHandler(error, req as any, res as any, vi.fn());
   return { req, res };
 }
@@ -197,6 +203,47 @@ describe('uncaughtErrorHandler logging levels', () => {
       { err: expect.objectContaining({ message: 'Upstream unavailable' }), res: { statusCode: 503 } },
       '[RESPONSE][ERROR]',
     );
+  });
+});
+
+describe('uncaughtErrorHandler Salesforce connection error normalization', () => {
+  it('normalizes an expired-token error to 401 (and marks the org invalid) even when Salesforce returned a 500', async () => {
+    // Mirrors the incident: a SOAP/metadata auth failure whose refresh also fails re-throws with
+    // Salesforce's original HTTP 500 (INVALID_SESSION_ID). Left unnormalized, that 500 passes through to
+    // the client and trips 5xx alerting, despite being an auth failure.
+    const apiRequestError = new ApiRequestError(ERROR_MESSAGES.SFDC_EXPIRED_TOKEN, { status: 500 } as any);
+    const { res } = await handleError(new UserFacingError(apiRequestError), { org: { id: 'org-1', uniqueId: 'unique-1' } });
+
+    expect(res.status).toHaveBeenLastCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ message: ERROR_MESSAGES.SFDC_EXPIRED_TOKEN }));
+    // The org is still marked invalid and the client is signaled to prompt a reconnect.
+    expect(res.set).toHaveBeenCalledWith(HTTP.HEADERS.X_SFDC_ORG_CONNECTION_ERROR, ERROR_MESSAGES.SFDC_EXPIRED_TOKEN);
+    expect(salesforceOrgsDb.updateOrg_UNSAFE).toHaveBeenCalledWith(expect.objectContaining({ id: 'org-1' }), {
+      connectionError: ERROR_MESSAGES.SFDC_EXPIRED_TOKEN,
+    });
+  });
+
+  it('normalizes a "REST API not enabled" error to 403', async () => {
+    const apiRequestError = new ApiRequestError('API is not enabled for this Organization or Partner', { status: 500 } as any);
+    const { res } = await handleError(new UserFacingError(apiRequestError));
+
+    expect(res.status).toHaveBeenLastCalledWith(403);
+  });
+
+  it('normalizes a bare (unwrapped) connection error that reaches the generic handler to 401 instead of 500', async () => {
+    const error = new Error(ERROR_MESSAGES.SFDC_EXPIRED_TOKEN) as Error & { status: number };
+    error.status = 500;
+
+    const { res } = await handleError(error);
+
+    expect(res.status).toHaveBeenLastCalledWith(401);
+  });
+
+  it('still passes through the upstream status for non-connection UserFacingErrors', async () => {
+    const apiRequestError = new ApiRequestError('Some other Salesforce error', { status: 404 } as any);
+    const { res } = await handleError(new UserFacingError(apiRequestError));
+
+    expect(res.status).toHaveBeenLastCalledWith(404);
   });
 });
 

--- a/apps/api/src/app/utils/response.handlers.ts
+++ b/apps/api/src/app/utils/response.handlers.ts
@@ -156,16 +156,28 @@ export async function uncaughtErrorHandler(err: any, req: express.Request, res: 
     // Logger is not added to the response object in all cases depending on where error is encountered
     const responseLogger = getLogger();
 
+    // Known Salesforce connection/auth errors mean the org's stored credentials are dead (or the org is
+    // unreachable) and the user must reconnect. The callout adapter surfaces these as specific error
+    // messages, which we match to (1) mark the org invalid + signal the client and (2) normalize the
+    // response status below. Detection is message-based (independent of `res.locals.org`) so the status is
+    // normalized even when the error can't be attributed to a specific org.
+    const sfdcErrorMessage = typeof err?.message === 'string' ? err.message : '';
+    const isSfdcConnectionError =
+      sfdcErrorMessage === ERROR_MESSAGES.SFDC_EXPIRED_TOKEN ||
+      sfdcErrorMessage === ERROR_MESSAGES.SFDC_EXPIRED_SESSION ||
+      sfdcErrorMessage === ERROR_MESSAGES.SFDC_EXPIRED_TOKEN_VALIDITY ||
+      ERROR_MESSAGES.SFDC_ORG_DOES_NOT_EXIST.test(sfdcErrorMessage);
+    const isSfdcRestApiNotEnabled = ERROR_MESSAGES.SFDC_REST_API_NOT_ENABLED.test(sfdcErrorMessage);
+    // Salesforce reports the same auth failure with different HTTP statuses depending on the API (REST is
+    // 401, but a SOAP INVALID_SESSION_ID is HTTP 500). We pass Salesforce's upstream status through by
+    // default, so without this an auth failure surfaces as a 500 — mislabeling it as a server error and
+    // tripping 5xx alerting. Pin known connection errors to a deterministic 4xx instead.
+    const sfdcConnectionErrorStatus = isSfdcConnectionError ? 401 : isSfdcRestApiNotEnabled ? 403 : undefined;
+
     // If org had a connection error, ensure that the database is updated
     // This runs before the headersSent/deferred checks so the DB side effect always happens
     // TODO: what about alternate org?
-    if (
-      (err.message === ERROR_MESSAGES.SFDC_EXPIRED_TOKEN ||
-        err.message === ERROR_MESSAGES.SFDC_EXPIRED_SESSION ||
-        err.message === ERROR_MESSAGES.SFDC_EXPIRED_TOKEN_VALIDITY ||
-        ERROR_MESSAGES.SFDC_ORG_DOES_NOT_EXIST.test(err.message)) &&
-      !!res.locals?.org
-    ) {
+    if (isSfdcConnectionError && !!res.locals?.org) {
       try {
         if (!res.headersSent) {
           res.set(HTTP.HEADERS.X_SFDC_ORG_CONNECTION_ERROR, ERROR_MESSAGES.SFDC_EXPIRED_TOKEN);
@@ -175,7 +187,7 @@ export async function uncaughtErrorHandler(err: any, req: express.Request, res: 
       } catch (ex) {
         responseLogger.warn({ err: ex }, '[RESPONSE][ERROR UPDATING INVALID ORG]');
       }
-    } else if (ERROR_MESSAGES.SFDC_REST_API_NOT_ENABLED.test(err.message) && !!res.locals?.org) {
+    } else if (isSfdcRestApiNotEnabled && !!res.locals?.org) {
       try {
         if (!res.headersSent) {
           res.set(HTTP.HEADERS.X_SFDC_ORG_CONNECTION_ERROR, ERROR_MESSAGES.SFDC_REST_API_NOT_ENABLED_MSG);
@@ -217,14 +229,9 @@ export async function uncaughtErrorHandler(err: any, req: express.Request, res: 
       };
 
       // Include org connection error info that would normally be sent via X-SFDC-ORG-CONNECTION-ERROR header
-      if (
-        err.message === ERROR_MESSAGES.SFDC_EXPIRED_TOKEN ||
-        err.message === ERROR_MESSAGES.SFDC_EXPIRED_SESSION ||
-        err.message === ERROR_MESSAGES.SFDC_EXPIRED_TOKEN_VALIDITY ||
-        ERROR_MESSAGES.SFDC_ORG_DOES_NOT_EXIST.test(err.message)
-      ) {
+      if (isSfdcConnectionError) {
         deferredErrorBody.orgConnectionError = ERROR_MESSAGES.SFDC_EXPIRED_TOKEN;
-      } else if (ERROR_MESSAGES.SFDC_REST_API_NOT_ENABLED.test(err.message)) {
+      } else if (isSfdcRestApiNotEnabled) {
         deferredErrorBody.orgConnectionError = ERROR_MESSAGES.SFDC_REST_API_NOT_ENABLED_MSG;
       }
 
@@ -296,8 +303,10 @@ export async function uncaughtErrorHandler(err: any, req: express.Request, res: 
       const params = new URLSearchParams({ error: err.type }).toString();
       return res.redirect(`${ENV.JETSTREAM_SERVER_URL}/auth/login/?${params}`);
     } else if (err instanceof UserFacingError) {
-      // Attempt to use response code from 3rd party request if we have it available
-      const statusCode = err.apiRequestError?.status || status || 400;
+      // Prefer the normalized connection-error status over Salesforce's upstream status (which can be a
+      // 5xx, e.g. SOAP INVALID_SESSION_ID) so an auth failure is reported as a 4xx; otherwise fall back to
+      // the 3rd-party request status when available.
+      const statusCode = sfdcConnectionErrorStatus ?? (err.apiRequestError?.status || status || 400);
       res.status(statusCode);
       responseLogger.debug({ err, res: { statusCode } }, '[RESPONSE][ERROR]');
       return res.json({
@@ -369,7 +378,11 @@ export async function uncaughtErrorHandler(err: any, req: express.Request, res: 
     }
 
     const errorMessage = 'There was an error processing the request';
-    if (!status || status < 100 || status > 599) {
+    // A known Salesforce connection/auth error that reached the generic handler (i.e. was not wrapped in a
+    // typed error class) still normalizes to 4xx instead of defaulting to 500.
+    if (sfdcConnectionErrorStatus) {
+      status = sfdcConnectionErrorStatus;
+    } else if (!status || status < 100 || status > 599) {
       status = 500;
     }
     res.status(status);


### PR DESCRIPTION
Improve error handling for Salesforce connection issues by normalizing specific errors to their corresponding HTTP status codes. This change prevents misleading 500 errors from being sent to clients for authentication failures and ensures that users are prompted to reconnect when necessary.