### PR TITLE
fix: improve bulk record update failure states

### DIFF
--- a/libs/features/query/src/QueryResults/BulkUpdateFromQuery/BulkUpdateFromQueryModal.tsx
+++ b/libs/features/query/src/QueryResults/BulkUpdateFromQuery/BulkUpdateFromQueryModal.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/react';
 import { clearCacheForOrg } from '@jetstream/shared/data';
 import { convertDateToLocale, filterLoadSobjects, formatNumber, tracker } from '@jetstream/shared/ui-utils';
-import { getRecordIdFromAttributes, pluralizeFromNumber } from '@jetstream/shared/utils';
+import { getErrorMessage, getRecordIdFromAttributes, pluralizeFromNumber } from '@jetstream/shared/utils';
 import { ListItem, Maybe, SalesforceOrgUi, SalesforceRecord } from '@jetstream/types';
 import {
   Checkbox,
@@ -28,7 +28,7 @@ import {
   MetadataRowConfiguration,
   useDeployRecords,
 } from '@jetstream/ui-core';
-import { Query } from '@jetstreamapp/soql-parser-js';
+import { composeQuery, Query } from '@jetstreamapp/soql-parser-js';
 import { useAtom } from 'jotai';
 import { atomWithReset, useAtomCallback, useResetAtom } from 'jotai/utils';
 import isNumber from 'lodash/isNumber';
@@ -237,8 +237,28 @@ export const BulkUpdateFromQueryModal: FunctionComponent<BulkUpdateFromQueryModa
       if (abortController.signal.aborted) {
         return;
       }
-      setFatalError('There was a problem loading records. Please try again.');
-      tracker.error('Error previewing bulk update records', ex);
+      // A failed preview is transient/retryable (e.g. a Salesforce query timeout), so surface it as a
+      // recoverable errorMessage rather than a fatalError — fatalError disables the Preview button and is
+      // never cleared, which would trap the user with no way to retry or continue. Show Salesforce's actual
+      // message when available since it's actionable (e.g. "running for too long" → narrow the selection).
+      setErrorMessage(`There was a problem loading records. ${getErrorMessage(ex)}`.trim());
+      // Include the query shape + selection context so a failed preview can be diagnosed from the error alone
+      // (e.g. the SF errors caused by oversized `WHERE Id IN (...)` re-fetches). The WHERE clause is stripped
+      // before reporting since its filter literals can hold user data — the field/sobject structure plus the
+      // full query length are enough to diagnose without shipping that to telemetry.
+      tracker.error('Error previewing bulk update records', ex, {
+        sobject,
+        recordSource: downloadRecordsValue,
+        browserRecordCount: records.length,
+        totalRecordCount,
+        query: composeQuery({ ...parsedQuery, where: undefined }),
+        queryLength: composeQuery(parsedQuery).length,
+        fieldConfiguration: selectedConfig.map(({ selectedField, transformationOptions }) => ({
+          selectedField,
+          option: transformationOptions.option,
+          criteria: transformationOptions.criteria,
+        })),
+      });
     } finally {
       if (previewFetchAbortRef.current === abortController) {
         previewFetchAbortRef.current = null;
@@ -283,7 +303,19 @@ export const BulkUpdateFromQueryModal: FunctionComponent<BulkUpdateFromQueryModa
       });
       pollResultsUntilDone(getDeploymentResults);
     } catch (ex) {
-      setFatalError('There was a problem loading records. Please try again.');
+      // Reset the deployment status out of the in-progress state so the Close button re-enables (an in-progress
+      // status disables it) and surface a recoverable errorMessage instead of a fatalError — otherwise a failure
+      // here (e.g. a synchronous throw before the batch upload) would leave the user with no way to close or retry.
+      setDeployResults({
+        done: true,
+        processingStartTime: convertDateToLocale(new Date()),
+        processingEndTime: convertDateToLocale(new Date()),
+        processingErrors: [],
+        records: [],
+        batchIdToIndex: {},
+        status: 'Error',
+      });
+      setErrorMessage('There was a problem updating records. Please try again.');
       tracker.error('Error bulk updating records', ex);
     } finally {
       setLoading(false);

--- a/libs/shared/ui-core/src/mass-update-records/__tests__/mass-update-records.utils.spec.ts
+++ b/libs/shared/ui-core/src/mass-update-records/__tests__/mass-update-records.utils.spec.ts
@@ -7,6 +7,7 @@ import {
   fetchRecordsWithRequiredFields,
   getFieldsToQuery,
   isValidRow,
+  MAX_ID_QUERY_LENGTH,
   prepareRecords,
 } from '../mass-update-records.utils';
 
@@ -598,10 +599,11 @@ describe('mass-update-records.utils#fetchRecordsWithRequiredFields', () => {
     expect(result).toBe(fetchedRecords);
   });
 
-  it('Should split large id sets into multiple chunked queries', async () => {
+  it('Should split large id sets into multiple length-bounded chunks that each stay under the query-URL limit', async () => {
     vi.mocked(clientData.queryAllFromList).mockResolvedValue({ queryResults: { records: [], totalSize: 0, done: true } } as any);
 
-    const ids = Array.from({ length: 1001 }, (_, index) => `id${index}`);
+    // Use realistic 18-char Salesforce Ids (as returned by query results) so the length math matches production
+    const ids = Array.from({ length: 2000 }, (_, index) => `001${String(index).padStart(15, '0')}`);
     await fetchRecordsWithRequiredFields({
       selectedOrg,
       parsedQuery: parseQuery('SELECT Id FROM Account'),
@@ -610,8 +612,10 @@ describe('mass-update-records.utils#fetchRecordsWithRequiredFields', () => {
     });
 
     const [, soqlQueries] = vi.mocked(clientData.queryAllFromList).mock.calls[0];
-    // 1001 ids / 500 per chunk => 3 queries
-    expect(soqlQueries).toHaveLength(3);
+    // Bounding by length (not a fixed count) is the fix for the SF 500s, so assert the guarantee directly:
+    // more than one chunk is produced and every chunk stays under Salesforce's query-URL length limit.
+    expect(soqlQueries.length).toBeGreaterThan(1);
+    soqlQueries.forEach((soql: string) => expect(soql.length).toBeLessThanOrEqual(MAX_ID_QUERY_LENGTH));
   });
 
   it('Should return an empty array without querying when idsToInclude is empty', async () => {

--- a/libs/shared/ui-core/src/mass-update-records/mass-update-records.utils.tsx
+++ b/libs/shared/ui-core/src/mass-update-records/mass-update-records.utils.tsx
@@ -2,7 +2,6 @@ import { logger } from '@jetstream/shared/client-logger';
 import { SFDC_BULK_API_NULL_VALUE } from '@jetstream/shared/constants';
 import { queryAll, queryAllFromList } from '@jetstream/shared/data';
 import { escapeSoqlString } from '@jetstream/shared/ui-utils';
-import { splitArrayToMaxSize } from '@jetstream/shared/utils';
 import { DescribeGlobalSObjectResult, ListItem, Maybe, SalesforceOrgUi, SalesforceRecord } from '@jetstream/types';
 import { Query, composeQuery, getField, isQueryValid } from '@jetstreamapp/soql-parser-js';
 import lodashGet from 'lodash/get';
@@ -10,11 +9,46 @@ import isNil from 'lodash/isNil';
 import { MetadataRow, MetadataRowConfiguration } from './mass-update-records.types';
 
 /**
- * Max number of record Ids to include in a single `WHERE Id IN (...)` query when re-fetching a
- * specific set of records (selected / filtered). 18-char Ids quoted ≈ 21 chars each, so 500 keeps
- * each query well under Salesforce's 100k character SOQL limit.
+ * SOQL sent to the Salesforce REST query endpoint travels in the request URL (`GET /query?q=...`), and
+ * that URL has a length limit far below the 100k-character SOQL limit — empirically anything over ~10k
+ * characters is rejected (Salesforce responds 414/431/500, which surfaces to the user as a generic
+ * failure). So a `WHERE Id IN (...)` re-fetch must be chunked by the resulting query length, not by a
+ * fixed record count. Mirrors `MAX_QUERY_LENGTH` in load-records-utils.
  */
-const ID_CHUNK_SIZE = 500;
+export const MAX_ID_QUERY_LENGTH = 9500;
+
+/**
+ * Split a set of record Ids into as few `WHERE Id IN (...)` queries as possible while keeping each query
+ * under {@link MAX_ID_QUERY_LENGTH} so it does not blow past Salesforce's query-URL length limit.
+ */
+function buildChunkedIdInQueries(baseSoql: string, ids: string[]): string[] {
+  const queries: string[] = [];
+  const wrapperLength = baseSoql.length + ' WHERE Id IN ()'.length;
+  let chunk: string[] = [];
+  let chunkLength = wrapperLength;
+
+  const flushChunk = () => {
+    if (chunk.length > 0) {
+      queries.push(`${baseSoql} WHERE Id IN (${chunk.join(',')})`);
+      chunk = [];
+      chunkLength = wrapperLength;
+    }
+  };
+
+  ids.forEach((id) => {
+    const token = `'${escapeSoqlString(id)}'`;
+    // a comma separator only exists between Ids, so it is not counted for the first Id in a chunk
+    if (chunk.length > 0 && chunkLength + 1 + token.length > MAX_ID_QUERY_LENGTH) {
+      flushChunk();
+    }
+    const separatorLength = chunk.length > 0 ? 1 : 0;
+    chunkLength += separatorLength + token.length;
+    chunk.push(token);
+  });
+  flushChunk();
+
+  return queries;
+}
 
 export const startsWithWhereRgx = /^( )*WHERE( )*/i;
 
@@ -244,9 +278,7 @@ export async function fetchRecordsWithRequiredFields({
     }
     // Build a minimal query (drop the original WHERE/LIMIT/ORDER BY); the Id list is already the exact set.
     const baseSoql = composeQuery({ sObject: parsedQuery.sObject, fields });
-    const soqlQueries = splitArrayToMaxSize(idsToFetch, ID_CHUNK_SIZE).map(
-      (idChunk) => `${baseSoql} WHERE Id IN (${idChunk.map((id) => `'${escapeSoqlString(id)}'`).join(',')})`,
-    );
+    const soqlQueries = buildChunkedIdInQueries(baseSoql, idsToFetch);
     const { queryResults } = await queryAllFromList(
       selectedOrg,
       soqlQueries,

--- a/libs/shared/utils/src/lib/utils.ts
+++ b/libs/shared/utils/src/lib/utils.ts
@@ -53,11 +53,16 @@ export function getDefaultAppState(initial?: Maybe<Partial<ApplicationState>>): 
   };
 }
 
-export function getErrorMessage(error: unknown) {
+export function getErrorMessage(error: unknown): string {
   if (error instanceof Error) {
     return error.message;
   }
-  return JSON.stringify(error);
+  try {
+    // JSON.stringify returns undefined for undefined/functions/symbols, so fall back to String()
+    return JSON.stringify(error) ?? String(error);
+  } catch {
+    return String(error);
+  }
 }
 
 export function getErrorStack(error: unknown) {


### PR DESCRIPTION
Ensure queries are not too large

log the error message and track additional context for ease of troubleshooting

ensure user can retry and is not blocked if Salesforce returns an error