### PR TITLE
feat: add Salesforce Canvas org management functionality

### DIFF
--- a/apps-sfdx/canvas-app/jetstream/main/default/permissionsets/Jetstream.permissionset-meta.xml
+++ b/apps-sfdx/canvas-app/jetstream/main/default/permissionsets/Jetstream.permissionset-meta.xml
@@ -8,6 +8,7 @@
         <enabled>true</enabled>
         <name>UserPreferences__c</name>
     </customSettingAccesses>
+    <description>Grants access to Jetstream.</description>
     <fieldPermissions>
         <editable>true</editable>
         <field>UserPreferences__c.FieldMaxLineLength__c</field>

--- a/apps/api/src/app/controllers/canvas-org.controller.ts
+++ b/apps/api/src/app/controllers/canvas-org.controller.ts
@@ -1,0 +1,98 @@
+import { CreateSalesforceCanvasOrgRequestSchema, UpdateSalesforceCanvasOrgRequestSchema } from '@jetstream/types';
+import { z } from 'zod';
+import * as canvasOrgDb from '../db/canvas-entitlement.db';
+import { resolveActiveTeamIdForUser } from '../db/feature-flags.db';
+import { NotAllowedError } from '../utils/error-handler';
+import { sendJson } from '../utils/response.handlers';
+import { createRoute, RouteValidator } from '../utils/route.utils';
+
+const TEAM_MANAGED_MESSAGE = 'Your team manages authorized Canvas orgs. Ask a team admin to update them from the Team Dashboard.';
+
+export const routeDefinition = {
+  getCanvasOrgs: {
+    controllerFn: () => getCanvasOrgs,
+    validators: {
+      hasSourceOrg: false,
+    } satisfies RouteValidator,
+  },
+  createCanvasOrg: {
+    controllerFn: () => createCanvasOrg,
+    validators: {
+      hasSourceOrg: false,
+      body: CreateSalesforceCanvasOrgRequestSchema,
+    } satisfies RouteValidator,
+  },
+  updateCanvasOrg: {
+    controllerFn: () => updateCanvasOrg,
+    validators: {
+      hasSourceOrg: false,
+      params: z.object({ id: z.uuid() }),
+      body: UpdateSalesforceCanvasOrgRequestSchema,
+    } satisfies RouteValidator,
+  },
+  deleteCanvasOrg: {
+    controllerFn: () => deleteCanvasOrg,
+    validators: {
+      hasSourceOrg: false,
+      params: z.object({ id: z.uuid() }),
+    } satisfies RouteValidator,
+  },
+};
+
+/**
+ * Team members must manage authorized orgs at the team level (the team entitlement — not the personal
+ * one — gates Canvas access for them), so these personal endpoints refuse when the caller is on an
+ * active team and point them to the team UI.
+ */
+async function assertNotOnTeam(userId: string) {
+  const teamId = await resolveActiveTeamIdForUser(userId);
+  if (teamId) {
+    throw new NotAllowedError(TEAM_MANAGED_MESSAGE);
+  }
+}
+
+const getCanvasOrgs = createRoute(routeDefinition.getCanvasOrgs.validators, async ({ user }, _req, res, next) => {
+  try {
+    await assertNotOnTeam(user.id);
+    const orgs = await canvasOrgDb.listCanvasOrgsForOwner({ type: 'user', userId: user.id });
+    sendJson(res, orgs);
+  } catch (ex) {
+    next(ex);
+  }
+});
+
+const createCanvasOrg = createRoute(routeDefinition.createCanvasOrg.validators, async ({ user, body }, _req, res, next) => {
+  try {
+    await assertNotOnTeam(user.id);
+    const org = await canvasOrgDb.createCanvasOrg({
+      owner: { type: 'user', userId: user.id },
+      authorizedByUserId: user.id,
+      organizationId: body.organizationId,
+      myDomainBase: body.myDomainBase,
+      orgName: body.orgName,
+    });
+    sendJson(res, org);
+  } catch (ex) {
+    next(ex);
+  }
+});
+
+const updateCanvasOrg = createRoute(routeDefinition.updateCanvasOrg.validators, async ({ user, params, body }, _req, res, next) => {
+  try {
+    await assertNotOnTeam(user.id);
+    const org = await canvasOrgDb.updateCanvasOrg({ owner: { type: 'user', userId: user.id }, id: params.id, data: body });
+    sendJson(res, org, 200);
+  } catch (ex) {
+    next(ex);
+  }
+});
+
+const deleteCanvasOrg = createRoute(routeDefinition.deleteCanvasOrg.validators, async ({ user, params }, _req, res, next) => {
+  try {
+    await assertNotOnTeam(user.id);
+    await canvasOrgDb.deleteCanvasOrg({ owner: { type: 'user', userId: user.id }, id: params.id });
+    sendJson(res, undefined, 204);
+  } catch (ex) {
+    next(ex);
+  }
+});

--- a/apps/api/src/app/controllers/team.controller.ts
+++ b/apps/api/src/app/controllers/team.controller.ts
@@ -7,6 +7,7 @@ import { BLOCKED_PUBLIC_EMAIL_DOMAINS } from '@jetstream/shared/constants';
 import { assertDomainResolvesToPublicIp, fetchWithPinnedPublicIp } from '@jetstream/shared/node-utils';
 import { getErrorMessage, getErrorMessageAndStackObj } from '@jetstream/shared/utils';
 import {
+  CreateSalesforceCanvasOrgRequestSchema,
   TEAM_MEMBER_ROLE_ACCESS,
   TEAM_MEMBER_ROLE_MEMBER,
   TEAM_MEMBER_STATUS_INACTIVE,
@@ -17,11 +18,13 @@ import {
   TeamMemberRoleSchema,
   TeamMemberStatusUpdateRequestSchema,
   TeamMemberUpdateRequestSchema,
+  UpdateSalesforceCanvasOrgRequestSchema,
 } from '@jetstream/types';
 import * as crypto from 'crypto';
 import * as dns from 'dns/promises';
 import { unparse } from 'papaparse';
 import { z } from 'zod';
+import * as canvasOrgDb from '../db/canvas-entitlement.db';
 import * as teamDb from '../db/team.db';
 import * as teamService from '../services/team.service';
 import { NotAllowedError, NotFoundError, UserFacingError } from '../utils/error-handler';
@@ -427,6 +430,44 @@ export const routeDefinition = {
         teamId: z.uuid(),
         domainId: z.uuid(),
       }),
+    } satisfies RouteValidator,
+  },
+  getCanvasOrgs: {
+    controllerFn: () => getCanvasOrgs,
+    responseType: z.any(),
+    validators: {
+      hasSourceOrg: false,
+      logErrorToBugTracker: true,
+      params: z.object({ teamId: z.uuid() }),
+    } satisfies RouteValidator,
+  },
+  createCanvasOrg: {
+    controllerFn: () => createCanvasOrg,
+    responseType: z.any(),
+    validators: {
+      hasSourceOrg: false,
+      logErrorToBugTracker: true,
+      params: z.object({ teamId: z.uuid() }),
+      body: CreateSalesforceCanvasOrgRequestSchema,
+    } satisfies RouteValidator,
+  },
+  updateCanvasOrg: {
+    controllerFn: () => updateCanvasOrg,
+    responseType: z.any(),
+    validators: {
+      hasSourceOrg: false,
+      logErrorToBugTracker: true,
+      params: z.object({ teamId: z.uuid(), id: z.uuid() }),
+      body: UpdateSalesforceCanvasOrgRequestSchema,
+    } satisfies RouteValidator,
+  },
+  deleteCanvasOrg: {
+    controllerFn: () => deleteCanvasOrg,
+    responseType: z.any(),
+    validators: {
+      hasSourceOrg: false,
+      logErrorToBugTracker: true,
+      params: z.object({ teamId: z.uuid(), id: z.uuid() }),
     } satisfies RouteValidator,
   },
   getTeamAuditLogs: {
@@ -1322,6 +1363,80 @@ const deleteDomainVerification = createRoute(
     }
   },
 );
+
+const getCanvasOrgs = createRoute(routeDefinition.getCanvasOrgs.validators, async ({ params }, _req, res, next) => {
+  try {
+    const orgs = await canvasOrgDb.listCanvasOrgsForOwner({ type: 'team', teamId: params.teamId });
+    sendJson(res, orgs);
+  } catch (ex) {
+    getLogger().error(getErrorMessageAndStackObj(ex), 'Failed to get team Canvas orgs');
+    next(ex);
+  }
+});
+
+const createCanvasOrg = createRoute(routeDefinition.createCanvasOrg.validators, async ({ params, body, user }, req, res, next) => {
+  try {
+    const { teamId } = params;
+    const entitlements = await teamDb.findEntitlements({ teamId });
+    if (!entitlements.salesforceCanvas) {
+      throw new NotAllowedError('Your team does not have access to the Canvas app.');
+    }
+    const org = await canvasOrgDb.createCanvasOrg({
+      owner: { type: 'team', teamId },
+      authorizedByUserId: user.id,
+      organizationId: body.organizationId,
+      myDomainBase: body.myDomainBase,
+      orgName: body.orgName,
+    });
+    sendJson(res, org);
+
+    createTeamAuditLog({
+      userId: user.id,
+      teamId,
+      action: AuditLogAction.CANVAS_ORG_AUTHORIZED,
+      resource: AuditLogResource.SALESFORCE_CANVAS_ORG,
+      resourceId: org.id,
+      metadata: { organizationId: org.organizationId, myDomainBase: org.myDomainBase, orgName: org.orgName },
+      ipAddress: req.ip,
+      userAgent: req.headers['user-agent'] as string,
+    });
+  } catch (ex) {
+    getLogger().error(getErrorMessageAndStackObj(ex), 'Failed to create team Canvas org');
+    next(ex);
+  }
+});
+
+const updateCanvasOrg = createRoute(routeDefinition.updateCanvasOrg.validators, async ({ params, body }, _req, res, next) => {
+  try {
+    const { teamId, id } = params;
+    const org = await canvasOrgDb.updateCanvasOrg({ owner: { type: 'team', teamId }, id, data: body });
+    sendJson(res, org, 200);
+  } catch (ex) {
+    getLogger().error(getErrorMessageAndStackObj(ex), 'Failed to update team Canvas org');
+    next(ex);
+  }
+});
+
+const deleteCanvasOrg = createRoute(routeDefinition.deleteCanvasOrg.validators, async ({ params, user }, req, res, next) => {
+  try {
+    const { teamId, id } = params;
+    await canvasOrgDb.deleteCanvasOrg({ owner: { type: 'team', teamId }, id });
+    sendJson(res, undefined, 204);
+
+    createTeamAuditLog({
+      userId: user.id,
+      teamId,
+      action: AuditLogAction.CANVAS_ORG_DELETED,
+      resource: AuditLogResource.SALESFORCE_CANVAS_ORG,
+      resourceId: id,
+      ipAddress: req.ip,
+      userAgent: req.headers['user-agent'] as string,
+    });
+  } catch (ex) {
+    getLogger().error(getErrorMessageAndStackObj(ex), 'Failed to delete team Canvas org');
+    next(ex);
+  }
+});
 
 const AUDIT_LOG_EXPORT_MAX_DAYS = 365;
 

--- a/apps/api/src/app/db/__tests__/canvas-entitlement.db.spec.ts
+++ b/apps/api/src/app/db/__tests__/canvas-entitlement.db.spec.ts
@@ -1,9 +1,23 @@
+import { Prisma } from '@jetstream/prisma';
+import { SALESFORCE_CANVAS_ORG_LIMIT } from '@jetstream/types';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { isCanvasOrgEntitled, parseMyDomainBase } from '../canvas-entitlement.db';
+import {
+  createCanvasOrg,
+  deleteCanvasOrg,
+  isCanvasOrgEntitled,
+  listCanvasOrgsForOwner,
+  parseMyDomainBase,
+  updateCanvasOrg,
+} from '../canvas-entitlement.db';
 
 const prismaMock = vi.hoisted(() => ({
   salesforceCanvasOrg: {
     findMany: vi.fn(),
+    count: vi.fn(),
+    create: vi.fn(),
+    updateMany: vi.fn(),
+    deleteMany: vi.fn(),
+    findFirstOrThrow: vi.fn(),
   },
   teamEntitlement: {
     count: vi.fn(),
@@ -93,5 +107,167 @@ describe('isCanvasOrgEntitled', () => {
 
     expect(await isCanvasOrgEntitled(PROD_ORG_ID, 'https://acme.my.salesforce.com')).toBe(false);
     expect(prismaMock.entitlement.count).not.toHaveBeenCalled();
+  });
+});
+
+describe('createCanvasOrg', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    prismaMock.salesforceCanvasOrg.count.mockResolvedValue(0);
+  });
+
+  it('normalizes the org id to 15 chars, derives instanceUrl, and scopes to the user owner', async () => {
+    prismaMock.salesforceCanvasOrg.create.mockImplementation(({ data }: { data: Record<string, unknown> }) =>
+      Promise.resolve({
+        id: 'row-1',
+        organizationId: data.organizationId,
+        instanceUrl: data.instanceUrl,
+        myDomainBase: data.myDomainBase,
+        orgName: data.orgName ?? null,
+        isSandbox: data.isSandbox,
+        status: data.status,
+        createdAt: new Date('2026-01-01T00:00:00Z'),
+        updatedAt: new Date('2026-01-01T00:00:00Z'),
+      }),
+    );
+
+    const result = await createCanvasOrg({
+      owner: { type: 'user', userId: 'user-1' },
+      authorizedByUserId: 'user-1',
+      organizationId: PROD_ORG_ID, // 18 chars
+      myDomainBase: 'Acme',
+    });
+
+    expect(result.organizationId).toBe(PROD_ORG_ID.slice(0, 15));
+    expect(result.instanceUrl).toBe('https://acme.my.salesforce.com');
+    const createArg = prismaMock.salesforceCanvasOrg.create.mock.calls[0][0];
+    expect(createArg.data).toMatchObject({
+      organizationId: PROD_ORG_ID.slice(0, 15),
+      myDomainBase: 'acme',
+      instanceUrl: 'https://acme.my.salesforce.com',
+      isSandbox: false,
+      status: 'ACTIVE',
+      authorizedByUserId: 'user-1',
+      jetstreamUserId: 'user-1',
+    });
+    expect(createArg.data.teamId).toBeUndefined();
+  });
+
+  it('enforces the org limit and does not create beyond it', async () => {
+    prismaMock.salesforceCanvasOrg.count.mockResolvedValue(SALESFORCE_CANVAS_ORG_LIMIT);
+
+    await expect(
+      createCanvasOrg({
+        owner: { type: 'team', teamId: 'team-1' },
+        authorizedByUserId: 'user-1',
+        organizationId: PROD_ORG_ID,
+        myDomainBase: 'acme',
+      }),
+    ).rejects.toThrow(/limit/i);
+    expect(prismaMock.salesforceCanvasOrg.create).not.toHaveBeenCalled();
+  });
+
+  it('surfaces a friendly error when the org is already authorized (unique violation)', async () => {
+    prismaMock.salesforceCanvasOrg.create.mockRejectedValue(
+      new Prisma.PrismaClientKnownRequestError('Unique constraint failed', { code: 'P2002', clientVersion: 'test' }),
+    );
+
+    await expect(
+      createCanvasOrg({
+        owner: { type: 'user', userId: 'user-1' },
+        authorizedByUserId: 'user-1',
+        organizationId: PROD_ORG_ID,
+        myDomainBase: 'acme',
+      }),
+    ).rejects.toThrow(/already authorized/i);
+  });
+});
+
+describe('deleteCanvasOrg', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('scopes the delete to the team owner', async () => {
+    prismaMock.salesforceCanvasOrg.deleteMany.mockResolvedValue({ count: 1 });
+
+    await deleteCanvasOrg({ owner: { type: 'team', teamId: 'team-1' }, id: 'row-1' });
+
+    expect(prismaMock.salesforceCanvasOrg.deleteMany).toHaveBeenCalledWith({ where: { id: 'row-1', teamId: 'team-1' } });
+  });
+
+  it('throws when nothing matches the owner scope', async () => {
+    prismaMock.salesforceCanvasOrg.deleteMany.mockResolvedValue({ count: 0 });
+
+    await expect(deleteCanvasOrg({ owner: { type: 'user', userId: 'user-1' }, id: 'row-1' })).rejects.toThrow(/not found/i);
+  });
+});
+
+const CANVAS_ORG_ROW = {
+  id: 'row-1',
+  organizationId: '00D000000000001',
+  instanceUrl: 'https://acme.my.salesforce.com',
+  myDomainBase: 'acme',
+  orgName: 'Acme Production',
+  isSandbox: false,
+  status: 'ACTIVE',
+  createdAt: new Date('2026-01-01T00:00:00Z'),
+  updatedAt: new Date('2026-01-01T00:00:00Z'),
+};
+
+describe('listCanvasOrgsForOwner', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('scopes the query to the user owner and returns parsed rows', async () => {
+    prismaMock.salesforceCanvasOrg.findMany.mockResolvedValue([CANVAS_ORG_ROW]);
+
+    const result = await listCanvasOrgsForOwner({ type: 'user', userId: 'user-1' });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].organizationId).toBe('00D000000000001');
+    expect(prismaMock.salesforceCanvasOrg.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { jetstreamUserId: 'user-1' }, orderBy: { createdAt: 'asc' } }),
+    );
+  });
+
+  it('scopes the query to the team owner', async () => {
+    prismaMock.salesforceCanvasOrg.findMany.mockResolvedValue([]);
+
+    await listCanvasOrgsForOwner({ type: 'team', teamId: 'team-1' });
+
+    expect(prismaMock.salesforceCanvasOrg.findMany).toHaveBeenCalledWith(expect.objectContaining({ where: { teamId: 'team-1' } }));
+  });
+});
+
+describe('updateCanvasOrg', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('scopes the update to the owner and returns the refreshed record', async () => {
+    prismaMock.salesforceCanvasOrg.updateMany.mockResolvedValue({ count: 1 });
+    prismaMock.salesforceCanvasOrg.findFirstOrThrow.mockResolvedValue({ ...CANVAS_ORG_ROW, orgName: 'Renamed', status: 'REVOKED' });
+
+    const result = await updateCanvasOrg({
+      owner: { type: 'user', userId: 'user-1' },
+      id: 'row-1',
+      data: { orgName: 'Renamed', status: 'REVOKED' },
+    });
+
+    expect(result.orgName).toBe('Renamed');
+    expect(result.status).toBe('REVOKED');
+    expect(prismaMock.salesforceCanvasOrg.updateMany).toHaveBeenCalledWith({
+      where: { id: 'row-1', jetstreamUserId: 'user-1' },
+      data: { orgName: 'Renamed', status: 'REVOKED' },
+    });
+    // The refreshed read is scoped by the same owner filter for tenant isolation
+    expect(prismaMock.salesforceCanvasOrg.findFirstOrThrow).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: 'row-1', jetstreamUserId: 'user-1' } }),
+    );
+  });
+
+  it('throws when nothing matches the owner scope and never reads the record back', async () => {
+    prismaMock.salesforceCanvasOrg.updateMany.mockResolvedValue({ count: 0 });
+
+    await expect(updateCanvasOrg({ owner: { type: 'team', teamId: 'team-1' }, id: 'row-1', data: { status: 'REVOKED' } })).rejects.toThrow(
+      /not found/i,
+    );
+    expect(prismaMock.salesforceCanvasOrg.findFirstOrThrow).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/app/db/canvas-entitlement.db.ts
+++ b/apps/api/src/app/db/canvas-entitlement.db.ts
@@ -1,19 +1,21 @@
 import { prisma } from '@jetstream/api-config';
-
-/**
- * Default number of Salesforce orgs an entitled subscription may authorize for the Canvas app
- * ("Canvas deployment to one org"). Enforced only in the web-app registration flow — the access
- * gate never checks this, so manually-inserted DB rows intentionally bypass the cap for one-off
- * edge cases (e.g. the occasional consultant working across several orgs).
- */
-export const CANVAS_ORG_LIMIT_DEFAULT = 1;
+import { Prisma } from '@jetstream/prisma';
+import {
+  SALESFORCE_CANVAS_ORG_LIMIT,
+  SalesforceCanvasOrg,
+  SalesforceCanvasOrgSchema,
+  SalesforceCanvasOrgStatus,
+  SalesforceCanvasOrgStatusSchema,
+} from '@jetstream/types';
+import { NotFoundError, UserFacingError } from '../utils/error-handler';
 
 /**
  * Resolves the authorized-org cap for a scope. Kept as a function so it can vary per plan later
- * without touching the registration controller.
+ * without touching the callers. Enforced by `createCanvasOrg`; the access gate never checks it, so
+ * manually-inserted DB rows intentionally still bypass the cap for one-off edge cases.
  */
 export function getCanvasOrgLimit(): number {
-  return CANVAS_ORG_LIMIT_DEFAULT;
+  return SALESFORCE_CANVAS_ORG_LIMIT;
 }
 
 /**
@@ -78,4 +80,114 @@ export async function isCanvasOrgEntitled(organizationId: string, instanceUrl?: 
     }
   }
   return false;
+}
+
+/**
+ * Identifies which scope owns a set of authorized Canvas orgs. Ownership is a strict user XOR team
+ * (enforced by the `salesforce_canvas_org_owner_check` DB constraint), so every query is scoped to
+ * exactly one of these for tenant isolation.
+ */
+export type CanvasOrgOwnerScope = { type: 'user'; userId: string } | { type: 'team'; teamId: string };
+
+function ownerWhere(owner: CanvasOrgOwnerScope): Prisma.SalesforceCanvasOrgWhereInput {
+  return owner.type === 'team' ? { teamId: owner.teamId } : { jetstreamUserId: owner.userId };
+}
+
+const CANVAS_ORG_SELECT = {
+  id: true,
+  organizationId: true,
+  instanceUrl: true,
+  myDomainBase: true,
+  orgName: true,
+  isSandbox: true,
+  status: true,
+  createdAt: true,
+  updatedAt: true,
+} satisfies Prisma.SalesforceCanvasOrgSelect;
+
+export async function listCanvasOrgsForOwner(owner: CanvasOrgOwnerScope): Promise<SalesforceCanvasOrg[]> {
+  return prisma.salesforceCanvasOrg
+    .findMany({ where: ownerWhere(owner), select: CANVAS_ORG_SELECT, orderBy: { createdAt: 'asc' } })
+    .then((items) => SalesforceCanvasOrgSchema.array().parse(items));
+}
+
+export async function createCanvasOrg({
+  owner,
+  authorizedByUserId,
+  organizationId,
+  myDomainBase,
+  orgName,
+}: {
+  owner: CanvasOrgOwnerScope;
+  authorizedByUserId: string;
+  organizationId: string;
+  myDomainBase: string;
+  orgName?: string | null;
+}): Promise<SalesforceCanvasOrg> {
+  // Normalize to the 15-char id prefix so the 15/18-char forms of the same org collapse to a single
+  // row (via the unique constraint) and match the access gate's `startsWith` lookup in isCanvasOrgEntitled.
+  const normalizedOrgId = organizationId.trim().slice(0, 15);
+  const normalizedDomain = myDomainBase.trim().toLowerCase();
+
+  const currentCount = await prisma.salesforceCanvasOrg.count({ where: ownerWhere(owner) });
+  if (currentCount >= getCanvasOrgLimit()) {
+    throw new UserFacingError(
+      `You have reached the limit of ${getCanvasOrgLimit()} authorized orgs. Remove an existing org or contact support if you need more.`,
+    );
+  }
+
+  try {
+    return await prisma.salesforceCanvasOrg
+      .create({
+        select: CANVAS_ORG_SELECT,
+        data: {
+          organizationId: normalizedOrgId,
+          instanceUrl: `https://${normalizedDomain}.my.salesforce.com`,
+          myDomainBase: normalizedDomain,
+          orgName: orgName?.trim() || null,
+          isSandbox: false,
+          status: SalesforceCanvasOrgStatusSchema.enum.ACTIVE,
+          authorizedByUserId,
+          ...(owner.type === 'team' ? { teamId: owner.teamId } : { jetstreamUserId: owner.userId }),
+        },
+      })
+      .then((item) => SalesforceCanvasOrgSchema.parse(item));
+  } catch (ex) {
+    if (ex instanceof Prisma.PrismaClientKnownRequestError && ex.code === 'P2002') {
+      throw new UserFacingError('This Salesforce org is already authorized for the Canvas app.');
+    }
+    throw ex;
+  }
+}
+
+export async function updateCanvasOrg({
+  owner,
+  id,
+  data,
+}: {
+  owner: CanvasOrgOwnerScope;
+  id: string;
+  data: { orgName?: string | null; status?: SalesforceCanvasOrgStatus };
+}): Promise<SalesforceCanvasOrg> {
+  // updateMany scopes the write by owner so one tenant can never mutate another's record.
+  const result = await prisma.salesforceCanvasOrg.updateMany({
+    where: { id, ...ownerWhere(owner) },
+    data: {
+      ...(data.orgName !== undefined ? { orgName: data.orgName?.trim() || null } : {}),
+      ...(data.status !== undefined ? { status: data.status } : {}),
+    },
+  });
+  if (result.count === 0) {
+    throw new NotFoundError('Authorized org not found');
+  }
+  return prisma.salesforceCanvasOrg
+    .findFirstOrThrow({ where: { id, ...ownerWhere(owner) }, select: CANVAS_ORG_SELECT })
+    .then((item) => SalesforceCanvasOrgSchema.parse(item));
+}
+
+export async function deleteCanvasOrg({ owner, id }: { owner: CanvasOrgOwnerScope; id: string }): Promise<void> {
+  const result = await prisma.salesforceCanvasOrg.deleteMany({ where: { id, ...ownerWhere(owner) } });
+  if (result.count === 0) {
+    throw new NotFoundError('Authorized org not found');
+  }
 }

--- a/apps/api/src/app/db/user.db.ts
+++ b/apps/api/src/app/db/user.db.ts
@@ -92,6 +92,7 @@ const UserFacingProfileSelect = {
       desktop: true,
       googleDrive: true,
       recordSync: true,
+      salesforceCanvas: true,
     },
   },
   subscriptions: {
@@ -119,6 +120,7 @@ const UserFacingProfileSelect = {
               desktop: true,
               googleDrive: true,
               recordSync: true,
+              salesforceCanvas: true,
             },
           },
         },

--- a/apps/api/src/app/routes/api.routes.ts
+++ b/apps/api/src/app/routes/api.routes.ts
@@ -3,6 +3,7 @@ import { getDefaultAppState } from '@jetstream/shared/utils';
 import { AppInfo } from '@jetstream/types';
 import express, { Router } from 'express';
 import { getAnnouncements } from '../announcements';
+import { routeDefinition as canvasOrgController } from '../controllers/canvas-org.controller';
 import { routeDefinition as dataSyncController } from '../controllers/data-sync.controller';
 import { routeDefinition as orgGroupController } from '../controllers/org-groups.controller';
 import { routeDefinition as orgsController } from '../controllers/orgs.controller';
@@ -114,6 +115,12 @@ routes.post('/orgs/groups', orgGroupController.createOrganization.controllerFn()
 routes.put('/orgs/groups/:id', orgGroupController.updateOrganization.controllerFn());
 routes.delete('/orgs/groups/:id', orgGroupController.deleteOrganization.controllerFn());
 routes.delete('/orgs/groups/:id/with-orgs', orgGroupController.deleteOrganizationWithOrgs.controllerFn());
+
+// Salesforce Canvas app — personal authorized-orgs management (team members manage at the team level)
+routes.get('/canvas-orgs', verifyEntitlement('salesforceCanvas'), canvasOrgController.getCanvasOrgs.controllerFn());
+routes.post('/canvas-orgs', verifyEntitlement('salesforceCanvas'), canvasOrgController.createCanvasOrg.controllerFn());
+routes.patch('/canvas-orgs/:id', verifyEntitlement('salesforceCanvas'), canvasOrgController.updateCanvasOrg.controllerFn());
+routes.delete('/canvas-orgs/:id', verifyEntitlement('salesforceCanvas'), canvasOrgController.deleteCanvasOrg.controllerFn());
 
 /**
  * ************************************

--- a/apps/api/src/app/routes/team.routes.ts
+++ b/apps/api/src/app/routes/team.routes.ts
@@ -195,6 +195,27 @@ routes.delete(
   teamController.deleteDomainVerification.controllerFn(),
 );
 
+// Salesforce Canvas authorized orgs
+routes.get(
+  '/:teamId/canvas-orgs',
+  validateTeamRoleMiddlewareFn([TEAM_MEMBER_ROLE_ADMIN, TEAM_MEMBER_ROLE_BILLING]),
+  teamController.getCanvasOrgs.controllerFn(),
+);
+
+routes.post('/:teamId/canvas-orgs', validateTeamRoleMiddlewareFn([TEAM_MEMBER_ROLE_ADMIN]), teamController.createCanvasOrg.controllerFn());
+
+routes.patch(
+  '/:teamId/canvas-orgs/:id',
+  validateTeamRoleMiddlewareFn([TEAM_MEMBER_ROLE_ADMIN]),
+  teamController.updateCanvasOrg.controllerFn(),
+);
+
+routes.delete(
+  '/:teamId/canvas-orgs/:id',
+  validateTeamRoleMiddlewareFn([TEAM_MEMBER_ROLE_ADMIN]),
+  teamController.deleteCanvasOrg.controllerFn(),
+);
+
 // Audit Logs (ADMIN only)
 routes.get('/:teamId/audit-logs', validateTeamRoleMiddlewareFn([TEAM_MEMBER_ROLE_ADMIN]), teamController.getTeamAuditLogs.controllerFn());
 

--- a/apps/jetstream/src/app/components/settings/Settings.tsx
+++ b/apps/jetstream/src/app/components/settings/Settings.tsx
@@ -16,8 +16,8 @@ import {
   Spinner,
   fireToast,
 } from '@jetstream/ui';
-import { SoqlQueryFormatConfig, useAmplitude } from '@jetstream/ui-core';
-import { fromAppState, userProfileState } from '@jetstream/ui/app-state';
+import { SalesforceCanvasOrgs, SoqlQueryFormatConfig, useAmplitude } from '@jetstream/ui-core';
+import { fromAppState, useFeatureFlag, userProfileState } from '@jetstream/ui/app-state';
 import { dexieDataSync, recentHistoryItemsDb } from '@jetstream/ui/db';
 import { useAtom, useAtomValue } from 'jotai';
 import localforage from 'localforage';
@@ -44,6 +44,10 @@ export const Settings = () => {
 
   // TODO: Give option to disable
   const recordSyncEnabled = ability.can('access', 'RecordSync');
+  // Canvas org management: gated by the feature flag + entitlement, and only for individual (non-team)
+  // users — team members manage authorized orgs from the Team Dashboard.
+  const canvasEnabled = useFeatureFlag('salesforce-canvas');
+  const showCanvasOrgs = canvasEnabled && userProfile.entitlements.salesforceCanvas && !userProfile.teamMembership;
 
   const soqlQueryFormatOptions = modifiedUser?.preferences?.soqlQueryFormatOptions ?? SoqlQueryFormatOptionsSchema.parse({});
 
@@ -268,6 +272,12 @@ export const Settings = () => {
               <h2 className="slds-text-heading_medium slds-m-vertical_small">Analytics</h2>
               <AnalyticsTrackingSetting />
             </div>
+
+            {showCanvasOrgs && (
+              <div className="slds-m-top_large">
+                <SalesforceCanvasOrgs scope={{ type: 'user' }} />
+              </div>
+            )}
 
             {!userProfile.teamMembership && <SettingsDeleteAccount onDeleteAccount={handleDelete} />}
           </div>

--- a/libs/audit-logs/src/lib/audit-logs.ts
+++ b/libs/audit-logs/src/lib/audit-logs.ts
@@ -40,6 +40,10 @@ export enum AuditLogAction {
   DOMAIN_VERIFICATION_ADDED = 'DOMAIN_VERIFICATION_ADDED',
   DOMAIN_VERIFIED = 'DOMAIN_VERIFIED',
   DOMAIN_DELETED = 'DOMAIN_DELETED',
+
+  // Salesforce Canvas app authorization
+  CANVAS_ORG_AUTHORIZED = 'CANVAS_ORG_AUTHORIZED',
+  CANVAS_ORG_DELETED = 'CANVAS_ORG_DELETED',
 }
 
 export enum AuditLogResource {
@@ -50,6 +54,7 @@ export enum AuditLogResource {
   TEAM_INVITATION = 'team_invitation',
   TEAM_SSO_CONFIG = 'sso_config',
   TEAM_DOMAIN_VERIFICATION = 'domain_verification',
+  SALESFORCE_CANVAS_ORG = 'salesforce_canvas_org',
 }
 
 export interface CreateAuditLogParams {

--- a/libs/features/teams/src/lib/TeamDashboard/TeamDashboard.tsx
+++ b/libs/features/teams/src/lib/TeamDashboard/TeamDashboard.tsx
@@ -35,7 +35,8 @@ import {
   ScopedNotification,
   Spinner,
 } from '@jetstream/ui';
-import { abilityState, fromAppState } from '@jetstream/ui/app-state';
+import { SalesforceCanvasOrgs } from '@jetstream/ui-core';
+import { abilityState, fromAppState, useFeatureFlag } from '@jetstream/ui/app-state';
 import { useAtomValue } from 'jotai';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router';
@@ -76,6 +77,12 @@ export function TeamDashboard() {
   const [teamAuditLogModalOpen, setTeamAuditLogModalOpen] = useState(false);
   const [teamMemberUpdateState, setTeamMemberUpdateState] = useState<TeamMemberEditModalState>({ open: false });
   const [teamMemberStatusUpdateState, setTeamMemberStatusUpdateState] = useState<TeamMemberEditStatusModalState>({ open: false });
+
+  const canvasEnabled = useFeatureFlag('salesforce-canvas');
+  // Team members' Canvas access is gated by the team entitlement (resolved onto the profile), and only
+  // team admins may manage the authorized-orgs list.
+  const showCanvasOrgs = canvasEnabled && userProfile.entitlements.salesforceCanvas;
+  const isTeamAdmin = userProfile.teamMembership?.role === TeamMemberRoleSchema.enum.ADMIN;
 
   const canReadDomainConfiguration = ability.can('read', 'DomainConfiguration');
   const canReadSsoConfiguration = ability.can('read', 'SsoConfiguration');
@@ -361,6 +368,8 @@ export function TeamDashboard() {
           {team && domains && (
             <TeamDomainConfiguration teamId={team.id} domains={domains} hasSsoEnabled={hasSsoConfigured} onChange={handleDomainChange} />
           )}
+
+          {team && showCanvasOrgs && <SalesforceCanvasOrgs scope={{ type: 'team', teamId: team.id }} canManage={isTeamAdmin} />}
 
           {team && ssoConfig && (
             <div data-testid="team-sso-configuration-container" className="slds-m-bottom_medium">

--- a/libs/shared/data/src/lib/client-data.ts
+++ b/libs/shared/data/src/lib/client-data.ts
@@ -32,6 +32,7 @@ import {
   CloudinarySignature,
   CloudinaryUploadResponse,
   ColorScheme,
+  CreateSalesforceCanvasOrgRequest,
   DeployOptions,
   DeployResult,
   DescribeGlobalResult,
@@ -59,6 +60,7 @@ import {
   RecordResult,
   RetrieveResult,
   SalesforceApiRequest,
+  SalesforceCanvasOrg,
   SalesforceOrgUi,
   SobjectCollectionResponse,
   SobjectOperation,
@@ -74,6 +76,7 @@ import {
   TeamMemberStatus,
   TeamMemberUpdateRequest,
   TeamUserFacing,
+  UpdateSalesforceCanvasOrgRequest,
   UserProfileUi,
   VerifyInvitationResponse,
 } from '@jetstream/types';
@@ -1360,6 +1363,44 @@ export async function verifyDomain(
 
 export async function deleteDomainVerification(teamId: string, domainId: string): Promise<void> {
   return handleRequest({ method: 'DELETE', url: `/api/teams/${teamId}/domain-verification/${domainId}` }).then(unwrapResponseIgnoreCache);
+}
+
+//// SALESFORCE CANVAS AUTHORIZED ORGS
+
+export async function getCanvasOrgs(): Promise<SalesforceCanvasOrg[]> {
+  return handleRequest({ method: 'GET', url: '/api/canvas-orgs' }).then(unwrapResponseIgnoreCache);
+}
+
+export async function createCanvasOrg(payload: CreateSalesforceCanvasOrgRequest): Promise<SalesforceCanvasOrg> {
+  return handleRequest({ method: 'POST', url: '/api/canvas-orgs', data: payload }).then(unwrapResponseIgnoreCache);
+}
+
+export async function updateCanvasOrg(id: string, payload: UpdateSalesforceCanvasOrgRequest): Promise<SalesforceCanvasOrg> {
+  return handleRequest({ method: 'PATCH', url: `/api/canvas-orgs/${id}`, data: payload }).then(unwrapResponseIgnoreCache);
+}
+
+export async function deleteCanvasOrg(id: string): Promise<void> {
+  return handleRequest({ method: 'DELETE', url: `/api/canvas-orgs/${id}` }).then(unwrapResponseIgnoreCache);
+}
+
+export async function getTeamCanvasOrgs(teamId: string): Promise<SalesforceCanvasOrg[]> {
+  return handleRequest({ method: 'GET', url: `/api/teams/${teamId}/canvas-orgs` }).then(unwrapResponseIgnoreCache);
+}
+
+export async function createTeamCanvasOrg(teamId: string, payload: CreateSalesforceCanvasOrgRequest): Promise<SalesforceCanvasOrg> {
+  return handleRequest({ method: 'POST', url: `/api/teams/${teamId}/canvas-orgs`, data: payload }).then(unwrapResponseIgnoreCache);
+}
+
+export async function updateTeamCanvasOrg(
+  teamId: string,
+  id: string,
+  payload: UpdateSalesforceCanvasOrgRequest,
+): Promise<SalesforceCanvasOrg> {
+  return handleRequest({ method: 'PATCH', url: `/api/teams/${teamId}/canvas-orgs/${id}`, data: payload }).then(unwrapResponseIgnoreCache);
+}
+
+export async function deleteTeamCanvasOrg(teamId: string, id: string): Promise<void> {
+  return handleRequest({ method: 'DELETE', url: `/api/teams/${teamId}/canvas-orgs/${id}` }).then(unwrapResponseIgnoreCache);
 }
 
 export async function getTeamAuditLogs(

--- a/libs/shared/ui-core/src/index.ts
+++ b/libs/shared/ui-core/src/index.ts
@@ -84,6 +84,7 @@ export * from './record/RecordSearchPopover';
 export * from './record/ViewChildRecords';
 export * from './record/ViewEditCloneRecord';
 export * from './record/ViewEditCloneRecordWrapper';
+export * from './settings/SalesforceCanvasOrgs';
 export * from './settings/SoqlQueryFormatConfig';
 export * from './settings/SoqlQueryFormatConfigPopover';
 export * as fromAutomationControlState from './state-management/automation-control.state';

--- a/libs/shared/ui-core/src/settings/SalesforceCanvasOrgs.tsx
+++ b/libs/shared/ui-core/src/settings/SalesforceCanvasOrgs.tsx
@@ -1,0 +1,305 @@
+import { zodResolver } from '@hookform/resolvers/zod';
+import {
+  createCanvasOrg,
+  createTeamCanvasOrg,
+  deleteCanvasOrg,
+  deleteTeamCanvasOrg,
+  getCanvasOrgs,
+  getTeamCanvasOrgs,
+} from '@jetstream/shared/data';
+import { getErrorMessage } from '@jetstream/shared/utils';
+import {
+  CreateSalesforceCanvasOrgRequest,
+  CreateSalesforceCanvasOrgRequestSchema,
+  ListItem,
+  SALESFORCE_CANVAS_ORG_LIMIT,
+  SalesforceCanvasOrg,
+} from '@jetstream/types';
+import {
+  Card,
+  ConfirmationModalPromise,
+  fireToast,
+  Grid,
+  GridCol,
+  Icon,
+  Input,
+  Modal,
+  Picklist,
+  ScopedNotification,
+  Spinner,
+} from '@jetstream/ui';
+import { fromAppState } from '@jetstream/ui/app-state';
+import { useAtomValue } from 'jotai';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useForm } from 'react-hook-form';
+
+/**
+ * Best-effort parse of the "My Domain" base from a connected org's instance URL, so we can prefill the
+ * form. Mirrors the server's parseMyDomainBase; the field stays editable if the URL is unusual.
+ *   https://acme.my.salesforce.com               -> "acme"
+ *   https://acme--uat.sandbox.my.salesforce.com  -> "acme"
+ */
+function parseMyDomainBaseFromInstanceUrl(instanceUrl: string): string {
+  try {
+    const { hostname } = new URL(instanceUrl);
+    const [subdomain] = hostname.split('.');
+    return subdomain?.split('--')[0] ?? '';
+  } catch {
+    return '';
+  }
+}
+
+/** Whether this card manages the current user's personal orgs or a team's shared orgs. */
+export type CanvasOrgScope = { type: 'user' } | { type: 'team'; teamId: string };
+
+interface SalesforceCanvasOrgsProps {
+  scope: CanvasOrgScope;
+  /** When false, the card is view-only (no authorize/remove actions) — e.g. a non-admin team member. */
+  canManage?: boolean;
+}
+
+/**
+ * Self-contained card for managing the Salesforce orgs authorized to load the Jetstream Canvas app.
+ * Rendered on the personal Settings page (user scope) and the Team Dashboard (team scope); the backing
+ * data functions are selected from `scope`.
+ */
+export function SalesforceCanvasOrgs({ scope, canManage = true }: SalesforceCanvasOrgsProps) {
+  const teamId = scope.type === 'team' ? scope.teamId : null;
+  const [loading, setLoading] = useState(true);
+  const [loadingError, setLoadingError] = useState<string | null>(null);
+  const [orgs, setOrgs] = useState<SalesforceCanvasOrg[]>([]);
+  const [addModalOpen, setAddModalOpen] = useState(false);
+
+  const loadOrgs = useCallback(async () => {
+    try {
+      setLoading(true);
+      setLoadingError(null);
+      const results = teamId ? await getTeamCanvasOrgs(teamId) : await getCanvasOrgs();
+      setOrgs(results);
+    } catch (ex) {
+      setLoadingError(getErrorMessage(ex));
+    } finally {
+      setLoading(false);
+    }
+  }, [teamId]);
+
+  useEffect(() => {
+    loadOrgs();
+  }, [loadOrgs]);
+
+  const atLimit = orgs.length >= SALESFORCE_CANVAS_ORG_LIMIT;
+
+  // Errors intentionally propagate to the modal so they render inline — a toast would be hidden behind
+  // the modal overlay.
+  async function handleAdd(payload: CreateSalesforceCanvasOrgRequest) {
+    const created = teamId ? await createTeamCanvasOrg(teamId, payload) : await createCanvasOrg(payload);
+    setOrgs((prior) => [...prior, created]);
+    setAddModalOpen(false);
+    fireToast({ type: 'success', message: 'Org authorized for the Managed Package' });
+  }
+
+  async function handleDelete(org: SalesforceCanvasOrg) {
+    if (
+      await ConfirmationModalPromise({
+        header: 'Remove authorized org',
+        content: `Remove ${org.orgName || org.organizationId}? This org (and its sandboxes) will no longer be able to use the Managed Package.`,
+      })
+    ) {
+      try {
+        if (teamId) {
+          await deleteTeamCanvasOrg(teamId, org.id);
+        } else {
+          await deleteCanvasOrg(org.id);
+        }
+        setOrgs((prior) => prior.filter((item) => item.id !== org.id));
+        fireToast({ type: 'success', message: 'Org removed' });
+      } catch (ex) {
+        fireToast({ type: 'error', message: getErrorMessage(ex) });
+      }
+    }
+  }
+
+  return (
+    <Card
+      title="Salesforce Managed Package Authorized Orgs"
+      className="slds-m-bottom_medium slds-card_boundary"
+      icon={{ type: 'standard', icon: 'connected_apps' }}
+      actions={
+        canManage ? (
+          <button
+            className="slds-button slds-button_neutral"
+            type="button"
+            disabled={atLimit}
+            title={atLimit ? `You have reached the limit of ${SALESFORCE_CANVAS_ORG_LIMIT} orgs` : undefined}
+            onClick={() => setAddModalOpen(true)}
+          >
+            Authorize Org
+          </button>
+        ) : undefined
+      }
+    >
+      {loading && <Spinner />}
+      {loadingError && (
+        <ScopedNotification theme="error" className="slds-m-vertical_small">
+          {loadingError}
+        </ScopedNotification>
+      )}
+      {!loading && !loadingError && (
+        <>
+          <p className="slds-text-color_weak slds-m-bottom_small">
+            Authorize your production org id and My Domain so it can load the Jetstream Managed Package. All sandboxes that share the same
+            My Domain are covered automatically.
+          </p>
+          {orgs.length === 0 ? (
+            <p className="slds-text-color_weak">No orgs are authorized yet.</p>
+          ) : (
+            <ul className="slds-list">
+              {orgs.map((org, index) => (
+                <li key={org.id} className={index > 0 ? 'slds-p-top_x-small' : undefined}>
+                  <Grid verticalAlign="center">
+                    <GridCol className="slds-col">
+                      <div>
+                        <strong>{org.orgName || org.organizationId}</strong>
+                      </div>
+                      <div className="slds-text-body_small slds-text-color_weak">
+                        {org.organizationId}
+                        {org.myDomainBase ? ` · ${org.myDomainBase}.my.salesforce.com` : ''}
+                      </div>
+                    </GridCol>
+                    {canManage && (
+                      <GridCol bump="left">
+                        <button
+                          className="slds-button slds-button_icon slds-button_icon-border-filled"
+                          type="button"
+                          title="Remove"
+                          onClick={() => handleDelete(org)}
+                        >
+                          <Icon type="utility" icon="delete" className="slds-button__icon" omitContainer />
+                        </button>
+                      </GridCol>
+                    )}
+                  </Grid>
+                </li>
+              ))}
+            </ul>
+          )}
+        </>
+      )}
+
+      {addModalOpen && <AddCanvasOrgModal onClose={() => setAddModalOpen(false)} onSave={handleAdd} />}
+    </Card>
+  );
+}
+
+function AddCanvasOrgModal({
+  onClose,
+  onSave,
+}: {
+  onClose: () => void;
+  onSave: (payload: CreateSalesforceCanvasOrgRequest) => Promise<void>;
+}) {
+  const connectedOrgs = useAtomValue(fromAppState.salesforceOrgsState);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const {
+    register,
+    handleSubmit,
+    setValue,
+    formState: { errors, isSubmitting },
+  } = useForm({
+    resolver: zodResolver(CreateSalesforceCanvasOrgRequestSchema),
+    defaultValues: { organizationId: '', myDomainBase: '', orgName: '' },
+  });
+
+  async function handleSave(values: CreateSalesforceCanvasOrgRequest) {
+    setSaveError(null);
+    try {
+      await onSave(values);
+    } catch (ex) {
+      setSaveError(getErrorMessage(ex));
+    }
+  }
+
+  const connectedOrgItems = useMemo<ListItem[]>(
+    () =>
+      connectedOrgs.map((org) => ({
+        id: org.uniqueId,
+        label: org.label,
+        secondaryLabel: org.orgIsSandbox ? 'Sandbox' : 'Production',
+        value: org.uniqueId,
+      })),
+    [connectedOrgs],
+  );
+
+  function handlePrefillFromOrg(selectedItems: ListItem[]) {
+    const selectedOrg = connectedOrgs.find((org) => org.uniqueId === selectedItems[0]?.id);
+    if (!selectedOrg) {
+      return;
+    }
+    setValue('organizationId', selectedOrg.organizationId, { shouldValidate: true, shouldDirty: true });
+    setValue('myDomainBase', parseMyDomainBaseFromInstanceUrl(selectedOrg.instanceUrl), { shouldValidate: true, shouldDirty: true });
+    setValue('orgName', selectedOrg.orgName || selectedOrg.label, { shouldValidate: true, shouldDirty: true });
+  }
+
+  return (
+    <Modal
+      header="Authorize an Org"
+      onClose={onClose}
+      footer={
+        <>
+          <button className="slds-button slds-button_neutral" type="button" onClick={onClose}>
+            Cancel
+          </button>
+          <button form="canvas-org-form" className="slds-button slds-button_brand" type="submit" disabled={isSubmitting}>
+            Authorize
+          </button>
+        </>
+      }
+    >
+      <form id="canvas-org-form" onSubmit={handleSubmit(handleSave)}>
+        {saveError && (
+          <ScopedNotification theme="error" className="slds-m-bottom_small">
+            {saveError}
+          </ScopedNotification>
+        )}
+        {connectedOrgItems.length > 0 && (
+          <>
+            <Picklist
+              className="slds-m-bottom_x-small"
+              label="Prefill from a connected org"
+              placeholder="Select a connected org"
+              helpText="Optional: fills in the fields below from an org you've already connected. You can still edit them."
+              items={connectedOrgItems}
+              allowDeselection
+              onChange={handlePrefillFromOrg}
+            />
+            <p className="slds-m-bottom_small slds-text-color_weak slds-text-body_small">Or enter the details manually.</p>
+          </>
+        )}
+        <Input
+          label="Production Organization Id"
+          errorMessage={errors.organizationId?.message}
+          hasError={!!errors.organizationId}
+          isRequired
+        >
+          <input className="slds-input" type="text" {...register('organizationId')} placeholder="00Dxxxxxxxxxxxxxxx" />
+        </Input>
+        <Input
+          className="slds-m-top_small"
+          label="My Domain"
+          errorMessage={errors.myDomainBase?.message}
+          hasError={!!errors.myDomainBase}
+          isRequired
+        >
+          <input className="slds-input" type="text" {...register('myDomainBase')} placeholder="acme" />
+        </Input>
+        <Input className="slds-m-top_small" label="Label (optional)" errorMessage={errors.orgName?.message} hasError={!!errors.orgName}>
+          <input className="slds-input" type="text" {...register('orgName')} placeholder="Acme Production" />
+        </Input>
+        <p className="slds-m-top_small slds-text-color_weak">
+          Enter your production org id and just the My Domain name (for example, <code>acme</code> for <code>acme.my.salesforce.com</code>).
+          All sandboxes that share this My Domain will be able to use the Managed Package.
+        </p>
+      </form>
+    </Modal>
+  );
+}

--- a/libs/types/src/index.ts
+++ b/libs/types/src/index.ts
@@ -2,6 +2,7 @@ export * from './lib/analysis-job-types';
 export * from './lib/billing.types';
 export * from './lib/feature-flags';
 export * from './lib/jobs/types';
+export * from './lib/salesforce-canvas.types';
 export * from './lib/salesforce/apex.types';
 export * from './lib/salesforce/bulk.types';
 export * as Canvas from './lib/salesforce/canvas.types';

--- a/libs/types/src/lib/feature-flags.ts
+++ b/libs/types/src/lib/feature-flags.ts
@@ -15,6 +15,10 @@ export const FEATURE_FLAGS = {
     defaultValue: false,
     description: 'Data and record analysis tools.',
   },
+  'salesforce-canvas': {
+    defaultValue: false,
+    description: 'Manage Salesforce orgs authorized to use the Canvas app.',
+  },
 } as const satisfies Record<string, { defaultValue: boolean; description: string }>;
 
 export type FeatureFlagKey = keyof typeof FEATURE_FLAGS;

--- a/libs/types/src/lib/salesforce-canvas.types.ts
+++ b/libs/types/src/lib/salesforce-canvas.types.ts
@@ -1,0 +1,58 @@
+import { z } from 'zod';
+
+/**
+ * Default number of Salesforce orgs an entitled user/team may authorize for the Canvas app.
+ * A single production org already covers all of its sandboxes (matched by My Domain base), so the
+ * cap is generous headroom for genuine multi-org cases (consultants, M&A) rather than a per-sandbox
+ * limit. Shared between the create endpoint (enforcement) and the UI (disable "Authorize Org" at the cap).
+ */
+export const SALESFORCE_CANVAS_ORG_LIMIT = 10;
+
+/** A Salesforce org id: 15- or 18-character, always beginning with the `00D` key prefix. */
+export const SALESFORCE_ORG_ID_REGEX = /^00D[A-Za-z0-9]{12}([A-Za-z0-9]{3})?$/;
+
+/**
+ * The "My Domain" base fragment (e.g. `acme` from `acme.my.salesforce.com`) — lowercase letters,
+ * digits, and internal hyphens. Authorizing this extends Canvas access to the org's sandboxes, which
+ * share the same base but get a brand-new org id.
+ */
+export const SALESFORCE_MY_DOMAIN_BASE_REGEX = /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/;
+
+export const SalesforceCanvasOrgStatusSchema = z.enum(['ACTIVE', 'REVOKED']);
+export type SalesforceCanvasOrgStatus = z.infer<typeof SalesforceCanvasOrgStatusSchema>;
+
+/** User-facing representation of an authorized Canvas org (owner ids intentionally omitted). */
+export const SalesforceCanvasOrgSchema = z.object({
+  id: z.string(),
+  organizationId: z.string(),
+  instanceUrl: z.string(),
+  myDomainBase: z.string().nullish(),
+  orgName: z.string().nullish(),
+  isSandbox: z.boolean().nullish(),
+  status: SalesforceCanvasOrgStatusSchema,
+  createdAt: z.coerce.date(),
+  updatedAt: z.coerce.date(),
+});
+export type SalesforceCanvasOrg = z.infer<typeof SalesforceCanvasOrgSchema>;
+
+export const CreateSalesforceCanvasOrgRequestSchema = z.object({
+  organizationId: z
+    .string()
+    .trim()
+    .regex(SALESFORCE_ORG_ID_REGEX, { error: 'Enter a valid 15 or 18 character Salesforce organization id (starts with 00D)' }),
+  myDomainBase: z
+    .string()
+    .trim()
+    .toLowerCase()
+    .min(1)
+    .max(255)
+    .regex(SALESFORCE_MY_DOMAIN_BASE_REGEX, { error: 'Enter just the My Domain name, for example "acme"' }),
+  orgName: z.string().trim().max(255).optional(),
+});
+export type CreateSalesforceCanvasOrgRequest = z.infer<typeof CreateSalesforceCanvasOrgRequestSchema>;
+
+export const UpdateSalesforceCanvasOrgRequestSchema = z.object({
+  orgName: z.string().trim().max(255).nullish(),
+  status: SalesforceCanvasOrgStatusSchema.optional(),
+});
+export type UpdateSalesforceCanvasOrgRequest = z.infer<typeof UpdateSalesforceCanvasOrgRequestSchema>;


### PR DESCRIPTION
- Implemented CRUD operations for Salesforce Canvas orgs in the team controller.
- Added validation schemas for creating and updating Canvas orgs.
- Introduced new database functions for managing Canvas orgs.
- Updated API routes to include endpoints for Canvas org management.
- Enhanced user settings and team dashboard to support Canvas org management.
- Added feature flag for Salesforce Canvas functionality.
- Created UI components for managing authorized Salesforce orgs.
- Implemented tests for Canvas org database functions and controller logic.