### PR TITLE
fix: update Windows signing configuration and clarify publisher name requirements

### DIFF
--- a/electron-builder.config.js
+++ b/electron-builder.config.js
@@ -57,11 +57,6 @@ if (ENV.IS_CODESIGNING_ENABLED && process.platform === 'win32') {
   assertRequiredEnvVars('Windows', ['AZURE_TENANT_ID', 'AZURE_CLIENT_ID', 'AZURE_CLIENT_SECRET']);
   winSigningConfig = {
     forceCodeSigning: true,
-    // This allows signing to succeed on either the Digicert signing key or the Azure signing key
-    // Users must have a Desktop version with both publishers to ensure the update will work
-    // once we migrate to Azure for signing. If users do not update to the intermediate versions (4.1.0 or 4.1.1),
-    // they will need to manually download and install the latest version to continue receiving updates.
-    publisherName: ['Jetstream Solutions, LLC', 'JETSTREAM SOLUTIONS, LLC'],
     azureSignOptions: {
       publisherName: 'Jetstream Solutions, LLC',
       endpoint: 'https://eus.codesigning.azure.net',
@@ -189,7 +184,15 @@ const config = {
           {
             provider: 'generic',
             url: 'https://release-updates.getjetstream.app/jetstream/releases',
+            /**
+             * The auto-updater validates the publisher names exactly and will fail if they don't match.
+             *
+             * Azure: Jetstream Solutions, LLC
+             * Digicert: JETSTREAM SOLUTIONS, LLC
+             */
+            publisherName: ['Jetstream Solutions, LLC', 'JETSTREAM SOLUTIONS, LLC'],
           },
+          // Used for publishing, clients always use the first entry (generic provider above)
           {
             provider: 's3',
             endpoint: ENV.AWS_ENDPOINT_URL,


### PR DESCRIPTION
Resolves build failure:

```
$ electron-builder build --win --config electron-builder.config.js -p always
  • electron-builder  version=26.15.3 os=10.0.26100
  • loaded configuration  file=D:\a\jetstream\jetstream\dist\desktop-build\electron-builder.config.js
  ⨯ Invalid configuration object. electron-builder 26.15.3 has been initialized using a configuration object that does not match the API schema.
 - configuration.win should be one of these:
   null
     How to fix:
     1. Open https://www.electron.build/win
     2. Search the option name on the page (or type in into Search to find across the docs).
       * Not found? The option was deprecated or not exists (check spelling).
       * Found? Check that the option in the appropriate place. e.g. "title" only in the "dmg", not in the root.
  failedTask=build stackTrace=Error: Invalid configuration object. electron-builder 26.15.3 has been initialized using a configuration object that does not match the API schema.
 - configuration.win should be one of these:
   null
     How to fix:
     1. Open https://www.electron.build/win
     2. Search the option name on the page (or type in into Search to find across the docs).
       * Not found? The option was deprecated or not exists (check spelling).
       * Found? Check that the option in the appropriate place. e.g. "title" only in the "dmg", not in the root.
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       at validateSchema (D:\a\jetstream\jetstream\dist\desktop-build\node_modules\.pnpm\app-builder-lib@26.15.3_dmg_c5739d9600ac3f98a55503c35c5a46a9\node_modules\app-builder-lib\src\util\config\schemaValidator.ts:45:9)
    at validateConfiguration (D:\a\jetstream\jetstream\dist\desktop-build\node_modules\.pnpm\app-builder-lib@26.15.3_dmg_c5739d9600ac3f98a55503c35c5a46a9\node_modules\app-builder-lib\src\util\config\config.ts:238:17)
    at Packager.validateConfig (D:\a\jetstream\jetstream\dist\desktop-build\node_modules\.pnpm\app-builder-lib@26.15.3_dmg_c5739d9600ac3f98a55503c35c5a46a9\node_modules\app-builder-lib\src\packager.ts:390:5)
    at Packager.build (D:\a\jetstream\jetstream\dist\desktop-build\node_modules\.pnpm\app-builder-lib@26.15.3_dmg_c5739d9600ac3f98a55503c35c5a46a9\node_modules\app-builder-lib\src\packager.ts:398:5)
    at executeFinally (D:\a\jetstream\jetstream\dist\desktop-build\node_modules\.pnpm\builder-util@26.15.3\node_modules\builder-util\src\promise.ts:12:14)
[ELIFECYCLE] Command failed with exit code 1.
Error: Process completed with exit code 1.
```