### PR TITLE
fix: enhance EditorHost to support dynamic editor swapping and add CSS global shim for tests

### DIFF
--- a/libs/test-utils/src/test-setup-dom.ts
+++ b/libs/test-utils/src/test-setup-dom.ts
@@ -18,3 +18,14 @@ if (typeof globalThis.ResizeObserver === 'undefined') {
   }
   globalThis.ResizeObserver = ResizeObserverShim as unknown as typeof ResizeObserver;
 }
+
+/**
+ * jsdom does not expose the `CSS` global (EditorHost uses `CSS.escape` to build cell selectors).
+ * Minimal approximation of the spec: backslash-escapes selector-special characters; skips the
+ * leading-digit/NUL edge cases, which unit tests don't exercise.
+ */
+if (typeof globalThis.CSS === 'undefined') {
+  globalThis.CSS = {
+    escape: (value: string) => String(value).replace(/[^a-zA-Z0-9_\u00A0-\uFFFF-]/g, '\\$&'),
+  } as unknown as typeof CSS;
+}

--- a/libs/ui/src/lib/data-table/grid/__tests__/EditorHost.spec.tsx
+++ b/libs/ui/src/lib/data-table/grid/__tests__/EditorHost.spec.tsx
@@ -1,0 +1,83 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { useState } from 'react';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import { useJetstreamTable } from '../core/useJetstreamTable';
+import { EditorHost } from '../editors/EditorHost';
+import { ColumnWithFilter, DataTableEditorProps } from '../grid-types';
+
+interface Row {
+  _key: string;
+  Id: string;
+  Name: string;
+}
+
+const data: Row[] = [
+  { _key: '1', Id: '001', Name: 'Charlie' },
+  { _key: '2', Id: '002', Name: 'Alpha' },
+];
+
+/** Mirrors EditorText: a hookless editor, as columns have before field metadata resolves. */
+function EditorNoHooks({ row, onRowChange }: DataTableEditorProps<Row>) {
+  return (
+    <input data-testid="editor-no-hooks" value={row.Name || ''} onChange={(event) => onRowChange({ ...row, Name: event.target.value })} />
+  );
+}
+
+/** Mirrors EditorRecordLookup/editorDropdown: an editor with hook state. */
+function EditorWithHooks({ row }: DataTableEditorProps<Row>) {
+  const [initialValue] = useState(() => row.Name);
+  return <div data-testid="editor-with-hooks">{initialValue}</div>;
+}
+
+function buildColumns(renderEditCell: ColumnWithFilter<Row>['renderEditCell']): ColumnWithFilter<Row>[] {
+  return [
+    { key: 'Id', name: 'Id' },
+    { key: 'Name', name: 'Name', editable: true, renderEditCell },
+  ];
+}
+
+function Harness({ columns, getRootElement }: { columns: ColumnWithFilter<Row>[]; getRootElement: () => HTMLElement | null }) {
+  const { table } = useJetstreamTable<Row>({ data, columns, getRowKey: (row) => row._key });
+  return (
+    <EditorHost
+      editingCell={{ rowId: '1', columnId: 'Name' }}
+      table={table}
+      getRootElement={getRootElement}
+      onCommitRow={vi.fn()}
+      onClose={vi.fn()}
+    />
+  );
+}
+
+/** EditorHost anchors to the live cell via `[data-row-id][data-col-id]`, so provide one. */
+function createGridRoot(): HTMLElement {
+  const root = document.createElement('div');
+  const cell = document.createElement('div');
+  cell.setAttribute('data-row-id', '1');
+  cell.setAttribute('data-col-id', 'Name');
+  root.appendChild(cell);
+  document.body.appendChild(root);
+  return root;
+}
+
+describe('EditorHost', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  test('swapping to a hook-bearing editor mid-edit remounts the editor instead of crashing (React #310 regression)', () => {
+    const root = createGridRoot();
+    const { rerender } = render(<Harness columns={buildColumns(EditorNoHooks)} getRootElement={() => root} />);
+
+    // Draft an edit through the hookless editor, mirroring a user typing before metadata resolves.
+    fireEvent.change(screen.getByTestId('editor-no-hooks'), { target: { value: 'Drafted value' } });
+
+    // Field metadata resolving rebuilds columns, swapping in a hook-bearing editor mid-edit. When the
+    // editor was invoked as a plain function its hooks lived on EditorHost's fiber, so this rerender
+    // threw "Rendered more hooks than during the previous render" (React #310).
+    rerender(<Harness columns={buildColumns(EditorWithHooks)} getRootElement={() => root} />);
+
+    // The new editor mounted and received the in-progress draft (draft state lives on EditorHost).
+    expect(screen.getByTestId('editor-with-hooks').textContent).toBe('Drafted value');
+  });
+});

--- a/libs/ui/src/lib/data-table/grid/editors/EditorHost.tsx
+++ b/libs/ui/src/lib/data-table/grid/editors/EditorHost.tsx
@@ -57,6 +57,13 @@ export function EditorHost<TRow>({ editingCell, table, getRootElement, onCommitR
     return null;
   }
 
+  // Must be rendered as a JSX component (never a plain `renderEditCell(...)` call) so the editor's hooks
+  // live on the editor's own fiber. The editor function can change identity mid-edit — e.g. field metadata
+  // resolves and swaps EditorText for a lookup/picklist editor — and as a component that swap remounts the
+  // editor instead of shifting EditorHost's hook order (React error #310). The draft row lives here in
+  // EditorHost, so in-progress edits survive the remount.
+  const EditCell = authorColumn.renderEditCell;
+
   const minWidth = Math.max(cellEl.offsetWidth, 200);
 
   // Name the editor dialog so screen readers announce the column being edited instead of a bare "dialog".
@@ -115,14 +122,14 @@ export function EditorHost<TRow>({ editingCell, table, getRootElement, onCommitR
           className="slds-p-around_x-small"
           onOutsideClick={() => handleClose(draftRow !== null ? true : (authorColumn.editorOptions?.commitOnOutsideClick ?? false), false)}
         >
-          {authorColumn.renderEditCell({
-            row: draftRow ?? row.original,
-            column: authorColumn,
-            rowIndex,
-            colIndex,
-            onRowChange: handleRowChange,
-            onClose: handleClose,
-          })}
+          <EditCell
+            row={draftRow ?? row.original}
+            column={authorColumn}
+            rowIndex={rowIndex}
+            colIndex={colIndex}
+            onRowChange={handleRowChange}
+            onClose={handleClose}
+          />
         </OutsideClickHandler>
       </div>
     </FloatingPortal>


### PR DESCRIPTION
Resolves BetterStack error 4872ea91beff23f2e58079fb4efa963c188810d1c7707a70d133d8d3fc92a1ed?s=2336599