### PR TITLE
fix: Use composite API by default for all queries

### DIFF
--- a/apps/api/src/app/controllers/sf-query.controller.ts
+++ b/apps/api/src/app/controllers/sf-query.controller.ts
@@ -28,6 +28,7 @@ export const routeDefinition = {
       query: z.object({
         isTooling: BooleanQueryParamSchema,
         includeDeletedRecords: BooleanQueryParamSchema,
+        useCompositeApi: BooleanQueryParamSchema,
       }),
     } satisfies RouteValidator,
   },
@@ -67,9 +68,12 @@ const query = createRoute(routeDefinition.query.validators, async ({ body, query
   try {
     const isTooling = query.isTooling;
     const includeDeletedRecords = query.includeDeletedRecords;
+    const useCompositeApi = query.useCompositeApi;
     const soql = body.query;
 
-    const results = await jetstreamConn.query.query(soql, isTooling, includeDeletedRecords);
+    const results = useCompositeApi
+      ? await jetstreamConn.query.queryComposite(soql, isTooling, includeDeletedRecords)
+      : await jetstreamConn.query.query(soql, isTooling, includeDeletedRecords);
 
     sendJson(res, results);
   } catch (ex) {

--- a/apps/jetstream-canvas/src/controllers/sf-query.canvas.controller.ts
+++ b/apps/jetstream-canvas/src/controllers/sf-query.canvas.controller.ts
@@ -23,6 +23,7 @@ export const routeDefinition = {
       query: z.object({
         isTooling: BooleanQueryParamSchema,
         includeDeletedRecords: BooleanQueryParamSchema,
+        useCompositeApi: BooleanQueryParamSchema,
       }),
     } satisfies RouteValidator,
   },
@@ -60,9 +61,12 @@ const query = createRoute(routeDefinition.query.validators, async ({ body, query
   try {
     const isTooling = query.isTooling;
     const includeDeletedRecords = query.includeDeletedRecords;
+    const useCompositeApi = query.useCompositeApi;
     const soql = body.query;
 
-    const results = await jetstreamConn!.query.query(soql, isTooling, includeDeletedRecords);
+    const results = useCompositeApi
+      ? await jetstreamConn!.query.queryComposite(soql, isTooling, includeDeletedRecords)
+      : await jetstreamConn!.query.query(soql, isTooling, includeDeletedRecords);
 
     return handleJsonResponse(results);
   } catch (ex) {

--- a/apps/jetstream-desktop/src/controllers/sf-query.desktop.controller.ts
+++ b/apps/jetstream-desktop/src/controllers/sf-query.desktop.controller.ts
@@ -23,6 +23,7 @@ export const routeDefinition = {
       query: z.object({
         isTooling: BooleanQueryParamSchema,
         includeDeletedRecords: BooleanQueryParamSchema,
+        useCompositeApi: BooleanQueryParamSchema,
       }),
     } satisfies RouteValidator,
   },
@@ -60,9 +61,12 @@ const query = createRoute(routeDefinition.query.validators, async ({ body, query
   try {
     const isTooling = query.isTooling;
     const includeDeletedRecords = query.includeDeletedRecords;
+    const useCompositeApi = query.useCompositeApi;
     const soql = body.query;
 
-    const results = await jetstreamConn!.query.query(soql, isTooling, includeDeletedRecords);
+    const results = useCompositeApi
+      ? await jetstreamConn!.query.queryComposite(soql, isTooling, includeDeletedRecords)
+      : await jetstreamConn!.query.query(soql, isTooling, includeDeletedRecords);
 
     return handleJsonResponse(results);
   } catch (ex) {

--- a/apps/jetstream-web-extension/src/controllers/sf-query.web-ext.controller.ts
+++ b/apps/jetstream-web-extension/src/controllers/sf-query.web-ext.controller.ts
@@ -23,6 +23,7 @@ export const routeDefinition = {
       query: z.object({
         isTooling: BooleanQueryParamSchema,
         includeDeletedRecords: BooleanQueryParamSchema,
+        useCompositeApi: BooleanQueryParamSchema,
       }),
     } satisfies RouteValidator,
   },
@@ -60,9 +61,12 @@ const query = createRoute(routeDefinition.query.validators, async ({ body, query
   try {
     const isTooling = query.isTooling;
     const includeDeletedRecords = query.includeDeletedRecords;
+    const useCompositeApi = query.useCompositeApi;
     const soql = body.query;
 
-    const results = await jetstreamConn!.query.query(soql, isTooling, includeDeletedRecords);
+    const results = useCompositeApi
+      ? await jetstreamConn!.query.queryComposite(soql, isTooling, includeDeletedRecords)
+      : await jetstreamConn!.query.query(soql, isTooling, includeDeletedRecords);
 
     return handleJsonResponse(results);
   } catch (ex) {

--- a/libs/salesforce-api/src/lib/api-query.ts
+++ b/libs/salesforce-api/src/lib/api-query.ts
@@ -1,5 +1,5 @@
 import { flattenQueryColumn, getErrorMessage } from '@jetstream/shared/utils';
-import { QueryColumnsSfdc, QueryResult, QueryResults, QueryResultsColumns } from '@jetstream/types';
+import { CompositeResponse, Maybe, QueryColumnsSfdc, QueryResult, QueryResults, QueryResultsColumns } from '@jetstream/types';
 import { Query, parseQuery } from '@jetstreamapp/soql-parser-js';
 import { ApiConnection } from './connection';
 import { SalesforceApi } from './utils';
@@ -27,6 +27,80 @@ export class ApiQuery extends SalesforceApi {
         sessionInfo: this.sessionInfo,
         url: this.getRestApiUrl(`/query?${new URLSearchParams({ q: soql, columns: 'true' }).toString()}`, isTooling),
       });
+
+      columns = {
+        entityName: tempColumns.entityName,
+        groupBy: tempColumns.groupBy,
+        idSelected: tempColumns.idSelected,
+        keyPrefix: tempColumns.keyPrefix,
+        columns: tempColumns.columnMetadata?.flatMap((column) => flattenQueryColumn(column)),
+      };
+    } catch (ex) {
+      this.logger.debug({ message: getErrorMessage(ex) }, 'Error fetching columns');
+    }
+
+    // Attempt to parse columns from query
+    try {
+      parsedQuery = parseQuery(soql);
+    } catch (ex) {
+      this.logger.debug({ message: getErrorMessage(ex) }, 'Error parsing query');
+    }
+
+    return { queryResults, columns, parsedQuery };
+  }
+
+  /**
+   * Identical to query(), but tunnels the requests through the Composite API. The SOQL is still
+   * embedded in each subrequest's url, but those travel inside the POST body rather than the HTTP
+   * request line, avoiding URL length limits for very long queries, which fail with HTTP 431/414 errors.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  async queryComposite<T = any>(soql: string, isTooling = false, includeDeletedRecords = false): Promise<QueryResults<T>> {
+    const queryVerb = includeDeletedRecords ? 'queryAll' : 'query';
+    const QUERY_REF_ID = 'queryResults';
+    const COLUMNS_REF_ID = 'queryColumns';
+
+    // allOrNone defaults to false, so a failed columns subrequest does not impact the query subrequest
+    const { compositeResponse } = await this.apiRequest<CompositeResponse>({
+      method: 'POST',
+      sessionInfo: this.sessionInfo,
+      url: this.getRestApiUrl('/composite', isTooling),
+      body: {
+        compositeRequest: [
+          {
+            method: 'GET',
+            url: this.getRestApiUrl(`/${queryVerb}?${new URLSearchParams({ q: soql }).toString()}`, isTooling),
+            referenceId: QUERY_REF_ID,
+          },
+          {
+            method: 'GET',
+            url: this.getRestApiUrl(`/query?${new URLSearchParams({ q: soql, columns: 'true' }).toString()}`, isTooling),
+            referenceId: COLUMNS_REF_ID,
+          },
+        ],
+      },
+    });
+
+    const queryResultsResponse = compositeResponse.find(({ referenceId }) => referenceId === QUERY_REF_ID);
+    if (!queryResultsResponse || queryResultsResponse.httpStatusCode < 200 || queryResultsResponse.httpStatusCode > 299) {
+      const errors = queryResultsResponse?.body as Maybe<{ message?: string; errorCode?: string }[]>;
+      this.logger.warn(
+        { httpStatusCode: queryResultsResponse?.httpStatusCode, errorCode: errors?.[0]?.errorCode },
+        'Composite query subrequest failed',
+      );
+      throw new Error(errors?.[0]?.message || errors?.[0]?.errorCode || 'An unknown error has occurred');
+    }
+    const queryResults = queryResultsResponse.body as QueryResult<T>;
+
+    let columns: QueryResultsColumns | undefined;
+    let parsedQuery: Query | undefined;
+
+    try {
+      const columnsResponse = compositeResponse.find(({ referenceId }) => referenceId === COLUMNS_REF_ID);
+      if (!columnsResponse || columnsResponse.httpStatusCode < 200 || columnsResponse.httpStatusCode > 299) {
+        throw new Error(`Columns subrequest failed with status ${columnsResponse?.httpStatusCode}`);
+      }
+      const tempColumns = columnsResponse.body as QueryColumnsSfdc;
 
       columns = {
         entityName: tempColumns.entityName,

--- a/libs/shared/data/src/lib/client-data.ts
+++ b/libs/shared/data/src/lib/client-data.ts
@@ -297,9 +297,7 @@ export async function updateUserProfile<T = UserProfileUiWithIdentities>(userPro
  * These pass the org so the canvas-axios-adapter receives the X_SFDC_ID header
  * and provides jetstreamConn to the route handler.
  */
-export async function getCanvasPreferences(
-  org: SalesforceOrgUi,
-): Promise<{
+export async function getCanvasPreferences(org: SalesforceOrgUi): Promise<{
   skipFrontdoorLogin?: boolean;
   recordSyncEnabled?: boolean;
   colorScheme?: ColorScheme;
@@ -680,12 +678,16 @@ export async function query<T = any>(
   isTooling = false,
   includeDeletedRecords = false,
   signal?: AbortSignal,
+  /**
+   * The composite API is used to get around normal query limits where the request URL is too long.
+   */
+  useCompositeApi = true,
 ): Promise<QueryResults<T>> {
   if (!query) {
     throw new Error('Query cannot be empty');
   }
   return handleRequest(
-    { method: 'POST', url: `/api/query`, params: { isTooling, includeDeletedRecords }, data: { query }, signal },
+    { method: 'POST', url: `/api/query`, params: { isTooling, includeDeletedRecords, useCompositeApi }, data: { query }, signal },
     { org, useQueryParamsInCacheKey: true, useBodyInCacheKey: true },
   ).then(unwrapResponseIgnoreCache);
 }
@@ -696,12 +698,16 @@ export async function queryWithCache<T = any>(
   isTooling = false,
   skipRequestCache = false,
   includeDeletedRecords = false,
+  /**
+   * The composite API is used to get around normal query limits where the request URL is too long.
+   */
+  useCompositeApi = true,
 ): Promise<ApiResponse<QueryResults<T>>> {
   if (!query) {
     throw new Error('Query cannot be empty');
   }
   return handleRequest(
-    { method: 'POST', url: `/api/query`, params: { isTooling, includeDeletedRecords }, data: { query } },
+    { method: 'POST', url: `/api/query`, params: { isTooling, includeDeletedRecords, useCompositeApi }, data: { query } },
     { org, useCache: true, skipRequestCache, useQueryParamsInCacheKey: true, useBodyInCacheKey: true },
   );
 }
@@ -1473,4 +1479,3 @@ export async function updatePermissionSetRecords(
     }),
   ]);
 }
-


### PR DESCRIPTION
This avoids Salesforce errors for request headers being too large and allows a single request for column metadata and query results