### PR TITLE
fix(security): scope renderer local storage per user

### DIFF
--- a/apps/jetstream-canvas/src/app/core/AppInitializer.tsx
+++ b/apps/jetstream-canvas/src/app/core/AppInitializer.tsx
@@ -5,18 +5,21 @@ import { initErrorTracker, setErrorTrackerUser, useObservable } from '@jetstream
 import { JetstreamEventSaveSoqlQueryFormatOptionsPayload, SalesforceOrgUi } from '@jetstream/types';
 import { AppLoading, fromJetstreamEvents } from '@jetstream/ui-core';
 import { fromAppState } from '@jetstream/ui/app-state';
-import { initDexieDb } from '@jetstream/ui/db';
+import { ensureLocalStorageReady, initDexieDb } from '@jetstream/ui/db';
 import { useAtomValue, useSetAtom } from 'jotai';
 import localforage from 'localforage';
-import React, { FunctionComponent, useEffect, useState } from 'react';
+import React, { FunctionComponent, use, useEffect, useState } from 'react';
 import { Observable } from 'rxjs';
 import { environment } from '../../environments/environment';
-import { getCanvasOrg } from '../../utils/canvas.utils';
+import { getCanvasOrg, getCanvasStorageScopeId } from '../../utils/canvas.utils';
 import { canvasColorSchemeState } from './useCanvasColorScheme';
 
-// Configure IndexedDB database
+// IndexedDB database holding the localforage stores. The default instance is configured here for
+// the surfaces that read it directly (see `getUnscopedLocalStore`); everything scoped to a user
+// goes through the per-user store set up by `ensureLocalStorageReady` below.
+const LOCAL_STORE_DB_NAME = 'jetstream-canvas';
 localforage.config({
-  name: 'jetstream-canvas',
+  name: LOCAL_STORE_DB_NAME,
 });
 
 export interface AppInitializerProps {
@@ -49,6 +52,15 @@ export const AppInitializer: FunctionComponent<AppInitializerProps> = ({ allowWi
     }
   });
 
+  // Canvas has no Jetstream login, so local storage is scoped by the user's production username, which
+  // is stable across a production org and its sandboxes (see getCanvasStorageScopeId) — the same user's
+  // history follows them between prod and sandbox, while different users stay isolated. Children are
+  // gated on `selectedOrg` below, so this runs before any descendant reads local storage.
+  const storageScopeId = selectedOrg?.uniqueId ? getCanvasStorageScopeId() : null;
+  // Suspend until both local stores are scoped to this user, so no descendant reads local storage
+  // before it points at the right account.
+  use(ensureLocalStorageReady({ userId: storageScopeId, dbName: LOCAL_STORE_DB_NAME }));
+
   useEffect(() => {
     initErrorTracker({
       dsn: environment.sentryDsn,
@@ -62,10 +74,12 @@ export const AppInitializer: FunctionComponent<AppInitializerProps> = ({ allowWi
   useEffect(() => {
     // wait until this data has initialized before proceeding
     const recordSyncEnabled = false;
-    initDexieDb({ recordSyncEnabled }).catch((ex) => {
-      logger.error('[DB] Error initializing db', ex);
-    });
-  }, []);
+    if (storageScopeId) {
+      initDexieDb({ userId: storageScopeId, dbName: LOCAL_STORE_DB_NAME, recordSyncEnabled }).catch((ex) => {
+        logger.error('[DB] Error initializing db', ex);
+      });
+    }
+  }, [storageScopeId]);
 
   // Load preferences from Salesforce custom setting on mount
   useEffect(() => {

--- a/apps/jetstream-canvas/src/utils/__tests__/canvas.utils.spec.ts
+++ b/apps/jetstream-canvas/src/utils/__tests__/canvas.utils.spec.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import { deriveCanvasScopeId, extractSandboxName } from '../canvas.utils';
+
+describe('extractSandboxName', () => {
+  it('extracts the sandbox name from a My Domain sandbox host', () => {
+    expect(extractSandboxName('https://acme--uat.sandbox.my.salesforce.com')).toBe('uat');
+  });
+
+  it('extracts from a lightning sandbox host', () => {
+    expect(extractSandboxName('https://acme--uat.sandbox.lightning.force.com')).toBe('uat');
+  });
+
+  it('returns null for a production My Domain host', () => {
+    expect(extractSandboxName('https://acme.my.salesforce.com')).toBeNull();
+  });
+
+  it('returns null for empty/undefined input', () => {
+    expect(extractSandboxName(undefined)).toBeNull();
+    expect(extractSandboxName(null)).toBeNull();
+    expect(extractSandboxName('')).toBeNull();
+  });
+});
+
+describe('deriveCanvasScopeId', () => {
+  it('strips the sandbox suffix to recover the production username', () => {
+    expect(deriveCanvasScopeId({ username: 'alice@acme.com.uat', hostOrUrl: 'https://acme--uat.sandbox.my.salesforce.com' })).toBe(
+      'alice@acme.com',
+    );
+  });
+
+  it('matches the sandbox suffix case-insensitively', () => {
+    expect(deriveCanvasScopeId({ username: 'alice@acme.com.UAT', hostOrUrl: 'https://acme--uat.sandbox.my.salesforce.com' })).toBe(
+      'alice@acme.com',
+    );
+  });
+
+  it('returns a production username unchanged', () => {
+    expect(deriveCanvasScopeId({ username: 'alice@acme.com', hostOrUrl: 'https://acme.my.salesforce.com' })).toBe('alice@acme.com');
+  });
+
+  it('maps a user across production and multiple sandboxes to the same scope', () => {
+    const prod = deriveCanvasScopeId({ username: 'alice@acme.com', hostOrUrl: 'https://acme.my.salesforce.com' });
+    const uat = deriveCanvasScopeId({ username: 'alice@acme.com.uat', hostOrUrl: 'https://acme--uat.sandbox.my.salesforce.com' });
+    const dev = deriveCanvasScopeId({ username: 'alice@acme.com.dev', hostOrUrl: 'https://acme--dev.sandbox.my.salesforce.com' });
+    expect(uat).toBe(prod);
+    expect(dev).toBe(prod);
+  });
+
+  it('keeps different users in the same sandbox isolated', () => {
+    const alice = deriveCanvasScopeId({ username: 'alice@acme.com.uat', hostOrUrl: 'https://acme--uat.sandbox.my.salesforce.com' });
+    const bob = deriveCanvasScopeId({ username: 'bob@acme.com.uat', hostOrUrl: 'https://acme--uat.sandbox.my.salesforce.com' });
+    expect(alice).not.toBe(bob);
+  });
+
+  it('falls back to the full username when the username does not carry the sandbox suffix', () => {
+    // e.g. an admin renamed the sandbox user — safe fallback keeps them isolated rather than mis-grouping
+    expect(deriveCanvasScopeId({ username: 'alice@acme.com', hostOrUrl: 'https://acme--uat.sandbox.my.salesforce.com' })).toBe(
+      'alice@acme.com',
+    );
+  });
+});

--- a/apps/jetstream-canvas/src/utils/canvas.utils.ts
+++ b/apps/jetstream-canvas/src/utils/canvas.utils.ts
@@ -18,3 +18,45 @@ export function getCanvasOrg(): SalesforceOrgUi {
     displayName: user.fullName,
   };
 }
+
+/**
+ * Extract the sandbox name from a Salesforce My Domain host/URL, e.g.
+ * `https://acme--uat.sandbox.my.salesforce.com` -> `uat`. Returns null for production or
+ * hosts that don't match the sandbox My Domain pattern.
+ */
+export function extractSandboxName(hostOrUrl: string | undefined | null): string | null {
+  if (!hostOrUrl) {
+    return null;
+  }
+  const match = /--([^.]+)\.sandbox\./i.exec(hostOrUrl);
+  return match ? match[1] : null;
+}
+
+/**
+ * Derive the local-storage scope id for canvas. Canvas has no Jetstream login, and keying storage by
+ * the exact org means a user's query history / saved mappings do not follow them from a production org
+ * to its sandboxes (each has a distinct org + user id). Salesforce usernames are globally unique and a
+ * sandbox username is exactly `<productionUsername>.<sandboxName>`, so stripping the sandbox suffix
+ * (derived from the My Domain host) recovers the production username — stable across a prod org and all
+ * its sandboxes for that user. Falls back to the full username when the org is not a detectable sandbox.
+ * Two different users never share a scope because usernames are globally unique (unlike email, which some
+ * orgs bulk-rewrite on sandbox refresh).
+ */
+export function deriveCanvasScopeId({ username, hostOrUrl }: { username: string; hostOrUrl?: string | null }): string {
+  const sandboxName = extractSandboxName(hostOrUrl);
+  if (sandboxName) {
+    const suffix = `.${sandboxName}`.toLowerCase();
+    if (username.toLowerCase().endsWith(suffix)) {
+      return username.slice(0, username.length - suffix.length);
+    }
+  }
+  return username;
+}
+
+export function getCanvasStorageScopeId(): string {
+  const { client, context } = window.sr;
+  return deriveCanvasScopeId({
+    username: context.user.userName,
+    hostOrUrl: client.instanceUrl || context.environment.locationUrl,
+  });
+}

--- a/apps/jetstream-desktop-client/src/app/components/core/AppInitializer.tsx
+++ b/apps/jetstream-desktop-client/src/app/components/core/AppInitializer.tsx
@@ -6,12 +6,12 @@ import { setErrorTrackerUser, tracker, useObservable } from '@jetstream/shared/u
 import { Announcement, JetstreamEventSaveSoqlQueryFormatOptionsPayload, SalesforceOrgUi } from '@jetstream/types';
 import { fireToast } from '@jetstream/ui';
 import { fromJetstreamEvents, useAmplitude } from '@jetstream/ui-core';
-import { fromAppState } from '@jetstream/ui/app-state';
-import { initDexieDb, pruneAnalysisJobHistory } from '@jetstream/ui/db';
+import { DEFAULT_PROFILE, fromAppState } from '@jetstream/ui/app-state';
+import { ensureLocalStorageReady, initDexieDb, pruneAnalysisJobHistory } from '@jetstream/ui/db';
 import { AxiosResponse } from 'axios';
 import { useAtom, useAtomValue } from 'jotai';
 import localforage from 'localforage';
-import React, { Fragment, FunctionComponent, useEffect } from 'react';
+import React, { Fragment, FunctionComponent, use, useEffect } from 'react';
 import { Observable, Subject } from 'rxjs';
 import { environment } from '../../../environments/environment';
 import { useDesktopErrorTracker } from './useDesktopErrorTracker';
@@ -29,9 +29,12 @@ registerMiddleware('Error', (response: AxiosResponse, org?: SalesforceOrgUi) => 
   }
 });
 
-// Configure IndexedDB database
+// IndexedDB database holding the localforage stores. The default instance is configured here for
+// the pre-auth surfaces that read it directly (see `getUnscopedLocalStore`); everything behind a
+// signed-in user goes through the per-user store scoped by `ensureLocalStorageReady` below.
+const LOCAL_STORE_DB_NAME = environment.name;
 localforage.config({
-  name: environment.name,
+  name: LOCAL_STORE_DB_NAME,
 });
 
 export interface AppInitializerProps {
@@ -55,6 +58,11 @@ export const AppInitializer: FunctionComponent<AppInitializerProps> = ({ authInf
 
   const recordSyncEntitlementEnabled = ability.can('access', 'RecordSync');
   const recordSyncEnabled = recordSyncEntitlementEnabled && userProfile.preferences.recordSyncEnabled;
+
+  const activeUserId = userProfile.id && userProfile.id !== DEFAULT_PROFILE.id ? userProfile.id : null;
+  // Suspend until both local stores are scoped to this user, so no descendant reads local storage
+  // before it points at the right account.
+  use(ensureLocalStorageReady({ userId: activeUserId, dbName: LOCAL_STORE_DB_NAME }));
 
   useEffect(() => {
     console.log(
@@ -87,17 +95,20 @@ APP VERSION ${version}
     } else {
       disconnectSocket();
     }
-    initDexieDb({ recordSyncEnabled })
-      .then(() => pruneAnalysisJobHistory())
-      .catch((ex) => {
-        logger.error('[DB] Error initializing db', ex);
-      });
+
+    if (activeUserId) {
+      initDexieDb({ userId: activeUserId, dbName: LOCAL_STORE_DB_NAME, recordSyncEnabled })
+        .then(() => pruneAnalysisJobHistory())
+        .catch((ex) => {
+          logger.error('[DB] Error initializing db', ex);
+        });
+    }
     // Tear down the authenticated socket when this component unmounts (logout) or the auth
     // material changes, so a subsequent account never reuses the previous user's connection.
     return () => {
       disconnectSocket();
     };
-  }, [appInfo.serverUrl, authInfo.accessToken, authInfo.deviceId, recordSyncEnabled]);
+  }, [appInfo.serverUrl, authInfo.accessToken, authInfo.deviceId, recordSyncEnabled, activeUserId]);
 
   useEffect(() => {
     announcements && onAnnouncements && onAnnouncements(announcements);

--- a/apps/jetstream-desktop-client/src/app/components/core/Login.tsx
+++ b/apps/jetstream-desktop-client/src/app/components/core/Login.tsx
@@ -3,9 +3,11 @@ import { AuthenticatePayload, DesktopAuthInfo } from '@jetstream/desktop/types';
 import { logger } from '@jetstream/shared/client-logger';
 import { disconnectSocket, getOrgGroups, getOrgs } from '@jetstream/shared/data';
 import { applyVerifiedFeatureFlags } from '@jetstream/shared/ui-utils';
+import { UserProfileUi } from '@jetstream/types';
 import { Grid } from '@jetstream/ui';
 import { AppLoading, JetstreamLogoInverse } from '@jetstream/ui-core';
 import { DEFAULT_PROFILE, fromAppState } from '@jetstream/ui/app-state';
+import { clearLocalStorageScope, isDifferentUserThanPageSession } from '@jetstream/ui/db';
 import { useAtom, useSetAtom } from 'jotai';
 import { useCallback, useEffect, useState } from 'react';
 
@@ -38,12 +40,35 @@ export function Login({ children }: LoginProps) {
     }
   }, [setOrgs, setOrgGroups]);
 
+  /**
+   * Adopt the signed-in user, or reload the renderer first when this is a different account than the
+   * one local storage was already scoped to. `handleLogout` reloads for the normal sign out path, but
+   * a session that expires drops back to the login screen in place — without this, the next account
+   * to sign in from there would inherit the previous user's in-memory state.
+   *
+   * Returns false when a reload is underway, so callers skip the rest of their sign in work.
+   */
+  const applySignedInUser = useCallback(
+    async (userProfile: UserProfileUi) => {
+      if (isDifferentUserThanPageSession(userProfile.id)) {
+        clearLocalStorageScope();
+        window.location.reload();
+        return false;
+      }
+      // Verify the feature flag signature before trusting flags from the main process (fail-closed to code defaults)
+      setUserProfile(await applyVerifiedFeatureFlags(userProfile));
+      return true;
+    },
+    [setUserProfile],
+  );
+
   const authenticationEventHandler = useCallback(
     async (response: AuthenticatePayload) => {
       if (response.success) {
         setLoginError(null);
-        // Verify the feature flag signature before trusting flags from the main process (fail-closed to code defaults)
-        setUserProfile(await applyVerifiedFeatureFlags(response.userProfile));
+        if (!(await applySignedInUser(response.userProfile))) {
+          return;
+        }
         setAuthInfo(response.authInfo);
         // Re-fetch orgs and org groups now that the encryption key is set on the main process
         await refreshOrgsAndGroups();
@@ -52,16 +77,27 @@ export function Login({ children }: LoginProps) {
         setLoginError(response.error || 'Unable to complete sign in. Please try again.');
       }
     },
-    [setUserProfile, refreshOrgsAndGroups],
+    [applySignedInUser, refreshOrgsAndGroups],
   );
 
-  const handleLogout = useCallback(() => {
+  const handleLogout = useCallback(async () => {
     // Tear down the authenticated data-sync socket before clearing session state so it is not
     // reused by the next account that signs in on the same running app instance.
     disconnectSocket();
-    window.electronAPI?.logout();
+    // Unbind the per-user Dexie/localforage stores so nothing can read this account's local data
+    // between here and the reload below.
+    clearLocalStorageScope();
     setLoginError(null);
     setUserProfile(DEFAULT_PROFILE);
+    try {
+      await window.electronAPI?.logout();
+    } catch (ex) {
+      logger.error('Error during logout', ex);
+    }
+    // Reload the renderer so all in-memory state and the per-user local databases are rebuilt from
+    // scratch for the next account. The Dexie/localforage stores are scoped and selected at init,
+    // so a fresh boot guarantees the next user never reads the previous user's local data.
+    window.location.reload();
   }, [setUserProfile]);
 
   useEffect(() => {
@@ -78,8 +114,10 @@ export function Login({ children }: LoginProps) {
       .then(async (response) => {
         if (response) {
           const { authInfo, userProfile } = response;
+          if (!(await applySignedInUser(userProfile))) {
+            return;
+          }
           setAuthInfo(authInfo);
-          setUserProfile(await applyVerifiedFeatureFlags(userProfile));
           // Re-fetch orgs and org groups after auth completes — the encryption key
           // is now set on the main process, so orgs can be decrypted successfully.
           await refreshOrgsAndGroups();
@@ -92,9 +130,15 @@ export function Login({ children }: LoginProps) {
       window.electronAPI?.checkAuth().then(async (response) => {
         if (response) {
           const { authInfo, userProfile } = response;
+          if (!(await applySignedInUser(userProfile))) {
+            return;
+          }
           setAuthInfo(authInfo);
-          setUserProfile(await applyVerifiedFeatureFlags(userProfile));
         } else {
+          // The session ended without going through `handleLogout` (expired or revoked) and this
+          // renderer stays mounted, so unbind the stores here too rather than leaving the departing
+          // account's local data readable until the next sign in.
+          clearLocalStorageScope();
           setAuthInfo(undefined);
           setUserProfile(DEFAULT_PROFILE);
         }
@@ -105,7 +149,7 @@ export function Login({ children }: LoginProps) {
       clearInterval(interval);
       unsubscribeAuth();
     };
-  }, [authenticationEventHandler, setUserProfile, refreshOrgsAndGroups]);
+  }, [authenticationEventHandler, applySignedInUser, setUserProfile, refreshOrgsAndGroups]);
 
   function handleLogin() {
     setLoginError(null);

--- a/apps/jetstream-web-extension/src/core/AppInitializer.tsx
+++ b/apps/jetstream-web-extension/src/core/AppInitializer.tsx
@@ -13,11 +13,11 @@ import { JetstreamEventSaveSoqlQueryFormatOptionsPayload, UserProfileUi } from '
 import { ScopedNotification } from '@jetstream/ui';
 import { AppLoading, fromJetstreamEvents } from '@jetstream/ui-core';
 import { fromAppState } from '@jetstream/ui/app-state';
-import { initDexieDb } from '@jetstream/ui/db';
+import { clearLocalStorageScope, ensureLocalStorageReady, initDexieDb, isDifferentUserThanPageSession } from '@jetstream/ui/db';
 import { useObservable } from 'dexie-react-hooks';
 import { useAtomValue, useSetAtom } from 'jotai';
 import localforage from 'localforage';
-import React, { FunctionComponent, useEffect, useState } from 'react';
+import React, { FunctionComponent, use, useEffect, useState } from 'react';
 import { useLocation } from 'react-router';
 import { Observable } from 'rxjs';
 import browser from 'webextension-polyfill';
@@ -31,9 +31,12 @@ import { GlobalExtensionLoggedOut } from './GlobalExtensionLoggedOut';
 const args = new URLSearchParams(location.search.slice(1));
 const salesforceHost = args.get('host');
 
-// Configure IndexedDB database
+// IndexedDB database holding the localforage stores. The default instance is configured here for
+// the surfaces that read it directly (see `getUnscopedLocalStore`); everything behind a signed-in
+// user goes through the per-user store scoped by `ensureLocalStorageReady` below.
+const LOCAL_STORE_DB_NAME = 'jetstream-web-ext-no-sync';
 localforage.config({
-  name: 'jetstream-web-ext-no-sync',
+  name: LOCAL_STORE_DB_NAME,
 });
 
 export interface AppInitializerProps {
@@ -61,6 +64,37 @@ export const AppInitializer: FunctionComponent<AppInitializerProps> = ({ allowWi
 
   const [fatalError, setFatalError] = useState<string>();
 
+  const activeUserId = chromeUserProfile?.id ?? null;
+  // Sign in and sign out reach this page through `browser.storage` events rather than a page load,
+  // so a second account can take over a page still holding the first account's in-memory state
+  // (jotai atoms, module level caches). Local storage re-scopes itself, the rest does not, so a
+  // different user gets a fresh page instead.
+  const isDifferentUser = isDifferentUserThanPageSession(activeUserId);
+
+  // Suspend until both local stores are scoped to this user, so no descendant reads local storage
+  // before it points at the right account. When a different account takes over, never scope to it
+  // in this page instance: the reload below owns the transition, and binding the new user's stores
+  // here would let in-flight async work from the departing account write into them. Leaving the
+  // departing account's stores bound until the reload effect clears them keeps its late writes
+  // attributed to its own database.
+  use(ensureLocalStorageReady({ userId: isDifferentUser ? null : activeUserId, dbName: LOCAL_STORE_DB_NAME }));
+
+  useEffect(() => {
+    if (isDifferentUser) {
+      clearLocalStorageScope();
+      window.location.reload();
+    }
+  }, [isDifferentUser]);
+
+  // Unlike every other surface, signing out here re-renders in place instead of reloading or
+  // navigating away, so unbind the stores explicitly - otherwise the departing account's data stays
+  // readable for as long as the page is open.
+  useEffect(() => {
+    if (!activeUserId) {
+      clearLocalStorageScope();
+    }
+  }, [activeUserId]);
+
   // Ensure the appInfoState has the correct serverUrl from the extension environment
   // The default is 'https://getjetstream.app' which is incorrect in dev
   useEffect(() => {
@@ -81,8 +115,9 @@ export const AppInitializer: FunctionComponent<AppInitializerProps> = ({ allowWi
   }, [chromeUserProfile]);
 
   useEffect(() => {
-    // wait until this data has initialized before proceeding
-    if (!authTokens?.accessToken || !extIdentifier?.id) {
+    // wait until this data has initialized before proceeding; never initialize for a different
+    // account taking over this page — the reload effect above replaces the page for it instead
+    if (!authTokens?.accessToken || !extIdentifier?.id || !chromeUserProfile?.id || isDifferentUser) {
       return;
     }
     const recordSyncEnabled = options.recordSyncEnabled && !!authTokens?.accessToken && !!extIdentifier?.id;
@@ -94,10 +129,10 @@ export const AppInitializer: FunctionComponent<AppInitializerProps> = ({ allowWi
     } else {
       disconnectSocket();
     }
-    initDexieDb({ recordSyncEnabled }).catch((ex) => {
+    initDexieDb({ userId: chromeUserProfile.id, dbName: LOCAL_STORE_DB_NAME, recordSyncEnabled }).catch((ex) => {
       logger.error('[DB] Error initializing db', ex);
     });
-  }, [authTokens?.accessToken, extIdentifier?.id, options.recordSyncEnabled, serverUrl]);
+  }, [authTokens?.accessToken, extIdentifier?.id, chromeUserProfile?.id, isDifferentUser, options.recordSyncEnabled, serverUrl]);
 
   // Ensure user access token is valid
   useEffect(() => {
@@ -172,6 +207,12 @@ export const AppInitializer: FunctionComponent<AppInitializerProps> = ({ allowWi
       }
     })();
   }, [setSalesforceOrgs, setSelectedOrgId]);
+
+  // Hold everything back until the reload above replaces the page - the app state still in memory
+  // belongs to the account that was signed in a moment ago, not to this one.
+  if (isDifferentUser) {
+    return <AppLoading />;
+  }
 
   if (fatalError) {
     return <GlobalExtensionError message={fatalError} />;

--- a/apps/jetstream/src/app/components/core/AppInitializer.tsx
+++ b/apps/jetstream/src/app/components/core/AppInitializer.tsx
@@ -5,13 +5,13 @@ import { initErrorTracker, setErrorTrackerUser, tracker, useObservable } from '@
 import { Announcement, JetstreamEventSaveSoqlQueryFormatOptionsPayload, SalesforceOrgUi } from '@jetstream/types';
 import { fireToast } from '@jetstream/ui';
 import { fromJetstreamEvents, useAmplitude } from '@jetstream/ui-core';
-import { fromAppState } from '@jetstream/ui/app-state';
+import { DEFAULT_PROFILE, fromAppState } from '@jetstream/ui/app-state';
 import { CookieConsentBanner, useConditionalGoogleAnalytics } from '@jetstream/ui/cookie-consent-banner';
-import { initDexieDb, pruneAnalysisJobHistory } from '@jetstream/ui/db';
+import { ensureLocalStorageReady, initDexieDb, pruneAnalysisJobHistory } from '@jetstream/ui/db';
 import { AxiosResponse } from 'axios';
 import { useAtom, useAtomValue } from 'jotai';
 import localforage from 'localforage';
-import React, { Fragment, FunctionComponent, useCallback, useEffect } from 'react';
+import React, { Fragment, FunctionComponent, use, useCallback, useEffect } from 'react';
 import { useSearchParams } from 'react-router';
 import { Observable, Subject } from 'rxjs';
 import { environment } from '../../../environments/environment';
@@ -28,9 +28,12 @@ registerMiddleware('Error', (response: AxiosResponse, org?: SalesforceOrgUi) => 
   }
 });
 
-// Configure IndexedDB database
+// IndexedDB database holding the localforage stores. The default instance is configured here for
+// the pre-auth surfaces that read it directly (see `getUnscopedLocalStore`); everything behind a
+// signed-in user goes through the per-user store scoped by `ensureLocalStorageReady` below.
+const LOCAL_STORE_DB_NAME = environment.name;
 localforage.config({
-  name: environment.name,
+  name: LOCAL_STORE_DB_NAME,
 });
 
 export interface AppInitializerProps {
@@ -55,6 +58,11 @@ export const AppInitializer: FunctionComponent<AppInitializerProps> = ({ onAnnou
 
   const recordSyncEntitlementEnabled = ability.can('access', 'RecordSync');
   const recordSyncEnabled = recordSyncEntitlementEnabled && userProfile.preferences.recordSyncEnabled;
+
+  const activeUserId = userProfile.id && userProfile.id !== DEFAULT_PROFILE.id ? userProfile.id : null;
+  // Suspend until both local stores are scoped to this user, so no descendant reads local storage
+  // before it points at the right account.
+  use(ensureLocalStorageReady({ userId: activeUserId, dbName: LOCAL_STORE_DB_NAME }));
 
   useEffect(() => {
     if (errorParam && AUTH_ERROR_MESSAGES[errorParam]) {
@@ -90,12 +98,15 @@ APP VERSION ${version}
     } else {
       disconnectSocket();
     }
-    initDexieDb({ recordSyncEnabled })
-      .then(() => pruneAnalysisJobHistory())
-      .catch((ex) => {
-        logger.error('[DB] Error initializing db', ex);
-      });
-  }, [appInfo.serverUrl, recordSyncEnabled]);
+
+    if (activeUserId) {
+      initDexieDb({ userId: activeUserId, dbName: LOCAL_STORE_DB_NAME, recordSyncEnabled })
+        .then(() => pruneAnalysisJobHistory())
+        .catch((ex) => {
+          logger.error('[DB] Error initializing db', ex);
+        });
+    }
+  }, [appInfo.serverUrl, recordSyncEnabled, activeUserId]);
 
   useEffect(() => {
     announcements && onAnnouncements && onAnnouncements(announcements);

--- a/apps/jetstream/src/app/components/settings/Settings.tsx
+++ b/apps/jetstream/src/app/components/settings/Settings.tsx
@@ -18,9 +18,8 @@ import {
 } from '@jetstream/ui';
 import { SalesforceCanvasOrgs, SoqlQueryFormatConfig, useAmplitude } from '@jetstream/ui-core';
 import { fromAppState, useFeatureFlag, userProfileState } from '@jetstream/ui/app-state';
-import { dexieDataSync, recentHistoryItemsDb } from '@jetstream/ui/db';
+import { deleteAllLocalData, dexieDataSync, recentHistoryItemsDb } from '@jetstream/ui/db';
 import { useAtom, useAtomValue } from 'jotai';
-import localforage from 'localforage';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { AnalyticsTrackingSetting } from './AnalyticsTrackingSetting';
 import LoggerConfig from './LoggerConfig';
@@ -133,24 +132,27 @@ export const Settings = () => {
     trackEvent(ANALYTICS_KEYS.settings_delete_account, { reason });
     setLoading(true);
     try {
-      localStorage.clear();
-      await localforage.clear();
-    } catch {
-      // error clearing local storage
-    }
-
-    try {
       await deleteUserProfile(reason);
-      eraseCookies();
-
-      window.location.href = '/goodbye/';
     } catch {
       // error deleting everything from server
       fireToast({
         message: 'There was a problem deleting your account. Try again or file a support ticket for assistance.',
         type: 'error',
       });
+      setLoading(false);
+      return;
     }
+
+    // Only wipe local data once the server-side delete succeeded — deleteAllLocalData unbinds the
+    // local stores, so doing it before a delete that then fails would leave the still-running app
+    // unable to read local storage. The redirect below immediately replaces the page.
+    try {
+      await deleteAllLocalData(userProfile.id);
+    } catch {
+      // error clearing local storage
+    }
+    eraseCookies();
+    window.location.href = '/goodbye/';
   }
 
   async function resetSync() {

--- a/libs/features/anon-apex/src/AnonymousApex.tsx
+++ b/libs/features/anon-apex/src/AnonymousApex.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/react';
 import { useSetTraceFlag } from '@jetstream/connected-ui';
 import { logger } from '@jetstream/shared/client-logger';
 import { ANALYTICS_KEYS, INDEXED_DB, LOG_LEVELS, TITLES } from '@jetstream/shared/constants';
-import { anonymousApex } from '@jetstream/shared/data';
+import { anonymousApex, getLocalStore } from '@jetstream/shared/data';
 import {
   sanitizePastedEditorText,
   setItemInLocalStorage,
@@ -36,7 +36,6 @@ import { MonacoEditor, useAmplitude } from '@jetstream/ui-core';
 import { STORAGE_KEYS, applicationCookieState, selectSkipFrontdoorAuth, selectedOrgState } from '@jetstream/ui/app-state';
 import { OnMount } from '@monaco-editor/react';
 import { useAtom, useAtomValue } from 'jotai';
-import localforage from 'localforage';
 import escapeRegExp from 'lodash/escapeRegExp';
 import type { editor } from 'monaco-editor';
 import { Fragment, FunctionComponent, MouseEvent, useCallback, useEffect, useRef, useState } from 'react';
@@ -110,7 +109,7 @@ export const AnonymousApex: FunctionComponent<AnonymousApexProps> = () => {
     if (apex) {
       (async () => {
         try {
-          await localforage.setItem<Record<string, ApexHistoryItem>>(INDEXED_DB.KEYS.apexHistory, historyItems);
+          await getLocalStore().setItem<Record<string, ApexHistoryItem>>(INDEXED_DB.KEYS.apexHistory, historyItems);
         } catch (ex) {
           logger.warn(ex);
         }

--- a/libs/features/anon-apex/src/apex.state.ts
+++ b/libs/features/anon-apex/src/apex.state.ts
@@ -1,5 +1,6 @@
 import { logger } from '@jetstream/shared/client-logger';
 import { DATE_FORMATS, INDEXED_DB } from '@jetstream/shared/constants';
+import { getLocalStore } from '@jetstream/shared/data';
 import { groupByFlat, hashString, pluralizeFromNumber, truncate } from '@jetstream/shared/utils';
 import { ApexHistoryItem, SalesforceOrgUi } from '@jetstream/types';
 import { selectedOrgState } from '@jetstream/ui/app-state';
@@ -8,7 +9,7 @@ import { formatDate } from 'date-fns/format';
 import { isBefore } from 'date-fns/isBefore';
 import { startOfDay } from 'date-fns/startOfDay';
 import { atom } from 'jotai';
-import localforage from 'localforage';
+import { atomWithLazy } from 'jotai/utils';
 import orderBy from 'lodash/orderBy';
 
 let didRunCleanup = false;
@@ -41,7 +42,7 @@ export async function cleanUpHistoryState(): Promise<Record<string, ApexHistoryI
 
       logger.info('[APEX-HISTORY][CLEANUP]', 'Keeping items', itemsToKeep);
       try {
-        await localforage.setItem<Record<string, ApexHistoryItem>>(INDEXED_DB.KEYS.apexHistory, itemsToKeep);
+        await getLocalStore().setItem<Record<string, ApexHistoryItem>>(INDEXED_DB.KEYS.apexHistory, itemsToKeep);
       } catch (ex) {
         logger.warn('[APEX-HISTORY][CLEANUP]', 'Error saving cleaned up apex history', ex);
       }
@@ -54,7 +55,7 @@ export async function cleanUpHistoryState(): Promise<Record<string, ApexHistoryI
 
 const initApexHistory = async (): Promise<Record<string, ApexHistoryItem>> => {
   try {
-    return (await localforage.getItem<Record<string, ApexHistoryItem>>(INDEXED_DB.KEYS.apexHistory)) || {};
+    return (await getLocalStore().getItem<Record<string, ApexHistoryItem>>(INDEXED_DB.KEYS.apexHistory)) || {};
   } catch (ex) {
     logger.error('[APEX-HISTORY][INIT]', 'Error initializing apex history', ex);
     return {};
@@ -92,7 +93,12 @@ export async function initNewApexHistoryItem(org: SalesforceOrgUi, apex: string)
   return { ...historyItems, [newItem.key]: newItem };
 }
 
-export const apexHistoryState = atom<Promise<Record<string, ApexHistoryItem>> | Record<string, ApexHistoryItem>>(initApexHistory());
+/**
+ * Lazy so the storage read happens on first use (after `ensureLocalStorageReady` has scoped the
+ * store to the current user). The browser extension imports this module eagerly, so an eager read
+ * would hit the shared un-scoped store while every write lands in the per-user one.
+ */
+export const apexHistoryState = atomWithLazy<Promise<Record<string, ApexHistoryItem>> | Record<string, ApexHistoryItem>>(initApexHistory);
 
 export const apexHistoryWhichOrg = atom<'ALL' | 'SELECTED'>('SELECTED');
 

--- a/libs/features/data-analysis/src/FieldUsageAnalysisView.tsx
+++ b/libs/features/data-analysis/src/FieldUsageAnalysisView.tsx
@@ -39,7 +39,7 @@ import {
 } from '@jetstream/ui';
 import { PermissionAnalysisHistoryModal, RequireMetadataApiBanner, fromJetstreamEvents, jobsState } from '@jetstream/ui-core';
 import { applicationCookieState, selectSkipFrontdoorAuth, selectedOrgState } from '@jetstream/ui/app-state';
-import { dexieDb } from '@jetstream/ui/db';
+import { getDexieDb } from '@jetstream/ui/db';
 import { isValid } from 'date-fns/isValid';
 import { parseISO } from 'date-fns/parseISO';
 import { useLiveQuery } from 'dexie-react-hooks';
@@ -605,7 +605,7 @@ export const FieldUsageAnalysisView: FunctionComponent = () => {
     if (!jobId || !selectedOrgId) {
       return undefined;
     }
-    const row = await dexieDb.analysis_job_history.get(jobId);
+    const row = await getDexieDb().analysis_job_history.get(jobId);
     return row && row.org === selectedOrgId ? row : undefined;
   }, [jobId, selectedOrgId]);
 

--- a/libs/features/deploy/src/utils/deploy-metadata.utils.tsx
+++ b/libs/features/deploy/src/utils/deploy-metadata.utils.tsx
@@ -1,6 +1,7 @@
 import { getMetadataLabelFromFullName, ListMetadataResultItem } from '@jetstream/connected-ui';
 import { logger } from '@jetstream/shared/client-logger';
 import { DATE_FORMATS, INDEXED_DB } from '@jetstream/shared/constants';
+import { getLocalStore } from '@jetstream/shared/data';
 import { tracker } from '@jetstream/shared/ui-utils';
 import { ensureArray, getSuccessOrFailureChar, orderValues, pluralizeFromNumber } from '@jetstream/shared/utils';
 import {
@@ -36,7 +37,6 @@ import { formatISO } from 'date-fns/formatISO';
 import { isValid as isDateValid } from 'date-fns/isValid';
 import { parseISO } from 'date-fns/parseISO';
 import JSZip from 'jszip';
-import localforage from 'localforage';
 import isDate from 'lodash/isDate';
 import isString from 'lodash/isString';
 import { ReactNode } from 'react';
@@ -61,7 +61,7 @@ export function getLightningChangesetUrl(changeset: ChangeSet) {
 
 export async function getHistory() {
   try {
-    return (await localforage.getItem<SalesforceDeployHistoryItem[]>(INDEXED_DB.KEYS.deployHistory)) || [];
+    return (await getLocalStore().getItem<SalesforceDeployHistoryItem[]>(INDEXED_DB.KEYS.deployHistory)) || [];
   } catch (ex) {
     logger.warn('[DEPLOY][HISTORY][GET ERROR]', ex);
     return [];
@@ -71,7 +71,7 @@ export async function getHistory() {
 export async function getHistoryItemFile(item: SalesforceDeployHistoryItem) {
   let file: ArrayBuffer | null = null;
   if (item.fileKey) {
-    file = await localforage.getItem<ArrayBuffer>(item.fileKey);
+    file = await getLocalStore().getItem<ArrayBuffer>(item.fileKey);
   }
   if (!file) {
     throw new Error('The package file is not available');
@@ -135,17 +135,20 @@ export async function saveHistory({
         orgName: sourceOrg.orgName || '',
       };
     }
-    if (file && localforage.driver() === localforage.INDEXEDDB) {
+    const localStore = getLocalStore();
+    // The package file is only retained on IndexedDB — the other drivers cannot hold a blob this size
+    const canStorePackageFile = !!file && localStore.driver() === localStore.INDEXEDDB;
+    if (canStorePackageFile) {
       newItem.fileKey = `${INDEXED_DB.KEYS.deployHistory}:FILE:${newItem.key}`;
     }
     const existingItems = await getHistory();
     existingItems.unshift(newItem);
     try {
-      await localforage.setItem<SalesforceDeployHistoryItem[]>(INDEXED_DB.KEYS.deployHistory, existingItems.slice(0, MAX_HISTORY_ITEMS));
+      await localStore.setItem<SalesforceDeployHistoryItem[]>(INDEXED_DB.KEYS.deployHistory, existingItems.slice(0, MAX_HISTORY_ITEMS));
       logger.log('[DEPLOY][HISTORY][SAVE]', { newItem });
 
-      if (file && newItem.fileKey && localforage.driver() === localforage.INDEXEDDB) {
-        await localforage.setItem(newItem.fileKey, file);
+      if (canStorePackageFile && newItem.fileKey) {
+        await localStore.setItem(newItem.fileKey, file);
       }
     } catch (ex) {
       logger.warn('[DEPLOY][HISTORY][SAVE ERROR]', ex);
@@ -154,7 +157,7 @@ export async function saveHistory({
     try {
       if (existingItems.length > MAX_HISTORY_ITEMS) {
         for (const item of existingItems.slice(MAX_HISTORY_ITEMS).filter((item) => item.fileKey)) {
-          item.fileKey && (await localforage.removeItem(item.fileKey));
+          item.fileKey && (await getLocalStore().removeItem(item.fileKey));
         }
       }
     } catch (ex) {

--- a/libs/features/load-records/src/components/load-mapping-storage/LoadMappingPopover.tsx
+++ b/libs/features/load-records/src/components/load-mapping-storage/LoadMappingPopover.tsx
@@ -3,7 +3,7 @@ import { logger } from '@jetstream/shared/client-logger';
 import { LoadSavedMappingItem } from '@jetstream/types';
 import { BadgeNotification, EmptyState, fireToast, Icon, Popover, PopoverRef } from '@jetstream/ui';
 import { STATIC_MAPPING_PREFIX } from '@jetstream/ui-core';
-import { dexieDb, withReopenOnDatabaseClosed } from '@jetstream/ui/db';
+import { getDexieDb, withReopenOnDatabaseClosed } from '@jetstream/ui/db';
 import classNames from 'classnames';
 import { useLiveQuery } from 'dexie-react-hooks';
 import { FunctionComponent, useRef } from 'react';
@@ -21,8 +21,8 @@ export const LoadMappingPopover: FunctionComponent<LoadMappingPopoverProps> = ({
 
   const savedMappingsForObject = useLiveQuery(
     () =>
-      dexieDb.load_saved_mapping
-        .where('sobject')
+      getDexieDb()
+        .load_saved_mapping.where('sobject')
         .equalsIgnoreCase(sobject)
         .filter(
           (item) =>
@@ -49,7 +49,7 @@ export const LoadMappingPopover: FunctionComponent<LoadMappingPopoverProps> = ({
   async function handleButtonAction(id: string, metadata: LoadSavedMappingItem) {
     try {
       if (id === 'delete' && metadata) {
-        await withReopenOnDatabaseClosed(() => dexieDb.load_saved_mapping.where('key').equals(metadata.key).delete());
+        await withReopenOnDatabaseClosed(() => getDexieDb().load_saved_mapping.where('key').equals(metadata.key).delete());
       }
     } catch (ex) {
       logger.warn('Failed to delete field mapping', ex);

--- a/libs/features/load-records/src/components/load-mapping-storage/SaveMappingPopover.tsx
+++ b/libs/features/load-records/src/components/load-mapping-storage/SaveMappingPopover.tsx
@@ -4,7 +4,7 @@ import { formatNumber } from '@jetstream/shared/ui-utils';
 import { pluralizeIfMultiple } from '@jetstream/shared/utils';
 import { FieldMapping, LoadSavedMappingItem } from '@jetstream/types';
 import { fireToast, Grid, Icon, Input, Popover, PopoverRef, ScopedNotification } from '@jetstream/ui';
-import { dexieDb, getHashedRecordKey, withReopenOnDatabaseClosed } from '@jetstream/ui/db';
+import { getDexieDb, getHashedRecordKey, withReopenOnDatabaseClosed } from '@jetstream/ui/db';
 import { formatISO } from 'date-fns/formatISO';
 import omit from 'lodash/omit';
 import { FunctionComponent, useEffect, useMemo, useRef, useState } from 'react';
@@ -61,7 +61,7 @@ export const SaveMappingPopover: FunctionComponent<SaveMappingPopoverProps> = ({
       newMapping.createdAt = new Date();
       newMapping.key = `lsm_${sobject}:${newMapping.csvFields.length}:${formatISO(newMapping.createdAt).toLowerCase()}`;
       newMapping.hashedKey = await getHashedRecordKey(newMapping.key);
-      await withReopenOnDatabaseClosed(() => dexieDb.load_saved_mapping.put(newMapping));
+      await withReopenOnDatabaseClosed(() => getDexieDb().load_saved_mapping.put(newMapping));
       saveSetMappingName('');
       setCurrentSavedMapping(getDefaultItem(sobject));
       popoverRef.current?.close();

--- a/libs/features/permission-analysis/src/PermissionAnalysisView.tsx
+++ b/libs/features/permission-analysis/src/PermissionAnalysisView.tsx
@@ -18,7 +18,7 @@ import {
 } from '@jetstream/ui';
 import { PermissionAnalysisHistoryModal, RequireMetadataApiBanner, jobsState } from '@jetstream/ui-core';
 import { applicationCookieState, selectSkipFrontdoorAuth, selectedOrgState } from '@jetstream/ui/app-state';
-import { dexieDb } from '@jetstream/ui/db';
+import { getDexieDb } from '@jetstream/ui/db';
 import { useLiveQuery } from 'dexie-react-hooks';
 import { useAtomValue } from 'jotai';
 import { Fragment, FunctionComponent, useEffect, useMemo, useState } from 'react';
@@ -181,7 +181,7 @@ export const PermissionAnalysisView: FunctionComponent = () => {
     if (!jobId || !selectedOrgId) {
       return undefined;
     }
-    const row = await dexieDb.analysis_job_history.get(jobId);
+    const row = await getDexieDb().analysis_job_history.get(jobId);
     return row && row.org === selectedOrgId ? row : undefined;
   }, [jobId, selectedOrgId]);
 

--- a/libs/features/salesforce-api/src/SalesforceApiHistoryModal.tsx
+++ b/libs/features/salesforce-api/src/SalesforceApiHistoryModal.tsx
@@ -4,7 +4,7 @@ import { multiWordObjectFilter } from '@jetstream/shared/utils';
 import { ApiHistoryItem, SalesforceApiHistoryRequest, SalesforceOrgUi, UpDown } from '@jetstream/types';
 import { Badge, CopyToClipboard, Grid, GridCol, Icon, List, Modal, SearchInput } from '@jetstream/ui';
 import { MonacoEditor } from '@jetstream/ui-core';
-import { dexieDb } from '@jetstream/ui/db';
+import { getDexieDb } from '@jetstream/ui/db';
 import { useLiveQuery } from 'dexie-react-hooks';
 import { createRef, useEffect, useState } from 'react';
 import { HistoryWhichOrg } from './HistoryWhichOrg';
@@ -27,8 +27,8 @@ export const SalesforceApiHistoryModal = ({ selectedOrg, onSubmit, onClose }: Sa
 
   const historyItems = useLiveQuery(
     () =>
-      dexieDb.api_request_history
-        .orderBy('lastRun')
+      getDexieDb()
+        .api_request_history.orderBy('lastRun')
         .reverse()
         .filter((item) => whichOrg === 'ALL' || item.org === selectedOrg.uniqueId)
         .toArray(),
@@ -37,7 +37,7 @@ export const SalesforceApiHistoryModal = ({ selectedOrg, onSubmit, onClose }: Sa
   );
 
   const selectedHistoryItem = useLiveQuery(
-    () => (selectedItemKey ? dexieDb.api_request_history.get(selectedItemKey) : undefined),
+    () => (selectedItemKey ? getDexieDb().api_request_history.get(selectedItemKey) : undefined),
     [selectedItemKey],
   );
 

--- a/libs/features/salesforce-api/src/salesforceApi.state.ts
+++ b/libs/features/salesforce-api/src/salesforceApi.state.ts
@@ -1,11 +1,11 @@
 import { logger } from '@jetstream/shared/client-logger';
 import { INDEXED_DB } from '@jetstream/shared/constants';
+import { getLocalStore } from '@jetstream/shared/data';
 import { groupByFlat } from '@jetstream/shared/utils';
 import { SalesforceApiHistoryItem } from '@jetstream/types';
 import { addDays } from 'date-fns/addDays';
 import { isBefore } from 'date-fns/isBefore';
 import { startOfDay } from 'date-fns/startOfDay';
-import localforage from 'localforage';
 
 let didRunCleanup = false;
 
@@ -36,7 +36,7 @@ export async function cleanUpHistoryState(): Promise<Record<string, SalesforceAp
       }
 
       logger.info('[API-HISTORY][CLEANUP]', 'Keeping items', itemsToKeep);
-      await localforage.setItem<Record<string, SalesforceApiHistoryItem>>(INDEXED_DB.KEYS.salesforceApiHistory, itemsToKeep);
+      await getLocalStore().setItem<Record<string, SalesforceApiHistoryItem>>(INDEXED_DB.KEYS.salesforceApiHistory, itemsToKeep);
       return itemsToKeep;
     }
   } catch (ex) {
@@ -46,7 +46,7 @@ export async function cleanUpHistoryState(): Promise<Record<string, SalesforceAp
 
 async function initSalesforceApiHistory(): Promise<Record<string, SalesforceApiHistoryItem>> {
   try {
-    return (await localforage.getItem<Record<string, SalesforceApiHistoryItem>>(INDEXED_DB.KEYS.salesforceApiHistory)) || {};
+    return (await getLocalStore().getItem<Record<string, SalesforceApiHistoryItem>>(INDEXED_DB.KEYS.salesforceApiHistory)) || {};
   } catch (ex) {
     logger.error('Error getting salesforceApiHistory from localforage', ex);
     return {};

--- a/libs/features/sobject-export/src/SObjectExport.tsx
+++ b/libs/features/sobject-export/src/SObjectExport.tsx
@@ -1,6 +1,7 @@
 import { css } from '@emotion/react';
 import { logger } from '@jetstream/shared/client-logger';
 import { INDEXED_DB, TITLES } from '@jetstream/shared/constants';
+import { getLocalStore } from '@jetstream/shared/data';
 import { APP_ROUTES } from '@jetstream/shared/ui-router';
 import { tracker, usePrimaryActionShortcut, useTitle } from '@jetstream/shared/ui-utils';
 import { getErrorMessage } from '@jetstream/shared/utils';
@@ -31,7 +32,6 @@ import { fromJetstreamEvents, useAmplitude } from '@jetstream/ui-core';
 import { applicationCookieState, googleDriveAccessState, selectedOrgState } from '@jetstream/ui/app-state';
 import { recentHistoryItemsDb } from '@jetstream/ui/db';
 import { useAtomValue } from 'jotai';
-import localforage from 'localforage';
 import { Fragment, FunctionComponent, useEffect, useRef, useState } from 'react';
 import {
   ExportHeaderOption,
@@ -120,7 +120,7 @@ export const SObjectExport: FunctionComponent<SObjectExportProps> = () => {
   useEffect(() => {
     (async () => {
       try {
-        const results = await localforage.getItem<SavedExportOptions>(INDEXED_DB.KEYS.sobjectExportSelection);
+        const results = await getLocalStore().getItem<SavedExportOptions>(INDEXED_DB.KEYS.sobjectExportSelection);
         if (results?.options) {
           setOptions(results.options);
           if (picklistWorksheetLayoutRef.current) {
@@ -192,7 +192,7 @@ export const SObjectExport: FunctionComponent<SObjectExportProps> = () => {
 
       if (options.saveAsDefaultSelection) {
         try {
-          await localforage.setItem<SavedExportOptions>(INDEXED_DB.KEYS.sobjectExportSelection, {
+          await getLocalStore().setItem<SavedExportOptions>(INDEXED_DB.KEYS.sobjectExportSelection, {
             fields: selectedAttributes,
             options: { ...options, saveAsDefaultSelection: false },
           });

--- a/libs/shared/data/src/index.ts
+++ b/libs/shared/data/src/index.ts
@@ -3,4 +3,5 @@ export * from './lib/client-data-cache';
 export { AxiosAdapterConfig, createMultipartFromFormData, getCsrfTokenFromCookie } from './lib/client-data-data-helper';
 export * from './lib/client-socket-data';
 export * from './lib/data-utils';
+export * from './lib/local-store';
 export * from './lib/middleware';

--- a/libs/shared/data/src/lib/__tests__/local-store.spec.ts
+++ b/libs/shared/data/src/lib/__tests__/local-store.spec.ts
@@ -1,0 +1,73 @@
+import localforage from 'localforage';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createUserLocalStore, getLocalStore, getUnscopedLocalStore, hasLocalStore, setLocalStore } from '../local-store';
+
+type LocalStore = ReturnType<typeof localforage.createInstance>;
+
+function fakeLocalStore(name: string): LocalStore {
+  return { name, ready: () => Promise.resolve() } as unknown as LocalStore;
+}
+
+describe('local-store (per-user scoping)', () => {
+  beforeEach(() => {
+    setLocalStore(null);
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    setLocalStore(null);
+  });
+
+  it('throws instead of silently falling back to the shared instance before a user is bound', () => {
+    expect(hasLocalStore()).toBe(false);
+    expect(() => getLocalStore()).toThrow(/has not been initialized/);
+  });
+
+  it('exposes the shared instance only through the explicit un-scoped accessor', () => {
+    expect(getUnscopedLocalStore()).toBe(localforage);
+  });
+
+  it('creates the store scoped by a hash of the user id, without binding it', async () => {
+    const fakeInstance = fakeLocalStore('scoped');
+    const createInstance = vi.spyOn(localforage, 'createInstance').mockReturnValue(fakeInstance);
+
+    const store = await createUserLocalStore({ dbName: 'Jetstream', userId: 'user-123' });
+
+    expect(store).toBe(fakeInstance);
+    expect(createInstance).toHaveBeenCalledWith(
+      // 40 hex chars = SHA-1
+      expect.objectContaining({ name: 'Jetstream', storeName: expect.stringMatching(/^u_[0-9a-f]{40}$/) }),
+    );
+    // Creation alone must not bind — the scope owner commits via setLocalStore
+    expect(hasLocalStore()).toBe(false);
+  });
+
+  it('never uses the raw user id in the store name', async () => {
+    const userId = 'alice@example.com';
+    const createInstance = vi.spyOn(localforage, 'createInstance');
+    await createUserLocalStore({ dbName: 'Jetstream', userId });
+    const [{ storeName }] = createInstance.mock.calls[0] as unknown as [{ storeName: string }];
+    expect(storeName).not.toContain(userId);
+  });
+
+  it('is deterministic for the same user and distinct for different users', async () => {
+    const createInstance = vi.spyOn(localforage, 'createInstance');
+    await createUserLocalStore({ dbName: 'Jetstream', userId: 'user-a' });
+    await createUserLocalStore({ dbName: 'Jetstream', userId: 'user-a' });
+    await createUserLocalStore({ dbName: 'Jetstream', userId: 'user-b' });
+    const [[first], [second], [third]] = createInstance.mock.calls as unknown as Array<[{ storeName: string }]>;
+    expect(first.storeName).toBe(second.storeName);
+    expect(first.storeName).not.toBe(third.storeName);
+  });
+
+  it('binds and unbinds through setLocalStore so reads fail closed after a logout', () => {
+    const store = fakeLocalStore('scoped');
+    setLocalStore(store);
+    expect(hasLocalStore()).toBe(true);
+    expect(getLocalStore()).toBe(store);
+
+    setLocalStore(null);
+    expect(hasLocalStore()).toBe(false);
+    expect(() => getLocalStore()).toThrow(/has not been initialized/);
+  });
+});

--- a/libs/shared/data/src/lib/client-data-cache.ts
+++ b/libs/shared/data/src/lib/client-data-cache.ts
@@ -4,8 +4,8 @@ import { INDEXED_DB } from '@jetstream/shared/constants';
 import { REGEX } from '@jetstream/shared/utils';
 import { CacheItemWithData, OrgCacheItem, QueryHistoryItem, SalesforceOrgUi } from '@jetstream/types';
 import { AxiosRequestConfig } from 'axios';
-import localforage from 'localforage';
 import isString from 'lodash/isString';
+import { getLocalStore } from './local-store';
 
 // 3 days
 const CACHE_TTL = 1000 * 60 * 60 * 24 * 3;
@@ -17,7 +17,7 @@ export function isExpired(priorCacheTime: number): boolean {
 export async function clearCacheForOrg(org: SalesforceOrgUi) {
   try {
     const key = `${INDEXED_DB.KEYS.httpCache}:${org.uniqueId}`;
-    await localforage.removeItem(key);
+    await getLocalStore().removeItem(key);
     logger.log('[HTTP][CACHE][REMOVED]', key);
   } catch (ex) {
     logger.log('[HTTP][CACHE][ERROR]', ex);
@@ -26,13 +26,13 @@ export async function clearCacheForOrg(org: SalesforceOrgUi) {
 
 export async function clearQueryHistoryForOrg(org: SalesforceOrgUi) {
   try {
-    const queryHistory = (await localforage.getItem<Record<string, QueryHistoryItem | undefined>>(INDEXED_DB.KEYS.queryHistory)) || {};
+    const queryHistory = (await getLocalStore().getItem<Record<string, QueryHistoryItem | undefined>>(INDEXED_DB.KEYS.queryHistory)) || {};
     for (const [key] of Object.entries(queryHistory)) {
       if (key.startsWith(org.uniqueId)) {
         queryHistory[key] = undefined;
       }
     }
-    await localforage.setItem(INDEXED_DB.KEYS.queryHistory, JSON.parse(JSON.stringify(queryHistory)));
+    await getLocalStore().setItem(INDEXED_DB.KEYS.queryHistory, JSON.parse(JSON.stringify(queryHistory)));
     logger.log('[QUERY-HISTORY][REMOVED]');
   } catch (ex) {
     logger.log('[QUERY-HISTORY][ERROR]', ex);
@@ -56,7 +56,7 @@ export async function getCacheItemHttp<T>(
   try {
     const orgId = org?.uniqueId || 'unset';
     const cacheKey = getCacheKeyForHttp(config, useQueryParamsInCacheKey, useBodyInCacheKey);
-    const cacheItem = await localforage.getItem<OrgCacheItem<T>>(`${INDEXED_DB.KEYS.httpCache}:${orgId}`);
+    const cacheItem = await getLocalStore().getItem<OrgCacheItem<T>>(`${INDEXED_DB.KEYS.httpCache}:${orgId}`);
     const item = cacheItem && cacheItem[cacheKey];
     if (item && !isExpired(item.exp)) {
       return item;
@@ -79,7 +79,7 @@ export async function getCacheItemNonHttp<T>(org: SalesforceOrgUi, key: string):
   try {
     const orgId = org.uniqueId;
     const cacheKey = getCacheKeyForNonHttp(key);
-    const cacheItem = await localforage.getItem<OrgCacheItem<T>>(`${INDEXED_DB.KEYS.httpCache}:${orgId}`);
+    const cacheItem = await getLocalStore().getItem<OrgCacheItem<T>>(`${INDEXED_DB.KEYS.httpCache}:${orgId}`);
     const item = cacheItem && cacheItem[cacheKey];
     if (item && !isExpired(item.exp)) {
       return item;
@@ -106,7 +106,7 @@ export async function saveCacheItemHttp<T>(
 ): Promise<CacheItemWithData<T> | undefined> {
   try {
     const orgId = org?.uniqueId || 'unset';
-    let cacheItem = await localforage.getItem<OrgCacheItem<T>>(`${INDEXED_DB.KEYS.httpCache}:${orgId}`);
+    let cacheItem = await getLocalStore().getItem<OrgCacheItem<T>>(`${INDEXED_DB.KEYS.httpCache}:${orgId}`);
     const cacheKey = getCacheKeyForHttp(config, useQueryParamsInCacheKey, useBodyInCacheKey);
 
     cacheItem = cacheItem || {};
@@ -119,7 +119,7 @@ export async function saveCacheItemHttp<T>(
 
     cacheItem[cacheKey] = cacheItemData;
 
-    await localforage.setItem(`${INDEXED_DB.KEYS.httpCache}:${orgId}`, cacheItem);
+    await getLocalStore().setItem(`${INDEXED_DB.KEYS.httpCache}:${orgId}`, cacheItem);
     return cacheItemData;
   } catch (ex) {
     logger.log('[HTTP][CACHE][ERROR]', ex);
@@ -130,7 +130,7 @@ export async function saveCacheItemHttp<T>(
 export async function saveCacheItemNonHttp<T>(data: T, org: SalesforceOrgUi, key: string): Promise<CacheItemWithData<T> | undefined> {
   try {
     const orgId = org?.uniqueId || 'unset';
-    let cacheItem = await localforage.getItem<OrgCacheItem<T>>(`${INDEXED_DB.KEYS.httpCache}:${orgId}`);
+    let cacheItem = await getLocalStore().getItem<OrgCacheItem<T>>(`${INDEXED_DB.KEYS.httpCache}:${orgId}`);
     const cacheKey = getCacheKeyForNonHttp(key);
 
     cacheItem = cacheItem || {};
@@ -143,7 +143,7 @@ export async function saveCacheItemNonHttp<T>(data: T, org: SalesforceOrgUi, key
 
     cacheItem[cacheKey] = cacheItemData;
 
-    await localforage.setItem(`${INDEXED_DB.KEYS.httpCache}:${orgId}`, cacheItem);
+    await getLocalStore().setItem(`${INDEXED_DB.KEYS.httpCache}:${orgId}`, cacheItem);
     return cacheItemData;
   } catch (ex) {
     logger.log('[HTTP][CACHE][ERROR]', ex);

--- a/libs/shared/data/src/lib/local-store.ts
+++ b/libs/shared/data/src/lib/local-store.ts
@@ -1,0 +1,91 @@
+import { logger } from '@jetstream/shared/client-logger';
+import { sha1Hex } from '@jetstream/shared/utils';
+import localforage from 'localforage';
+
+/**
+ * Per-user localforage store.
+ *
+ * Before per-user scoping every account on a machine shared a single localforage store, so one
+ * user's history/preferences were readable by the next (see security finding F7). The store is
+ * now scoped per authenticated user by `storeName` (an object store) *within* the app's existing
+ * IndexedDB database — the database name is intentionally left unchanged because it is historically
+ * load-bearing. Callers must go through {@link getLocalStore} rather than the default localforage
+ * instance so their data always lands in the current user's store.
+ *
+ * This module is deliberately a dumb holder plus a factory. Which user is active — including every
+ * race around a fast user switch — is owned by a single authority, `DexieInitializer` in
+ * `@jetstream/ui/db`, which builds the instance via {@link createUserLocalStore} and commits it via
+ * {@link setLocalStore} together with the matching Dexie instance, so the two stores can never
+ * disagree about which account is bound.
+ *
+ * {@link getLocalStore} throws when no user has been scoped yet, mirroring `getDexieDb()`. That is
+ * deliberate: a silent fallback to the shared instance is exactly the pre-fix behavior, and it is
+ * invisible — a caller that reads before scoping (e.g. at module evaluation) would read the shared
+ * store while its writes land in the per-user one. The handful of surfaces that genuinely have no
+ * user must opt in explicitly via {@link getUnscopedLocalStore}.
+ */
+
+type LocalStore = ReturnType<typeof localforage.createInstance>;
+
+let localStore: LocalStore | null = null;
+
+export interface CreateUserLocalStoreOptions {
+  /** IndexedDB database name — the app's environment name, unchanged from the legacy store. */
+  dbName: string;
+  /** Authenticated user id used to scope the object store name. */
+  userId: string;
+}
+
+/**
+ * Create the per-user store instance without binding it — the caller decides whether to commit it
+ * via {@link setLocalStore} (a build can be superseded by a faster user switch).
+ *
+ * The user id is hashed so it is never exposed verbatim as an IndexedDB object store name —
+ * matching `getScopedDexieDbName`. This matters most for canvas, where the scope id is a
+ * Salesforce username (an email-shaped value).
+ */
+export async function createUserLocalStore({ dbName, userId }: CreateUserLocalStoreOptions): Promise<LocalStore> {
+  const store = localforage.createInstance({ name: dbName, storeName: `u_${await sha1Hex(userId)}` });
+  // Settle the driver up front so `driver()` is meaningful synchronously — deploy history only
+  // stores package files when IndexedDB is the active driver, and on a freshly created instance
+  // that check would otherwise run before a driver has been selected.
+  await store.ready().catch((ex) => logger.warn('[LOCAL-STORE] Storage driver failed to initialize', ex));
+  return store;
+}
+
+/**
+ * Bind the active per-user store, or unbind it with `null` (logout / account switch) so no read
+ * can reach the previous user's data. Only the scope owner (`DexieInitializer` in
+ * `@jetstream/ui/db`) may call this — everything else reads through {@link getLocalStore}.
+ */
+export function setLocalStore(store: LocalStore | null): void {
+  localStore = store;
+}
+
+/**
+ * Return the current user's store. Throws if called before a user has been scoped — every caller
+ * reached from authenticated UI is gated behind `ensureLocalStorageReady`, so this indicates a read
+ * that escaped that gate (typically an eagerly evaluated module-level read).
+ */
+export function getLocalStore(): LocalStore {
+  if (!localStore) {
+    throw new Error('Local store has not been initialized. Await ensureLocalStorageReady() before accessing local storage.');
+  }
+  return localStore;
+}
+
+/**
+ * The default, un-scoped localforage instance — shared by every account on the machine.
+ *
+ * Only for the few contexts that legitimately run without a signed-in user: reading the cached theme
+ * before React mounts, and reading the pre-user-scoping data during the adopt-once migration. Never
+ * use this for user data on an authenticated surface; use {@link getLocalStore}.
+ */
+export function getUnscopedLocalStore(): LocalStore {
+  return localforage;
+}
+
+/** True once a user-scoped store has been bound. */
+export function hasLocalStore(): boolean {
+  return !!localStore;
+}

--- a/libs/shared/ui-app-state/src/lib/ui-app-state.ts
+++ b/libs/shared/ui-app-state/src/lib/ui-app-state.ts
@@ -1,7 +1,7 @@
 import { getUserAbility } from '@jetstream/acl';
 import { logger } from '@jetstream/shared/client-logger';
 import { INDEXED_DB } from '@jetstream/shared/constants';
-import { checkHeartbeat, getOrgGroups, getOrgs, getUserProfile } from '@jetstream/shared/data';
+import { checkHeartbeat, getLocalStore, getOrgGroups, getOrgs, getUserProfile } from '@jetstream/shared/data';
 import {
   applyVerifiedFeatureFlags,
   getBrowserExtensionVersion,
@@ -32,8 +32,7 @@ import {
   type UserProfileUi,
 } from '@jetstream/types';
 import { atom, useAtom, useAtomValue, useSetAtom } from 'jotai';
-import { unwrap } from 'jotai/utils';
-import localforage from 'localforage';
+import { atomWithLazy, unwrap } from 'jotai/utils';
 import isString from 'lodash/isString';
 import z from 'zod';
 
@@ -105,7 +104,7 @@ function ensureUserProfileInit(pref?: Maybe<UserProfilePreferences>): UserProfil
 
 async function getUserPreferences(): Promise<UserProfilePreferences> {
   try {
-    const userPreferences = await localforage.getItem<UserProfilePreferences>(INDEXED_DB.KEYS.userPreferences);
+    const userPreferences = await getLocalStore().getItem<UserProfilePreferences>(INDEXED_DB.KEYS.userPreferences);
     return ensureUserProfileInit(userPreferences);
   } catch {
     return ensureUserProfileInit();
@@ -220,7 +219,12 @@ async function fetchUserProfile(): Promise<UserProfileUi> {
   return await applyVerifiedFeatureFlags(userProfile);
 }
 
-const userPreferenceState = atom<Promise<UserProfilePreferences>>(getUserPreferences());
+/**
+ * Lazy so the storage read happens on first render (after `ensureLocalStorageReady` has scoped the
+ * store to the current user) instead of at module evaluation, which would read the shared un-scoped
+ * store while every write lands in the per-user one.
+ */
+const userPreferenceState = atomWithLazy<Promise<UserProfilePreferences>>(getUserPreferences);
 
 export const actionInProgressState = atom<boolean>(false);
 
@@ -462,7 +466,7 @@ export const useUserPreferenceState = (): [UserProfilePreferences | undefined, (
   async function setUserPreferences(_userPreference: UserProfilePreferences) {
     setUserPreferenceState(Promise.resolve(_userPreference));
     try {
-      localforage.setItem<UserProfilePreferences>(INDEXED_DB.KEYS.userPreferences, _userPreference);
+      getLocalStore().setItem<UserProfilePreferences>(INDEXED_DB.KEYS.userPreferences, _userPreference);
     } catch {
       // could not save to localstorage
       logger.warn('could not save to localstorage');

--- a/libs/shared/ui-core/src/analysis/PermissionAnalysisHistoryModal.tsx
+++ b/libs/shared/ui-core/src/analysis/PermissionAnalysisHistoryModal.tsx
@@ -3,7 +3,7 @@ import { formatNumber } from '@jetstream/shared/ui-utils';
 import { multiWordObjectFilter } from '@jetstream/shared/utils';
 import { AnalysisJobHistoryItem, AnalysisJobType, SalesforceOrgUi } from '@jetstream/types';
 import { Badge, EmptyState, Grid, Icon, List, Modal, Popover, PopoverRef, SearchInput, Spinner } from '@jetstream/ui';
-import { dexieDb } from '@jetstream/ui/db';
+import { getDexieDb } from '@jetstream/ui/db';
 import classNames from 'classnames';
 import { useLiveQuery } from 'dexie-react-hooks';
 import { FunctionComponent, useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react';
@@ -287,8 +287,8 @@ export const PermissionAnalysisHistoryModal: FunctionComponent<PermissionAnalysi
    */
   const dexieRows = useLiveQuery(
     () =>
-      dexieDb.analysis_job_history
-        .where('[org+jobType+createdAt]')
+      getDexieDb()
+        .analysis_job_history.where('[org+jobType+createdAt]')
         .between([selectedOrg.uniqueId, analysisJobType, new Date(0)], [selectedOrg.uniqueId, analysisJobType, new Date(8.64e15)])
         .sortBy('createdAt')
         .then((rows) => rows.reverse()),

--- a/libs/shared/ui-core/src/app/ThemeApplier.tsx
+++ b/libs/shared/ui-core/src/app/ThemeApplier.tsx
@@ -1,7 +1,7 @@
 import { INDEXED_DB } from '@jetstream/shared/constants';
+import { getUnscopedLocalStore } from '@jetstream/shared/data';
 import { ColorScheme, UserProfilePreferences } from '@jetstream/types';
 import { useUserPreferenceState } from '@jetstream/ui/app-state';
-import localforage from 'localforage';
 import { useEffect } from 'react';
 
 const SCHEME_CLASSES = ['slds-color-scheme--light', 'slds-color-scheme--dark', 'slds-color-scheme--system'];
@@ -66,7 +66,10 @@ export async function applyThemeBeforeMount(forceScheme?: ColorScheme): Promise<
     return;
   }
   try {
-    const prefs = await localforage.getItem<UserProfilePreferences>(INDEXED_DB.KEYS.userPreferences);
+    // Runs before React mounts, so no user is scoped yet — read the shared store explicitly. Only a
+    // cold cache reaches this, and the mounted <ThemeApplier> immediately reconciles from the
+    // per-user preference and refreshes the cache.
+    const prefs = await getUnscopedLocalStore().getItem<UserProfilePreferences>(INDEXED_DB.KEYS.userPreferences);
     const scheme = prefs?.colorScheme ?? 'light';
     setBodyScheme(scheme);
     writeCachedScheme(scheme);

--- a/libs/shared/ui-core/src/jobs/JobWorker.ts
+++ b/libs/shared/ui-core/src/jobs/JobWorker.ts
@@ -62,7 +62,7 @@ import type {
   UploadToGoogleJob,
   WorkerMessage,
 } from '@jetstream/types';
-import { dexieDb, withReopenOnDatabaseClosed } from '@jetstream/ui/db';
+import { getDexieDb, withReopenOnDatabaseClosed } from '@jetstream/ui/db';
 import clamp from 'lodash/clamp';
 import isString from 'lodash/isString';
 
@@ -72,8 +72,9 @@ async function pruneAnalysisJobHistory(orgUniqueId: string, jobType: AnalysisJob
   try {
     // Wrap read + delete in a single transaction so a concurrent write (pin/unpin from another tab, or
     // another job finishing on the same org+type) cannot race between the sortBy and the bulkDelete.
-    await withReopenOnDatabaseClosed(() =>
-      dexieDb.transaction('rw', dexieDb.analysis_job_history, async () => {
+    await withReopenOnDatabaseClosed(() => {
+      const dexieDb = getDexieDb();
+      return dexieDb.transaction('rw', dexieDb.analysis_job_history, async () => {
         // sortBy returns ascending by createdAt; reverse the array to put newest first so slice(N) drops the older rows.
         const rowsAscending = await dexieDb.analysis_job_history
           .where('[org+jobType+createdAt]')
@@ -84,8 +85,8 @@ async function pruneAnalysisJobHistory(orgUniqueId: string, jobType: AnalysisJob
         if (overCap.length > 0) {
           await dexieDb.analysis_job_history.bulkDelete(overCap.map((row) => row.key));
         }
-      }),
-    );
+      });
+    });
   } catch (ex) {
     logger.warn('[JOB][ANALYSIS] Failed to prune analysis_job_history', ex);
   }
@@ -440,7 +441,7 @@ export class JobWorker {
             resultBlob: blob,
             resultBlobSize: blob.byteLength,
           };
-          await withReopenOnDatabaseClosed(() => dexieDb.analysis_job_history.put(historyRow));
+          await withReopenOnDatabaseClosed(() => getDexieDb().analysis_job_history.put(historyRow));
           await pruneAnalysisJobHistory(org.uniqueId, 'permission_export');
 
           const response: AsyncJobWorkerMessageResponse = {
@@ -472,7 +473,7 @@ export class JobWorker {
                 resultBlob: null,
                 resultBlobSize: 0,
               };
-              await withReopenOnDatabaseClosed(() => dexieDb.analysis_job_history.put(failedRow));
+              await withReopenOnDatabaseClosed(() => getDexieDb().analysis_job_history.put(failedRow));
               await pruneAnalysisJobHistory(org.uniqueId, 'permission_export');
             } catch (writeEx) {
               logger.warn('[JOB][PERMISSION_EXPORT] Failed to record failed analysis_job_history row', writeEx);
@@ -596,7 +597,7 @@ export class JobWorker {
             resultBlob: blob,
             resultBlobSize: blob.byteLength,
           };
-          await withReopenOnDatabaseClosed(() => dexieDb.analysis_job_history.put(historyRow));
+          await withReopenOnDatabaseClosed(() => getDexieDb().analysis_job_history.put(historyRow));
           await pruneAnalysisJobHistory(org.uniqueId, 'field_usage');
 
           const response: AsyncJobWorkerMessageResponse = {
@@ -627,7 +628,7 @@ export class JobWorker {
                 resultBlob: null,
                 resultBlobSize: 0,
               };
-              await withReopenOnDatabaseClosed(() => dexieDb.analysis_job_history.put(failedRow));
+              await withReopenOnDatabaseClosed(() => getDexieDb().analysis_job_history.put(failedRow));
               await pruneAnalysisJobHistory(org.uniqueId, 'field_usage');
             } catch (writeEx) {
               logger.warn('[JOB][FIELD_USAGE] Failed to record failed analysis_job_history row', writeEx);

--- a/libs/shared/ui-core/src/query/QueryHistory/QueryHistoryExportPopover.tsx
+++ b/libs/shared/ui-core/src/query/QueryHistory/QueryHistoryExportPopover.tsx
@@ -4,7 +4,7 @@ import { getFilenameWithoutOrg, prepareCsvFile, saveFile } from '@jetstream/shar
 import { orderObjectsBy } from '@jetstream/shared/utils';
 import { QueryHistoryItem, SalesforceOrgUi } from '@jetstream/types';
 import { Icon, Popover, PopoverRef, Radio, RadioGroup } from '@jetstream/ui';
-import { dexieDb, withReopenOnDatabaseClosed } from '@jetstream/ui/db';
+import { getDexieDb, withReopenOnDatabaseClosed } from '@jetstream/ui/db';
 import isDate from 'lodash/isDate';
 import { FunctionComponent, useRef, useState } from 'react';
 import { useAmplitude } from '../..';
@@ -43,7 +43,7 @@ export const QueryHistoryExportPopover: FunctionComponent<QueryHistoryExportPopo
 
       // Get query history items
       const queryHistory = await withReopenOnDatabaseClosed(() =>
-        dexieDb.query_history.orderBy('lastRun').reverse().filter(filterFn).toArray(),
+        getDexieDb().query_history.orderBy('lastRun').reverse().filter(filterFn).toArray(),
       );
 
       if (queryHistory.length === 0) {

--- a/libs/shared/ui-core/src/query/QueryHistory/QueryHistoryModal.tsx
+++ b/libs/shared/ui-core/src/query/QueryHistory/QueryHistoryModal.tsx
@@ -5,7 +5,7 @@ import { formatNumber, useNonInitialEffect } from '@jetstream/shared/ui-utils';
 import { multiWordObjectFilter } from '@jetstream/shared/utils';
 import { QueryHistoryItem, QueryHistorySelection, SalesforceOrgUi, UpDown } from '@jetstream/types';
 import { EmptyState, Grid, GridCol, Icon, List, Modal, SearchInput, Spinner } from '@jetstream/ui';
-import { dexieDb, queryHistoryDb } from '@jetstream/ui/db';
+import { getDexieDb, queryHistoryDb } from '@jetstream/ui/db';
 import { useLiveQuery } from 'dexie-react-hooks';
 import uniqBy from 'lodash/uniqBy';
 import { createRef, forwardRef, useCallback, useEffect, useState } from 'react';
@@ -53,8 +53,8 @@ export const QueryHistoryModal = forwardRef<any, QueryHistoryProps>(({ className
 
   const selectObjectsList = useLiveQuery(
     () =>
-      dexieDb._query_history_object
-        .orderBy('sObject')
+      getDexieDb()
+        ._query_history_object.orderBy('sObject')
         .filter((item) => whichOrg === 'ALL' || item.org === selectedOrg.uniqueId)
         .toArray()
         .then((items) => [
@@ -101,13 +101,13 @@ export const QueryHistoryModal = forwardRef<any, QueryHistoryProps>(({ className
 
   const queryHistory = useLiveQuery(
     // Since we want to sort by lastRun, we cannot use a normal where clause
-    () => dexieDb.query_history.orderBy('lastRun').reverse().filter(filterRecordsFn).limit(showingUpTo).toArray(),
+    () => getDexieDb().query_history.orderBy('lastRun').reverse().filter(filterRecordsFn).limit(showingUpTo).toArray(),
     [filterRecordsFn, showingUpTo, refreshCounter],
     [] as QueryHistoryItem[],
   );
 
   const totalRecordCount = useLiveQuery(
-    () => dexieDb.query_history.orderBy('lastRun').reverse().filter(filterRecordsFn).count(),
+    () => getDexieDb().query_history.orderBy('lastRun').reverse().filter(filterRecordsFn).count(),
     [filterRecordsFn, showingUpTo, refreshCounter],
     0,
   );

--- a/libs/shared/ui-core/src/query/QuickQueryPopover.tsx
+++ b/libs/shared/ui-core/src/query/QuickQueryPopover.tsx
@@ -22,7 +22,7 @@ import {
   Tooltip,
 } from '@jetstream/ui';
 import { selectedOrgState, soqlQueryFormatOptionsState } from '@jetstream/ui/app-state';
-import { dexieDb } from '@jetstream/ui/db';
+import { getDexieDb } from '@jetstream/ui/db';
 import { formatQuery, isQueryValid } from '@jetstreamapp/soql-parser-js';
 import { OnMount } from '@monaco-editor/react';
 import { useLiveQuery } from 'dexie-react-hooks';
@@ -69,7 +69,7 @@ export const QuickQueryPopover = () => {
   // Note: this is not scoped to the current org, which I guess is fine for now (could give user an option)
   const queryHistory = useLiveQuery(
     // Since we want to sort by lastRun, we cannot use a normal where clause
-    () => dexieDb.query_history.orderBy('lastRun').reverse().limit(NUM_HISTORY_ITEMS).toArray(),
+    () => getDexieDb().query_history.orderBy('lastRun').reverse().limit(NUM_HISTORY_ITEMS).toArray(),
     [],
     [] as QueryHistoryItem[],
   );

--- a/libs/shared/ui-core/src/record/record-utils.ts
+++ b/libs/shared/ui-core/src/record/record-utils.ts
@@ -1,8 +1,8 @@
 import { logger } from '@jetstream/shared/client-logger';
 import { INDEXED_DB } from '@jetstream/shared/constants';
+import { getLocalStore } from '@jetstream/shared/data';
 import { REGEX } from '@jetstream/shared/utils';
 import { composeQuery, getField, WhereClause } from '@jetstreamapp/soql-parser-js';
-import localforage from 'localforage';
 import uniqBy from 'lodash/uniqBy';
 
 type RecentRecordStorageMap = Record<string, RecentRecord[]>;
@@ -14,17 +14,56 @@ export interface RecentRecord {
 
 const NUM_HISTORY_ITEMS = 25;
 let recentItemsMapCache: RecentRecordStorageMap | null = null;
+/**
+ * The store the cached map was read from. Each user gets a distinct store instance, so comparing
+ * identity invalidates the cache on an account switch that happens without a reload. Without this
+ * the previous user's records would be served — and written back into the new user's store, since
+ * the callers below mutate this map and persist it wholesale.
+ */
+let cachedForStore: ReturnType<typeof getLocalStore> | null = null;
 
-export async function getRecentRecordsFromStorage() {
+/**
+ * Recent records are a convenience, never load-bearing, so every access here is best effort:
+ * a storage failure (including reading before a user is scoped) degrades to an empty list.
+ */
+function persistRecentRecords(recentItems: RecentRecordStorageMap) {
   try {
-    if (recentItemsMapCache) {
-      return recentItemsMapCache;
-    }
-    recentItemsMapCache = await localforage.getItem<RecentRecordStorageMap>(INDEXED_DB.KEYS.recentRecords);
-    return recentItemsMapCache || {};
-  } catch {
-    return recentItemsMapCache || {};
+    getLocalStore()
+      .setItem<RecentRecordStorageMap>(INDEXED_DB.KEYS.recentRecords, recentItems)
+      .catch((err) => {
+        logger.warn('[ERROR] Could not save recent record history', err);
+      });
+  } catch (err) {
+    logger.warn('[ERROR] Could not save recent record history', err);
   }
+}
+
+export async function getRecentRecordsFromStorage(): Promise<RecentRecordStorageMap> {
+  let localStore: ReturnType<typeof getLocalStore>;
+  try {
+    localStore = getLocalStore();
+  } catch {
+    // No user is scoped (logged out, or the store failed to initialize) — drop the cache instead of
+    // handing back whatever the last scoped user left in memory.
+    recentItemsMapCache = null;
+    cachedForStore = null;
+    return {};
+  }
+
+  if (cachedForStore !== localStore) {
+    recentItemsMapCache = null;
+    cachedForStore = localStore;
+  }
+  if (recentItemsMapCache) {
+    return recentItemsMapCache;
+  }
+
+  try {
+    recentItemsMapCache = await localStore.getItem<RecentRecordStorageMap>(INDEXED_DB.KEYS.recentRecords);
+  } catch (err) {
+    logger.warn('[ERROR] Could not read recent record history', err);
+  }
+  return recentItemsMapCache || {};
 }
 
 export async function addRecentRecordToStorage(record: RecentRecord, orgUniqueId: string) {
@@ -40,9 +79,7 @@ export async function addRecentRecordToStorage(record: RecentRecord, orgUniqueId
   recentItems[orgUniqueId].unshift({ recordId, sobject, name: name || existingItem?.name });
   recentItems[orgUniqueId] = uniqBy(recentItems[orgUniqueId], 'recordId').slice(0, NUM_HISTORY_ITEMS);
 
-  localforage.setItem<RecentRecordStorageMap>(INDEXED_DB.KEYS.recentRecords, recentItems).catch((err) => {
-    logger.warn('[ERROR] Could not save recent record history', err);
-  });
+  persistRecentRecords(recentItems);
 
   return recentItems[orgUniqueId];
 }
@@ -57,9 +94,7 @@ export async function updateRecentRecordItem(recordId: string, record: Partial<R
   recentItems[orgUniqueId] = recentItems[orgUniqueId] || [];
   recentItems[orgUniqueId] = recentItems[orgUniqueId].map((item) => (item.recordId !== recordId ? item : { ...item, ...record }));
 
-  localforage.setItem<RecentRecordStorageMap>(INDEXED_DB.KEYS.recentRecords, recentItems).catch((err) => {
-    logger.warn('[ERROR] Could not save recent record history', err);
-  });
+  persistRecentRecords(recentItems);
 
   return recentItems[orgUniqueId];
 }
@@ -74,9 +109,7 @@ export async function removeRecentRecordItem(recordId: string, orgUniqueId: stri
   recentItems[orgUniqueId] = recentItems[orgUniqueId] || [];
   recentItems[orgUniqueId] = recentItems[orgUniqueId].filter((item) => item.recordId !== recordId);
 
-  localforage.setItem<RecentRecordStorageMap>(INDEXED_DB.KEYS.recentRecords, recentItems).catch((err) => {
-    logger.warn('[ERROR] Could not save recent record history', err);
-  });
+  persistRecentRecords(recentItems);
 
   return recentItems[orgUniqueId];
 }

--- a/libs/shared/ui-db/src/lib/__tests__/client-data.db.spec.ts
+++ b/libs/shared/ui-db/src/lib/__tests__/client-data.db.spec.ts
@@ -1,0 +1,85 @@
+import { getLocalStore, hasLocalStore } from '@jetstream/shared/data';
+import { sha1Hex } from '@jetstream/shared/utils';
+import localforage from 'localforage';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { clearLocalStorageScope, ensureLocalStorageReady, isDifferentUserThanPageSession } from '../client-data.db';
+import { getDexieDb, getScopedDexieDbName, hasDexieDb } from '../ui-db';
+
+/**
+ * Runs as a single sequential test because the page session user is module state — the whole point
+ * is that it is captured once per page and survives a logout.
+ */
+describe('isDifferentUserThanPageSession', () => {
+  it('tracks the user this page scoped storage to, across sign out and back in', async () => {
+    expect(isDifferentUserThanPageSession('user-a')).toBe(false);
+
+    await ensureLocalStorageReady({ userId: 'user-a', dbName: 'Jetstream' });
+    expect(isDifferentUserThanPageSession('user-a')).toBe(false);
+    expect(isDifferentUserThanPageSession('user-b')).toBe(true);
+
+    // Signing out must not forget who this page belongs to, otherwise the next account to sign in
+    // would look like the original user and keep the previous user's in-memory state.
+    clearLocalStorageScope();
+    expect(isDifferentUserThanPageSession('user-a')).toBe(false);
+    expect(isDifferentUserThanPageSession('user-b')).toBe(true);
+
+    // Re-scoping to another user does not reset it either — the page still has to reload.
+    await ensureLocalStorageReady({ userId: 'user-b', dbName: 'Jetstream' });
+    expect(isDifferentUserThanPageSession('user-b')).toBe(true);
+  });
+
+  it('ignores the no-user state so a logged out page never asks for a reload', () => {
+    expect(isDifferentUserThanPageSession(null)).toBe(false);
+    expect(isDifferentUserThanPageSession(undefined)).toBe(false);
+    expect(isDifferentUserThanPageSession('')).toBe(false);
+  });
+});
+
+describe('ensureLocalStorageReady scope ownership', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    clearLocalStorageScope();
+  });
+
+  it('binds only the newest user when scope builds race, and both stores commit together', async () => {
+    type LocalStore = ReturnType<typeof localforage.createInstance>;
+    const createInstance = vi.spyOn(localforage, 'createInstance').mockImplementation(
+      (options) =>
+        ({
+          name: options?.storeName,
+          ready: () => Promise.resolve(),
+          getItem: () => Promise.resolve(null),
+        }) as unknown as LocalStore,
+    );
+
+    // Start user-a's build, then take over with user-b before it can commit. The synchronous claim
+    // in ensureScopeReady means the superseded build must never bind either store.
+    const first = ensureLocalStorageReady({ userId: 'race-user-a', dbName: 'Jetstream' });
+    const second = ensureLocalStorageReady({ userId: 'race-user-b', dbName: 'Jetstream' });
+    await Promise.all([first, second]);
+
+    expect(createInstance.mock.results).toHaveLength(2);
+    expect(hasLocalStore()).toBe(true);
+    expect(hasDexieDb()).toBe(true);
+    // Both bound stores belong to user-b — the superseded user-a build never committed either one
+    expect((getLocalStore() as unknown as { name: string }).name).toBe(`u_${await sha1Hex('race-user-b')}`);
+    expect(getDexieDb().name).toBe(await getScopedDexieDbName('race-user-b'));
+  });
+
+  it('fails closed when the store build throws, then recovers on the next attempt', async () => {
+    vi.spyOn(localforage, 'createInstance').mockImplementationOnce(() => {
+      throw new Error('storage unavailable');
+    });
+
+    // The promise must resolve (it gates render via Suspense), but nothing may be bound.
+    await ensureLocalStorageReady({ userId: 'failing-user', dbName: 'Jetstream' });
+    expect(hasLocalStore()).toBe(false);
+    expect(hasDexieDb()).toBe(false);
+    expect(() => getDexieDb()).toThrow(/has not been initialized/);
+
+    // The failed attempt is forgotten rather than cached as "ready", so a retry succeeds.
+    await ensureLocalStorageReady({ userId: 'failing-user', dbName: 'Jetstream' });
+    expect(hasLocalStore()).toBe(true);
+    expect(hasDexieDb()).toBe(true);
+  });
+});

--- a/libs/shared/ui-db/src/lib/__tests__/ui-db.spec.ts
+++ b/libs/shared/ui-db/src/lib/__tests__/ui-db.spec.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { DEXIE_DB_BASE_NAME, getScopedDexieDbName } from '../ui-db';
+
+describe('getScopedDexieDbName', () => {
+  it('scopes the database name by a hash of the user id', async () => {
+    const name = await getScopedDexieDbName('user-123');
+    // 40 hex chars = SHA-1
+    expect(name).toMatch(new RegExp(`^${DEXIE_DB_BASE_NAME}-u-[0-9a-f]{40}$`));
+  });
+
+  it('is deterministic for the same user id', async () => {
+    const first = await getScopedDexieDbName('user-123');
+    const second = await getScopedDexieDbName('user-123');
+    expect(first).toBe(second);
+  });
+
+  it('produces a different name for a different user id', async () => {
+    const userA = await getScopedDexieDbName('user-a');
+    const userB = await getScopedDexieDbName('user-b');
+    expect(userA).not.toBe(userB);
+  });
+
+  it('never uses the raw user id in the name', async () => {
+    const userId = 'super-secret-user-id';
+    const name = await getScopedDexieDbName(userId);
+    expect(name).not.toContain(userId);
+  });
+
+  it('never collides with the un-scoped base name, which the adopt-once migration reads from', async () => {
+    expect(DEXIE_DB_BASE_NAME).not.toContain('-u-');
+    expect(await getScopedDexieDbName('user-123')).not.toBe(DEXIE_DB_BASE_NAME);
+  });
+});

--- a/libs/shared/ui-db/src/lib/analysis-job-history-retention.ts
+++ b/libs/shared/ui-db/src/lib/analysis-job-history-retention.ts
@@ -1,5 +1,5 @@
 import { logger } from '@jetstream/shared/client-logger';
-import { dexieDb, withReopenOnDatabaseClosed } from './ui-db';
+import { getDexieDb, withReopenOnDatabaseClosed } from './ui-db';
 
 const FOURTEEN_DAYS_MS = 14 * 24 * 60 * 60 * 1000;
 const MAX_ROWS_PER_ORG_AND_JOB_TYPE = 10;
@@ -15,8 +15,9 @@ const JOB_TYPES = ['permission_export', 'field_usage'] as const;
  */
 export async function pruneAnalysisJobHistory(): Promise<void> {
   try {
-    await withReopenOnDatabaseClosed(() =>
-      dexieDb.transaction('rw', dexieDb.analysis_job_history, async () => {
+    await withReopenOnDatabaseClosed(() => {
+      const dexieDb = getDexieDb();
+      return dexieDb.transaction('rw', dexieDb.analysis_job_history, async () => {
         const fourteenDaysAgo = new Date(Date.now() - FOURTEEN_DAYS_MS);
         await dexieDb.analysis_job_history
           .where('createdAt')
@@ -46,8 +47,8 @@ export async function pruneAnalysisJobHistory(): Promise<void> {
             }
           }
         }
-      }),
-    );
+      });
+    });
   } catch (ex) {
     logger.warn('[DB][ANALYSIS_JOB_HISTORY][PRUNE] Failed to prune analysis_job_history', ex);
   }

--- a/libs/shared/ui-db/src/lib/api-request-history.db.ts
+++ b/libs/shared/ui-db/src/lib/api-request-history.db.ts
@@ -1,6 +1,6 @@
 import { logger } from '@jetstream/shared/client-logger';
 import { ApiHistoryItem, HttpMethod, SalesforceApiHistoryRequest, SalesforceApiHistoryResponse, SalesforceOrgUi } from '@jetstream/types';
-import { dexieDb, getHashedRecordKey, SyncableTables, wrapApiWithReopenOnDatabaseClosed } from './ui-db';
+import { getDexieDb, getHashedRecordKey, SyncableTables, wrapApiWithReopenOnDatabaseClosed } from './ui-db';
 
 export const apiRequestHistoryDb = wrapApiWithReopenOnDatabaseClosed({
   getAllQueryHistory,
@@ -13,7 +13,7 @@ function generateKey(orgUniqueId: string, method: HttpMethod, url: string): ApiH
 }
 
 async function getAllQueryHistory(): Promise<ApiHistoryItem[]> {
-  return await dexieDb.api_request_history.toArray();
+  return await getDexieDb().api_request_history.toArray();
 }
 
 async function saveApiHistoryItem(
@@ -21,6 +21,7 @@ async function saveApiHistoryItem(
   request: SalesforceApiHistoryRequest,
   response: SalesforceApiHistoryResponse,
 ): Promise<ApiHistoryItem> {
+  const dexieDb = getDexieDb();
   const key = generateKey(org.uniqueId, request.method, request.url);
   const hashedKey = await getHashedRecordKey(key);
   const existingItem = await dexieDb.api_request_history.get(key);
@@ -43,7 +44,7 @@ async function saveApiHistoryItem(
 
 async function deleteAllApiHistoryForOrg(org: SalesforceOrgUi): Promise<void> {
   try {
-    await dexieDb.api_request_history.where({ org: org.uniqueId }).delete();
+    await getDexieDb().api_request_history.where({ org: org.uniqueId }).delete();
   } catch (ex) {
     logger.error('[DB] Error deleting query history for org', ex);
   }

--- a/libs/shared/ui-db/src/lib/client-data-sync.db.ts
+++ b/libs/shared/ui-db/src/lib/client-data-sync.db.ts
@@ -21,7 +21,7 @@ import type { ICreateChange, IDatabaseChange, IDeleteChange, IUpdateChange } fro
 import { ApplyRemoteChangesFunction } from 'dexie-syncable/api';
 import isString from 'lodash/isString';
 import { v4 as uuid } from 'uuid';
-import { dexieDb, getHashedRecordKey, SyncableEntities, SyncableTables } from './ui-db';
+import { getDexieDb, getHashedRecordKey, SyncableEntities, SyncableTables } from './ui-db';
 
 interface CreateOrUpdateEventBase {
   type: 'create' | 'update';
@@ -436,6 +436,7 @@ function enrichDataTypesForApiRequestHistory(data: Record<string, unknown>) {
  * Since ids have a prefix, that is used to know what tables to fetch from
  */
 async function getAllSyncableRecordsById(ids: string[]): Promise<Record<string, any>> {
+  const dexieDb = getDexieDb();
   const records = await Promise.all(
     Object.values(SyncableTables).map((syncableTable) => {
       const keys = ids.filter((id) => id.startsWith(syncableTable.keyPrefix)) as (typeof syncableTable)['keyPrefix'][];

--- a/libs/shared/ui-db/src/lib/client-data.db.ts
+++ b/libs/shared/ui-db/src/lib/client-data.db.ts
@@ -1,20 +1,77 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { logger } from '@jetstream/shared/client-logger';
 import { INDEXED_DB } from '@jetstream/shared/constants';
+import { createUserLocalStore, getLocalStore, getUnscopedLocalStore, hasLocalStore, setLocalStore } from '@jetstream/shared/data';
 import { delay } from '@jetstream/shared/utils';
 import { ApiHistoryItem, LoadSavedMappingItem, QueryHistoryItem } from '@jetstream/types';
+import Dexie, { type Table } from 'dexie';
 import 'dexie-observable';
 import 'dexie-syncable';
-import localforage from 'localforage';
 import { initializeDexieSync } from './client-data-sync.db';
-import { DEXIE_DB_SYNC_NAME, dexieDataSync, dexieDb, getHashedRecordKey, SyncableTables } from './ui-db';
+import { registerDbHooks } from './db-hooks';
+import {
+  AdoptableTables,
+  createDexieInstance,
+  DEXIE_DB_BASE_NAME,
+  DEXIE_DB_SYNC_NAME,
+  dexieDataSync,
+  getDexieDb,
+  getHashedRecordKey,
+  getScopedDexieDbName,
+  hasDexieDb,
+  setDexieDbInstance,
+  SyncableTables,
+} from './ui-db';
+
+/**
+ * localStorage flag marking that the legacy (pre-user-scoping) shared stores have been
+ * adopted into a per-user database. Stored per-origin so it is shared across every account
+ * that signs in on the same machine/profile — this is what limits adoption to the first
+ * account after the upgrade and prevents a later account from inheriting the prior data.
+ */
+const LEGACY_CLAIM_KEY = 'JETSTREAM_LEGACY_STORE_CLAIMED';
+
+/**
+ * localStorage flag recording which user started adoption, written before any data is copied.
+ * Adoption is not atomic (it can be interrupted by a closed tab or a quit app), so the completion
+ * marker alone is not enough: without this, an interrupted adoption would let the *next* account on
+ * the machine re-run it and inherit the same legacy data. Owning the claim up front locks every
+ * other account out immediately while still allowing the claiming user to retry.
+ *
+ * The value is a *hash* of the user id, matching `getScopedDexieDbName` and the localforage store
+ * name. This marker outlives the session it was written in and is readable by every later account on
+ * the machine, so storing the raw id would hand the next user an identifier for the previous one —
+ * on canvas that id is a Salesforce username, which is email-shaped.
+ */
+const LEGACY_CLAIM_OWNER_KEY = 'JETSTREAM_LEGACY_STORE_CLAIM_OWNER';
+
+/**
+ * localStorage counter of failed adoption attempts by the claim owner. Adoption re-copies
+ * everything on retry, so a persistent failure (e.g. a quota error on the blob-heavy tables)
+ * would otherwise cost the user a full re-copy on every sign-in forever. After
+ * {@link MAX_LEGACY_ADOPTION_ATTEMPTS} failures the store is stamped claimed and adoption gives
+ * up, keeping whatever partial data landed (the small, irreplaceable tables copy first).
+ */
+const LEGACY_ADOPTION_ATTEMPTS_KEY = 'JETSTREAM_LEGACY_STORE_ADOPTION_ATTEMPTS';
+const MAX_LEGACY_ADOPTION_ATTEMPTS = 3;
+
+let syncProtocolRegistered = false;
+
+/**
+ * The first user this page scoped local storage to. Deliberately never cleared — it has to outlive
+ * a logout so {@link isDifferentUserThanPageSession} can tell "the same user signed back in" apart
+ * from "a different account took over a page that still holds the previous user's in-memory state".
+ */
+let pageSessionUserId: string | null = null;
 
 class DexieInitializer {
   private static instance: DexieInitializer;
-  private hasInitialized = false;
+  private scopedUserId: string | null = null;
+  private scopeReadyPromise: Promise<void> | null = null;
   private initPromise: Promise<void> | null = null;
 
-  private hasInitializedSync = false;
+  /** Tracks whether the current instance has an active sync connection (reset per user). */
+  private hasConnectedSync = false;
 
   static getInstance(): DexieInitializer {
     if (!this.instance) {
@@ -23,18 +80,92 @@ class DexieInitializer {
     return this.instance;
   }
 
-  async init() {
-    // Perform data migration if needed
+  /**
+   * Point both local stores — the localforage instance and the Dexie database — at the given user.
+   * Resolves as soon as they exist, deliberately BEFORE the slower legacy-adoption and sync steps,
+   * so UI gated on readiness (via React `use()`/Suspense) is not held on those. The promise is
+   * cached per user with a stable identity; switching users rebuilds it and invalidates any prior
+   * full-init/sync state.
+   */
+  ensureScopeReady(userId: string, dbName: string): Promise<void> {
+    if (this.scopedUserId === userId && this.scopeReadyPromise) {
+      return this.scopeReadyPromise;
+    }
+    // New user (or first init): drop the prior user's stores up front so reads fail closed while
+    // the new ones are built rather than handing out the previous account's data. Any prior sync
+    // connection and full-init promise no longer apply.
+    this.clearScope();
+    this.scopedUserId = userId;
+    pageSessionUserId = pageSessionUserId ?? userId;
+    this.scopeReadyPromise = (async () => {
+      try {
+        const [userLocalStore, scopedDbName] = await Promise.all([createUserLocalStore({ dbName, userId }), getScopedDexieDbName(userId)]);
+        if (this.isSupersededScope(userId)) {
+          return;
+        }
+        // Commit both stores back to back with no awaits in between, so they can never disagree
+        // about which user is bound — a superseded or failed build simply never commits either one.
+        const dexieInstance = createDexieInstance(scopedDbName, registerDbHooks);
+        setLocalStore(userLocalStore);
+        setDexieDbInstance(dexieInstance);
+        // The preferences key is read at first paint (theme), well before the full legacy adoption
+        // in `initDexieDb` runs — make it available before any consumer can read it and cache defaults.
+        await adoptLegacyUserPreferences(userId);
+      } catch (ex) {
+        if (this.isSupersededScope(userId)) {
+          return;
+        }
+        // Nothing was committed, so reads keep failing closed. Forget this attempt (rather than
+        // caching the failure as "ready") so the next render retries, but never reject: this
+        // promise gates app render via Suspense and must not take the app down.
+        this.clearScope();
+        logger.error('[DB] Error scoping local storage to user', ex);
+      }
+    })();
+    return this.scopeReadyPromise;
+  }
+
+  /**
+   * True when a newer user (or a logout) took over while this scope was still being built. Both
+   * stores are module-level singletons, so a superseded scope must never commit — doing so would
+   * rebind the app to an account it has already moved on from.
+   */
+  private isSupersededScope(userId: string): boolean {
+    return this.scopedUserId !== userId;
+  }
+
+  /**
+   * Drop both stores and all per-user state (user switch or logout) so reads throw instead of
+   * serving the previous account's data until the next user is scoped.
+   */
+  clearScope(): void {
+    if (!this.scopedUserId && !hasDexieDb() && !hasLocalStore()) {
+      return;
+    }
+    this.scopedUserId = null;
+    this.scopeReadyPromise = null;
+    this.initPromise = null;
+    this.hasConnectedSync = false;
+    setDexieDbInstance(null);
+    setLocalStore(null);
+  }
+
+  async init(userId: string, dbName: string) {
     try {
-      if (this.hasInitialized) {
+      // Guarantee the stores exist (and reset stale state if the user changed) before full init.
+      await this.ensureScopeReady(userId, dbName);
+      if (this.initPromise) {
+        await this.initPromise;
         return;
       }
-      this.hasInitialized = true;
-      this.initPromise = this._init();
+      this.initPromise = this._init(userId);
       await this.initPromise;
     } catch (ex) {
+      // The scope itself is either valid or already failed closed inside `ensureScopeReady` — a
+      // migration failure must not tear down working stores, so just drop the promise to let a
+      // later call retry.
+      this.initPromise = null;
       logger.error('[DB] Error initializing db', ex);
-      this.hasInitialized = false;
     }
   }
 
@@ -42,40 +173,103 @@ class DexieInitializer {
     // ensure we are initialized
     if (this.initPromise) {
       await this.initPromise;
-    } else if (!this.hasInitialized) {
-      await this.init();
-    }
-    // Sync is disabled and has never been enabled, no action
-    if (!enable && !this.hasInitializedSync) {
+    } else if (!this.scopedUserId) {
       return;
     }
-    // Sync is now disabled, disconnect
-    if (!enable && this.hasInitializedSync) {
-      await dexieDataSync.disconnect();
+    // Sync is disabled — disconnect if we have an active connection, otherwise no-op
+    if (!enable) {
+      if (this.hasConnectedSync) {
+        await dexieDataSync.disconnect();
+        this.hasConnectedSync = false;
+      }
       return;
     }
-    // Register protocol and mark as initialized
-    if (enable && !this.hasInitializedSync) {
+    // The scope failed to build (stores unbound) — there is no database to sync against
+    if (!hasDexieDb()) {
+      return;
+    }
+    // Register the sync protocol once per process (the protocol name is instance-independent)
+    if (!syncProtocolRegistered) {
       initializeDexieSync(DEXIE_DB_SYNC_NAME);
-      this.hasInitializedSync = true;
+      syncProtocolRegistered = true;
     }
     // sometimes the connection does not initialize properly, delaying to ensure it does
     await delay(1000);
     await dexieDataSync.connect();
+    this.hasConnectedSync = true;
   }
 
-  private async _init() {
-    await migrateQueryHistory();
-    await migrateLoadSavedMapping();
-    await migrateApiRequestHistory();
+  private async _init(userId: string) {
+    // The scope failed to build (see `ensureScopeReady`'s catch) — there is nothing to migrate
+    // into, and starting adoption now would burn the legacy claim against unusable stores.
+    if (!hasDexieDb() || !hasLocalStore()) {
+      return;
+    }
+
+    // Adopt the pre-user-scoping shared data exactly once per machine/profile (first user post-upgrade)
+    await adoptLegacySharedData(userId);
+
+    // Backfill hashed keys on this user's own database (idempotent, per-user gated)
     await addHashedKeyToRecord();
-    this.hasInitialized = true;
   }
 }
 
-export async function initDexieDb({ recordSyncEnabled }: { recordSyncEnabled: boolean }) {
+/** Stable resolved promise for the no-user state, so React `use()` never suspends without a user. */
+const NOOP_STORAGE_READY = Promise.resolve();
+
+export interface LocalStorageScope {
+  /** Authenticated user id, or null when there is no signed-in user yet. */
+  userId: string | null | undefined;
+  /** IndexedDB database name for the localforage store — the app's environment name. */
+  dbName: string;
+}
+
+/**
+ * Resolve once the given user's local stores exist, so `getLocalStore()` and {@link getDexieDb} are
+ * safe to call. Returns a stable per-user promise intended for React `use()` / Suspense, so no
+ * descendant renders (and reads local storage) before the stores are scoped to the current user.
+ * The heavier legacy-adoption and sync work runs separately in {@link initDexieDb} and is
+ * intentionally not awaited here.
+ *
+ * With no user this is a pure no-op: tearing the stores down here would be a side effect during
+ * render. Call {@link clearLocalStorageScope} explicitly where a session actually ends — on the
+ * surfaces that render a logged-out state in place instead of reloading or navigating away, that
+ * call is what keeps the departing account's stores from staying bound.
+ */
+export function ensureLocalStorageReady({ userId, dbName }: LocalStorageScope): Promise<void> {
+  if (!userId) {
+    return NOOP_STORAGE_READY;
+  }
+  return DexieInitializer.getInstance().ensureScopeReady(userId, dbName);
+}
+
+/**
+ * End the current user's local storage session: close the Dexie connection and unbind both stores
+ * so nothing can read the departing account's data. Call from logout, before reloading.
+ */
+export function clearLocalStorageScope(): void {
+  DexieInitializer.getInstance().clearScope();
+}
+
+/**
+ * True when `userId` is a different account than the one this page already scoped local storage to.
+ *
+ * Local storage re-scopes per user, but nothing else in the page does: jotai atoms and module level
+ * caches keep serving whatever the previous account loaded. The web app and canvas can only change
+ * users through a page load, but the desktop app and the browser extension can swap the signed-in
+ * user in place (a session that expired back to the login screen, or auth state arriving over
+ * `browser.storage`), so both check this and reload before rendering anything for the new user.
+ */
+export function isDifferentUserThanPageSession(userId: string | null | undefined): boolean {
+  return !!userId && !!pageSessionUserId && userId !== pageSessionUserId;
+}
+
+export async function initDexieDb({ userId, dbName, recordSyncEnabled }: LocalStorageScope & { recordSyncEnabled: boolean }) {
+  if (!userId) {
+    return;
+  }
   try {
-    await DexieInitializer.getInstance().init();
+    await DexieInitializer.getInstance().init(userId, dbName);
 
     await DexieInitializer.getInstance().enableSync(recordSyncEnabled);
   } catch (ex) {
@@ -84,106 +278,398 @@ export async function initDexieDb({ recordSyncEnabled }: { recordSyncEnabled: bo
 }
 
 /**
+ * ADOPT-ONCE MIGRATION
+ *
+ * Before per-user scoping there was a single shared Dexie database (and a single localforage
+ * store). Those stores cannot be attributed to a specific user, so we hand them to the first
+ * account that signs in after the upgrade (virtually always the single real user of the
+ * machine) and then mark them claimed so no later account on the same machine can read them.
+ * Adoption copies rather than moves: the legacy stores are left on disk, claimed and ignored.
+ * (`deleteAllLocalData` is the one flow that does remove them, since that copy belongs to the
+ * account being deleted.)
+ */
+
+function getLegacyStoreClaim(): string | null {
+  try {
+    return globalThis.localStorage?.getItem(LEGACY_CLAIM_KEY) ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function isLegacyStoreClaimed(): boolean {
+  return !!getLegacyStoreClaim();
+}
+
+function setLegacyStoreClaimed(claimedAt = new Date().toISOString()): void {
+  try {
+    globalThis.localStorage?.setItem(LEGACY_CLAIM_KEY, claimedAt);
+  } catch (ex) {
+    logger.warn('[DB] Unable to persist legacy store claim marker', ex);
+  }
+}
+
+function getLegacyClaimOwner(): string | null {
+  try {
+    return globalThis.localStorage?.getItem(LEGACY_CLAIM_OWNER_KEY) ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Records the claim owner and reports whether it verifiably persisted. Adoption is gated entirely on
+ * this marker, so a write that silently fails (blocked or full storage) would leave the legacy stores
+ * unclaimed and adoptable by every account that later signs in on this machine.
+ */
+function setLegacyClaimOwner(hashedUserId: string): boolean {
+  try {
+    globalThis.localStorage?.setItem(LEGACY_CLAIM_OWNER_KEY, hashedUserId);
+  } catch (ex) {
+    logger.warn('[DB] Unable to persist legacy store claim owner', ex);
+  }
+  return getLegacyClaimOwner() === hashedUserId;
+}
+
+/**
+ * The legacy stores are adoptable only by the first account to claim them — and only until adoption
+ * completes. An unfinished claim stays open to the owning user (so an interrupted adoption is
+ * retried on their next login) and closed to everyone else.
+ */
+function canAdoptLegacyStore(hashedUserId: string): boolean {
+  if (isLegacyStoreClaimed()) {
+    return false;
+  }
+  const claimOwner = getLegacyClaimOwner();
+  return !claimOwner || claimOwner === hashedUserId;
+}
+
+/**
+ * Wipe localStorage without losing the legacy store claim.
+ *
+ * `deleteAllLocalData` uses this instead of `localStorage.clear()` so the claim markers survive:
+ * even though that flow also deletes the legacy stores, keeping the markers guarantees the next
+ * account signing in on this machine cannot re-run adoption against anything that reappears.
+ */
+function clearLocalStorageRetainingLegacyClaim(): void {
+  const claimedAt = getLegacyStoreClaim();
+  const claimOwner = getLegacyClaimOwner();
+  try {
+    globalThis.localStorage?.clear();
+  } catch (ex) {
+    logger.warn('[DB] Unable to clear localStorage', ex);
+  }
+  if (claimedAt) {
+    setLegacyStoreClaimed(claimedAt);
+  }
+  if (claimOwner) {
+    setLegacyClaimOwner(claimOwner);
+  }
+}
+
+/**
+ * Erase every local trace of the current account (account deletion).
+ *
+ * Covers both the per-user stores and the legacy shared stores: adoption *copies* rather than
+ * moves, so for the account that won the claim the legacy database still holds a full copy of its
+ * history. Best-effort per step — a local cleanup failure must not block deleting the account
+ * server-side.
+ */
+export async function deleteAllLocalData(userId: string): Promise<void> {
+  clearLocalStorageRetainingLegacyClaim();
+
+  const localforageStores = hasLocalStore() ? [getLocalStore(), getUnscopedLocalStore()] : [getUnscopedLocalStore()];
+  for (const store of localforageStores) {
+    try {
+      await store.clear();
+    } catch (ex) {
+      logger.warn('[DB] Unable to clear localforage store', ex);
+    }
+  }
+
+  const databaseNames = [DEXIE_DB_BASE_NAME];
+  try {
+    databaseNames.unshift(await getScopedDexieDbName(userId));
+  } catch (ex) {
+    logger.warn('[DB] Unable to resolve scoped database name', ex);
+  }
+  // Close the active connection first — Dexie.delete blocks while one is open.
+  clearLocalStorageScope();
+  for (const databaseName of databaseNames) {
+    try {
+      // Another tab holding the database open blocks the delete indefinitely, which would hang the
+      // account deletion this is part of. Give up after a few seconds — the server-side delete is
+      // what matters, and the leftover database is unreachable once this account is gone.
+      await Promise.race([
+        Dexie.delete(databaseName),
+        new Promise((_, reject) => setTimeout(() => reject(new Error('Delete timed out, database may be open in another tab')), 5000)),
+      ]);
+    } catch (ex) {
+      logger.warn('[DB] Unable to delete database', databaseName, ex);
+    }
+  }
+}
+
+async function adoptLegacySharedData(userId: string): Promise<void> {
+  const hashedUserId = await getHashedRecordKey(userId);
+  if (!canAdoptLegacyStore(hashedUserId)) {
+    return;
+  }
+  // Take ownership before copying anything — adoption is not atomic, and an interrupted run must
+  // stay closed to every other account on this machine while remaining retryable by this user.
+  // Without a durable claim there is no lock at all, so skip adoption rather than risk handing the
+  // same legacy data to every account that signs in here.
+  if (!setLegacyClaimOwner(hashedUserId)) {
+    logger.warn('[DB] Skipping legacy data adoption, unable to persist claim owner');
+    return;
+  }
+  try {
+    // 1) Legacy shared Dexie database -> this user's per-user database
+    await copyLegacyDexieData();
+    // 2) Legacy localforage store -> this user's per-user Dexie tables (existing migrations)
+    await migrateQueryHistory();
+    await migrateLoadSavedMapping();
+    await migrateApiRequestHistory();
+    // 3) Legacy localforage default store -> this user's per-user localforage store
+    await copyLegacyLocalforageData();
+  } catch (ex) {
+    // Leave the completion marker unwritten so this user retries on their next sign in (each step
+    // is separately idempotent), up to the attempt cap. The claim owner marker stays, so no other
+    // account on this machine can adopt in the meantime. Swallowing here instead would strand a
+    // half-copied store as permanently "adopted".
+    recordFailedAdoptionAttempt(ex);
+    return;
+  }
+  setLegacyStoreClaimed();
+  try {
+    globalThis.localStorage?.removeItem(LEGACY_ADOPTION_ATTEMPTS_KEY);
+  } catch {
+    // best-effort cleanup; the claim marker already ends adoption
+  }
+}
+
+/**
+ * Count a failed adoption attempt and give up for good once the cap is reached — a user whose copy
+ * persistently fails (e.g. quota) must not pay a full re-copy on every sign-in forever. Giving up
+ * stamps the claim, keeping whatever partial data already landed.
+ */
+function recordFailedAdoptionAttempt(ex: unknown): void {
+  let attempts = 1;
+  try {
+    attempts = Number(globalThis.localStorage?.getItem(LEGACY_ADOPTION_ATTEMPTS_KEY) || 0) + 1;
+    globalThis.localStorage?.setItem(LEGACY_ADOPTION_ATTEMPTS_KEY, String(attempts));
+  } catch {
+    // If the counter cannot persist, adoption just keeps its retry-on-next-sign-in behavior.
+  }
+  if (attempts >= MAX_LEGACY_ADOPTION_ATTEMPTS) {
+    logger.warn(`[DB] Legacy data adoption failed ${attempts} times, giving up and keeping partial data`, ex);
+    setLegacyStoreClaimed();
+    return;
+  }
+  logger.warn('[DB] Legacy data adoption did not complete, will retry on next sign in', ex);
+}
+
+/**
+ * Copy just the (tiny) user-preferences key ahead of the full legacy adoption, before the scope
+ * ready promise resolves. The preference atom is read at first paint — structurally before the
+ * `initDexieDb` effect that runs adoption — and jotai caches that first read for the session, so
+ * without this the first sign-in after upgrade would show default preferences (e.g. light theme
+ * for a dark-theme user) even though adoption copies them moments later.
+ *
+ * Runs before the durable claim is taken, gated on the same `canAdoptLegacyStore` predicate as the
+ * full adoption, so it can never hand preferences to an account the claim already excludes. In the
+ * unclaimed window it may copy to an account that would have lost the claim race — acceptable for
+ * a cosmetic color scheme / notification flag, in exchange for having them ready on first paint.
+ * Never throws: by the time this runs both stores are committed, and a failure here must not make
+ * `ensureScopeReady`'s catch unbind them.
+ */
+async function adoptLegacyUserPreferences(userId: string): Promise<void> {
+  try {
+    if (!hasLocalStore()) {
+      return;
+    }
+    const hashedUserId = await getHashedRecordKey(userId);
+    if (!canAdoptLegacyStore(hashedUserId)) {
+      return;
+    }
+    const targetStore = getLocalStore();
+    // Never clobber preferences the user has already written into their per-user store
+    if ((await targetStore.getItem(INDEXED_DB.KEYS.userPreferences)) !== null) {
+      return;
+    }
+    const legacyPreferences = await getUnscopedLocalStore().getItem(INDEXED_DB.KEYS.userPreferences);
+    if (legacyPreferences !== null) {
+      await targetStore.setItem(INDEXED_DB.KEYS.userPreferences, legacyPreferences);
+    }
+  } catch (ex) {
+    logger.warn('[DB] Unable to copy legacy user preferences', ex);
+  }
+}
+
+async function copyLegacyDexieData(): Promise<void> {
+  if (!(await Dexie.exists(DEXIE_DB_BASE_NAME))) {
+    return;
+  }
+  // No hooks: this instance is only read from, and its writes would target the wrong database.
+  const legacyDb = createDexieInstance(DEXIE_DB_BASE_NAME);
+  try {
+    await legacyDb.open();
+    const targetDb = getDexieDb();
+    for (const tableName of AdoptableTables) {
+      // Indexing by the union of table names yields a union of table types, so narrow to a generic
+      // Table to call bulkPut/toArray uniformly.
+      const legacyTable = legacyDb[tableName] as unknown as Table<any, any>;
+      const targetTable = targetDb[tableName] as unknown as Table<any, any>;
+      const rows = await legacyTable.toArray();
+      if (rows.length) {
+        await targetTable.bulkPut(rows).catch((ex: any) => {
+          // Individual row failures are tolerable (and not retryable); anything else fails adoption.
+          if (ex.name === 'BulkError') {
+            logger.warn(`[DB] Error adopting legacy ${tableName}`, ex.failures);
+          } else {
+            throw ex;
+          }
+        });
+      }
+    }
+  } finally {
+    legacyDb.close();
+  }
+}
+
+async function copyLegacyLocalforageData(): Promise<void> {
+  // Without a user-scoped store the target would be the default (legacy) instance — copying it
+  // onto itself is pointless and could clobber data, so only run when a per-user store is active.
+  if (!hasLocalStore()) {
+    return;
+  }
+  const targetStore = getLocalStore();
+  const legacyStore = getUnscopedLocalStore();
+  for (const key of await legacyStore.keys()) {
+    // Skip the HTTP cache: it is regenerable (3 day TTL), it is by far the largest thing in the
+    // store, and copying it would roughly double IndexedDB usage — the most likely way to blow
+    // quota and fail an otherwise successful adoption.
+    if (key.startsWith(INDEXED_DB.KEYS.httpCache)) {
+      continue;
+    }
+    // Never clobber a value already in the per-user store: on an adoption retry the target may
+    // hold newer data the user wrote during an earlier session (e.g. changed preferences).
+    if ((await targetStore.getItem(key)) !== null) {
+      continue;
+    }
+    await targetStore.setItem(key, await legacyStore.getItem(key));
+  }
+}
+
+/**
  * MIGRATION FROM LOCALFORAGE TO DEXIE
+ *
+ * Each of these runs as part of `adoptLegacySharedData` and is independently gated by its own
+ * `_migration` record, so failures propagate: adoption is left un-stamped and retries, and the
+ * steps that already succeeded are skipped on the retry.
+ *
+ * For most users the gate is satisfied before these ever run: the legacy database already ran the
+ * migration years ago and `copyLegacyDexieData` carries its `_migration` markers over (see
+ * `AdoptableTables`), so these no-op — re-running them would overwrite the adopted, current rows
+ * with the stale pre-Dexie localforage snapshot, which was never deleted. They only do real work
+ * for a user whose legacy database never completed them (or never existed at all).
  */
 
 async function migrateQueryHistory() {
-  try {
-    const migrationRecord = await dexieDb._migration.get('query_history');
-    if (migrationRecord?.completedAt) {
-      return;
-    }
-    const queryHistory = await localforage.getItem<Record<string, QueryHistoryItem>>(INDEXED_DB.KEYS.queryHistory);
-    if (queryHistory) {
-      for (const item of Object.values(queryHistory)) {
-        const createdAt = new Date((item as any).created || item.createdAt || new Date());
-        delete (item as any)['created'];
-        item.key = `${SyncableTables.query_history.keyPrefix}_${item.key}`.toLowerCase() as QueryHistoryItem['key'];
-        item.hashedKey = await getHashedRecordKey(item.key);
-        item.updatedAt = new Date(item.updatedAt || item.lastRun);
-        item.lastRun = new Date(item.lastRun);
-        item.isFavoriteIdx = item.isFavorite ? 'true' : 'false';
-        item.createdAt = createdAt;
-      }
-      await dexieDb.query_history.bulkPut(Object.values(queryHistory)).catch((ex) => {
-        if (ex.name === 'BulkError') {
-          logger.warn('[DB] Error migrating query history', ex.failures);
-        }
-      });
-    }
-    await dexieDb._migration.put({ entity: 'query_history', completedAt: new Date() });
-  } catch (ex) {
-    logger.warn('[DB] Error migrating query history', ex);
+  const dexieDb = getDexieDb();
+  const migrationRecord = await dexieDb._migration.get('query_history');
+  if (migrationRecord?.completedAt) {
+    return;
   }
+  const queryHistory = await getUnscopedLocalStore().getItem<Record<string, QueryHistoryItem>>(INDEXED_DB.KEYS.queryHistory);
+  if (queryHistory) {
+    for (const item of Object.values(queryHistory)) {
+      const createdAt = new Date((item as any).created || item.createdAt || new Date());
+      delete (item as any)['created'];
+      item.key = `${SyncableTables.query_history.keyPrefix}_${item.key}`.toLowerCase() as QueryHistoryItem['key'];
+      item.hashedKey = await getHashedRecordKey(item.key);
+      item.updatedAt = new Date(item.updatedAt || item.lastRun);
+      item.lastRun = new Date(item.lastRun);
+      item.isFavoriteIdx = item.isFavorite ? 'true' : 'false';
+      item.createdAt = createdAt;
+    }
+    await dexieDb.query_history.bulkPut(Object.values(queryHistory)).catch((ex) => {
+      if (ex.name === 'BulkError') {
+        logger.warn('[DB] Error migrating query history', ex.failures);
+      } else {
+        throw ex;
+      }
+    });
+  }
+  await dexieDb._migration.put({ entity: 'query_history', completedAt: new Date() });
 }
 
 async function migrateLoadSavedMapping() {
-  try {
-    const migrationRecord = await dexieDb._migration.get('load_saved_mapping');
-    if (migrationRecord?.completedAt) {
-      return;
-    }
-    const loadSavedMapping = await localforage.getItem<Record<string, Record<string, LoadSavedMappingItem>>>(
-      INDEXED_DB.KEYS.loadSavedMapping,
-    );
-    if (loadSavedMapping) {
-      const records: LoadSavedMappingItem[] = [];
-      for (const sobject of Object.values(loadSavedMapping)) {
-        for (let item of Object.values(sobject)) {
-          item = { ...item };
-          const createdAt = new Date((item as any).createdDate || item.createdAt || new Date());
-          delete (item as any)['createdDate'];
-          item.key = `${SyncableTables.load_saved_mapping.keyPrefix}_${item.key}`.toLowerCase() as LoadSavedMappingItem['key'];
-          item.hashedKey = await getHashedRecordKey(item.key);
-          item.createdAt = createdAt;
-          item.updatedAt = createdAt;
-          records.push(item);
-        }
-      }
-
-      await dexieDb.load_saved_mapping.bulkPut(records).catch((ex) => {
-        if (ex.name === 'BulkError') {
-          logger.warn('[DB] Error migrating load_saved_mapping', ex.failures);
-        }
-      });
-    }
-    await dexieDb._migration.put({ entity: 'load_saved_mapping', completedAt: new Date() });
-  } catch (ex) {
-    logger.warn('[DB] Error migrating load_saved_mapping', ex);
+  const dexieDb = getDexieDb();
+  const migrationRecord = await dexieDb._migration.get('load_saved_mapping');
+  if (migrationRecord?.completedAt) {
+    return;
   }
+  const loadSavedMapping = await getUnscopedLocalStore().getItem<Record<string, Record<string, LoadSavedMappingItem>>>(
+    INDEXED_DB.KEYS.loadSavedMapping,
+  );
+  if (loadSavedMapping) {
+    const records: LoadSavedMappingItem[] = [];
+    for (const sobject of Object.values(loadSavedMapping)) {
+      for (let item of Object.values(sobject)) {
+        item = { ...item };
+        const createdAt = new Date((item as any).createdDate || item.createdAt || new Date());
+        delete (item as any)['createdDate'];
+        item.key = `${SyncableTables.load_saved_mapping.keyPrefix}_${item.key}`.toLowerCase() as LoadSavedMappingItem['key'];
+        item.hashedKey = await getHashedRecordKey(item.key);
+        item.createdAt = createdAt;
+        item.updatedAt = createdAt;
+        records.push(item);
+      }
+    }
+
+    await dexieDb.load_saved_mapping.bulkPut(records).catch((ex) => {
+      if (ex.name === 'BulkError') {
+        logger.warn('[DB] Error migrating load_saved_mapping', ex.failures);
+      } else {
+        throw ex;
+      }
+    });
+  }
+  await dexieDb._migration.put({ entity: 'load_saved_mapping', completedAt: new Date() });
 }
 
 async function migrateApiRequestHistory() {
-  try {
-    const migrationRecord = await dexieDb._migration.get('api_request_history');
-    if (migrationRecord?.completedAt) {
-      return;
-    }
-    const recordsById = await localforage.getItem<Record<string, ApiHistoryItem>>(INDEXED_DB.KEYS.salesforceApiHistory);
-    if (recordsById) {
-      for (const item of Object.values(recordsById)) {
-        const createdAt = new Date(item.lastRun || new Date());
-        item.key = `${SyncableTables.api_request_history.keyPrefix}_${item.key}`.toLowerCase() as ApiHistoryItem['key'];
-        item.hashedKey = await getHashedRecordKey(item.key);
-        item.updatedAt = new Date(item.lastRun);
-        item.lastRun = new Date(item.lastRun);
-        item.isFavorite = 'false';
-        item.createdAt = createdAt;
-      }
-      await dexieDb.api_request_history.bulkPut(Object.values(recordsById)).catch((ex) => {
-        if (ex.name === 'BulkError') {
-          logger.warn('[DB] Error migrating api history', ex.failures);
-        }
-      });
-    }
-    await dexieDb._migration.put({ entity: 'api_request_history', completedAt: new Date() });
-  } catch (ex) {
-    logger.warn('[DB] Error migrating api history', ex);
+  const dexieDb = getDexieDb();
+  const migrationRecord = await dexieDb._migration.get('api_request_history');
+  if (migrationRecord?.completedAt) {
+    return;
   }
+  const recordsById = await getUnscopedLocalStore().getItem<Record<string, ApiHistoryItem>>(INDEXED_DB.KEYS.salesforceApiHistory);
+  if (recordsById) {
+    for (const item of Object.values(recordsById)) {
+      const createdAt = new Date(item.lastRun || new Date());
+      item.key = `${SyncableTables.api_request_history.keyPrefix}_${item.key}`.toLowerCase() as ApiHistoryItem['key'];
+      item.hashedKey = await getHashedRecordKey(item.key);
+      item.updatedAt = new Date(item.lastRun);
+      item.lastRun = new Date(item.lastRun);
+      item.isFavorite = 'false';
+      item.createdAt = createdAt;
+    }
+    await dexieDb.api_request_history.bulkPut(Object.values(recordsById)).catch((ex) => {
+      if (ex.name === 'BulkError') {
+        logger.warn('[DB] Error migrating api history', ex.failures);
+      } else {
+        throw ex;
+      }
+    });
+  }
+  await dexieDb._migration.put({ entity: 'api_request_history', completedAt: new Date() });
 }
 
 async function addHashedKeyToRecord() {
   try {
+    const dexieDb = getDexieDb();
     const migrationRecord = await dexieDb._migration.get('hashed_key');
     if (migrationRecord?.completedAt) {
       return;

--- a/libs/shared/ui-db/src/lib/db-hooks.ts
+++ b/libs/shared/ui-db/src/lib/db-hooks.ts
@@ -1,0 +1,38 @@
+import { QueryHistoryItem } from '@jetstream/types';
+import { saveQueryHistoryObject } from './query-history-object.db';
+import type { DexieDb } from './ui-db';
+
+/**
+ * Table hooks applied to the active per-user database, passed to `createDexieInstance`.
+ *
+ * These live here rather than in `ui-db.ts` so that module stays free of feature-module imports
+ * (it is the base every `*.db.ts` module imports from), and rather than as module-level side
+ * effects — the database is now created per user, so hooks must be registered per instance.
+ */
+export function registerDbHooks(db: DexieDb) {
+  /**
+   * Boolean fields cannot be indexes, so we store a string version of the same field
+   */
+  db.query_history.hook('updating', function (mods) {
+    if ('isFavorite' in mods) {
+      return { ...mods, isFavoriteIdx: (mods as Partial<QueryHistoryItem>).isFavorite ? 'true' : 'false' };
+    }
+    return undefined;
+  });
+
+  /**
+   * Save object mapping for query history — used on the query history modal to show the list of objects
+   */
+  db.query_history.hook('creating', function (_, obj) {
+    obj.isFavoriteIdx = obj.isFavorite ? 'true' : 'false';
+    this.onsuccess = function () {
+      // Defer out of the current transaction — writing _query_history_object inline consistently fails.
+      // The object being created is already in hand, so use it directly rather than re-reading it by key,
+      // and write through the instance the hook was registered on: the active database may have been
+      // swapped by the time this runs (logout / account switch).
+      setTimeout(() => {
+        saveQueryHistoryObject(db, obj);
+      });
+    };
+  });
+}

--- a/libs/shared/ui-db/src/lib/query-history-object.db.ts
+++ b/libs/shared/ui-db/src/lib/query-history-object.db.ts
@@ -1,25 +1,9 @@
 import { logger } from '@jetstream/shared/client-logger';
 import { QueryHistoryItem, QueryHistoryObject, SalesforceOrgUi } from '@jetstream/types';
-import { dexieDb, wrapApiWithReopenOnDatabaseClosed } from './ui-db';
+import { DexieDb, getDexieDb, wrapApiWithReopenOnDatabaseClosed } from './ui-db';
 
 export const queryHistoryObjectDb = wrapApiWithReopenOnDatabaseClosed({
-  saveQueryHistoryObject,
-  saveQueryHistoryObjectFromKey,
   deleteAllQueryHistoryObjectForOrg,
-});
-
-/**
- * Save object mapping for query history
- * this is used on the query history modal to show the list of objects
- */
-dexieDb.query_history.hook('creating', function (_, obj) {
-  obj.isFavoriteIdx = obj.isFavorite ? 'true' : 'false';
-  this.onsuccess = function (key) {
-    // this would consistently fail if done in the same transaction
-    setTimeout(() => {
-      saveQueryHistoryObjectFromKey(key);
-    });
-  };
 });
 
 function generateKey(orgUniqueId: string, sObject: string, isTooling: boolean): string {
@@ -36,23 +20,17 @@ function getQueryHistoryObject(queryHistoryItem: QueryHistoryItem): QueryHistory
   };
 }
 
-async function saveQueryHistoryObject(queryHistoryItem: QueryHistoryItem): Promise<void> {
+/**
+ * Write the derived object row for a query history item.
+ *
+ * Takes the database explicitly instead of calling `getDexieDb()`: the only caller is the
+ * `query_history` creating hook, which defers this write out of the creating transaction, and the
+ * active database can be swapped in that window (logout / account switch). Going through the global
+ * accessor would land the departing user's row in the next user's database.
+ */
+export async function saveQueryHistoryObject(db: DexieDb, queryHistoryItem: QueryHistoryItem): Promise<void> {
   try {
-    const item = getQueryHistoryObject(queryHistoryItem);
-    await dexieDb._query_history_object.put(item);
-  } catch (ex) {
-    logger.warn('[DB] Error saving query history object', ex);
-  }
-}
-
-async function saveQueryHistoryObjectFromKey(queryHistoryItemKey: QueryHistoryItem['key']): Promise<void> {
-  try {
-    const queryHistoryItem = await dexieDb.query_history.get(queryHistoryItemKey);
-    if (!queryHistoryItem) {
-      return;
-    }
-    const item = getQueryHistoryObject(queryHistoryItem);
-    await dexieDb._query_history_object.put(item);
+    await db._query_history_object.put(getQueryHistoryObject(queryHistoryItem));
   } catch (ex) {
     logger.warn('[DB] Error saving query history object', ex);
   }
@@ -60,7 +38,7 @@ async function saveQueryHistoryObjectFromKey(queryHistoryItemKey: QueryHistoryIt
 
 async function deleteAllQueryHistoryObjectForOrg(org: SalesforceOrgUi): Promise<void> {
   try {
-    await dexieDb._query_history_object.where({ org: org.uniqueId }).delete();
+    await getDexieDb()._query_history_object.where({ org: org.uniqueId }).delete();
   } catch (ex) {
     logger.error('[DB] Error deleting query history object for org', ex);
   }

--- a/libs/shared/ui-db/src/lib/query-history.db.ts
+++ b/libs/shared/ui-db/src/lib/query-history.db.ts
@@ -4,7 +4,7 @@ import { REGEX } from '@jetstream/shared/utils';
 import { QueryHistoryItem, SalesforceOrgUi } from '@jetstream/types';
 import { parseQuery } from '@jetstreamapp/soql-parser-js';
 import { max } from 'date-fns/max';
-import { dexieDb, getHashedRecordKey, SyncableTables, wrapApiWithReopenOnDatabaseClosed } from './ui-db';
+import { getDexieDb, getHashedRecordKey, SyncableTables, wrapApiWithReopenOnDatabaseClosed } from './ui-db';
 
 export const queryHistoryDb = wrapApiWithReopenOnDatabaseClosed({
   getAllQueryHistory,
@@ -17,16 +17,6 @@ export const queryHistoryDb = wrapApiWithReopenOnDatabaseClosed({
   TEMP_deleteItem,
 });
 
-/**
- * Boolean fields cannot be indexes, so we store a string version of the same field
- */
-dexieDb.query_history.hook('updating', function (mods) {
-  if ('isFavorite' in mods) {
-    return { ...mods, isFavoriteIdx: mods.isFavorite ? 'true' : 'false' };
-  }
-  return undefined;
-});
-
 function generateKey(orgUniqueId: string, sObject: string, soql: string): QueryHistoryItem['key'] {
   return `${SyncableTables.query_history.keyPrefix}_${orgUniqueId}:${sObject}${soql.replace(
     REGEX.NOT_ALPHANUMERIC_OR_UNDERSCORE,
@@ -35,7 +25,7 @@ function generateKey(orgUniqueId: string, sObject: string, soql: string): QueryH
 }
 
 async function getAllQueryHistory(): Promise<QueryHistoryItem[]> {
-  return await dexieDb.query_history.toArray();
+  return await getDexieDb().query_history.toArray();
 }
 
 async function setAsFavorite(
@@ -43,6 +33,7 @@ async function setAsFavorite(
   isFavorite: boolean,
   customLabel?: string,
 ): Promise<QueryHistoryItem | undefined> {
+  const dexieDb = getDexieDb();
   const updates: Partial<QueryHistoryItem> = { isFavorite };
   // update custom label if provided
   if (customLabel) {
@@ -53,6 +44,7 @@ async function setAsFavorite(
 }
 
 async function updateCustomLabel(key: QueryHistoryItem['key'], customLabel: string | null): Promise<QueryHistoryItem | undefined> {
+  const dexieDb = getDexieDb();
   const updates: Partial<QueryHistoryItem> = { customLabel: customLabel || null };
   await dexieDb.query_history.update(key, updates);
   return await dexieDb.query_history.get(key);
@@ -65,6 +57,7 @@ async function updateSavedQuery(
   newLabel: string,
   isTooling: boolean,
 ): Promise<QueryHistoryItem> {
+  const dexieDb = getDexieDb();
   newSoql = newSoql.trim();
   newLabel = newLabel.trim();
 
@@ -145,7 +138,7 @@ async function getOrInitQueryHistoryItem(
 ): Promise<QueryHistoryItem> {
   // FIXME: isTooling should be part of key - not a huge deal either way but could have some edge-cases for the few duplicate objects
   const key = generateKey(org.uniqueId, sObject, soql);
-  const existingItem = await dexieDb.query_history.get(key);
+  const existingItem = await getDexieDb().query_history.get(key);
 
   sObjectLabel = sObjectLabel || existingItem?.label;
 
@@ -204,13 +197,13 @@ async function saveQueryHistoryItem(
   queryHistoryItem.customLabel = customLabel ?? queryHistoryItem.customLabel;
   queryHistoryItem.isTooling = isTooling ?? queryHistoryItem.isTooling;
 
-  await dexieDb.query_history.put(queryHistoryItem);
+  await getDexieDb().query_history.put(queryHistoryItem);
   return queryHistoryItem;
 }
 
 async function TEMP_deleteItem(key: string): Promise<void> {
   try {
-    await dexieDb.query_history.where({ key }).delete();
+    await getDexieDb().query_history.where({ key }).delete();
   } catch (ex) {
     logger.error('[DB] Error deleting query history for key', key, ex);
   }
@@ -218,7 +211,7 @@ async function TEMP_deleteItem(key: string): Promise<void> {
 
 async function deleteAllQueryHistoryForOrgExceptFavorites(org: SalesforceOrgUi): Promise<void> {
   try {
-    await dexieDb.query_history.where({ org: org.uniqueId, isFavoriteIdx: 'false' }).delete();
+    await getDexieDb().query_history.where({ org: org.uniqueId, isFavoriteIdx: 'false' }).delete();
   } catch (ex) {
     logger.error('[DB] Error deleting query history for org', ex);
   }

--- a/libs/shared/ui-db/src/lib/recent-history-items.db.ts
+++ b/libs/shared/ui-db/src/lib/recent-history-items.db.ts
@@ -2,7 +2,7 @@ import { logger } from '@jetstream/shared/client-logger';
 import { groupByFlat } from '@jetstream/shared/utils';
 import { RecentHistoryItem, RecentHistoryItemType } from '@jetstream/types';
 import uniqBy from 'lodash/uniqBy';
-import { dexieDb, getHashedRecordKey, SyncableTables, wrapApiWithReopenOnDatabaseClosed } from './ui-db';
+import { getDexieDb, getHashedRecordKey, SyncableTables, wrapApiWithReopenOnDatabaseClosed } from './ui-db';
 
 export const recentHistoryItemsDb = wrapApiWithReopenOnDatabaseClosed({
   addItemToRecentHistoryItems,
@@ -29,8 +29,8 @@ async function getRecentHistoryFromRecords<T extends { name: string }>({
 }) {
   const recordsByName = groupByFlat(records, 'name');
 
-  const items = await dexieDb.recent_history_item
-    .get(generateKey(orgUniqueId, recentItemsKey))
+  const items = await getDexieDb()
+    .recent_history_item.get(generateKey(orgUniqueId, recentItemsKey))
     .then((record) => record?.items?.map(({ name }) => name) || []);
   return items?.map((name) => recordsByName[name]).filter(Boolean);
 }
@@ -39,7 +39,7 @@ async function addItemToRecentHistoryItems(orgUniqueId: string, recentItemsKey: 
   try {
     const key = generateKey(orgUniqueId, recentItemsKey);
 
-    let newOrExistingRecord = await dexieDb.recent_history_item.get(generateKey(orgUniqueId, recentItemsKey));
+    let newOrExistingRecord = await getDexieDb().recent_history_item.get(generateKey(orgUniqueId, recentItemsKey));
     if (!newOrExistingRecord) {
       newOrExistingRecord = {
         key,
@@ -62,7 +62,7 @@ async function addItemToRecentHistoryItems(orgUniqueId: string, recentItemsKey: 
 
 async function clearRecentHistoryItemsForCurrentOrg(orgUniqueId: string) {
   try {
-    await dexieDb.recent_history_item.where('org').equals(orgUniqueId).delete();
+    await getDexieDb().recent_history_item.where('org').equals(orgUniqueId).delete();
   } catch (ex) {
     logger.error('Error deleting item to recent history items', ex);
   }
@@ -70,7 +70,7 @@ async function clearRecentHistoryItemsForCurrentOrg(orgUniqueId: string) {
 
 async function clearRecentHistoryItemsForAllOrgs() {
   try {
-    await dexieDb.recent_history_item.clear();
+    await getDexieDb().recent_history_item.clear();
   } catch (ex) {
     logger.error('Error deleting item to recent history items', ex);
   }
@@ -90,5 +90,5 @@ async function saveRecentHistoryItem(
     createdAt: recentHistoryItem.createdAt || new Date(),
     updatedAt: new Date(),
   };
-  return await dexieDb.recent_history_item.put(newItem);
+  return await getDexieDb().recent_history_item.put(newItem);
 }

--- a/libs/shared/ui-db/src/lib/ui-db.ts
+++ b/libs/shared/ui-db/src/lib/ui-db.ts
@@ -1,5 +1,6 @@
 /// <reference types="chrome" />
 import { logger } from '@jetstream/shared/client-logger';
+import { sha1Hex } from '@jetstream/shared/utils';
 import type {
   AnalysisJobHistoryItem,
   ApiHistoryItem,
@@ -14,6 +15,10 @@ import 'dexie-syncable';
 
 /**
  * This library is intentionally kept very small to allow importing in browser extension without importing the entire ui-core
+ *
+ * This module must not import the feature-specific `*.db.ts` modules — they all import from here,
+ * and a cycle would make module evaluation order load-bearing. Anything a table hook needs from a
+ * feature module is passed in via `createDexieInstance`'s `registerHooks` argument instead.
  */
 
 interface Migration {
@@ -21,7 +26,28 @@ interface Migration {
   completedAt: Date;
 }
 
-export type DexieDb = typeof dexieDb;
+/**
+ * Local IndexedDB, scoped per authenticated user (see {@link getScopedDexieDbName}).
+ * The instance is created lazily at login via {@link initDexieDb} rather than at module
+ * import, because the authenticated user id is not known until then. Consumers must go
+ * through {@link getDexieDb} instead of referencing a module-level singleton.
+ */
+export type DexieDb = Dexie & {
+  /**
+   * Keeps track of migration from localforage to dexie for any given table
+   */
+  _migration: EntityTable<Migration, 'entity'>;
+  /**
+   * Keeps track of objects used for query history
+   */
+  _query_history_object: EntityTable<QueryHistoryObject, 'key'>;
+  query_history: EntityTable<QueryHistoryItem, 'key'>;
+  load_saved_mapping: EntityTable<LoadSavedMappingItem, 'key'>;
+  recent_history_item: EntityTable<RecentHistoryItem, 'key'>;
+  api_request_history: EntityTable<ApiHistoryItem, 'key'>;
+  analysis_job_history: EntityTable<AnalysisJobHistoryItem, 'key'>;
+};
+
 export type SyncableEntity = keyof typeof SyncableTables;
 
 export const SyncableTables = {
@@ -54,6 +80,28 @@ export const LocalOnlyTables = {
   },
 } as const;
 
+/**
+ * Tables copied when adopting the legacy shared database into a per-user database
+ * (see `adoptLegacySharedData`). Order matters:
+ *
+ * - `_migration` must be included and copied: its completed markers are what stop the old
+ *   localforage→Dexie migrations from re-running against the fresh per-user database — the
+ *   pre-Dexie localforage snapshot was never deleted and its migrated keys collide with current
+ *   row keys, so a re-run would overwrite the adopted rows (favorites, labels, run counts) with
+ *   years-old data.
+ * - `analysis_job_history` is last: its rows carry large result blobs, so if the copy dies on
+ *   quota the small, irreplaceable tables have already landed.
+ */
+export const AdoptableTables = [
+  '_migration',
+  '_query_history_object',
+  'query_history',
+  'load_saved_mapping',
+  'recent_history_item',
+  'api_request_history',
+  'analysis_job_history',
+] as const;
+
 const isWebExtension = () => {
   try {
     return !!globalThis.__IS_BROWSER_EXTENSION__ || !!window?.chrome?.runtime?.id;
@@ -62,17 +110,20 @@ const isWebExtension = () => {
   }
 };
 
-export async function getHashedRecordKey(key: string) {
-  const encoder = new TextEncoder();
-  const data = encoder.encode(key);
-  const hashBuffer = await crypto.subtle.digest('SHA-1', data);
-  const hashArray = Array.from(new Uint8Array(hashBuffer));
-  const hashHex = hashArray.map((b) => b.toString(16).padStart(2, '0')).join('');
-  return hashHex;
-}
+export const getHashedRecordKey = sha1Hex;
 
-export const DEXIE_DB_NAME = isWebExtension() ? 'jetstream-web-extension' : 'jetstream';
-export const DEXIE_DB_SYNC_NAME = isWebExtension() ? 'jetstream-web-extension' : 'jetstream';
+/**
+ * Un-scoped database name. Two roles: the prefix every per-user database name is built from
+ * (see {@link getScopedDexieDbName}), and — on its own — the name of the legacy shared database
+ * that existed before per-user scoping, which the adopt-once migration reads from. Never open it
+ * for normal reads/writes.
+ */
+export const DEXIE_DB_BASE_NAME = isWebExtension() ? 'jetstream-web-extension' : 'jetstream';
+/**
+ * Sync protocol name — a stable identifier registered once with `Dexie.Syncable`,
+ * independent of the per-user database name.
+ */
+export const DEXIE_DB_SYNC_NAME = DEXIE_DB_BASE_NAME;
 export const DEXIE_DB_SYNC_PATH = '/';
 
 // dexie-observable coordinates multi-tab state through localStorage and writes a brand-new
@@ -80,7 +131,8 @@ export const DEXIE_DB_SYNC_PATH = '/';
 // localStorage sits at quota this throws an unhandled QuotaExceededError on page close (new keys
 // fail even when same-size overwrites succeed). Cross-tab signaling still requires REAL localStorage
 // writes (other tabs listen for storage events), so wrap the impl to swallow storage failures rather
-// than replacing it. Must run before `new Dexie(...)` — the addon captures the impl at construction.
+// than replacing it. Must run before any `new Dexie(...)` (see `createDexieInstance`) — the addon
+// captures the impl at construction, so this stays at module scope.
 const DexieObservable = (Dexie as unknown as { Observable?: { localStorageImpl?: unknown } }).Observable;
 if (DexieObservable && typeof localStorage !== 'undefined') {
   DexieObservable.localStorageImpl = {
@@ -102,42 +154,86 @@ if (DexieObservable && typeof localStorage !== 'undefined') {
   };
 }
 
-export const dexieDb = new Dexie(DEXIE_DB_NAME) as Dexie & {
-  /**
-   * Keeps track of migration from localforage to dexie for any given table
-   */
-  _migration: EntityTable<Migration, 'entity'>;
-  /**
-   * Keeps track of objects used for query history
-   */
-  _query_history_object: EntityTable<QueryHistoryObject, 'key'>;
-  query_history: EntityTable<QueryHistoryItem, 'key'>;
-  load_saved_mapping: EntityTable<LoadSavedMappingItem, 'key'>;
-  recent_history_item: EntityTable<RecentHistoryItem, 'key'>;
-  api_request_history: EntityTable<ApiHistoryItem, 'key'>;
-  analysis_job_history: EntityTable<AnalysisJobHistoryItem, 'key'>;
-};
-
 export const SyncableEntities = new Set<SyncableEntity>(Object.keys(SyncableTables) as Array<SyncableEntity>);
 
-dexieDb.version(1).stores({
-  _migration: 'entity',
-  _query_history_object: 'key,org,sObject,[org+sObject]',
-  query_history: 'key,org,sObject,updatedAt,lastRun,isFavoriteIdx,[sObject+org],[sObject+isFavoriteIdx],[org+isFavoriteIdx]',
-  load_saved_mapping: 'key,sobject,*csvFields,*sobjectFields',
-});
+/**
+ * Per-user database name. The authenticated user id is hashed so the raw id is never
+ * exposed in the IndexedDB database name.
+ */
+export async function getScopedDexieDbName(userId: string): Promise<string> {
+  const hashedUserId = await getHashedRecordKey(userId);
+  return `${DEXIE_DB_BASE_NAME}-u-${hashedUserId}`;
+}
 
-dexieDb.version(2).stores({
-  recent_history_item: 'key,org',
-});
+function applySchema(db: DexieDb) {
+  db.version(1).stores({
+    _migration: 'entity',
+    _query_history_object: 'key,org,sObject,[org+sObject]',
+    query_history: 'key,org,sObject,updatedAt,lastRun,isFavoriteIdx,[sObject+org],[sObject+isFavoriteIdx],[org+isFavoriteIdx]',
+    load_saved_mapping: 'key,sobject,*csvFields,*sobjectFields',
+  });
 
-dexieDb.version(3).stores({
-  api_request_history: 'key,org,lastRun,isFavorite,[org+isFavorite]',
-});
+  db.version(2).stores({
+    recent_history_item: 'key,org',
+  });
 
-dexieDb.version(4).stores({
-  analysis_job_history: 'key,org,jobType,createdAt,pinned,[org+jobType+createdAt]',
-});
+  db.version(3).stores({
+    api_request_history: 'key,org,lastRun,isFavorite,[org+isFavorite]',
+  });
+
+  db.version(4).stores({
+    analysis_job_history: 'key,org,jobType,createdAt,pinned,[org+jobType+createdAt]',
+  });
+}
+
+/**
+ * Build a Dexie instance for a given database name with the full schema applied.
+ *
+ * Table hooks are passed in (see `registerDbHooks`) rather than imported here, both to keep this
+ * module free of feature-module imports and because the legacy database — opened read-only by the
+ * adopt-once migration — deliberately gets no write hooks.
+ */
+export function createDexieInstance(name: string, registerHooks?: (db: DexieDb) => void): DexieDb {
+  const db = new Dexie(name) as DexieDb;
+  applySchema(db);
+  registerHooks?.(db);
+  return db;
+}
+
+let dexieDbInstance: DexieDb | null = null;
+
+/**
+ * Swap the active database instance, closing the one being replaced. Closing releases the
+ * IndexedDB connection and stops dexie-observable's heartbeat and any dexie-syncable connection
+ * on the departing user's database, so no background work continues against it after a logout
+ * or user switch.
+ */
+export function setDexieDbInstance(db: DexieDb | null) {
+  const previousDb = dexieDbInstance;
+  dexieDbInstance = db;
+  if (previousDb && previousDb !== db) {
+    try {
+      previousDb.close();
+    } catch (ex) {
+      logger.warn('[DB] Error closing previous database instance', ex);
+    }
+  }
+}
+
+/**
+ * Access the active per-user database. Throws if accessed before {@link initDexieDb} has run —
+ * every history/data feature is gated behind authentication, which is where init happens.
+ */
+export function getDexieDb(): DexieDb {
+  if (!dexieDbInstance) {
+    throw new Error('Dexie database has not been initialized. Call initDexieDb() before accessing the database.');
+  }
+  return dexieDbInstance;
+}
+
+export function hasDexieDb(): boolean {
+  return !!dexieDbInstance;
+}
 
 /**
  * dexie-observable can close the shared connection permanently mid-session (its multi-tab heartbeat
@@ -149,9 +245,11 @@ export async function withReopenOnDatabaseClosed<T>(operation: () => Promise<T>)
   try {
     return await operation();
   } catch (ex) {
-    if ((ex as Error)?.name === 'DatabaseClosedError') {
+    // The instance is torn down on logout, so only retry while one is still active — otherwise
+    // `getDexieDb()` would throw and mask the original error.
+    if ((ex as Error)?.name === 'DatabaseClosedError' && hasDexieDb()) {
       logger.warn('[DB] Database was closed - reopening and retrying');
-      await dexieDb.open();
+      await getDexieDb().open();
       return await operation();
     }
     throw ex;
@@ -171,20 +269,22 @@ export function wrapApiWithReopenOnDatabaseClosed<T extends Record<string, (...a
 
 export const dexieDataSync = {
   connect: async () => {
-    const status = await dexieDb.syncable.getStatus('/');
+    const db = getDexieDb();
+    const status = await db.syncable.getStatus('/');
     if (status === -1 /** SyncStatus.ERROR */) {
       logger.warn('[DB][SYNC] Resetting sync due to error status');
-      await dexieDb.syncable.delete(DEXIE_DB_SYNC_PATH);
+      await db.syncable.delete(DEXIE_DB_SYNC_PATH);
     }
-    await dexieDb.syncable.connect(DEXIE_DB_SYNC_NAME, '/');
+    await db.syncable.connect(DEXIE_DB_SYNC_NAME, '/');
   },
   disconnect: async () => {
-    await dexieDb.syncable.disconnect(DEXIE_DB_SYNC_PATH);
+    await getDexieDb().syncable.disconnect(DEXIE_DB_SYNC_PATH);
   },
   reset: async (reconnect?: boolean) => {
+    const db = getDexieDb();
     try {
       await Promise.race([
-        dexieDb.syncable.disconnect(DEXIE_DB_SYNC_PATH),
+        db.syncable.disconnect(DEXIE_DB_SYNC_PATH),
         new Promise((_, reject) => setTimeout(() => reject(new Error('Disconnect timeout')), 5000)),
       ]);
     } catch (ex) {
@@ -192,7 +292,7 @@ export const dexieDataSync = {
       logger.error('[DB][SYNC] Error resetting sync', ex);
     }
     try {
-      await dexieDb.syncable.delete(DEXIE_DB_SYNC_PATH);
+      await db.syncable.delete(DEXIE_DB_SYNC_PATH);
       if (reconnect) {
         await dexieDataSync.connect();
       }

--- a/libs/shared/utils/src/index.ts
+++ b/libs/shared/utils/src/index.ts
@@ -1,6 +1,7 @@
 export * from './lib/compression';
 export * from './lib/custom-field-tooling-names';
 export * from './lib/dedupe-field-usage-where-used';
+export * from './lib/hash.utils';
 export * from './lib/password-validation';
 export * from './lib/regex';
 export * from './lib/salesforce-org-expiration';

--- a/libs/shared/utils/src/lib/hash.utils.ts
+++ b/libs/shared/utils/src/lib/hash.utils.ts
@@ -1,0 +1,17 @@
+/**
+ * SHA-1 hex digest of a string.
+ *
+ * Used wherever an identifier has to be embedded in a name that is visible outside the app
+ * (IndexedDB database and object store names) or sent to the sync service, so the raw value —
+ * which may be a user id, email, or Salesforce username — is never exposed verbatim.
+ *
+ * Not a security primitive: this is about not leaking identifiers in plain sight, not about
+ * resisting a preimage attack on a value the caller already possesses.
+ */
+export async function sha1Hex(value: string): Promise<string> {
+  const data = new TextEncoder().encode(value);
+  const hashBuffer = await crypto.subtle.digest('SHA-1', data);
+  return Array.from(new Uint8Array(hashBuffer))
+    .map((byte) => byte.toString(16).padStart(2, '0'))
+    .join('');
+}


### PR DESCRIPTION
Per-user Dexie (getDexieDb/initDexieDb) + localforage (getLocalStore) stores so a shared machine no longer leaks the previous account's history on logout. Adopt-once migration hands existing shared data to the first user then locks it; nothing is deleted. Desktop reloads on logout; canvas scopes by production username so data follows a user across prod and sandboxes.