### PR TITLE
Harden authentication and session management

### DIFF
--- a/apps/api/src/app/controllers/__tests__/desktop-app.controller.spec.ts
+++ b/apps/api/src/app/controllers/__tests__/desktop-app.controller.spec.ts
@@ -172,3 +172,58 @@ describe('desktop-app.controller verifyToken token rotation gating', () => {
     );
   });
 });
+
+/**
+ * Regression coverage for the MFA-bypass fix: a half-authenticated session (first factor passed but
+ * 2FA verification / MFA enrollment / ToS acceptance still outstanding) must NOT be exchangeable for
+ * a desktop access token.
+ */
+describe('desktop-app.controller initSession pending-verification gate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.findIdByUserIdUserFacing.mockResolvedValue(userProfile);
+    mocks.checkUserEntitlement.mockResolvedValue(true);
+  });
+
+  async function invokeInitSession(session: Record<string, unknown>) {
+    const req = {
+      get: () => undefined,
+      body: {},
+      query: {},
+      params: {},
+      session: { user: { id: 'user-1' }, ...session },
+      externalAuth: { user: { id: 'user-1' }, deviceId: 'device-1' },
+      log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    };
+    const res = makeRes();
+    const next = vi.fn();
+    await routeDefinition.initSession.controllerFn()(req as never, res as never, next);
+    return { req, res, next };
+  }
+
+  it.each([
+    ['pendingVerification', { pendingVerification: [{ type: '2fa-otp', exp: Date.now() }] }],
+    ['pendingMfaEnrollment', { pendingMfaEnrollment: { factor: '2fa-otp' } }],
+    ['pendingTosAcceptance', { pendingTosAcceptance: true }],
+  ])('rejects token issuance and never checks entitlement when %s is set', async (_label, session) => {
+    const { next } = await invokeInitSession(session);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(next.mock.calls[0][0]).toBeInstanceOf(Error);
+    expect((next.mock.calls[0][0] as Error).name).toBe('InvalidSession');
+    // Guard short-circuits before any token work.
+    expect(mocks.checkUserEntitlement).not.toHaveBeenCalled();
+    expect(mocks.sendJson).not.toHaveBeenCalled();
+  });
+
+  it('allows a fully authenticated session past the gate to the entitlement check', async () => {
+    mocks.checkUserEntitlement.mockResolvedValue(false);
+
+    const { next } = await invokeInitSession({});
+
+    // Reached the entitlement check rather than being blocked by the pending-verification guard.
+    expect(mocks.checkUserEntitlement).toHaveBeenCalledWith({ userId: 'user-1', entitlement: 'desktop' });
+    expect(next).toHaveBeenCalledTimes(1);
+    expect((next.mock.calls[0][0] as Error).name).toBe('MissingEntitlement');
+  });
+});

--- a/apps/api/src/app/controllers/__tests__/desktop-app.controller.spec.ts
+++ b/apps/api/src/app/controllers/__tests__/desktop-app.controller.spec.ts
@@ -1,11 +1,15 @@
 /**
- * Regression coverage for the token-rotation gating in the desktop app verifyToken handler.
+ * Regression coverage for token rotation in the desktop app verifyToken handler.
  *
- * Mirrors the web extension change: the handler only rotates the access token when it is within
- * the refresh window, reducing rotation races that caused frequent logouts. These tests lock in:
- *   - rotation is skipped (and no accessToken is returned) when the token is not near expiry
- *   - rotation runs when the token is near expiry
+ * The desktop token is persisted in plaintext on disk (app-data.json) and cannot be machine-bound
+ * in VDI/roaming environments, so the handler rotates it on EVERY verify (not just near expiry) to
+ * minimize how long a copied token stays valid. A desktop token is scoped to a single
+ * (userId, deviceId), so aggressive rotation does not churn a token shared across other devices.
+ * These tests lock in:
+ *   - rotation runs on every verify (regardless of proximity to expiry) and returns the new token
+ *   - the race-loser is handed the current DB token (race-loss-current)
  *   - a race-loss-none rotation outcome still forces a 401
+ *   - rotation is skipped when the client does not opt in, or when no bearer token is present
  */
 import { HTTP } from '@jetstream/shared/constants';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -16,7 +20,6 @@ const mocks = vi.hoisted(() => ({
   redirect: vi.fn(),
   findIdByUserIdUserFacing: vi.fn(),
   checkUserEntitlement: vi.fn(),
-  isTokenWithinRefreshWindow: vi.fn(),
   rotateToken: vi.fn(),
   getApiAddressFromReq: vi.fn(() => '127.0.0.1'),
   createUserActivityFromReq: vi.fn(),
@@ -78,7 +81,6 @@ vi.mock('../../services/data-sync-broadcast.service', () => ({ emitRecordSyncEve
 vi.mock('../../services/external-auth.service', () => ({
   AUDIENCE_WEB_EXT: 'https://getjetstream.app/web-extension',
   AUDIENCE_DESKTOP: 'https://getjetstream.app/desktop-app',
-  isTokenWithinRefreshWindow: mocks.isTokenWithinRefreshWindow,
   rotateToken: mocks.rotateToken,
   issueAccessToken: vi.fn(),
   decodeToken: vi.fn(),
@@ -119,41 +121,35 @@ async function invokeVerify(headers: Record<string, string>) {
   return { req, res };
 }
 
-describe('desktop-app.controller verifyToken token rotation gating', () => {
+describe('desktop-app.controller verifyToken token rotation', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.findIdByUserIdUserFacing.mockResolvedValue(userProfile);
     mocks.getApiAddressFromReq.mockReturnValue('127.0.0.1');
   });
 
-  it('skips rotation and returns no accessToken when the token is not within the refresh window', async () => {
-    mocks.isTokenWithinRefreshWindow.mockReturnValue(false);
-
-    const { res } = await invokeVerify({ Authorization: 'Bearer old-token', [HTTP.HEADERS.X_SUPPORTS_TOKEN_ROTATION]: '1' });
-
-    expect(mocks.isTokenWithinRefreshWindow).toHaveBeenCalledWith('old-token');
-    expect(mocks.rotateToken).not.toHaveBeenCalled();
-    expect(mocks.sendJson).toHaveBeenCalledWith(
-      res,
-      expect.objectContaining({ success: true, userProfile, encryptionKey: expect.any(String), accessToken: undefined }),
-    );
-  });
-
-  it('rotates the token and returns the new accessToken when within the refresh window', async () => {
-    mocks.isTokenWithinRefreshWindow.mockReturnValue(true);
+  it('rotates the token on every verify and returns the new accessToken', async () => {
     mocks.rotateToken.mockResolvedValue({ outcome: 'rotated', token: 'new-token' });
 
     const { res } = await invokeVerify({ Authorization: 'Bearer old-token', [HTTP.HEADERS.X_SUPPORTS_TOKEN_ROTATION]: '1' });
 
     expect(mocks.rotateToken).toHaveBeenCalledTimes(1);
+    expect(mocks.rotateToken).toHaveBeenCalledWith(expect.objectContaining({ oldAccessToken: 'old-token', deviceId: 'device-1' }));
     expect(mocks.sendJson).toHaveBeenCalledWith(
       res,
       expect.objectContaining({ success: true, userProfile, encryptionKey: expect.any(String), accessToken: 'new-token' }),
     );
   });
 
+  it('hands the race-loser the current DB token (race-loss-current)', async () => {
+    mocks.rotateToken.mockResolvedValue({ outcome: 'race-loss-current', token: 'current-token' });
+
+    const { res } = await invokeVerify({ Authorization: 'Bearer old-token', [HTTP.HEADERS.X_SUPPORTS_TOKEN_ROTATION]: '1' });
+
+    expect(mocks.sendJson).toHaveBeenCalledWith(res, expect.objectContaining({ success: true, accessToken: 'current-token' }));
+  });
+
   it('returns a 401 when the rotation outcome is race-loss-none', async () => {
-    mocks.isTokenWithinRefreshWindow.mockReturnValue(true);
     mocks.rotateToken.mockResolvedValue({ outcome: 'race-loss-none', token: undefined });
 
     const { res } = await invokeVerify({ Authorization: 'Bearer old-token', [HTTP.HEADERS.X_SUPPORTS_TOKEN_ROTATION]: '1' });
@@ -164,12 +160,18 @@ describe('desktop-app.controller verifyToken token rotation gating', () => {
   it('does not rotate when the client does not support rotation', async () => {
     const { res } = await invokeVerify({ Authorization: 'Bearer old-token' });
 
-    expect(mocks.isTokenWithinRefreshWindow).not.toHaveBeenCalled();
     expect(mocks.rotateToken).not.toHaveBeenCalled();
     expect(mocks.sendJson).toHaveBeenCalledWith(
       res,
       expect.objectContaining({ success: true, userProfile, encryptionKey: expect.any(String), accessToken: undefined }),
     );
+  });
+
+  it('does not rotate when no bearer token is present even if rotation is supported', async () => {
+    const { res } = await invokeVerify({ [HTTP.HEADERS.X_SUPPORTS_TOKEN_ROTATION]: '1' });
+
+    expect(mocks.rotateToken).not.toHaveBeenCalled();
+    expect(mocks.sendJson).toHaveBeenCalledWith(res, expect.objectContaining({ success: true, accessToken: undefined }));
   });
 });
 

--- a/apps/api/src/app/controllers/__tests__/web-extension.controller.spec.ts
+++ b/apps/api/src/app/controllers/__tests__/web-extension.controller.spec.ts
@@ -161,3 +161,58 @@ describe('web-extension.controller verifyToken token rotation gating', () => {
     expect(mocks.sendJson).toHaveBeenCalledWith(res, { success: true, userProfile, accessToken: undefined });
   });
 });
+
+/**
+ * Regression coverage for the MFA-bypass fix: a half-authenticated session (first factor passed but
+ * 2FA verification / MFA enrollment / ToS acceptance still outstanding) must NOT be exchangeable for
+ * a browser-extension access token.
+ */
+describe('web-extension.controller initSession pending-verification gate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.findIdByUserIdUserFacing.mockResolvedValue(userProfile);
+    mocks.checkUserEntitlement.mockResolvedValue(true);
+  });
+
+  async function invokeInitSession(session: Record<string, unknown>) {
+    const req = {
+      get: () => undefined,
+      body: {},
+      query: {},
+      params: {},
+      session: { user: { id: 'user-1' }, ...session },
+      externalAuth: { user: { id: 'user-1' }, deviceId: 'device-1' },
+      log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    };
+    const res = makeRes();
+    const next = vi.fn();
+    await routeDefinition.initSession.controllerFn()(req as never, res as never, next);
+    return { req, res, next };
+  }
+
+  it.each([
+    ['pendingVerification', { pendingVerification: [{ type: '2fa-otp', exp: Date.now() }] }],
+    ['pendingMfaEnrollment', { pendingMfaEnrollment: { factor: '2fa-otp' } }],
+    ['pendingTosAcceptance', { pendingTosAcceptance: true }],
+  ])('rejects token issuance and never checks entitlement when %s is set', async (_label, session) => {
+    const { next } = await invokeInitSession(session);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(next.mock.calls[0][0]).toBeInstanceOf(Error);
+    expect((next.mock.calls[0][0] as Error).name).toBe('InvalidSession');
+    // Guard short-circuits before any token work.
+    expect(mocks.checkUserEntitlement).not.toHaveBeenCalled();
+    expect(mocks.sendJson).not.toHaveBeenCalled();
+  });
+
+  it('allows a fully authenticated session past the gate to the entitlement check', async () => {
+    mocks.checkUserEntitlement.mockResolvedValue(false);
+
+    const { next } = await invokeInitSession({});
+
+    // Reached the entitlement check rather than being blocked by the pending-verification guard.
+    expect(mocks.checkUserEntitlement).toHaveBeenCalledWith({ userId: 'user-1', entitlement: 'chromeExtension' });
+    expect(next).toHaveBeenCalledTimes(1);
+    expect((next.mock.calls[0][0] as Error).name).toBe('MissingEntitlement');
+  });
+});

--- a/apps/api/src/app/controllers/data-sync.controller.ts
+++ b/apps/api/src/app/controllers/data-sync.controller.ts
@@ -123,7 +123,7 @@ const push = createRoute(routeDefinition.push.validators, async ({ user, body: r
     userId: user.id,
   };
 
-  emitRecordSyncEventsToOtherClients(req.session.id, syncEvent);
+  emitRecordSyncEventsToOtherClients({ sessionId: req.session.id }, syncEvent);
 
   sendJson(res, response);
 });

--- a/apps/api/src/app/controllers/desktop-app.controller.ts
+++ b/apps/api/src/app/controllers/desktop-app.controller.ts
@@ -258,16 +258,24 @@ const verifyToken = createRoute(routeDefinition.verifyToken.validators, async ({
     const encryptionKey = createHmac('sha256', ENV.DESKTOP_ORG_ENCRYPTION_SECRET).update(user.id).digest('hex');
 
     // Token rotation: if the client supports it, issue a new short-lived JWT and replace the old one.
-    // This limits exposure from the JWT being stored in plain text on disk (VDI environments).
+    // This limits exposure from the JWT being stored in plain text on disk (app-data.json). In
+    // VDI/roaming environments the token cannot be bound to the machine — safeStorage/DPAPI keys do
+    // not roam to a fresh VM — so instead we minimize how long a copied token stays valid.
     const supportsRotation = req.get(HTTP.HEADERS.X_SUPPORTS_TOKEN_ROTATION) === '1';
     let rotatedAccessToken: string | undefined;
     if (supportsRotation && deviceId) {
       const oldAccessToken = req.get('Authorization')?.split(' ')[1];
-      // Only rotate as the token approaches expiry. Rotating on every verify churns the shared
-      // token across the user's devices, which can lose the rotation race and force a premature
-      // logout. The auth middleware still fully validates the token on every verify, so skipping
-      // rotation here does not weaken verification.
-      if (oldAccessToken && externalAuthService.isTokenWithinRefreshWindow(oldAccessToken)) {
+      // Rotate on every verify (not just near expiry) so the plaintext-on-disk token is continuously
+      // superseded: the desktop client verifies about every few hours, and each rotation mints a
+      // fresh short-lived token (sliding expiry) so an actively-used session is never logged out. A
+      // desktop token is scoped to a single (userId, deviceId), so this does not churn a token shared
+      // across the user's other devices, and rotateToken resolves the concurrent-rotation race
+      // (conditional replace; the race-loser is handed the current DB token). Residual risk: the
+      // per-user org encryption key returned below is static, so an attacker who makes even one verify
+      // call while a copied token is still current can still recover it — narrowing the token window
+      // does not by itself protect orgs.json (tracked separately as clone-detection / interactive-key
+      // gating follow-ups).
+      if (oldAccessToken) {
         const result = await externalAuthService.rotateToken({
           userProfile,
           audience: externalAuthService.AUDIENCE_DESKTOP,

--- a/apps/api/src/app/controllers/desktop-app.controller.ts
+++ b/apps/api/src/app/controllers/desktop-app.controller.ts
@@ -20,6 +20,7 @@ import * as webExtDb from '../db/web-extension.db';
 import { emitRecordSyncEventsToOtherClients, SyncEvent } from '../services/data-sync-broadcast.service';
 import * as externalAuthService from '../services/external-auth.service';
 import { decryptJwtTokenOrPlaintext } from '../services/jwt-token-encryption.service';
+import { getPendingSessionRedirectPath } from '../utils/pending-session.utils';
 import { redirect, sendJson } from '../utils/response.handlers';
 import { createRoute, RouteValidator } from '../utils/route.utils';
 import { routeDefinition as dataSyncController } from './data-sync.controller';
@@ -112,12 +113,13 @@ export const routeDefinition = {
  * Page calls back to API to initialize session so that we do not generate tokens in source code
  */
 const initAuthMiddleware = createRoute(routeDefinition.initAuthMiddleware.validators, async ({ setCookie }, req, res, next) => {
+  const queryParams = new URLSearchParams(req.query as Record<string, string>).toString();
+  const desktopAuthUrl = `${ENV.JETSTREAM_SERVER_URL}/desktop-app/auth`;
+  const desktopReturnUrl = queryParams ? `${desktopAuthUrl}?${queryParams}` : desktopAuthUrl;
+  const { redirectUrl: redirectUrlCookie } = getCookieConfig(ENV.USE_SECURE_COOKIES);
+
   // redirect to login flow if user is not signed in
   if (!req.session.user) {
-    const queryParams = new URLSearchParams(req.query as Record<string, string>).toString();
-    const desktopAuthUrl = `${ENV.JETSTREAM_SERVER_URL}/desktop-app/auth`;
-    const desktopReturnUrl = queryParams ? `${desktopAuthUrl}?${queryParams}` : desktopAuthUrl;
-    const { redirectUrl: redirectUrlCookie } = getCookieConfig(ENV.USE_SECURE_COOKIES);
     // Keep the cookie for OAuth/credentials flows that read it server-side. The query param is
     // needed specifically for SSO: SAML's cross-site POST back from the IdP drops SameSite=Lax
     // cookies, so the frontend must pass returnUrl forward to /api/auth/sso/start where it can
@@ -126,6 +128,19 @@ const initAuthMiddleware = createRoute(routeDefinition.initAuthMiddleware.valida
     redirect(res, `/auth/login/?returnUrl=${encodeURIComponent(desktopReturnUrl)}`);
     return;
   }
+
+  // First factor passed but the session still has an unmet requirement (2FA verification, MFA
+  // enrollment, or ToS acceptance). Route the browser to the correct step instead of serving the
+  // token-issuing page, and preserve the desktop return URL so the user lands back here once the
+  // requirement is satisfied. Without this a half-authenticated session could reach the token
+  // endpoint and bypass the second factor.
+  const pendingRedirectPath = getPendingSessionRedirectPath(req.session);
+  if (pendingRedirectPath) {
+    setCookie(redirectUrlCookie.name, desktopReturnUrl, redirectUrlCookie.options);
+    redirect(res, pendingRedirectPath);
+    return;
+  }
+
   next();
 });
 
@@ -137,6 +152,15 @@ const initSession = createRoute(routeDefinition.initSession.validators, async ({
   const { deviceId } = res.locals;
 
   if (!req.session.user || !deviceId) {
+    next(new InvalidSession());
+    return;
+  }
+
+  // Reject half-authenticated sessions: the first factor passed but 2FA verification, MFA
+  // enrollment, or ToS acceptance is still outstanding. Without this gate a session in a pending
+  // state could be exchanged for a full-access desktop token, bypassing the second factor. Guards
+  // both the token-reuse and token-issue branches below.
+  if (getPendingSessionRedirectPath(req.session)) {
     next(new InvalidSession());
     return;
   }

--- a/apps/api/src/app/controllers/desktop-app.controller.ts
+++ b/apps/api/src/app/controllers/desktop-app.controller.ts
@@ -351,7 +351,7 @@ const dataSyncPush = createRoute(routeDefinition.dataSyncPush.validators, async 
 
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   const deviceId = req.get(HTTP.HEADERS.X_EXT_DEVICE_ID)!;
-  emitRecordSyncEventsToOtherClients(deviceId, syncEvent);
+  emitRecordSyncEventsToOtherClients({ deviceId }, syncEvent);
 
   sendJson(res, response);
 });

--- a/apps/api/src/app/controllers/socket.controller.ts
+++ b/apps/api/src/app/controllers/socket.controller.ts
@@ -15,6 +15,16 @@ import * as externalAuthService from '../services/external-auth.service';
 
 let io: Server<DefaultEventsMap, DefaultEventsMap, DefaultEventsMap>;
 
+// Socket.io rooms share a single flat namespace, so a room name must encode which kind of
+// identifier it holds. The deviceId is fully client-controlled (see getDeviceId in
+// external-auth.service) and is the same UUID shape as a userId, so an un-prefixed device room
+// could be named to collide with a victim's userId room and receive that user's broadcasts.
+// Prefixing keeps user/session/device rooms in disjoint namespaces so a chosen deviceId can never
+// land a socket in another principal's room.
+export const socketRoomForUser = (userId: string) => `user:${userId}`;
+export const socketRoomForSession = (sessionId: string) => `session:${sessionId}`;
+export const socketRoomForDevice = (deviceId: string) => `device:${deviceId}`;
+
 // Same-origin allowlist for browser (cookie-authenticated) WebSocket upgrades. socket.io's
 // `cors.origin` only constrains the HTTP polling handshake, NOT the native WebSocket upgrade
 // (which is exempt from CORS), so we enforce the origin ourselves as a Cross-Site WebSocket
@@ -58,7 +68,7 @@ export function emitSocketEvent({
   payload?: unknown;
 }) {
   try {
-    let broadcastOperator = io.to(userId);
+    let broadcastOperator = io.to(socketRoomForUser(userId));
     if (exceptRooms) {
       broadcastOperator = broadcastOperator.except(exceptRooms);
     }
@@ -180,15 +190,15 @@ export function initSocketServer(
     socketLogger.debug('[SOCKET][CONNECT] %s', socket.id);
 
     if (userId) {
-      socket.join(userId);
+      socket.join(socketRoomForUser(userId));
     }
 
     if (sessionId) {
-      socket.join(sessionId);
+      socket.join(socketRoomForSession(sessionId));
     }
 
     if (deviceId) {
-      socket.join(deviceId);
+      socket.join(socketRoomForDevice(deviceId));
     }
 
     socket.on('disconnect', (reason) => {

--- a/apps/api/src/app/controllers/web-extension.controller.ts
+++ b/apps/api/src/app/controllers/web-extension.controller.ts
@@ -325,7 +325,7 @@ const dataSyncPush = createRoute(routeDefinition.dataSyncPush.validators, async 
 
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   const deviceId = req.get(HTTP.HEADERS.X_EXT_DEVICE_ID)! || req.get(HTTP.HEADERS.X_WEB_EXTENSION_DEVICE_ID)!;
-  emitRecordSyncEventsToOtherClients(deviceId, syncEvent);
+  emitRecordSyncEventsToOtherClients({ deviceId }, syncEvent);
 
   sendJson(res, response);
 });

--- a/apps/api/src/app/controllers/web-extension.controller.ts
+++ b/apps/api/src/app/controllers/web-extension.controller.ts
@@ -19,6 +19,7 @@ import * as webExtDb from '../db/web-extension.db';
 import { emitRecordSyncEventsToOtherClients, SyncEvent } from '../services/data-sync-broadcast.service';
 import * as externalAuthService from '../services/external-auth.service';
 import { decryptJwtTokenOrPlaintext } from '../services/jwt-token-encryption.service';
+import { getPendingSessionRedirectPath } from '../utils/pending-session.utils';
 import { redirect, sendJson } from '../utils/response.handlers';
 import { createRoute, RouteValidator } from '../utils/route.utils';
 
@@ -102,13 +103,28 @@ export const routeDefinition = {
  * Page calls back to API to initialize session so that we do not generate tokens in source code
  */
 const initAuthMiddleware = createRoute(routeDefinition.initAuthMiddleware.validators, async ({ setCookie }, req, res, next) => {
+  const { redirectUrl: redirectUrlCookie } = getCookieConfig(ENV.USE_SECURE_COOKIES);
+  const webExtensionAuthUrl = `${ENV.JETSTREAM_SERVER_URL}/web-extension/auth`;
+
   // redirect to login flow if user is not signed in
   if (!req.session.user) {
-    const { redirectUrl: redirectUrlCookie } = getCookieConfig(ENV.USE_SECURE_COOKIES);
-    setCookie(redirectUrlCookie.name, `${ENV.JETSTREAM_SERVER_URL}/web-extension/auth`, redirectUrlCookie.options);
+    setCookie(redirectUrlCookie.name, webExtensionAuthUrl, redirectUrlCookie.options);
     redirect(res, '/auth/login/');
     return;
   }
+
+  // First factor passed but the session still has an unmet requirement (2FA verification, MFA
+  // enrollment, or ToS acceptance). Route the browser to the correct step instead of serving the
+  // token-issuing page, and preserve the return URL so the user lands back here once the requirement
+  // is satisfied. Without this a half-authenticated session could reach the token endpoint and
+  // bypass the second factor.
+  const pendingRedirectPath = getPendingSessionRedirectPath(req.session);
+  if (pendingRedirectPath) {
+    setCookie(redirectUrlCookie.name, webExtensionAuthUrl, redirectUrlCookie.options);
+    redirect(res, pendingRedirectPath);
+    return;
+  }
+
   next();
 });
 
@@ -120,6 +136,15 @@ const initSession = createRoute(routeDefinition.initSession.validators, async ({
   const { deviceId } = res.locals;
 
   if (!req.session.user || !deviceId) {
+    next(new InvalidSession());
+    return;
+  }
+
+  // Reject half-authenticated sessions: the first factor passed but 2FA verification, MFA
+  // enrollment, or ToS acceptance is still outstanding. Without this gate a session in a pending
+  // state could be exchanged for a full-access browser-extension token, bypassing the second
+  // factor. Guards both the token-reuse and token-issue branches below.
+  if (getPendingSessionRedirectPath(req.session)) {
     next(new InvalidSession());
     return;
   }

--- a/apps/api/src/app/services/data-sync-broadcast.service.ts
+++ b/apps/api/src/app/services/data-sync-broadcast.service.ts
@@ -1,7 +1,7 @@
 import { logger } from '@jetstream/api-config';
 import { getErrorMessageAndStackObj } from '@jetstream/shared/utils';
 import { z } from 'zod';
-import { emitSocketEvent } from '../controllers/socket.controller';
+import { emitSocketEvent, socketRoomForDevice, socketRoomForSession } from '../controllers/socket.controller';
 import * as userSyncDbService from '../db/data-sync.db';
 
 const SyncEventSchema = z.object({
@@ -13,19 +13,27 @@ const SyncEventSchema = z.object({
 });
 export type SyncEvent = z.infer<typeof SyncEventSchema>;
 
-export const emitRecordSyncEventsToOtherClients = async (sessionOrDeviceId: string, event: unknown) => {
+/**
+ * Broadcast a user's record-sync payload to their other connected clients, skipping the client
+ * that originated the change. The origin is identified by its session (browser) or device
+ * (desktop/web-extension); we translate it into the matching namespaced room so the excluded room
+ * shares the same namespace the client actually joined.
+ */
+export const emitRecordSyncEventsToOtherClients = async (origin: { sessionId: string } | { deviceId: string }, event: unknown) => {
   try {
     const { data, userId } = SyncEventSchema.parse(event);
 
     const eventResponse = await userSyncDbService.findByKeys({ userId, hashedKeys: data.hashedKeys });
 
+    const exceptRoom = 'sessionId' in origin ? socketRoomForSession(origin.sessionId) : socketRoomForDevice(origin.deviceId);
+
     emitSocketEvent({
       event: 'RECORD_SYNC',
       userId,
-      exceptRooms: [sessionOrDeviceId],
+      exceptRooms: [exceptRoom],
       payload: eventResponse,
     });
   } catch (ex) {
-    logger.error({ ...getErrorMessageAndStackObj(ex), sessionOrDeviceId }, 'Error processing sync event');
+    logger.error({ ...getErrorMessageAndStackObj(ex), origin }, 'Error processing sync event');
   }
 };

--- a/apps/api/src/app/utils/__tests__/pending-session.utils.spec.ts
+++ b/apps/api/src/app/utils/__tests__/pending-session.utils.spec.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import { getPendingSessionRedirectPath, PENDING_SESSION_REDIRECT_PATHS } from '../pending-session.utils';
+
+describe('getPendingSessionRedirectPath', () => {
+  it('returns null for an undefined session', () => {
+    expect(getPendingSessionRedirectPath(undefined)).toBeNull();
+  });
+
+  it('returns null for a fully authenticated session with no pending state', () => {
+    expect(getPendingSessionRedirectPath({})).toBeNull();
+    expect(getPendingSessionRedirectPath({ pendingVerification: null, pendingMfaEnrollment: null, pendingTosAcceptance: null })).toBeNull();
+  });
+
+  it('routes a pending 2FA/email verification to /auth/verify', () => {
+    expect(getPendingSessionRedirectPath({ pendingVerification: [{ type: '2fa-otp', exp: Date.now() }] })).toBe(
+      PENDING_SESSION_REDIRECT_PATHS.pendingVerification,
+    );
+  });
+
+  it('treats a corrupted/empty pendingVerification array as still pending', () => {
+    // Mirrors checkAuth: any non-nullish pendingVerification blocks rather than silently passing.
+    expect(getPendingSessionRedirectPath({ pendingVerification: [] })).toBe(PENDING_SESSION_REDIRECT_PATHS.pendingVerification);
+  });
+
+  it('routes pending MFA enrollment to /auth/mfa-enroll', () => {
+    expect(getPendingSessionRedirectPath({ pendingMfaEnrollment: { factor: '2fa-otp' } })).toBe(
+      PENDING_SESSION_REDIRECT_PATHS.pendingMfaEnrollment,
+    );
+  });
+
+  it('routes pending ToS acceptance to /auth/accept-terms', () => {
+    expect(getPendingSessionRedirectPath({ pendingTosAcceptance: true })).toBe(PENDING_SESSION_REDIRECT_PATHS.pendingTosAcceptance);
+  });
+
+  it('prioritizes verification, then MFA enrollment, then ToS (matches the post-login redirect order)', () => {
+    expect(
+      getPendingSessionRedirectPath({
+        pendingVerification: [{ type: '2fa-otp', exp: Date.now() }],
+        pendingMfaEnrollment: { factor: '2fa-otp' },
+        pendingTosAcceptance: true,
+      }),
+    ).toBe(PENDING_SESSION_REDIRECT_PATHS.pendingVerification);
+
+    expect(getPendingSessionRedirectPath({ pendingMfaEnrollment: { factor: '2fa-otp' }, pendingTosAcceptance: true })).toBe(
+      PENDING_SESSION_REDIRECT_PATHS.pendingMfaEnrollment,
+    );
+  });
+});

--- a/apps/api/src/app/utils/pending-session.utils.ts
+++ b/apps/api/src/app/utils/pending-session.utils.ts
@@ -1,0 +1,42 @@
+import type { SessionData } from '@jetstream/auth/types';
+
+/**
+ * Auth-flow destinations for a session that has passed the first factor but still has an unmet
+ * requirement. These mirror the pending-state gates in route.middleware.ts and the post-login
+ * redirects in auth.controller.ts.
+ */
+export const PENDING_SESSION_REDIRECT_PATHS = {
+  pendingVerification: '/auth/verify',
+  pendingMfaEnrollment: '/auth/mfa-enroll',
+  pendingTosAcceptance: '/auth/accept-terms',
+} as const;
+
+type PendingSessionState = Pick<SessionData, 'pendingVerification' | 'pendingMfaEnrollment' | 'pendingTosAcceptance'>;
+
+/**
+ * If the session is mid-authentication — the first factor passed (`req.session.user` is set) but
+ * 2FA verification, MFA enrollment, or ToS acceptance is still outstanding — return the auth-flow
+ * path the browser should be routed to. Returns `null` when the session has no outstanding
+ * requirement (i.e. it is fully authenticated).
+ *
+ * External-token endpoints (desktop app, web extension) MUST consult this before issuing a token so
+ * a half-authenticated session cannot be exchanged for a full-access token, which would bypass the
+ * second factor. The ordering matches the post-login redirects in auth.controller.ts.
+ */
+export function getPendingSessionRedirectPath(session: Partial<PendingSessionState> | undefined): string | null {
+  if (!session) {
+    return null;
+  }
+  // Match checkAuth: treat any non-nullish pendingVerification as "still pending" so a corrupted or
+  // unexpectedly-empty array blocks rather than silently passing.
+  if (session.pendingVerification) {
+    return PENDING_SESSION_REDIRECT_PATHS.pendingVerification;
+  }
+  if (session.pendingMfaEnrollment) {
+    return PENDING_SESSION_REDIRECT_PATHS.pendingMfaEnrollment;
+  }
+  if (session.pendingTosAcceptance) {
+    return PENDING_SESSION_REDIRECT_PATHS.pendingTosAcceptance;
+  }
+  return null;
+}

--- a/apps/jetstream-desktop-client/src/app/components/core/AppInitializer.tsx
+++ b/apps/jetstream-desktop-client/src/app/components/core/AppInitializer.tsx
@@ -90,6 +90,11 @@ APP VERSION ${version}
       .catch((ex) => {
         logger.error('[DB] Error initializing db', ex);
       });
+    // Tear down the authenticated socket when this component unmounts (logout) or the auth
+    // material changes, so a subsequent account never reuses the previous user's connection.
+    return () => {
+      disconnectSocket();
+    };
   }, [appInfo.serverUrl, authInfo.accessToken, authInfo.deviceId, recordSyncEnabled]);
 
   useEffect(() => {

--- a/apps/jetstream-desktop-client/src/app/components/core/Login.tsx
+++ b/apps/jetstream-desktop-client/src/app/components/core/Login.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/react';
 import { AuthenticatePayload, DesktopAuthInfo } from '@jetstream/desktop/types';
 import { logger } from '@jetstream/shared/client-logger';
-import { getOrgGroups, getOrgs } from '@jetstream/shared/data';
+import { disconnectSocket, getOrgGroups, getOrgs } from '@jetstream/shared/data';
 import { applyVerifiedFeatureFlags } from '@jetstream/shared/ui-utils';
 import { Grid } from '@jetstream/ui';
 import { AppLoading, JetstreamLogoInverse } from '@jetstream/ui-core';
@@ -56,6 +56,9 @@ export function Login({ children }: LoginProps) {
   );
 
   const handleLogout = useCallback(() => {
+    // Tear down the authenticated data-sync socket before clearing session state so it is not
+    // reused by the next account that signs in on the same running app instance.
+    disconnectSocket();
     window.electronAPI?.logout();
     setLoginError(null);
     setUserProfile(DEFAULT_PROFILE);

--- a/apps/jetstream-desktop/src/services/__tests__/deep-link.service.spec.ts
+++ b/apps/jetstream-desktop/src/services/__tests__/deep-link.service.spec.ts
@@ -1,0 +1,87 @@
+import logger from 'electron-log';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { deepLink, handleCustomUrl } from '../deep-link.service';
+
+vi.mock('electron', () => ({
+  app: {
+    on: vi.fn(),
+    whenReady: vi.fn(() => Promise.resolve()),
+    requestSingleInstanceLock: vi.fn(() => true),
+    setAsDefaultProtocolClient: vi.fn(),
+    quit: vi.fn(),
+  },
+}));
+
+vi.mock('electron-log', () => ({
+  default: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+const ACCESS_TOKEN = 'eyJhbGciOiJIUzI1Nisecret-jwt-value';
+const CSRF_TOKEN = 'csrf-nonce-value';
+const DEVICE_ID = 'device-123';
+
+/** All strings the logger received across every info/error call, joined for easy substring assertions. */
+function allLoggedText(): string {
+  const calls = [...vi.mocked(logger.info).mock.calls, ...vi.mocked(logger.error).mock.calls];
+  return calls.map((args) => args.join(' ')).join('\n');
+}
+
+describe('handleCustomUrl', () => {
+  beforeEach(() => {
+    vi.mocked(logger.info).mockClear();
+    vi.mocked(logger.error).mockClear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('never logs sensitive param values from the query string', () => {
+    handleCustomUrl(`jetstream://auth?deviceId=${DEVICE_ID}&token=${CSRF_TOKEN}&accessToken=${ACCESS_TOKEN}`);
+
+    const logged = allLoggedText();
+    expect(logged).not.toContain(ACCESS_TOKEN);
+    expect(logged).not.toContain(CSRF_TOKEN);
+    // Param names are still logged for debuggability
+    expect(logged).toContain('accessToken');
+    expect(logged).toContain('auth');
+  });
+
+  it('never logs sensitive param values carried in the hash fragment', () => {
+    handleCustomUrl(`jetstream://auth?deviceId=${DEVICE_ID}#accessToken=${ACCESS_TOKEN}`);
+
+    const logged = allLoggedText();
+    expect(logged).not.toContain(ACCESS_TOKEN);
+    expect(logged).toContain('accessToken');
+  });
+
+  it('still dispatches query and hash params (merged) to listeners', () => {
+    const listener = vi.fn();
+    deepLink.on('auth', listener);
+
+    handleCustomUrl(`jetstream://auth?deviceId=${DEVICE_ID}&token=${CSRF_TOKEN}#accessToken=${ACCESS_TOKEN}`);
+
+    expect(listener).toHaveBeenCalledWith({
+      deviceId: DEVICE_ID,
+      token: CSRF_TOKEN,
+      accessToken: ACCESS_TOKEN,
+    });
+    deepLink.remove('auth', listener);
+  });
+
+  it('rejects non-jetstream protocols without dispatching', () => {
+    const listener = vi.fn();
+    deepLink.on('auth', listener);
+
+    handleCustomUrl(`https://evil.example.com/auth?accessToken=${ACCESS_TOKEN}`);
+
+    expect(listener).not.toHaveBeenCalled();
+    expect(allLoggedText()).not.toContain(ACCESS_TOKEN);
+    deepLink.remove('auth', listener);
+  });
+});

--- a/apps/jetstream-desktop/src/services/deep-link.service.ts
+++ b/apps/jetstream-desktop/src/services/deep-link.service.ts
@@ -71,8 +71,10 @@ export const handleCustomUrl = (targetUrl: string) => {
 
     const action = url.hostname;
     // Log only the action and parameter names — never their values — so tokens carried in the
-    // query string or hash fragment are never written to the persistent log file.
-    logger.info(`Deep link: handling action "${action}" with params: ${getDeepLinkParamNames(url).join(', ') || '(none)'}`);
+    // query string or hash fragment are never written to the persistent log file. The action and
+    // param names are user-controlled, so strip control characters to prevent log forging.
+    const paramNames = getDeepLinkParamNames(url).map(sanitizeForLog).join(', ');
+    logger.info(`Deep link: handling action "${sanitizeForLog(action)}" with params: ${paramNames || '(none)'}`);
 
     const query = Object.fromEntries(url.searchParams.entries());
 
@@ -90,6 +92,12 @@ export const handleCustomUrl = (targetUrl: string) => {
     logger.error(`Deep link: error parsing URL: ${error}`);
   }
 };
+
+/**
+ * Replace control characters before logging user-controlled deep-link values. Percent-decoded
+ * param names can contain newlines or ANSI escapes, which would otherwise forge/corrupt log lines (CWE-117).
+ */
+const sanitizeForLog = (value: string): string => value.replace(/[\u0000-\u001f\u007f-\u009f]/g, '?');
 
 /** Collect parameter names from both the query string and hash fragment, without their (possibly sensitive) values. */
 const getDeepLinkParamNames = (url: URL): string[] => {

--- a/apps/jetstream-desktop/src/services/deep-link.service.ts
+++ b/apps/jetstream-desktop/src/services/deep-link.service.ts
@@ -60,11 +60,8 @@ export const initDeepLink = () => {
  * so they don't appear in system logs or URL caches. The hash is merged
  * into the query object before dispatching to listeners, then discarded.
  */
-const handleCustomUrl = (targetUrl: string) => {
+export const handleCustomUrl = (targetUrl: string) => {
   try {
-    // Log the URL without hash fragment to avoid leaking tokens
-    const sanitizedUrl = targetUrl.split('#')[0];
-    logger.info(`Deep link: attempting to handle: ${sanitizedUrl}`);
     const url = new URL(targetUrl);
 
     if (url.protocol !== 'jetstream:') {
@@ -73,7 +70,9 @@ const handleCustomUrl = (targetUrl: string) => {
     }
 
     const action = url.hostname;
-    logger.info(`Deep link: action found: ${action}`);
+    // Log only the action and parameter names — never their values — so tokens carried in the
+    // query string or hash fragment are never written to the persistent log file.
+    logger.info(`Deep link: handling action "${action}" with params: ${getDeepLinkParamNames(url).join(', ') || '(none)'}`);
 
     const query = Object.fromEntries(url.searchParams.entries());
 
@@ -90,6 +89,17 @@ const handleCustomUrl = (targetUrl: string) => {
   } catch (error) {
     logger.error(`Deep link: error parsing URL: ${error}`);
   }
+};
+
+/** Collect parameter names from both the query string and hash fragment, without their (possibly sensitive) values. */
+const getDeepLinkParamNames = (url: URL): string[] => {
+  const names = new Set(url.searchParams.keys());
+  if (url.hash && url.hash.length > 1) {
+    for (const key of new URLSearchParams(url.hash.slice(1)).keys()) {
+      names.add(key);
+    }
+  }
+  return [...names];
 };
 
 class ListenersMap {

--- a/apps/jetstream-desktop/src/services/persistence.service.ts
+++ b/apps/jetstream-desktop/src/services/persistence.service.ts
@@ -17,7 +17,7 @@ import { createCipheriv, createDecipheriv, randomBytes, randomUUID } from 'crypt
 import { fromUnixTime } from 'date-fns';
 import { app, safeStorage } from 'electron';
 import logger from 'electron-log';
-import { existsSync, readFileSync, renameSync, unlinkSync, writeFileSync } from 'fs';
+import { chmodSync, existsSync, readFileSync, renameSync, unlinkSync, writeFileSync } from 'fs';
 import { jwtDecode } from 'jwt-decode';
 import { join } from 'path';
 import writeFileAtomic from 'write-file-atomic';
@@ -29,6 +29,16 @@ const USER_PREFERENCES_FILE = join(userData, 'preferences.json');
 
 /** Magic bytes identifying the portable AES-256-GCM encryption format */
 const JSEK_MAGIC = Buffer.from('JSEK');
+
+/**
+ * Restrictive file mode (owner read/write only) for the credential-bearing files:
+ * app-data.json (holds the Jetstream session JWT) and orgs.json (holds the AES-GCM-encrypted
+ * Salesforce tokens). Defends against other local accounts and loosely-permissioned
+ * roaming/VDI profile shares reading these files. POSIX only — Node largely ignores mode bits
+ * on Windows, where NTFS ACLs govern access. Applied on every atomic write, so pre-existing
+ * world-readable files are tightened on the next write.
+ */
+const SECURE_FILE_MODE = 0o600;
 
 let APP_DATA: AppData;
 let SALESFORCE_ORGS: SalesforceOrgServer[];
@@ -147,16 +157,32 @@ export function decryptTokenPortable(encoded: string): string {
   return safeStorage.decryptString(Buffer.from(encoded, 'base64'));
 }
 
+/**
+ * Best-effort permission tightening for the non-atomic fallback writes. chmod can throw on Windows,
+ * network shares, or restrictive file systems; the data has already been written successfully at this
+ * point, so a chmod failure must not crash the app or be surfaced as a write failure — log and move on.
+ */
+function chmodBestEffort(path: string): void {
+  try {
+    chmodSync(path, SECURE_FILE_MODE);
+  } catch (error) {
+    logger.warn(`Unable to tighten permissions on ${path} (best-effort):`, error);
+  }
+}
+
 function writeFile(path: string, data: string, encrypt = false) {
   let _data: string | Buffer = data;
   if (encrypt) {
     _data = safeStorage.encryptString(data);
   }
   try {
-    writeFileAtomic.sync(path, _data);
+    writeFileAtomic.sync(path, _data, { mode: SECURE_FILE_MODE });
   } catch (error) {
     logger.error(`Error writing file ${path}:`, error);
-    writeFileSync(path, Buffer.isBuffer(_data) ? new Uint8Array(_data) : _data);
+    writeFileSync(path, Buffer.isBuffer(_data) ? new Uint8Array(_data) : _data, { mode: SECURE_FILE_MODE });
+    // writeFileSync's mode only applies when it creates the file; explicitly chmod so a pre-existing
+    // world-readable file is tightened even when the atomic write (which replaces the inode) failed.
+    chmodBestEffort(path);
   }
 }
 
@@ -355,10 +381,12 @@ function readOrgs(): OrgsPersistence {
         const emptyData = JSON.stringify({ jetstreamOrganizations: [], salesforceOrgs: [] });
         const encrypted = encryptOrgsData(emptyData);
         try {
-          writeFileAtomic.sync(SFDC_ORGS_FILE, encrypted);
+          writeFileAtomic.sync(SFDC_ORGS_FILE, encrypted, { mode: SECURE_FILE_MODE });
         } catch (error) {
           logger.error('Error writing initial orgs file (atomic):', error);
-          writeFileSync(SFDC_ORGS_FILE, new Uint8Array(encrypted));
+          writeFileSync(SFDC_ORGS_FILE, new Uint8Array(encrypted), { mode: SECURE_FILE_MODE });
+          // writeFileSync's mode is ignored for a pre-existing file, so chmod to guarantee 0600 (see writeFile).
+          chmodBestEffort(SFDC_ORGS_FILE);
         }
         ORG_FILE_IS_PORTABLE = true;
       } else {
@@ -473,10 +501,12 @@ function saveOrgs() {
     if (ORG_ENCRYPTION_KEY) {
       const encrypted = encryptOrgsData(JSON.stringify(data));
       try {
-        writeFileAtomic.sync(SFDC_ORGS_FILE, encrypted);
+        writeFileAtomic.sync(SFDC_ORGS_FILE, encrypted, { mode: SECURE_FILE_MODE });
       } catch (error) {
         logger.error('Error writing orgs file (atomic):', error);
-        writeFileSync(SFDC_ORGS_FILE, new Uint8Array(encrypted));
+        writeFileSync(SFDC_ORGS_FILE, new Uint8Array(encrypted), { mode: SECURE_FILE_MODE });
+        // writeFileSync's mode is ignored for a pre-existing file, so chmod to guarantee 0600 (see writeFile).
+        chmodBestEffort(SFDC_ORGS_FILE);
       }
       ORG_FILE_IS_PORTABLE = true;
       logger.info(`saveOrgs: wrote ${orgCount} orgs and ${groupCount} groups (portable encryption)`);

--- a/apps/jetstream-e2e/src/tests/authentication/external-auth/external-auth-logged-in.spec.ts
+++ b/apps/jetstream-e2e/src/tests/authentication/external-auth/external-auth-logged-in.spec.ts
@@ -156,13 +156,17 @@ test.describe('Desktop / Web-Extension Token Rotation', () => {
     await authenticationPage.acceptCookieBanner();
   });
 
-  // A freshly issued session token is well outside the refresh window (TOKEN_AUTO_REFRESH_DAYS), so
-  // verifying with the rotation header must NOT rotate it: the response succeeds without a new
-  // accessToken and the original token keeps working. Rotation only fires as a token nears expiry.
-  // The full gating + rotation mechanics (skip-when-fresh, rotate-when-near-expiry, race-loss-none
-  // -> 401, no-header -> no rotation) are covered against mocked time/DB in
-  // desktop-app.controller.spec.ts, web-extension.controller.spec.ts, and external-auth.service.spec.ts.
-  test('Desktop - fresh token is not rotated when rotation is supported', async ({ page, teamCreationUtils1User, apiRequestUtils }) => {
+  // The desktop token is stored in plaintext on disk and cannot be machine-bound in VDI/roaming
+  // environments, so it rotates on EVERY verify (not just near expiry) to bound how long a copied
+  // token stays valid. A desktop token is scoped to a single (userId, deviceId), so rotating this
+  // aggressively does not churn a token shared across the user's other devices. The full rotation
+  // mechanics (race-loss-current, race-loss-none -> 401, no-header -> no rotation) are covered
+  // against mocked time/DB in desktop-app.controller.spec.ts and external-auth.service.spec.ts.
+  test('Desktop - token is rotated on every verify when rotation is supported', async ({
+    page,
+    teamCreationUtils1User,
+    apiRequestUtils,
+  }) => {
     const deviceId = uuid();
 
     // 1. Create session and get original token
@@ -173,7 +177,7 @@ test.describe('Desktop / Web-Extension Token Rotation', () => {
     const { accessToken: originalToken } = await sessionResponse.json().then(({ data }) => data);
     expect(typeof originalToken).toBe('string');
 
-    // 2. Verify with rotation header — fresh token is not near expiry, so it is not rotated
+    // 2. Verify with rotation header — a new token is issued even though the original is fresh
     const rotateResponse = await apiRequestUtils.request.post(`/desktop-app/auth/verify`, {
       headers: {
         Accept: 'application/json',
@@ -186,9 +190,10 @@ test.describe('Desktop / Web-Extension Token Rotation', () => {
     expect(rotateResponse.status()).toBe(200);
     const rotateData = await rotateResponse.json().then(({ data }) => data);
     expect(rotateData.success).toBe(true);
-    expect(rotateData.accessToken).toBeUndefined();
+    expect(typeof rotateData.accessToken).toBe('string');
+    expect(rotateData.accessToken).not.toBe(originalToken);
 
-    // 3. Original token still works — verifying did not rotate or invalidate it
+    // 3. Original token is superseded — the whole point of rotating is that a copy stops working
     const verifyWithOriginal = await apiRequestUtils.request.post(`/desktop-app/auth/verify`, {
       headers: {
         Accept: 'application/json',
@@ -198,9 +203,33 @@ test.describe('Desktop / Web-Extension Token Rotation', () => {
         [HTTP.HEADERS.X_SUPPORTS_TOKEN_ROTATION]: '1',
       },
     });
-    expect(verifyWithOriginal.status()).toBe(200);
+    expect(verifyWithOriginal.status()).toBe(401);
+    const verifyWithOriginalData = await verifyWithOriginal.json();
+    expect(verifyWithOriginalData.success).toBe(false);
+
+    // 4. Rotated token works and itself rotates again
+    const verifyWithRotated = await apiRequestUtils.request.post(`/desktop-app/auth/verify`, {
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${rotateData.accessToken}`,
+        [HTTP.HEADERS.X_EXT_DEVICE_ID]: deviceId,
+        [HTTP.HEADERS.X_SUPPORTS_TOKEN_ROTATION]: '1',
+      },
+    });
+    expect(verifyWithRotated.status()).toBe(200);
+    const verifyWithRotatedData = await verifyWithRotated.json().then(({ data }) => data);
+    expect(verifyWithRotatedData.success).toBe(true);
+    expect(typeof verifyWithRotatedData.accessToken).toBe('string');
+    expect(verifyWithRotatedData.accessToken).not.toBe(rotateData.accessToken);
   });
 
+  // Unlike desktop, the web extension token is shared across the user's devices via browser
+  // storage.sync, so it only rotates as it nears expiry (TOKEN_AUTO_REFRESH_DAYS) — rotating on
+  // every verify would churn the shared token and lose the rotation race. A freshly issued token is
+  // well outside that window, so verifying it returns no new accessToken and the original keeps
+  // working. Skip-when-fresh / rotate-when-near-expiry are covered against mocked time/DB in
+  // web-extension.controller.spec.ts and external-auth.service.spec.ts.
   test('Web extension - fresh token is not rotated when rotation is supported', async ({
     page,
     teamCreationUtils1User,

--- a/libs/shared/data/src/lib/__tests__/client-socket-data.spec.ts
+++ b/libs/shared/data/src/lib/__tests__/client-socket-data.spec.ts
@@ -1,0 +1,74 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { disconnectSocket, initSocket } from '../client-socket-data';
+
+type FakeSocket = {
+  on: ReturnType<typeof vi.fn>;
+  io: { on: ReturnType<typeof vi.fn> };
+  disconnect: ReturnType<typeof vi.fn>;
+  connected: boolean;
+};
+
+const { mockIo, createdSockets } = vi.hoisted(() => {
+  const createdSockets: FakeSocket[] = [];
+  const mockIo = vi.fn(() => {
+    const socket: FakeSocket = {
+      on: vi.fn(),
+      io: { on: vi.fn() },
+      disconnect: vi.fn(),
+      connected: false,
+    };
+    createdSockets.push(socket);
+    return socket;
+  });
+  return { mockIo, createdSockets };
+});
+
+// vitest hoists vi.mock above the imports above, so mocking socket.io-client before the
+// client-socket-data import resolves takes effect despite appearing lower in the file.
+vi.mock('socket.io-client', () => ({
+  io: mockIo,
+  Socket: class {},
+}));
+
+const SERVER_URL = 'https://example.com';
+
+describe('client-socket-data socket lifecycle', () => {
+  beforeEach(() => {
+    // Reset module-level socket state, then clear recorded calls for a clean slate.
+    disconnectSocket();
+    createdSockets.length = 0;
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    disconnectSocket();
+  });
+
+  it('creates a socket on first initSocket and reuses it on subsequent calls', () => {
+    initSocket(SERVER_URL, { Authorization: 'Bearer a' });
+    initSocket(SERVER_URL, { Authorization: 'Bearer a' });
+    expect(mockIo).toHaveBeenCalledTimes(1);
+  });
+
+  it('disconnects and clears the socket even when it is not connected, allowing a fresh connection', () => {
+    initSocket(SERVER_URL, { Authorization: 'Bearer a' });
+    expect(mockIo).toHaveBeenCalledTimes(1);
+    const [firstSocket] = createdSockets;
+    expect(firstSocket.connected).toBe(false);
+
+    // Regression (F6): disconnectSocket() previously no-oped while the socket was not connected,
+    // leaving a stale socket so the next user's initSocket() early-returned and silently reused the
+    // prior user's authenticated connection.
+    disconnectSocket();
+    expect(firstSocket.disconnect).toHaveBeenCalledTimes(1);
+
+    // The next login must open a brand-new socket rather than inherit the previous one.
+    initSocket(SERVER_URL, { Authorization: 'Bearer b' });
+    expect(mockIo).toHaveBeenCalledTimes(2);
+  });
+
+  it('is a safe no-op when no socket exists', () => {
+    expect(() => disconnectSocket()).not.toThrow();
+    expect(mockIo).not.toHaveBeenCalled();
+  });
+});

--- a/libs/shared/data/src/lib/client-socket-data.ts
+++ b/libs/shared/data/src/lib/client-socket-data.ts
@@ -57,7 +57,10 @@ export function initSocket(serverUrl?: string, additionalHeaders?: Record<string
 }
 
 export function disconnectSocket() {
-  if (socket?.connected) {
+  if (socket) {
+    // Always disconnect and null the reference, even if the socket is mid-connect/reconnect.
+    // Otherwise a stale socket lingers and initSocket() early-returns, causing the next
+    // authenticated user to silently reuse the previous user's connection.
     socket.disconnect();
     socket = null;
   }


### PR DESCRIPTION
Enhance security by preventing token issuance for half-authenticated sessions, stopping sensitive token logging, and ensuring socket namespaces are disjoint to avoid data leaks. Implement session cleanup on logout and reduce plaintext session-token exposure at rest. Add regression tests for new security measures.