### PR TITLE
fix: map bulk API results to the correct records when batches split by size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [10.8.1](https://github.com/jetstreamapp/jetstream/compare/v10.8.0...v10.8.1) (2026-07-29)
+
+### Bug Fixes
+
+* map bulk API results to the correct records when a batch is split by size ([60f9bb0](https://github.com/jetstreamapp/jetstream/commit/60f9bb08035f9b216451eac1727510bc3c6134b9))
+
 ## [10.8.0](https://github.com/jetstreamapp/jetstream/compare/v10.7.2...v10.8.0) (2026-07-28)
 
 ### Features

--- a/apps/jetstream-web-extension/src/manifest.json
+++ b/apps/jetstream-web-extension/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Jetstream",
   "description": "Jetstream is a set of tools that supercharge your administration of Salesforce.com.",
-  "version": "3.7.1",
+  "version": "3.7.2",
   "manifest_version": 3,
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAmPjyzVG3Kpm0wyjDECyDLnwPlyEhlNmfzcPVybZz9gFKiHTm0qEuUYqGqOSAOWE6KnOR8RbiNkyrROGeEbGmhZIXxS02yKPTpJsA4qflKtTUGoeT7XcOm9cHWw3+BrVuqABCdXEwv/Do1/UX2vu9WeOMHQAr911nVl77JrhhaMQvpu0ruJjD+sZ9QbfjdLNeVeU1+hzgpuvpDnMihDIfZv47GaqvTTwxT67P09loBySjXMmx2mrtOpyLzsATLwQr6kmQQAX5X23ykw3PxY4NWBDldqXxKqTomMkwa3x6mh/4jmI5h6p6Wt6Gaf9FcG1pBOXTrUHNfdFzuK6ahYBsRQIDAQAB",
   "icons": {

--- a/libs/features/load-records/src/components/load-results/LoadRecordsBulkApiResults.tsx
+++ b/libs/features/load-records/src/components/load-results/LoadRecordsBulkApiResults.tsx
@@ -525,11 +525,9 @@ export const LoadRecordsBulkApiResults = ({
           });
         }
         // A user-initiated abort surfaces through the same loadError path — keep the UI messaging but
-        // don't report it as an application error unless some batch failed for a non-abort reason.
-        const abortMessagePattern = /aborted by user|data load was aborted|current job state is 'Aborted'/i;
-        const onlyUserAbortErrors =
-          loadError.additionalErrors.length > 0 && loadError.additionalErrors.every((error) => abortMessagePattern.test(error.message));
-        if (!onlyUserAbortErrors) {
+        // don't report it as an application error. Aborting also makes Salesforce reject any in-flight
+        // or subsequent batch, so every error in this payload is downstream of the abort.
+        if (!isAborted.current) {
           tracker.error('Error loading batches', loadError, {
             specificErrors: loadError.additionalErrors.map((error) => ({
               message: error.message,

--- a/libs/features/load-records/src/components/load-results/LoadRecordsBulkApiResults.tsx
+++ b/libs/features/load-records/src/components/load-results/LoadRecordsBulkApiResults.tsx
@@ -87,7 +87,6 @@ async function collectFailedRecordsForRetry({
   jobInfo,
   batchSummary,
   preparedData,
-  batchSize,
   loadType,
   selectedOrg,
 }: {
@@ -95,7 +94,6 @@ async function collectFailedRecordsForRetry({
   jobInfo: BulkJobWithBatches;
   batchSummary: LoadDataBulkApiStatusPayload;
   preparedData: PrepareDataResponse;
-  batchSize: number;
   loadType: InsertUpdateUpsertDelete;
   selectedOrg: SalesforceOrgUi;
 }): Promise<any[]> {
@@ -105,7 +103,14 @@ async function collectFailedRecordsForRetry({
 
   const jobId = jobInfo.id;
   const isDelete = loadType === 'DELETE' || loadType === 'HARD_DELETE';
-  const splitRecords = splitArrayToMaxSize(preparedData.data, batchSize);
+  // Batches are capped by record count AND by CSV size, so an oversized batch gets split and the
+  // records in a batch cannot be derived from `batchSize` — use the ranges the loader recorded.
+  const recordsByBatchNumber = new Map<number, any[]>(
+    batchSummary.batchSummary.map(({ batchNumber, startIndex, recordCount }) => [
+      batchNumber,
+      preparedData.data.slice(startIndex, startIndex + recordCount),
+    ]),
+  );
   const failedRecords: any[] = [];
 
   const completedBatchIds = jobInfo.batches
@@ -114,9 +119,9 @@ async function collectFailedRecordsForRetry({
     .filter((batchId): batchId is string => !!batchId);
 
   // No completed batches means either everything failed up-front or was unsubmitted/aborted.
-  // Fall back to treating every split record as failed.
+  // Fall back to treating every record as failed.
   if (completedBatchIds.length === 0) {
-    return splitRecords.flat();
+    return preparedData.data.slice();
   }
 
   const batchNumberById = new Map(
@@ -149,10 +154,10 @@ async function collectFailedRecordsForRetry({
   const resolvedBatchNumbers = new Set<number>();
   completedBatchResults.forEach(({ batchId, results }) => {
     const originalBatchIndex = batchNumberById.get(batchId);
-    if (typeof originalBatchIndex !== 'number' || !splitRecords[originalBatchIndex]) {
+    const recordsForBatch = typeof originalBatchIndex === 'number' ? recordsByBatchNumber.get(originalBatchIndex) : undefined;
+    if (typeof originalBatchIndex !== 'number' || !recordsForBatch) {
       return;
     }
-    const recordsForBatch = splitRecords[originalBatchIndex];
     const recordsWithIds = recordsForBatch.filter((record: Record<string, unknown>) => !!record.Id);
     const resultsExcludeMissingIdRecords =
       isDelete && results.length === recordsWithIds.length && recordsWithIds.length !== recordsForBatch.length;
@@ -175,8 +180,8 @@ async function collectFailedRecordsForRetry({
 
   // Include all records from any batch we couldn't resolve (fetch failed, unmapped batch id,
   // state !== Completed, etc.). These are conservatively considered failed and retryable.
-  splitRecords.forEach((records, index) => {
-    if (!resolvedBatchNumbers.has(index)) {
+  recordsByBatchNumber.forEach((records, batchNumber) => {
+    if (!resolvedBatchNumbers.has(batchNumber)) {
       failedRecords.push(...records);
     }
   });
@@ -320,7 +325,6 @@ export const LoadRecordsBulkApiResults = ({
             jobInfo,
             batchSummary,
             preparedData,
-            batchSize,
             loadType,
             selectedOrg,
           });
@@ -608,15 +612,7 @@ export const LoadRecordsBulkApiResults = ({
 
       if (scope === 'all') {
         // Download results across all batches
-        const splitRecordsByBatchSize = splitArrayToMaxSize(records, batchSize);
-        jobInfo.batches.forEach((batch, i) => {
-          if (batch.state !== 'Completed') {
-            // remove batch from result records
-            splitRecordsByBatchSize.splice(i, 1);
-            removedBatches = true;
-          }
-        });
-        records = splitRecordsByBatchSize.flat();
+        removedBatches = jobInfo.batches.some((batch) => batch.state !== 'Completed');
         const batchIds = jobInfo.batches.filter((batch) => batch.state === 'Completed').map((batch) => batch.id);
         // download records, combine results from salesforce with actual records, open download modal
         results = await bulkApiGetRecordsFromAllBatches<BulkJobResultRecord>(selectedOrg, jobInfo.id, batchIds);
@@ -627,13 +623,16 @@ export const LoadRecordsBulkApiResults = ({
         // download records, combine results from salesforce with actual records, open download modal
         results = await bulkApiGetRecords<BulkJobResultRecord>(selectedOrg, jobInfo.id, batch.id, 'result');
         // this should match, but will fallback to batchIndex if for some reason we cannot find the batch
-        const batchSummaryItem = batchSummary.batchSummary.find((item) => item.id === batch.id);
-        const startIdx = (batchSummaryItem?.batchNumber ?? batchIndex) * batchSize;
+        const batchSummaryItem = batchSummary.batchSummary.find((item) => item.id === batch.id) ?? batchSummary.batchSummary[batchIndex];
         /**
-         * Get records from this one batch
+         * Get records from this one batch. Batches are capped by record count AND by CSV size, so an
+         * oversized batch gets split — the record range comes from the batch summary rather than
+         * `batchNumber * batchSize`, which is only correct when no batch was split.
          * For delete, only records with a mapped Id will be included in response from SFDC
          */
-        records = preparedData.data.slice(startIdx, startIdx + batchSize).filter((record) => (isDelete ? !!record.Id : true));
+        const startIdx = batchSummaryItem?.startIndex ?? batchIndex * batchSize;
+        const recordCount = batchSummaryItem?.recordCount ?? batchSize;
+        records = preparedData.data.slice(startIdx, startIdx + recordCount).filter((record) => (isDelete ? !!record.Id : true));
       }
 
       const combinedResults: BulkJobResultRecord[] = [];

--- a/libs/features/load-records/src/components/load-results/LoadRecordsBulkApiResults.tsx
+++ b/libs/features/load-records/src/components/load-results/LoadRecordsBulkApiResults.tsx
@@ -36,6 +36,7 @@ import {
   Icon,
   ProgressRing,
   SalesforceLogin,
+  ScopedNotification,
   Spinner,
   Tooltip,
   fireToast,
@@ -265,6 +266,16 @@ export const LoadRecordsBulkApiResults = ({
   const [resultsModalData, setResultsModalData] = useState<ViewModalData>({ open: false, data: [], header: [], type: 'results' });
   const [downloadState, setDownloadState] = useState<DownloadScope | null>(null);
   const { notifyUser } = useBrowserNotifications(serverUrl);
+
+  /**
+   * Batches are capped by CSV size as well as by record count, so a batch of wide records gets split
+   * into smaller ones and more batches are submitted than the configured batch size implies. Detected
+   * by comparing the submitted batch count against what the record count alone would produce.
+   */
+  const autoSplitBatchCount =
+    batchSummary && preparedData && batchSize > 0
+      ? Math.max(batchSummary.totalBatches - Math.ceil(preparedData.data.length / batchSize), 0)
+      : 0;
 
   useEffect(() => {
     isMounted.current = true;
@@ -609,13 +620,26 @@ export const LoadRecordsBulkApiResults = ({
       const isDelete = loadType === 'DELETE' || loadType === 'HARD_DELETE';
 
       if (scope === 'all') {
-        // Download results across all batches
-        removedBatches = jobInfo.batches.some((batch) => batch.state !== 'Completed');
-        const batchIds = jobInfo.batches.filter((batch) => batch.state === 'Completed').map((batch) => batch.id);
+        // Download results across all batches. Results only come back for completed batches, so the
+        // records must be built from those same batches in the same order — using the full prepared
+        // data would shift every row after a non-completed batch onto the wrong result. Both the
+        // fetch and the records are derived from one list so they cannot diverge.
+        const summaryByBatchId = new Map(batchSummary.batchSummary.filter(({ id }) => id).map((item) => [item.id as string, item]));
+        const includedBatches = jobInfo.batches.flatMap((batch) => {
+          const summaryItem = batch.state === 'Completed' ? summaryByBatchId.get(batch.id) : undefined;
+          return summaryItem ? [{ batchId: batch.id, summaryItem }] : [];
+        });
+        removedBatches = includedBatches.length !== jobInfo.batches.length;
         // download records, combine results from salesforce with actual records, open download modal
-        results = await bulkApiGetRecordsFromAllBatches<BulkJobResultRecord>(selectedOrg, jobInfo.id, batchIds);
+        results = await bulkApiGetRecordsFromAllBatches<BulkJobResultRecord>(
+          selectedOrg,
+          jobInfo.id,
+          includedBatches.map(({ batchId }) => batchId),
+        );
         /** For delete, only records with a mapped Id will be included in response from SFDC */
-        records = preparedData.data.filter((record) => (isDelete ? !!record.Id : true));
+        records = includedBatches
+          .flatMap(({ summaryItem }) => preparedData.data.slice(summaryItem.startIndex, summaryItem.startIndex + summaryItem.recordCount))
+          .filter((record) => (isDelete ? !!record.Id : true));
       } else {
         // Download results for a single batch
         // download records, combine results from salesforce with actual records, open download modal
@@ -891,6 +915,11 @@ export const LoadRecordsBulkApiResults = ({
           )}
         </div>
       </Grid>
+      {autoSplitBatchCount > 0 && (
+        <ScopedNotification theme="info" className="slds-m-vertical_x-small" allowClose>
+          Some of your batches were larger than Salesforce allows, so they were automatically split into smaller batches.
+        </ScopedNotification>
+      )}
       {/* Data is being processed */}
       {jobInfo && preparedData && (
         <LoadRecordsBulkApiResultsTable

--- a/libs/features/load-records/src/utils/__tests__/load-records-process.spec.ts
+++ b/libs/features/load-records/src/utils/__tests__/load-records-process.spec.ts
@@ -1,4 +1,10 @@
-import { MAX_BATCH_CSV_CHARS, MAX_CONSECUTIVE_FAILURES, generateSizeCappedBatchCsvs, isFatalBulkApiError } from '../load-records-process';
+import {
+  BatchCsv,
+  MAX_BATCH_CSV_CHARS,
+  MAX_CONSECUTIVE_FAILURES,
+  generateSizeCappedBatchCsvs,
+  isFatalBulkApiError,
+} from '../load-records-process';
 
 describe('MAX_CONSECUTIVE_FAILURES', () => {
   it('should equal 5', () => {
@@ -7,17 +13,33 @@ describe('MAX_CONSECUTIVE_FAILURES', () => {
 });
 
 describe('generateSizeCappedBatchCsvs', () => {
+  /** Every record must appear in exactly one batch, and each batch's reported range must contain it */
+  function expectRangesCoverEveryRecordExactlyOnce(batches: BatchCsv[], records: { Id: string }[]) {
+    records.forEach(({ Id }, recordIndex) => {
+      const matchingBatches = batches.filter(({ csv }) => csv.includes(`${Id},`));
+      expect(matchingBatches).toHaveLength(1);
+      const [{ startIndex, recordCount }] = matchingBatches;
+      expect(recordIndex).toBeGreaterThanOrEqual(startIndex);
+      expect(recordIndex).toBeLessThan(startIndex + recordCount);
+    });
+    expect(batches.reduce((total, { recordCount }) => total + recordCount, 0)).toBe(records.length);
+  }
+
   it('splits by record count when all batches are within the size cap', () => {
     const records = Array.from({ length: 10 }, (_, i) => ({ Id: `rec-${i}`, Name: `Record ${i}` }));
 
-    const csvs = generateSizeCappedBatchCsvs(records, 3);
+    const batches = generateSizeCappedBatchCsvs(records, 3);
 
-    expect(csvs).toHaveLength(4);
+    expect(batches).toHaveLength(4);
+    expect(batches.map(({ startIndex, recordCount }) => [startIndex, recordCount])).toEqual([
+      [0, 3],
+      [3, 3],
+      [6, 3],
+      [9, 1],
+    ]);
     // Every record lands in exactly one batch and each batch repeats the header
-    records.forEach(({ Id }) => {
-      expect(csvs.filter((csv) => csv.includes(Id))).toHaveLength(1);
-    });
-    csvs.forEach((csv) => expect(csv.startsWith('Id')).toBe(true));
+    expectRangesCoverEveryRecordExactlyOnce(batches, records);
+    batches.forEach(({ csv }) => expect(csv.startsWith('Id')).toBe(true));
   });
 
   it('halves batches whose CSV exceeds the character cap', () => {
@@ -25,22 +47,38 @@ describe('generateSizeCappedBatchCsvs', () => {
     const bigValue = 'x'.repeat(2_000_000);
     const records = Array.from({ length: 8 }, (_, i) => ({ Id: `rec-${i}`, Description: bigValue }));
 
-    const csvs = generateSizeCappedBatchCsvs(records, 8);
+    const batches = generateSizeCappedBatchCsvs(records, 8);
 
-    expect(csvs.length).toBeGreaterThan(1);
-    csvs.forEach((csv) => expect(csv.length).toBeLessThanOrEqual(MAX_BATCH_CSV_CHARS));
-    records.forEach(({ Id }) => {
-      expect(csvs.filter((csv) => csv.includes(`${Id},`))).toHaveLength(1);
-    });
+    expect(batches.length).toBeGreaterThan(1);
+    batches.forEach(({ csv }) => expect(csv.length).toBeLessThanOrEqual(MAX_BATCH_CSV_CHARS));
+    expectRangesCoverEveryRecordExactlyOnce(batches, records);
+  });
+
+  it('reports contiguous ranges when a split batch is followed by more count-based batches', () => {
+    // First batch of 4 is oversized and splits into 2+2; the remaining batches must still report
+    // ranges into the original record array so results can be mapped back to records.
+    const bigValue = 'x'.repeat(3_000_000);
+    const records = Array.from({ length: 12 }, (_, i) => ({ Id: `rec-${i}`, Description: i < 4 ? bigValue : 'small' }));
+
+    const batches = generateSizeCappedBatchCsvs(records, 4);
+
+    expect(batches.map(({ startIndex, recordCount }) => [startIndex, recordCount])).toEqual([
+      [0, 2],
+      [2, 2],
+      [4, 4],
+      [8, 4],
+    ]);
+    expectRangesCoverEveryRecordExactlyOnce(batches, records);
   });
 
   it('passes through a single record that alone exceeds the cap', () => {
     const records = [{ Id: 'rec-0', Description: 'x'.repeat(MAX_BATCH_CSV_CHARS + 100) }];
 
-    const csvs = generateSizeCappedBatchCsvs(records, 100);
+    const batches = generateSizeCappedBatchCsvs(records, 100);
 
-    expect(csvs).toHaveLength(1);
-    expect(csvs[0].length).toBeGreaterThan(MAX_BATCH_CSV_CHARS);
+    expect(batches).toHaveLength(1);
+    expect(batches[0]).toEqual(expect.objectContaining({ startIndex: 0, recordCount: 1 }));
+    expect(batches[0].csv.length).toBeGreaterThan(MAX_BATCH_CSV_CHARS);
   });
 });
 

--- a/libs/features/load-records/src/utils/load-records-process.ts
+++ b/libs/features/load-records/src/utils/load-records-process.ts
@@ -79,22 +79,42 @@ export function isFatalBulkApiError(error: unknown): boolean {
   return FATAL_BULK_ERROR_PATTERNS.some((pattern) => pattern.test(message));
 }
 
+/** A single batch CSV along with the range of source records it was built from */
+export interface BatchCsv {
+  csv: string;
+  /** Index of the first record from the source array included in this CSV */
+  startIndex: number;
+  recordCount: number;
+}
+
 /**
  * Generate batch CSVs capped both by record count and by CSV character count. A batch whose CSV
  * exceeds `MAX_BATCH_CSV_CHARS` is recursively halved until it fits; a single record that alone
  * exceeds the cap is passed through as-is (Salesforce rejects it with a per-batch error, same as today).
+ *
+ * Because splitting makes the resulting batch count and per-batch record count unpredictable, each
+ * CSV carries the record range it came from — callers must use that to map results back to records
+ * instead of assuming every batch holds `batchSize` records.
  */
-export function generateSizeCappedBatchCsvs(records: unknown[], batchSize: number): string[] {
-  return splitArrayToMaxSize(records, batchSize).flatMap(csvForBatchRecords);
+export function generateSizeCappedBatchCsvs(records: unknown[], batchSize: number): BatchCsv[] {
+  let startIndex = 0;
+  return splitArrayToMaxSize(records, batchSize).flatMap((batchRecords) => {
+    const batchCsvs = csvForBatchRecords(batchRecords, startIndex);
+    startIndex += batchRecords.length;
+    return batchCsvs;
+  });
 }
 
-function csvForBatchRecords(batchRecords: unknown[]): string[] {
+function csvForBatchRecords(batchRecords: unknown[], startIndex: number): BatchCsv[] {
   const csv = generateCsv(batchRecords, { delimiter: ',' });
   if (csv.length <= MAX_BATCH_CSV_CHARS || batchRecords.length <= 1) {
-    return [csv];
+    return [{ csv, startIndex, recordCount: batchRecords.length }];
   }
   const midpoint = Math.ceil(batchRecords.length / 2);
-  return [...csvForBatchRecords(batchRecords.slice(0, midpoint)), ...csvForBatchRecords(batchRecords.slice(midpoint))];
+  return [
+    ...csvForBatchRecords(batchRecords.slice(0, midpoint), startIndex),
+    ...csvForBatchRecords(batchRecords.slice(midpoint), startIndex + midpoint),
+  ];
 }
 
 /**
@@ -114,7 +134,14 @@ export async function loadBulkApiData(
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const jobId = results.id!;
     let batches: LoadDataBulkApi[] = [];
-    batches = generateSizeCappedBatchCsvs(data, batchSize).map((data, i) => ({ data, batchNumber: i, completed: false, success: false }));
+    batches = generateSizeCappedBatchCsvs(data, batchSize).map(({ csv, startIndex, recordCount }, i) => ({
+      data: csv,
+      batchNumber: i,
+      startIndex,
+      recordCount,
+      completed: false,
+      success: false,
+    }));
 
     let submittedBatchCount = 0;
 
@@ -491,9 +518,11 @@ function getBatchSummary(
     jobInfo: results,
     totalBatches: batches.length,
     submittedBatchCount,
-    batchSummary: batches.map(({ id, batchNumber, completed, success, errorMessage }) => ({
+    batchSummary: batches.map(({ id, batchNumber, startIndex, recordCount, completed, success, errorMessage }) => ({
       id,
       batchNumber,
+      startIndex,
+      recordCount,
       completed,
       success,
       errorMessage,

--- a/libs/shared/ui-core/src/jobs/JobWorker.ts
+++ b/libs/shared/ui-core/src/jobs/JobWorker.ts
@@ -61,7 +61,7 @@ import type {
   UploadToGoogleJob,
   WorkerMessage,
 } from '@jetstream/types';
-import { dexieDb } from '@jetstream/ui/db';
+import { dexieDb, withReopenOnDatabaseClosed } from '@jetstream/ui/db';
 import clamp from 'lodash/clamp';
 import isString from 'lodash/isString';
 
@@ -71,18 +71,20 @@ async function pruneAnalysisJobHistory(orgUniqueId: string, jobType: AnalysisJob
   try {
     // Wrap read + delete in a single transaction so a concurrent write (pin/unpin from another tab, or
     // another job finishing on the same org+type) cannot race between the sortBy and the bulkDelete.
-    await dexieDb.transaction('rw', dexieDb.analysis_job_history, async () => {
-      // sortBy returns ascending by createdAt; reverse the array to put newest first so slice(N) drops the older rows.
-      const rowsAscending = await dexieDb.analysis_job_history
-        .where('[org+jobType+createdAt]')
-        .between([orgUniqueId, jobType, new Date(0)], [orgUniqueId, jobType, new Date(8640000000000000)])
-        .sortBy('createdAt');
-      const rowsNewestFirst = rowsAscending.slice().reverse();
-      const overCap = rowsNewestFirst.filter((row) => !row.pinned).slice(ANALYSIS_HISTORY_PER_ORG_TYPE_CAP);
-      if (overCap.length > 0) {
-        await dexieDb.analysis_job_history.bulkDelete(overCap.map((row) => row.key));
-      }
-    });
+    await withReopenOnDatabaseClosed(() =>
+      dexieDb.transaction('rw', dexieDb.analysis_job_history, async () => {
+        // sortBy returns ascending by createdAt; reverse the array to put newest first so slice(N) drops the older rows.
+        const rowsAscending = await dexieDb.analysis_job_history
+          .where('[org+jobType+createdAt]')
+          .between([orgUniqueId, jobType, new Date(0)], [orgUniqueId, jobType, new Date(8640000000000000)])
+          .sortBy('createdAt');
+        const rowsNewestFirst = rowsAscending.slice().reverse();
+        const overCap = rowsNewestFirst.filter((row) => !row.pinned).slice(ANALYSIS_HISTORY_PER_ORG_TYPE_CAP);
+        if (overCap.length > 0) {
+          await dexieDb.analysis_job_history.bulkDelete(overCap.map((row) => row.key));
+        }
+      }),
+    );
   } catch (ex) {
     logger.warn('[JOB][ANALYSIS] Failed to prune analysis_job_history', ex);
   }
@@ -420,7 +422,7 @@ export class JobWorker {
             resultBlob: blob,
             resultBlobSize: blob.byteLength,
           };
-          await dexieDb.analysis_job_history.put(historyRow);
+          await withReopenOnDatabaseClosed(() => dexieDb.analysis_job_history.put(historyRow));
           await pruneAnalysisJobHistory(org.uniqueId, 'permission_export');
 
           const response: AsyncJobWorkerMessageResponse = {
@@ -452,7 +454,7 @@ export class JobWorker {
                 resultBlob: null,
                 resultBlobSize: 0,
               };
-              await dexieDb.analysis_job_history.put(failedRow);
+              await withReopenOnDatabaseClosed(() => dexieDb.analysis_job_history.put(failedRow));
               await pruneAnalysisJobHistory(org.uniqueId, 'permission_export');
             } catch (writeEx) {
               logger.warn('[JOB][PERMISSION_EXPORT] Failed to record failed analysis_job_history row', writeEx);
@@ -576,7 +578,7 @@ export class JobWorker {
             resultBlob: blob,
             resultBlobSize: blob.byteLength,
           };
-          await dexieDb.analysis_job_history.put(historyRow);
+          await withReopenOnDatabaseClosed(() => dexieDb.analysis_job_history.put(historyRow));
           await pruneAnalysisJobHistory(org.uniqueId, 'field_usage');
 
           const response: AsyncJobWorkerMessageResponse = {
@@ -607,7 +609,7 @@ export class JobWorker {
                 resultBlob: null,
                 resultBlobSize: 0,
               };
-              await dexieDb.analysis_job_history.put(failedRow);
+              await withReopenOnDatabaseClosed(() => dexieDb.analysis_job_history.put(failedRow));
               await pruneAnalysisJobHistory(org.uniqueId, 'field_usage');
             } catch (writeEx) {
               logger.warn('[JOB][FIELD_USAGE] Failed to record failed analysis_job_history row', writeEx);

--- a/libs/shared/ui-core/src/query/QueryHistory/QueryHistoryExportPopover.tsx
+++ b/libs/shared/ui-core/src/query/QueryHistory/QueryHistoryExportPopover.tsx
@@ -4,7 +4,7 @@ import { getFilenameWithoutOrg, prepareCsvFile, saveFile } from '@jetstream/shar
 import { orderObjectsBy } from '@jetstream/shared/utils';
 import { QueryHistoryItem, SalesforceOrgUi } from '@jetstream/types';
 import { Icon, Popover, PopoverRef, Radio, RadioGroup } from '@jetstream/ui';
-import { dexieDb } from '@jetstream/ui/db';
+import { dexieDb, withReopenOnDatabaseClosed } from '@jetstream/ui/db';
 import isDate from 'lodash/isDate';
 import { FunctionComponent, useRef, useState } from 'react';
 import { useAmplitude } from '../..';
@@ -42,7 +42,9 @@ export const QueryHistoryExportPopover: FunctionComponent<QueryHistoryExportPopo
       };
 
       // Get query history items
-      const queryHistory = await dexieDb.query_history.orderBy('lastRun').reverse().filter(filterFn).toArray();
+      const queryHistory = await withReopenOnDatabaseClosed(() =>
+        dexieDb.query_history.orderBy('lastRun').reverse().filter(filterFn).toArray(),
+      );
 
       if (queryHistory.length === 0) {
         return;

--- a/libs/shared/ui-db/src/lib/analysis-job-history-retention.ts
+++ b/libs/shared/ui-db/src/lib/analysis-job-history-retention.ts
@@ -1,5 +1,5 @@
 import { logger } from '@jetstream/shared/client-logger';
-import { dexieDb } from './ui-db';
+import { dexieDb, withReopenOnDatabaseClosed } from './ui-db';
 
 const FOURTEEN_DAYS_MS = 14 * 24 * 60 * 60 * 1000;
 const MAX_ROWS_PER_ORG_AND_JOB_TYPE = 10;
@@ -15,37 +15,39 @@ const JOB_TYPES = ['permission_export', 'field_usage'] as const;
  */
 export async function pruneAnalysisJobHistory(): Promise<void> {
   try {
-    await dexieDb.transaction('rw', dexieDb.analysis_job_history, async () => {
-      const fourteenDaysAgo = new Date(Date.now() - FOURTEEN_DAYS_MS);
-      await dexieDb.analysis_job_history
-        .where('createdAt')
-        .below(fourteenDaysAgo)
-        .filter((row) => !row.pinned)
-        .delete();
+    await withReopenOnDatabaseClosed(() =>
+      dexieDb.transaction('rw', dexieDb.analysis_job_history, async () => {
+        const fourteenDaysAgo = new Date(Date.now() - FOURTEEN_DAYS_MS);
+        await dexieDb.analysis_job_history
+          .where('createdAt')
+          .below(fourteenDaysAgo)
+          .filter((row) => !row.pinned)
+          .delete();
 
-      const allOrgs = await dexieDb.analysis_job_history.orderBy('org').uniqueKeys();
-      for (const orgKey of allOrgs) {
-        const org = String(orgKey);
-        for (const jobType of JOB_TYPES) {
-          // sortBy returns ascending by createdAt (Dexie always re-sorts in-memory; chained reverse() is a no-op).
-          // Reverse the array in JS to put newest first, then drop the first N to retain the newest N.
-          const rowsAscending = await dexieDb.analysis_job_history
-            .where('[org+jobType+createdAt]')
-            .between([org, jobType, new Date(0)], [org, jobType, new Date(8.64e15)])
-            .sortBy('createdAt');
-          const rowsNewestFirst = rowsAscending.slice().reverse();
+        const allOrgs = await dexieDb.analysis_job_history.orderBy('org').uniqueKeys();
+        for (const orgKey of allOrgs) {
+          const org = String(orgKey);
+          for (const jobType of JOB_TYPES) {
+            // sortBy returns ascending by createdAt (Dexie always re-sorts in-memory; chained reverse() is a no-op).
+            // Reverse the array in JS to put newest first, then drop the first N to retain the newest N.
+            const rowsAscending = await dexieDb.analysis_job_history
+              .where('[org+jobType+createdAt]')
+              .between([org, jobType, new Date(0)], [org, jobType, new Date(8.64e15)])
+              .sortBy('createdAt');
+            const rowsNewestFirst = rowsAscending.slice().reverse();
 
-          const keysToDelete = rowsNewestFirst
-            .filter((row) => !row.pinned)
-            .slice(MAX_ROWS_PER_ORG_AND_JOB_TYPE)
-            .map((row) => row.key);
+            const keysToDelete = rowsNewestFirst
+              .filter((row) => !row.pinned)
+              .slice(MAX_ROWS_PER_ORG_AND_JOB_TYPE)
+              .map((row) => row.key);
 
-          if (keysToDelete.length > 0) {
-            await dexieDb.analysis_job_history.bulkDelete(keysToDelete);
+            if (keysToDelete.length > 0) {
+              await dexieDb.analysis_job_history.bulkDelete(keysToDelete);
+            }
           }
         }
-      }
-    });
+      }),
+    );
   } catch (ex) {
     logger.warn('[DB][ANALYSIS_JOB_HISTORY][PRUNE] Failed to prune analysis_job_history', ex);
   }

--- a/libs/shared/ui-utils/src/lib/__tests__/shared-ui-utils.spec.ts
+++ b/libs/shared/ui-utils/src/lib/__tests__/shared-ui-utils.spec.ts
@@ -45,6 +45,47 @@ describe('prepareExcelFile cell truncation', () => {
     const [, dataRow] = readBackRows(fileData);
     expect((dataRow[1] as string).length).toBe(EXCEL_MAX_CELL_CHARS);
   });
+
+  it('reports the truncated cell count across every sheet so the user can be warned', () => {
+    const oversized = 'z'.repeat(EXCEL_MAX_CELL_CHARS * 2);
+    const onCellsTruncated = vi.fn();
+
+    prepareExcelFile(
+      {
+        records: [
+          { Id: 'rec-1', Notes: oversized },
+          { Id: 'rec-2', Notes: 'short' },
+        ],
+        subquery: [{ Id: 'rec-3', Notes: oversized }],
+      },
+      { records: ['Id', 'Notes'], subquery: ['Id', 'Notes'] },
+      undefined,
+      { onCellsTruncated },
+    );
+
+    expect(onCellsTruncated).toHaveBeenCalledTimes(1);
+    expect(onCellsTruncated).toHaveBeenCalledWith(2);
+  });
+
+  it('does not report truncation when every cell is within the limit', () => {
+    const onCellsTruncated = vi.fn();
+
+    prepareExcelFile([{ Id: 'rec-1', Description: 'short' }], ['Id', 'Description'], undefined, { onCellsTruncated });
+
+    expect(onCellsTruncated).not.toHaveBeenCalled();
+  });
+
+  it('leaves rows without an oversized cell as the same array instance', () => {
+    const untouchedRow = ['rec-1', 'short'];
+    const truncatedRow = ['rec-2', 'x'.repeat(EXCEL_MAX_CELL_CHARS + 1)];
+    const rows = [['Id', 'Description'], untouchedRow, truncatedRow];
+
+    // Array-of-array sheets are caller-owned, so they must never be mutated in place
+    prepareExcelFile({ records: rows });
+
+    expect(rows[1]).toBe(untouchedRow);
+    expect(truncatedRow[1]).toHaveLength(EXCEL_MAX_CELL_CHARS + 1);
+  });
 });
 
 describe('formatNumber', () => {

--- a/libs/shared/ui-utils/src/lib/errorTracker.ts
+++ b/libs/shared/ui-utils/src/lib/errorTracker.ts
@@ -1,4 +1,5 @@
 import { logger } from '@jetstream/shared/client-logger';
+import { INVALID_QUERY_LOCATOR_REGEX } from '@jetstream/shared/utils';
 import { Environment, UserProfileUi } from '@jetstream/types';
 import * as Sentry from '@sentry/react';
 
@@ -21,13 +22,13 @@ const ignoredMessageSubstrings = [
   // dexie-observable's unload-time localStorage write for users at storage quota — guarded in ui-db,
   // but old bundles remain in the field.
   'Dexie.Observable/deadnode',
-  // Expired/evicted Salesforce query cursor — the user must re-run their query; nothing to fix client-side.
-  // Salesforce surfaces this as either the lowercase message or the uppercase error code depending on the API.
-  'invalid query locator',
-  'INVALID_QUERY_LOCATOR',
 ];
+// Expired/evicted Salesforce query cursor — the user must re-run their query; nothing to fix client-side.
+// Shared with the UI so the "your query results expired" messaging and this ignore rule match the same errors.
+const ignoredMessagePatterns = [INVALID_QUERY_LOCATOR_REGEX];
 // 'DatabaseClosedError' matches the exception TYPE: dexie-observable closes the shared connection after
-// a tab freeze/sleep; history writes reopen-and-retry, and anything residual is not actionable.
+// a tab freeze/sleep. Every user-triggered read/write goes through `withReopenOnDatabaseClosed`, which
+// reopens and retries, so anything still reaching here is residual and not actionable.
 const ignoredExactMessages = new Set(['Canceled', 'ChunkLoadError', '(unknown)', 'DatabaseClosedError']);
 const extensionUrlPrefixes = ['chrome-extension://', 'moz-extension://', 'safari-web-extension://', 'safari-extension://'];
 
@@ -75,6 +76,9 @@ function shouldIgnore(event: Sentry.ErrorEvent): boolean {
       return true;
     }
     if (ignoredMessageSubstrings.some((needle) => candidate.includes(needle))) {
+      return true;
+    }
+    if (ignoredMessagePatterns.some((pattern) => pattern.test(candidate))) {
       return true;
     }
   }

--- a/libs/shared/ui-utils/src/lib/shared-ui-utils.ts
+++ b/libs/shared/ui-utils/src/lib/shared-ui-utils.ts
@@ -291,6 +291,14 @@ export function polyfillFieldDefinition(field: Field): string {
   return `${prefix}${value}${suffix}`;
 }
 
+export type PrepareExcelFileOptions = XLSX.WritingOptions & {
+  /**
+   * Called with the number of cells that exceeded Excel's per-cell limit and were truncated.
+   * Only called when at least one cell was truncated — use it to tell the user the file is lossy.
+   */
+  onCellsTruncated?: (truncatedCellCount: number) => void;
+};
+
 /**
  * Prepares excel file
  * @param data Array of objects for one sheet, or map of multiple objects where the key is sheet name
@@ -298,30 +306,43 @@ export function polyfillFieldDefinition(field: Field): string {
  * @param [defaultSheetName]
  * @returns excel file
  */
-export function prepareExcelFile(data: any[], header?: string[], defaultSheetName?: string, options?: XLSX.WritingOptions): ArrayBuffer;
+export function prepareExcelFile(data: any[], header?: string[], defaultSheetName?: string, options?: PrepareExcelFileOptions): ArrayBuffer;
 export function prepareExcelFile(
   data: Record<string, any[]>,
   header?: Record<string, string[]>,
   defaultSheetName?: void,
-  options?: XLSX.WritingOptions,
+  options?: PrepareExcelFileOptions,
 ): ArrayBuffer;
-export function prepareExcelFile(data: any, header: any, defaultSheetName: any = 'Records', options?: XLSX.WritingOptions): ArrayBuffer {
+export function prepareExcelFile(
+  data: any,
+  header: any,
+  defaultSheetName: any = 'Records',
+  options?: PrepareExcelFileOptions,
+): ArrayBuffer {
   const COMPRESS_SHEET_ROW_COUNT = 10_000;
   const workbook = XLSX.utils.book_new();
-  options = { compression: false, ...options };
+  const { onCellsTruncated, ...writingOptions } = { compression: false, ...options };
+  let truncatedCellCount = 0;
+
+  /** Truncate over-limit cells for one sheet, accumulating the count across all sheets */
+  function truncate(rows: any[][]): any[][] {
+    const result = truncateCellsForExcel(rows);
+    truncatedCellCount += result.truncatedCellCount;
+    return result.rows;
+  }
 
   if (Array.isArray(data)) {
     header = header || Object.keys(data[0] || {});
-    const worksheet = XLSX.utils.aoa_to_sheet(truncateCellsForExcel(convertArrayOfObjectToArrayOfArray(data, header as string[])), {
+    const worksheet = XLSX.utils.aoa_to_sheet(truncate(convertArrayOfObjectToArrayOfArray(data, header as string[])), {
       dense: true,
     });
     XLSX.utils.book_append_sheet(workbook, worksheet, defaultSheetName);
-    options.compression = options.compression || data.length > COMPRESS_SHEET_ROW_COUNT;
+    writingOptions.compression = writingOptions.compression || data.length > COMPRESS_SHEET_ROW_COUNT;
   } else {
     Object.keys(data).forEach((sheetName) => {
       const values = data[sheetName];
       if (values.length > 0) {
-        options.compression = options.compression || values.length > COMPRESS_SHEET_ROW_COUNT;
+        writingOptions.compression = writingOptions.compression || values.length > COMPRESS_SHEET_ROW_COUNT;
         let currentHeader = header && header[sheetName];
         let isArrayOfArray = false;
         if (!currentHeader) {
@@ -333,19 +354,20 @@ export function prepareExcelFile(data: any, header: any, defaultSheetName: any =
         }
         XLSX.utils.book_append_sheet(
           workbook,
-          XLSX.utils.aoa_to_sheet(
-            truncateCellsForExcel(isArrayOfArray ? values : convertArrayOfObjectToArrayOfArray(values, currentHeader)),
-            {
-              dense: true,
-            },
-          ),
+          XLSX.utils.aoa_to_sheet(truncate(isArrayOfArray ? values : convertArrayOfObjectToArrayOfArray(values, currentHeader)), {
+            dense: true,
+          }),
           sheetName,
         );
       }
     });
   }
 
-  return excelWorkbookToArrayBuffer(workbook, options);
+  if (truncatedCellCount > 0) {
+    onCellsTruncated?.(truncatedCellCount);
+  }
+
+  return excelWorkbookToArrayBuffer(workbook, writingOptions);
 }
 
 // Excel's hard per-cell limit — XLSX.write throws "Text length must not exceed 32767 characters" beyond it.
@@ -354,14 +376,44 @@ export function prepareExcelFile(data: any, header: any, defaultSheetName: any =
 export const EXCEL_MAX_CELL_CHARS = 32_767;
 const EXCEL_TRUNCATION_SUFFIX = '...(truncated)';
 
-function truncateCellsForExcel(rows: any[][]): any[][] {
-  return rows.map((row) =>
-    row.map((value) =>
-      typeof value === 'string' && value.length > EXCEL_MAX_CELL_CHARS
-        ? `${value.slice(0, EXCEL_MAX_CELL_CHARS - EXCEL_TRUNCATION_SUFFIX.length)}${EXCEL_TRUNCATION_SUFFIX}`
-        : value,
+function isOversizedExcelCell(value: unknown): value is string {
+  return typeof value === 'string' && value.length > EXCEL_MAX_CELL_CHARS;
+}
+
+/**
+ * Truncate any cell over Excel's per-cell limit. Runs immediately before the workbook is written —
+ * the peak-memory moment of an export — so rows are scanned first and only rows that actually
+ * contain an oversized cell are re-allocated. The common case (nothing over the limit) returns the
+ * original array untouched. Rows are never mutated in place because callers may own them.
+ */
+function truncateCellsForExcel(rows: any[][]): { rows: any[][]; truncatedCellCount: number } {
+  let truncatedCellCount = 0;
+  const rowIndexesToTruncate = new Set<number>();
+  rows.forEach((row, index) => {
+    for (const value of row) {
+      if (isOversizedExcelCell(value)) {
+        rowIndexesToTruncate.add(index);
+        truncatedCellCount++;
+      }
+    }
+  });
+
+  if (truncatedCellCount === 0) {
+    return { rows, truncatedCellCount };
+  }
+
+  return {
+    rows: rows.map((row, index) =>
+      rowIndexesToTruncate.has(index)
+        ? row.map((value) =>
+            isOversizedExcelCell(value)
+              ? `${value.slice(0, EXCEL_MAX_CELL_CHARS - EXCEL_TRUNCATION_SUFFIX.length)}${EXCEL_TRUNCATION_SUFFIX}`
+              : value,
+          )
+        : row,
     ),
-  );
+    truncatedCellCount,
+  };
 }
 
 export function excelWorkbookToArrayBuffer(workbook: XLSX.WorkBook, options?: XLSX.WritingOptions): ArrayBuffer {

--- a/libs/shared/utils/src/lib/utils.ts
+++ b/libs/shared/utils/src/lib/utils.ts
@@ -65,6 +65,21 @@ export function getErrorMessage(error: unknown): string {
   }
 }
 
+/**
+ * An expired or evicted Salesforce query cursor. Depending on which API returned it, Salesforce
+ * surfaces this as the message form ("invalid query locator") or the error-code form
+ * (INVALID_QUERY_LOCATOR), so both must be matched.
+ */
+export const INVALID_QUERY_LOCATOR_REGEX = /invalid[ _]query[ _]locator/i;
+
+/**
+ * The query must be re-run — retrying with the same locator can never succeed and there is nothing
+ * to fix client-side.
+ */
+export function isInvalidQueryLocatorError(error: unknown): boolean {
+  return INVALID_QUERY_LOCATOR_REGEX.test(getErrorMessage(error));
+}
+
 export function getErrorStack(error: unknown) {
   if (error instanceof Error) {
     return error.stack;

--- a/libs/types/src/lib/ui/load-records-types.ts
+++ b/libs/types/src/lib/ui/load-records-types.ts
@@ -131,6 +131,14 @@ export interface LoadDataBulkApi {
   id?: string;
   data: any;
   batchNumber: number;
+  /** Index of this batch's first record within the prepared record array */
+  startIndex: number;
+  /**
+   * Number of records in this batch. Batches are capped by record count AND by CSV size, so an
+   * oversized batch is split and this will not always equal the configured batch size — record
+   * boundaries must be read from here rather than derived from `batchNumber * batchSize`.
+   */
+  recordCount: number;
   completed: boolean;
   success: boolean;
   errorMessage?: string;

--- a/libs/ui/src/lib/data-table/SalesforceRecordDataTable.tsx
+++ b/libs/ui/src/lib/data-table/SalesforceRecordDataTable.tsx
@@ -4,7 +4,14 @@ import { logger } from '@jetstream/shared/client-logger';
 import { ANALYTICS_KEYS } from '@jetstream/shared/constants';
 import { queryRemaining } from '@jetstream/shared/data';
 import { formatNumber, hasCtrlOrMeta, isEnterKey, tracker, useGlobalEventHandler } from '@jetstream/shared/ui-utils';
-import { flattenRecord, getErrorMessage, getIdFromRecordUrl, groupByFlat, nullifyEmptyStrings } from '@jetstream/shared/utils';
+import {
+  flattenRecord,
+  getErrorMessage,
+  getIdFromRecordUrl,
+  groupByFlat,
+  isInvalidQueryLocatorError,
+  nullifyEmptyStrings,
+} from '@jetstream/shared/utils';
 import {
   CloneEditView,
   ContextMenuItem,
@@ -401,7 +408,7 @@ export const SalesforceRecordDataTable = memo<SalesforceRecordDataTableProps>(
         }
         setIsLoadingMore(false);
         // An expired/evicted Salesforce query cursor can never succeed on retry — the query must be re-run
-        if (getErrorMessage(ex).toLowerCase().includes('invalid query locator')) {
+        if (isInvalidQueryLocatorError(ex)) {
           setHasMoreRecords(false);
           setLoadMoreErrorMessage('Your query results expired. Re-run your query to load all records.');
         } else {

--- a/libs/ui/src/lib/file-download-modal/FileDownloadModal.tsx
+++ b/libs/ui/src/lib/file-download-modal/FileDownloadModal.tsx
@@ -37,6 +37,7 @@ import RadioGroup from '../form/radio/RadioGroup';
 import Modal from '../modal/Modal';
 import {
   getInitialDownloadFileFormat,
+  notifyExcelCellsTruncated,
   RADIO_FORMAT_CSV,
   RADIO_FORMAT_GDRIVE,
   RADIO_FORMAT_JSON,
@@ -199,9 +200,11 @@ export const FileDownloadModal: FunctionComponent<FileDownloadModalProps> = ({
             } else if (Array.isArray(data)) {
               const headerFields = (header ? header : Object.keys(data[0])) as string[];
               const _data = transformData ? transformData({ fileFormat, data, header: headerFields }) : data;
-              fileData = prepareExcelFile(_data, headerFields);
+              fileData = prepareExcelFile(_data, headerFields, undefined, { onCellsTruncated: notifyExcelCellsTruncated });
             } else {
-              fileData = prepareExcelFile(data as any, header as Record<string, string[]>);
+              fileData = prepareExcelFile(data as any, header as Record<string, string[]>, undefined, {
+                onCellsTruncated: notifyExcelCellsTruncated,
+              });
             }
             mimeType = MIME_TYPES.XLSX;
             break;
@@ -265,9 +268,11 @@ export const FileDownloadModal: FunctionComponent<FileDownloadModalProps> = ({
         const headerFields = (header ? header : Object.keys(data[0])) as string[];
         const _data =
           transformData && Array.isArray(data) ? transformData({ fileFormat: 'xlsx', data, header: headerFields }) : (data as any[]);
-        fileData = prepareExcelFile(_data, headerFields);
+        fileData = prepareExcelFile(_data, headerFields, undefined, { onCellsTruncated: notifyExcelCellsTruncated });
       } else {
-        fileData = prepareExcelFile(data as any, header as Record<string, string[]>);
+        fileData = prepareExcelFile(data as any, header as Record<string, string[]>, undefined, {
+          onCellsTruncated: notifyExcelCellsTruncated,
+        });
       }
     } else {
       fileType = 'zip';

--- a/libs/ui/src/lib/file-download-modal/RecordDownloadModal.tsx
+++ b/libs/ui/src/lib/file-download-modal/RecordDownloadModal.tsx
@@ -39,6 +39,7 @@ import { PopoverErrorButton } from '../popover/PopoverErrorButton';
 import ScopedNotification from '../scoped-notification/ScopedNotification';
 import {
   getInitialDownloadFileFormat,
+  notifyExcelCellsTruncated,
   RADIO_ALL_BROWSER,
   RADIO_ALL_SERVER,
   RADIO_DOWNLOAD_METHOD_BULK_API,
@@ -296,7 +297,7 @@ export const RecordDownloadModal: FunctionComponent<RecordDownloadModalProps> = 
               data['records'] = flattenRecords(activeRecords, fields);
             }
 
-            fileData = prepareExcelFile(data);
+            fileData = prepareExcelFile(data, undefined, undefined, { onCellsTruncated: notifyExcelCellsTruncated });
             mimeType = MIME_TYPES.XLSX;
             break;
           }

--- a/libs/ui/src/lib/file-download-modal/download-modal-utils.ts
+++ b/libs/ui/src/lib/file-download-modal/download-modal-utils.ts
@@ -1,4 +1,7 @@
+import { EXCEL_MAX_CELL_CHARS, formatNumber } from '@jetstream/shared/ui-utils';
+import { pluralizeFromNumber } from '@jetstream/shared/utils';
 import { FileExtCsv, FileExtJson, FileExtXLSX, FileExtXml, FileExtZip } from '@jetstream/types';
+import { fireToast } from '../toast/AppToast';
 
 export const RADIO_FORMAT_XLSX: FileExtXLSX = 'xlsx';
 export const RADIO_FORMAT_CSV: FileExtCsv = 'csv';
@@ -26,6 +29,20 @@ export const getInitialDownloadFileFormat = <T>(allowedTypes: T[], localStorageK
     // do nothing
   }
   return allowedTypes[0];
+};
+
+/**
+ * A generated .xlsx is not a faithful copy when any cell hit Excel's per-cell limit — the download
+ * succeeds either way, so warn the user and point them at a format without the limit.
+ * Pass as `onCellsTruncated` to `prepareExcelFile` from any interactive download.
+ */
+export const notifyExcelCellsTruncated = (truncatedCellCount: number) => {
+  fireToast({
+    type: 'warning',
+    message: `${formatNumber(truncatedCellCount)} ${pluralizeFromNumber('value', truncatedCellCount)} exceeded Excel's ${formatNumber(
+      EXCEL_MAX_CELL_CHARS,
+    )} character cell limit and ${truncatedCellCount === 1 ? 'was' : 'were'} truncated. Download as CSV or JSON to get the full values.`,
+  });
 };
 
 export const saveFileFormatToStorage = (type: string, localStorageKey: string) => {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "url": "https://github.com/jetstreamapp/jetstream"
   },
   "author": "Jetstream Solutions, LLC",
-  "version": "10.8.0",
+  "version": "10.8.1",
   "license": "SEE LICENSE IN LICENSE.md",
   "engines": {
     "node": ">=24 <25",


### PR DESCRIPTION
Size-capped batch splitting makes a batch's record range unpredictable, but the retry and per-batch download paths still derived it from `batchNumber * batchSize`. Once a batch was split, Salesforce result rows were joined to the wrong records: downloaded error files pointed at the wrong rows, and "retry failed records" would re-run records that had actually succeeded. `generateSizeCappedBatchCsvs` now returns the record range for each CSV, carried through `LoadDataBulkApi` and the batch summary so both consumers slice by real boundaries.

Also from review of the error-tracker changes:

- Suppress abort noise using `isAborted.current` rather than matching error message text, which missed the common case where Salesforce rejects the in-flight batch with its own message before the abort marker is appended.
- Wrap the remaining `analysis_job_history` writes and the query history export read in `withReopenOnDatabaseClosed`. `DatabaseClosedError` is now globally ignored by the tracker, which would have made those failures silent.
- Re-allocate only spreadsheet rows that contain an over-limit cell instead of copying the whole row matrix right before `XLSX.write`.
- Warn the user when an xlsx download truncated cells instead of silently shipping a lossy file.
- Share one invalid-query-locator matcher between the UI messaging and the tracker ignore list so they cannot drift; it now also matches the INVALID_QUERY_LOCATOR error-code form.