### PR TITLE
HOTFIX: map bulk API results to the correct records when a batch is split by size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [10.8.1](https://github.com/jetstreamapp/jetstream/compare/v10.8.0...v10.8.1) (2026-07-29)
+
+### Bug Fixes
+
+* map bulk API results to the correct records when a batch is split by size ([60f9bb0](https://github.com/jetstreamapp/jetstream/commit/60f9bb08035f9b216451eac1727510bc3c6134b9))
+
 ## [10.8.0](https://github.com/jetstreamapp/jetstream/compare/v10.7.2...v10.8.0) (2026-07-28)
 
 ### Features

--- a/apps/jetstream-web-extension/src/manifest.json
+++ b/apps/jetstream-web-extension/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Jetstream",
   "description": "Jetstream is a set of tools that supercharge your administration of Salesforce.com.",
-  "version": "3.7.1",
+  "version": "3.7.2",
   "manifest_version": 3,
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAmPjyzVG3Kpm0wyjDECyDLnwPlyEhlNmfzcPVybZz9gFKiHTm0qEuUYqGqOSAOWE6KnOR8RbiNkyrROGeEbGmhZIXxS02yKPTpJsA4qflKtTUGoeT7XcOm9cHWw3+BrVuqABCdXEwv/Do1/UX2vu9WeOMHQAr911nVl77JrhhaMQvpu0ruJjD+sZ9QbfjdLNeVeU1+hzgpuvpDnMihDIfZv47GaqvTTwxT67P09loBySjXMmx2mrtOpyLzsATLwQr6kmQQAX5X23ykw3PxY4NWBDldqXxKqTomMkwa3x6mh/4jmI5h6p6Wt6Gaf9FcG1pBOXTrUHNfdFzuK6ahYBsRQIDAQAB",
   "icons": {

--- a/libs/features/load-records/src/components/load-results/LoadRecordsBulkApiResults.tsx
+++ b/libs/features/load-records/src/components/load-results/LoadRecordsBulkApiResults.tsx
@@ -87,7 +87,6 @@ async function collectFailedRecordsForRetry({
   jobInfo,
   batchSummary,
   preparedData,
-  batchSize,
   loadType,
   selectedOrg,
 }: {
@@ -95,7 +94,6 @@ async function collectFailedRecordsForRetry({
   jobInfo: BulkJobWithBatches;
   batchSummary: LoadDataBulkApiStatusPayload;
   preparedData: PrepareDataResponse;
-  batchSize: number;
   loadType: InsertUpdateUpsertDelete;
   selectedOrg: SalesforceOrgUi;
 }): Promise<any[]> {
@@ -105,7 +103,14 @@ async function collectFailedRecordsForRetry({
 
   const jobId = jobInfo.id;
   const isDelete = loadType === 'DELETE' || loadType === 'HARD_DELETE';
-  const splitRecords = splitArrayToMaxSize(preparedData.data, batchSize);
+  // Batches are capped by record count AND by CSV size, so an oversized batch gets split and the
+  // records in a batch cannot be derived from `batchSize` — use the ranges the loader recorded.
+  const recordsByBatchNumber = new Map<number, any[]>(
+    batchSummary.batchSummary.map(({ batchNumber, startIndex, recordCount }) => [
+      batchNumber,
+      preparedData.data.slice(startIndex, startIndex + recordCount),
+    ]),
+  );
   const failedRecords: any[] = [];
 
   const completedBatchIds = jobInfo.batches
@@ -114,9 +119,9 @@ async function collectFailedRecordsForRetry({
     .filter((batchId): batchId is string => !!batchId);
 
   // No completed batches means either everything failed up-front or was unsubmitted/aborted.
-  // Fall back to treating every split record as failed.
+  // Fall back to treating every record as failed.
   if (completedBatchIds.length === 0) {
-    return splitRecords.flat();
+    return preparedData.data.slice();
   }
 
   const batchNumberById = new Map(
@@ -149,10 +154,10 @@ async function collectFailedRecordsForRetry({
   const resolvedBatchNumbers = new Set<number>();
   completedBatchResults.forEach(({ batchId, results }) => {
     const originalBatchIndex = batchNumberById.get(batchId);
-    if (typeof originalBatchIndex !== 'number' || !splitRecords[originalBatchIndex]) {
+    const recordsForBatch = typeof originalBatchIndex === 'number' ? recordsByBatchNumber.get(originalBatchIndex) : undefined;
+    if (typeof originalBatchIndex !== 'number' || !recordsForBatch) {
       return;
     }
-    const recordsForBatch = splitRecords[originalBatchIndex];
     const recordsWithIds = recordsForBatch.filter((record: Record<string, unknown>) => !!record.Id);
     const resultsExcludeMissingIdRecords =
       isDelete && results.length === recordsWithIds.length && recordsWithIds.length !== recordsForBatch.length;
@@ -175,8 +180,8 @@ async function collectFailedRecordsForRetry({
 
   // Include all records from any batch we couldn't resolve (fetch failed, unmapped batch id,
   // state !== Completed, etc.). These are conservatively considered failed and retryable.
-  splitRecords.forEach((records, index) => {
-    if (!resolvedBatchNumbers.has(index)) {
+  recordsByBatchNumber.forEach((records, batchNumber) => {
+    if (!resolvedBatchNumbers.has(batchNumber)) {
       failedRecords.push(...records);
     }
   });
@@ -320,7 +325,6 @@ export const LoadRecordsBulkApiResults = ({
             jobInfo,
             batchSummary,
             preparedData,
-            batchSize,
             loadType,
             selectedOrg,
           });
@@ -608,15 +612,7 @@ export const LoadRecordsBulkApiResults = ({
 
       if (scope === 'all') {
         // Download results across all batches
-        const splitRecordsByBatchSize = splitArrayToMaxSize(records, batchSize);
-        jobInfo.batches.forEach((batch, i) => {
-          if (batch.state !== 'Completed') {
-            // remove batch from result records
-            splitRecordsByBatchSize.splice(i, 1);
-            removedBatches = true;
-          }
-        });
-        records = splitRecordsByBatchSize.flat();
+        removedBatches = jobInfo.batches.some((batch) => batch.state !== 'Completed');
         const batchIds = jobInfo.batches.filter((batch) => batch.state === 'Completed').map((batch) => batch.id);
         // download records, combine results from salesforce with actual records, open download modal
         results = await bulkApiGetRecordsFromAllBatches<BulkJobResultRecord>(selectedOrg, jobInfo.id, batchIds);
@@ -627,13 +623,16 @@ export const LoadRecordsBulkApiResults = ({
         // download records, combine results from salesforce with actual records, open download modal
         results = await bulkApiGetRecords<BulkJobResultRecord>(selectedOrg, jobInfo.id, batch.id, 'result');
         // this should match, but will fallback to batchIndex if for some reason we cannot find the batch
-        const batchSummaryItem = batchSummary.batchSummary.find((item) => item.id === batch.id);
-        const startIdx = (batchSummaryItem?.batchNumber ?? batchIndex) * batchSize;
+        const batchSummaryItem = batchSummary.batchSummary.find((item) => item.id === batch.id) ?? batchSummary.batchSummary[batchIndex];
         /**
-         * Get records from this one batch
+         * Get records from this one batch. Batches are capped by record count AND by CSV size, so an
+         * oversized batch gets split — the record range comes from the batch summary rather than
+         * `batchNumber * batchSize`, which is only correct when no batch was split.
          * For delete, only records with a mapped Id will be included in response from SFDC
          */
-        records = preparedData.data.slice(startIdx, startIdx + batchSize).filter((record) => (isDelete ? !!record.Id : true));
+        const startIdx = batchSummaryItem?.startIndex ?? batchIndex * batchSize;
+        const recordCount = batchSummaryItem?.recordCount ?? batchSize;
+        records = preparedData.data.slice(startIdx, startIdx + recordCount).filter((record) => (isDelete ? !!record.Id : true));
       }
 
       const combinedResults: BulkJobResultRecord[] = [];

--- a/libs/features/load-records/src/utils/__tests__/load-records-process.spec.ts
+++ b/libs/features/load-records/src/utils/__tests__/load-records-process.spec.ts
@@ -1,4 +1,10 @@
-import { MAX_BATCH_CSV_CHARS, MAX_CONSECUTIVE_FAILURES, generateSizeCappedBatchCsvs, isFatalBulkApiError } from '../load-records-process';
+import {
+  BatchCsv,
+  MAX_BATCH_CSV_CHARS,
+  MAX_CONSECUTIVE_FAILURES,
+  generateSizeCappedBatchCsvs,
+  isFatalBulkApiError,
+} from '../load-records-process';
 
 describe('MAX_CONSECUTIVE_FAILURES', () => {
   it('should equal 5', () => {
@@ -7,17 +13,33 @@ describe('MAX_CONSECUTIVE_FAILURES', () => {
 });
 
 describe('generateSizeCappedBatchCsvs', () => {
+  /** Every record must appear in exactly one batch, and each batch's reported range must contain it */
+  function expectRangesCoverEveryRecordExactlyOnce(batches: BatchCsv[], records: { Id: string }[]) {
+    records.forEach(({ Id }, recordIndex) => {
+      const matchingBatches = batches.filter(({ csv }) => csv.includes(`${Id},`));
+      expect(matchingBatches).toHaveLength(1);
+      const [{ startIndex, recordCount }] = matchingBatches;
+      expect(recordIndex).toBeGreaterThanOrEqual(startIndex);
+      expect(recordIndex).toBeLessThan(startIndex + recordCount);
+    });
+    expect(batches.reduce((total, { recordCount }) => total + recordCount, 0)).toBe(records.length);
+  }
+
   it('splits by record count when all batches are within the size cap', () => {
     const records = Array.from({ length: 10 }, (_, i) => ({ Id: `rec-${i}`, Name: `Record ${i}` }));
 
-    const csvs = generateSizeCappedBatchCsvs(records, 3);
+    const batches = generateSizeCappedBatchCsvs(records, 3);
 
-    expect(csvs).toHaveLength(4);
+    expect(batches).toHaveLength(4);
+    expect(batches.map(({ startIndex, recordCount }) => [startIndex, recordCount])).toEqual([
+      [0, 3],
+      [3, 3],
+      [6, 3],
+      [9, 1],
+    ]);
     // Every record lands in exactly one batch and each batch repeats the header
-    records.forEach(({ Id }) => {
-      expect(csvs.filter((csv) => csv.includes(Id))).toHaveLength(1);
-    });
-    csvs.forEach((csv) => expect(csv.startsWith('Id')).toBe(true));
+    expectRangesCoverEveryRecordExactlyOnce(batches, records);
+    batches.forEach(({ csv }) => expect(csv.startsWith('Id')).toBe(true));
   });
 
   it('halves batches whose CSV exceeds the character cap', () => {
@@ -25,22 +47,38 @@ describe('generateSizeCappedBatchCsvs', () => {
     const bigValue = 'x'.repeat(2_000_000);
     const records = Array.from({ length: 8 }, (_, i) => ({ Id: `rec-${i}`, Description: bigValue }));
 
-    const csvs = generateSizeCappedBatchCsvs(records, 8);
+    const batches = generateSizeCappedBatchCsvs(records, 8);
 
-    expect(csvs.length).toBeGreaterThan(1);
-    csvs.forEach((csv) => expect(csv.length).toBeLessThanOrEqual(MAX_BATCH_CSV_CHARS));
-    records.forEach(({ Id }) => {
-      expect(csvs.filter((csv) => csv.includes(`${Id},`))).toHaveLength(1);
-    });
+    expect(batches.length).toBeGreaterThan(1);
+    batches.forEach(({ csv }) => expect(csv.length).toBeLessThanOrEqual(MAX_BATCH_CSV_CHARS));
+    expectRangesCoverEveryRecordExactlyOnce(batches, records);
+  });
+
+  it('reports contiguous ranges when a split batch is followed by more count-based batches', () => {
+    // First batch of 4 is oversized and splits into 2+2; the remaining batches must still report
+    // ranges into the original record array so results can be mapped back to records.
+    const bigValue = 'x'.repeat(3_000_000);
+    const records = Array.from({ length: 12 }, (_, i) => ({ Id: `rec-${i}`, Description: i < 4 ? bigValue : 'small' }));
+
+    const batches = generateSizeCappedBatchCsvs(records, 4);
+
+    expect(batches.map(({ startIndex, recordCount }) => [startIndex, recordCount])).toEqual([
+      [0, 2],
+      [2, 2],
+      [4, 4],
+      [8, 4],
+    ]);
+    expectRangesCoverEveryRecordExactlyOnce(batches, records);
   });
 
   it('passes through a single record that alone exceeds the cap', () => {
     const records = [{ Id: 'rec-0', Description: 'x'.repeat(MAX_BATCH_CSV_CHARS + 100) }];
 
-    const csvs = generateSizeCappedBatchCsvs(records, 100);
+    const batches = generateSizeCappedBatchCsvs(records, 100);
 
-    expect(csvs).toHaveLength(1);
-    expect(csvs[0].length).toBeGreaterThan(MAX_BATCH_CSV_CHARS);
+    expect(batches).toHaveLength(1);
+    expect(batches[0]).toEqual(expect.objectContaining({ startIndex: 0, recordCount: 1 }));
+    expect(batches[0].csv.length).toBeGreaterThan(MAX_BATCH_CSV_CHARS);
   });
 });
 

--- a/libs/features/load-records/src/utils/load-records-process.ts
+++ b/libs/features/load-records/src/utils/load-records-process.ts
@@ -79,22 +79,42 @@ export function isFatalBulkApiError(error: unknown): boolean {
   return FATAL_BULK_ERROR_PATTERNS.some((pattern) => pattern.test(message));
 }
 
+/** A single batch CSV along with the range of source records it was built from */
+export interface BatchCsv {
+  csv: string;
+  /** Index of the first record from the source array included in this CSV */
+  startIndex: number;
+  recordCount: number;
+}
+
 /**
  * Generate batch CSVs capped both by record count and by CSV character count. A batch whose CSV
  * exceeds `MAX_BATCH_CSV_CHARS` is recursively halved until it fits; a single record that alone
  * exceeds the cap is passed through as-is (Salesforce rejects it with a per-batch error, same as today).
+ *
+ * Because splitting makes the resulting batch count and per-batch record count unpredictable, each
+ * CSV carries the record range it came from — callers must use that to map results back to records
+ * instead of assuming every batch holds `batchSize` records.
  */
-export function generateSizeCappedBatchCsvs(records: unknown[], batchSize: number): string[] {
-  return splitArrayToMaxSize(records, batchSize).flatMap(csvForBatchRecords);
+export function generateSizeCappedBatchCsvs(records: unknown[], batchSize: number): BatchCsv[] {
+  let startIndex = 0;
+  return splitArrayToMaxSize(records, batchSize).flatMap((batchRecords) => {
+    const batchCsvs = csvForBatchRecords(batchRecords, startIndex);
+    startIndex += batchRecords.length;
+    return batchCsvs;
+  });
 }
 
-function csvForBatchRecords(batchRecords: unknown[]): string[] {
+function csvForBatchRecords(batchRecords: unknown[], startIndex: number): BatchCsv[] {
   const csv = generateCsv(batchRecords, { delimiter: ',' });
   if (csv.length <= MAX_BATCH_CSV_CHARS || batchRecords.length <= 1) {
-    return [csv];
+    return [{ csv, startIndex, recordCount: batchRecords.length }];
   }
   const midpoint = Math.ceil(batchRecords.length / 2);
-  return [...csvForBatchRecords(batchRecords.slice(0, midpoint)), ...csvForBatchRecords(batchRecords.slice(midpoint))];
+  return [
+    ...csvForBatchRecords(batchRecords.slice(0, midpoint), startIndex),
+    ...csvForBatchRecords(batchRecords.slice(midpoint), startIndex + midpoint),
+  ];
 }
 
 /**
@@ -114,7 +134,14 @@ export async function loadBulkApiData(
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const jobId = results.id!;
     let batches: LoadDataBulkApi[] = [];
-    batches = generateSizeCappedBatchCsvs(data, batchSize).map((data, i) => ({ data, batchNumber: i, completed: false, success: false }));
+    batches = generateSizeCappedBatchCsvs(data, batchSize).map(({ csv, startIndex, recordCount }, i) => ({
+      data: csv,
+      batchNumber: i,
+      startIndex,
+      recordCount,
+      completed: false,
+      success: false,
+    }));
 
     let submittedBatchCount = 0;
 
@@ -491,9 +518,11 @@ function getBatchSummary(
     jobInfo: results,
     totalBatches: batches.length,
     submittedBatchCount,
-    batchSummary: batches.map(({ id, batchNumber, completed, success, errorMessage }) => ({
+    batchSummary: batches.map(({ id, batchNumber, startIndex, recordCount, completed, success, errorMessage }) => ({
       id,
       batchNumber,
+      startIndex,
+      recordCount,
       completed,
       success,
       errorMessage,

--- a/libs/types/src/lib/ui/load-records-types.ts
+++ b/libs/types/src/lib/ui/load-records-types.ts
@@ -131,6 +131,14 @@ export interface LoadDataBulkApi {
   id?: string;
   data: any;
   batchNumber: number;
+  /** Index of this batch's first record within the prepared record array */
+  startIndex: number;
+  /**
+   * Number of records in this batch. Batches are capped by record count AND by CSV size, so an
+   * oversized batch is split and this will not always equal the configured batch size — record
+   * boundaries must be read from here rather than derived from `batchNumber * batchSize`.
+   */
+  recordCount: number;
   completed: boolean;
   success: boolean;
   errorMessage?: string;

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "url": "https://github.com/jetstreamapp/jetstream"
   },
   "author": "Jetstream Solutions, LLC",
-  "version": "10.8.0",
+  "version": "10.8.1",
   "license": "SEE LICENSE IN LICENSE.md",
   "engines": {
     "node": ">=24 <25",


### PR DESCRIPTION
Batches are capped by record count AND by CSV size, so an oversized batch is split and no longer holds `batchSize` records. Two consumers still derived a batch's record range from `batchNumber * batchSize`:

- `collectFailedRecordsForRetry` joined each batch's results against the wrong slice, so "retry failed records" re-ran records that had succeeded (duplicates on insert) and silently dropped records that actually failed.
- The per-batch results download joined Salesforce result rows to the wrong records.

`generateSizeCappedBatchCsvs` now returns the record range for each CSV, carried through `LoadDataBulkApi` and the batch summary so both consumers slice by the real boundaries. Loads where no batch exceeds the size cap are unaffected — the ranges match the previous count-based chunks exactly.


Fixes regression from #1875