### PR TITLE
chore: improve hotfix release process by syncing version files with released versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -187,6 +187,18 @@ jobs:
           git config user.email "${USER_ID}+${APP_SLUG}[bot]@users.noreply.github.com"
           git remote set-url origin "https://x-access-token:${APP_TOKEN}@github.com/${REPO}.git"
 
+      # Hotfix branches are cut from the deployed web release, so their extension and
+      # desktop version files lag behind any release tagged from main afterward.
+      # Bumping from those stale files would publish a downgrade, so fast-forward each
+      # one to its highest tag (and commit) before release-it bumps.
+      - name: Sync hotfix versions with released versions
+        if: ${{ startsWith(github.ref_name, 'hotfix/') }}
+        env:
+          RELEASE_WEB: ${{ inputs.release_web }}
+          RELEASE_WEB_EXTENSION: ${{ inputs.release_web_extension }}
+          RELEASE_DESKTOP: ${{ inputs.release_desktop }}
+        run: node scripts/sync-hotfix-versions.mjs
+
       # RELEASE CORE WEB APPLICATION
       # NOTE: Each application has its own tag format - so it is safe to have release-it run multiple times
       - name: Release Web

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,3 +67,21 @@ always as their own pull request:
 
 This keeps every release note — including AI-generated drafts — reviewed and committed exclusively through a
 pull request. The automated release workflow never authors or commits release-note content.
+
+### Hotfixes
+
+`pnpm hotfix` cuts a `hotfix/*` branch from `origin/release` — the commit currently running in production for
+the **web** application. Commit the fix there, then run `pnpm release` from the branch (patch bump, forced) and
+open a PR to merge the branch back into main.
+
+Because the branch is anchored to the deployed _web_ commit, its web extension and desktop version files are
+frequently behind: those applications are tagged from their own commits on main, which land after the web
+release commit. The release workflow therefore runs
+[`scripts/sync-hotfix-versions.mjs`](scripts/sync-hotfix-versions.mjs) first, fast-forwarding each version file
+being released to its highest existing tag so the bump can never publish a downgrade (for example, a branch
+sitting at extension `3.7.1` releases `3.8.1` rather than `3.7.2` when `3.8.0` is already in the store).
+`pnpm release` previews the resulting versions before you confirm.
+
+The merge back into main will still conflict on any version file both sides bumped — the hotfix branched before
+main's bump, so git sees two edits to the same line. **Always keep the hotfix side**: after the sync it is the
+higher version, and it is the one that was actually tagged and published.

--- a/scripts/lib/release-versions.mjs
+++ b/scripts/lib/release-versions.mjs
@@ -1,0 +1,122 @@
+/**
+ * Shared version metadata for the three independently released applications.
+ *
+ * Each application tracks its version in its own file and tags with its own
+ * prefix, so a single commit can carry a release for any combination of them.
+ * Used by `scripts/release.mjs` (preview) and `scripts/sync-hotfix-versions.mjs`
+ * (run by the release workflow on hotfix branches).
+ */
+import { readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { $ } from 'zx';
+
+export const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+
+/** `key` matches the platform values used by `scripts/release.mjs` and the release workflow inputs. */
+export const RELEASE_TARGETS = [
+  {
+    key: 'web',
+    label: 'web',
+    versionFile: 'package.json',
+    tagPattern: 'v[0-9]*',
+    tagPrefix: 'v',
+  },
+  {
+    key: 'extension',
+    label: 'extension',
+    versionFile: 'apps/jetstream-web-extension/src/manifest.json',
+    tagPattern: 'web-ext-v*',
+    tagPrefix: 'web-ext-v',
+  },
+  {
+    key: 'desktop',
+    label: 'desktop',
+    versionFile: 'apps/jetstream-desktop/package.json',
+    tagPattern: 'desktop-v*',
+    tagPrefix: 'desktop-v',
+  },
+];
+
+const STABLE_VERSION_REGEX = /^v?(\d+)\.(\d+)\.(\d+)$/;
+
+/** Parses a stable `X.Y.Z` version into numeric segments. Prereleases return null — they never count as released. */
+export function parseVersion(value) {
+  const match = STABLE_VERSION_REGEX.exec(String(value ?? '').trim());
+  return match ? match.slice(1, 4).map(Number) : null;
+}
+
+/** Comparator for stable version strings. Anything unparseable sorts lowest. */
+export function compareVersions(left, right) {
+  const leftSegments = parseVersion(left) ?? [-1, -1, -1];
+  const rightSegments = parseVersion(right) ?? [-1, -1, -1];
+  for (let i = 0; i < 3; i++) {
+    if (leftSegments[i] !== rightSegments[i]) {
+      return leftSegments[i] < rightSegments[i] ? -1 : 1;
+    }
+  }
+  return 0;
+}
+
+export function bumpVersion(version, bump) {
+  const segments = parseVersion(version);
+  if (!segments) {
+    throw new Error(`Cannot bump version "${version}" — expected a stable X.Y.Z version.`);
+  }
+  const [major, minor, patch] = segments;
+  if (bump === 'major') {
+    return `${major + 1}.0.0`;
+  }
+  if (bump === 'minor') {
+    return `${major}.${minor + 1}.0`;
+  }
+  return `${major}.${minor}.${patch + 1}`;
+}
+
+export async function readVersion(target) {
+  const contents = await readFile(path.join(ROOT, target.versionFile), 'utf8');
+  return JSON.parse(contents).version;
+}
+
+/**
+ * Rewrites only the top-level `version` value, leaving the rest of the file byte
+ * for byte intact so the change never shows up as a reformat in the diff.
+ */
+export async function writeVersion(target, version) {
+  const file = path.join(ROOT, target.versionFile);
+  const contents = await readFile(file, 'utf8');
+  const currentVersion = JSON.parse(contents).version;
+  const versionField = new RegExp(`("version"\\s*:\\s*")${currentVersion.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}(")`);
+  if (!versionField.test(contents)) {
+    throw new Error(`Could not locate the version field in ${target.versionFile}`);
+  }
+  await writeFile(file, contents.replace(versionField, `$1${version}$2`));
+}
+
+/** Highest stable version already tagged for the application, or null if it has never been released. */
+export async function latestReleasedVersion(target) {
+  const { stdout } = await $`git tag --list ${target.tagPattern}`.quiet();
+  const versions = stdout
+    .split('\n')
+    .map((tag) => tag.trim())
+    .filter((tag) => tag.startsWith(target.tagPrefix))
+    .map((tag) => tag.slice(target.tagPrefix.length))
+    .filter((version) => parseVersion(version));
+  return versions.sort(compareVersions).at(-1) ?? null;
+}
+
+/**
+ * The version the next release should bump from — whichever is higher between the
+ * file on this branch and the highest existing tag.
+ *
+ * They diverge on hotfix branches: those are cut from `origin/release`, which tracks
+ * the deployed *web* commit, so any extension or desktop release tagged from main
+ * afterward leaves the corresponding file behind. Bumping the file directly would
+ * publish a downgrade, so the tag wins.
+ */
+export async function resolveBaseVersion(target) {
+  const fileVersion = await readVersion(target);
+  const taggedVersion = await latestReleasedVersion(target);
+  const isStale = !!taggedVersion && compareVersions(taggedVersion, fileVersion) > 0;
+  return { fileVersion, taggedVersion, baseVersion: isStale ? taggedVersion : fileVersion, isStale };
+}

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -8,14 +8,13 @@
  */
 
 import { checkbox, confirm, select } from '@inquirer/prompts';
-import { readdir, readFile } from 'node:fs/promises';
+import { readdir } from 'node:fs/promises';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 import { $, chalk } from 'zx';
+import { bumpVersion, RELEASE_TARGETS, resolveBaseVersion, ROOT } from './lib/release-versions.mjs';
 
 const REPO = 'jetstreamapp/jetstream';
 const WORKFLOW = 'release.yml';
-const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const RELEASE_NOTES_DIR = path.join(ROOT, 'apps/docs/release-notes');
 
 const STATUS_COLORS = {
@@ -32,20 +31,6 @@ const STATUS_COLORS = {
 function colorStatus(value) {
   const fn = STATUS_COLORS[/** @type {keyof typeof STATUS_COLORS} */ (value)] ?? chalk.white;
   return fn(value);
-}
-
-function bumpVersion(version, bump) {
-  const [major, minor, patch] = version
-    .replace(/^v/, '')
-    .split('.')
-    .map((segment) => parseInt(segment, 10) || 0);
-  if (bump === 'major') {
-    return `${major + 1}.0.0`;
-  }
-  if (bump === 'minor') {
-    return `${major}.${minor + 1}.0`;
-  }
-  return `${major}.${minor}.${patch + 1}`;
 }
 
 // Looks for a release-note file (e.g. `2026-06-22-v10.4.0.mdx`) for the given web version.
@@ -145,15 +130,37 @@ const releaseWeb = platforms.includes('web');
 const releaseExtension = platforms.includes('extension');
 const releaseDesktop = platforms.includes('desktop');
 
+// ── Resolve planned versions ───────────────────────────────────────────────
+// Each version is bumped from the higher of the file on this branch and the app's
+// latest tag. They only differ on hotfix branches, where the workflow re-syncs the
+// files first (see scripts/sync-hotfix-versions.mjs) — mirror that here so the
+// preview shows the versions that will actually be released.
+const plannedVersions = new Map();
+for (const target of RELEASE_TARGETS.filter(({ key }) => platforms.includes(key))) {
+  const planned = await resolveBaseVersion(target);
+  plannedVersions.set(target.key, { ...planned, nextVersion: bumpVersion(planned.baseVersion, bump) });
+}
+
+function platformSummary(platform) {
+  const planned = plannedVersions.get(platform);
+  if (!planned) {
+    return chalk.dim('no');
+  }
+  const staleNote = planned.isStale
+    ? chalk.yellow(`  (branch file says ${planned.fileVersion}; ${planned.taggedVersion} already released)`)
+    : '';
+  return `${chalk.green('yes')}  ${chalk.dim(`${planned.baseVersion} →`)} ${chalk.cyan(planned.nextVersion)}${staleNote}`;
+}
+
 // ── Confirm ────────────────────────────────────────────────────────────────
 console.log('');
 console.log(chalk.bold('  Release summary'));
 console.log(chalk.dim('  ─────────────────────────'));
 console.log(`  ${chalk.dim('branch')}    ${chalk.cyan(releaseRef)}${isHotfix ? '  ' + chalk.bgRed.white.bold(' HOTFIX ') : ''}`);
 console.log(`  ${chalk.dim('bump')}      ${chalk.cyan(bump)}`);
-console.log(`  ${chalk.dim('web')}       ${releaseWeb ? chalk.green('yes') : chalk.dim('no')}`);
-console.log(`  ${chalk.dim('extension')} ${releaseExtension ? chalk.green('yes') : chalk.dim('no')}`);
-console.log(`  ${chalk.dim('desktop')}   ${releaseDesktop ? chalk.green('yes') : chalk.dim('no')}`);
+console.log(`  ${chalk.dim('web')}       ${platformSummary('web')}`);
+console.log(`  ${chalk.dim('extension')} ${platformSummary('extension')}`);
+console.log(`  ${chalk.dim('desktop')}   ${platformSummary('desktop')}`);
 console.log('');
 
 // ── Release-note reminder ──────────────────────────────────────────────────
@@ -163,8 +170,7 @@ console.log('');
 // upcoming web version, remind the user but let them proceed and backfill.
 // See CONTRIBUTING.md → Releasing → Release notes.
 if (releaseWeb) {
-  const pkg = JSON.parse(await readFile(path.join(ROOT, 'package.json'), 'utf8'));
-  const nextWebVersion = bumpVersion(pkg.version, bump);
+  const { nextVersion: nextWebVersion } = plannedVersions.get('web');
   if (!(await hasReleaseNoteFor(nextWebVersion))) {
     console.log(chalk.yellow(`  ⚠ No release note found for v${nextWebVersion}.`));
     console.log(chalk.dim(`    Draft one with the Claude Code /release-notes command (or pnpm release-notes:context) —`));

--- a/scripts/sync-hotfix-versions.mjs
+++ b/scripts/sync-hotfix-versions.mjs
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+
+/**
+ * Align a hotfix branch's version files with what has already been released,
+ * before release-it bumps them.
+ *
+ * Hotfix branches are cut from `origin/release`, which tracks the commit running in
+ * production for the *web* application. The web extension and desktop app are tagged
+ * from their own commits on main, so their version files on a hotfix branch are
+ * routinely behind what has already shipped. Bumping from the stale file publishes a
+ * downgrade — e.g. a hotfix branch at extension 3.7.1 releases 3.7.2 while 3.8.0 is
+ * already in the store — so each file is first fast-forwarded to its highest tag.
+ *
+ * Any file that changes is committed so release-it starts from a clean tree.
+ *
+ * Usage: node scripts/sync-hotfix-versions.mjs
+ * Env:   RELEASE_WEB / RELEASE_WEB_EXTENSION / RELEASE_DESKTOP — "true" to include a platform
+ */
+
+import { $, chalk } from 'zx';
+import { RELEASE_TARGETS, resolveBaseVersion, writeVersion } from './lib/release-versions.mjs';
+
+$.verbose = false;
+
+const PLATFORM_ENV_VAR = {
+  web: 'RELEASE_WEB',
+  extension: 'RELEASE_WEB_EXTENSION',
+  desktop: 'RELEASE_DESKTOP',
+};
+
+const selectedTargets = RELEASE_TARGETS.filter((target) => process.env[PLATFORM_ENV_VAR[target.key]] === 'true');
+if (!selectedTargets.length) {
+  console.log('No platforms selected — nothing to sync.');
+  process.exit(0);
+}
+
+const syncedTargets = [];
+for (const target of selectedTargets) {
+  const { fileVersion, taggedVersion, isStale } = await resolveBaseVersion(target);
+  if (!isStale) {
+    console.log(`${target.label}: ${fileVersion} is current`);
+    continue;
+  }
+  await writeVersion(target, taggedVersion);
+  syncedTargets.push({ target, fileVersion, taggedVersion });
+  console.log(chalk.yellow(`${target.label}: ${fileVersion} → ${taggedVersion} (already released as ${target.tagPrefix}${taggedVersion})`));
+}
+
+if (!syncedTargets.length) {
+  console.log(chalk.green('\nAll version files already match the latest release tags.'));
+  process.exit(0);
+}
+
+const summary = syncedTargets
+  .map(({ target, fileVersion, taggedVersion }) => `${target.label} ${fileVersion} → ${taggedVersion}`)
+  .join(', ');
+
+await $`git add ${syncedTargets.map(({ target }) => target.versionFile)}`;
+await $`git commit -m ${`chore: sync hotfix version files with released versions (${summary})`}`;
+
+console.log(chalk.green('\nCommitted version sync — release-it will bump from the released versions.'));


### PR DESCRIPTION
Ensure that version bumps for desktop and web extension are not downgrades