### PR TITLE
fix: correct permission analysis issue detection and severity handling

### DIFF
--- a/apps/docs/docs/analysis/permission-analysis.mdx
+++ b/apps/docs/docs/analysis/permission-analysis.mdx
@@ -23,7 +23,7 @@ sidebar_label: Permission Analysis
 slug: /permission-analysis
 ---
 
-:::caution Pre-release · paid feature
+:::info
 
 Permission Analysis is available on a **paid Jetstream plan** and is currently in **pre-release**. It is fully functional, but the interface and the set of detected issues may change as we continue to refine it. Upgrade from within Jetstream (**Settings &rarr; Billing**) to enable it.
 
@@ -89,10 +89,18 @@ Examples of what is detected:
 
 - **Modify All Records** / **View All Records** on an object — bypasses the sharing model for that object.
 - **High-risk or elevated system permissions** — such as Modify All Data, View All Data, Author Apex, Manage Users, Customize Application, or Export Reports.
-- **Field access with no effect** — field Read or Edit is granted, but the object grants no corresponding access.
+- **Field access not backed by object access in the same container** — field Read or Edit is granted, but that profile or permission set grants no corresponding object access.
 - **Object permission with no field permissions configured** — default field-level security applies.
 - **Permission set with no direct assignments** that is also not part of a permission set group (likely dead configuration).
 - **Tab visible without object read** — a tab is visible but the underlying object grants no Read.
+
+:::note
+
+Salesforce effective access is the **union** of a user's profile and all of their assigned permission sets. Alignment findings compare a field permission against the object permission on the **same** profile or permission set, then suppress the finding when another permission set that reaches the same users already supplies the missing access — either a sibling in the same permission set group, or another permission set assigned to every one of its assignees.
+
+What Jetstream cannot see is the assignees' **profile**, and any permission set outside the selection you exported. So an alignment finding means _"this container alone does not grant it"_ — not _"this field access does nothing"_. If you deliberately grant object access on the profile and field access in a permission set, expect to see these as warnings.
+
+:::
 
 ### Working with the Issues tab
 
@@ -111,7 +119,7 @@ Completed runs are stored in your browser, per org. Use **Export history** on th
 
 :::info
 
-Permission Analysis is processed in your browser and results are cached locally. Very large exports may be truncated to keep the result size manageable; when that happens Jetstream shows a warning so you know some rows may be missing.
+Permission Analysis is processed in your browser and results are cached locally. Very large exports may be truncated to keep the result size manageable; when that happens Jetstream shows a warning so you know some rows may be missing. Errors are always kept ahead of warnings, so truncation never hides an exposure finding — but narrow the permission set or object selection and re-run if you need complete warning coverage.
 
 :::
 

--- a/libs/features/analysis-shared/src/permission-export/__tests__/build-permission-export-findings.spec.ts
+++ b/libs/features/analysis-shared/src/permission-export/__tests__/build-permission-export-findings.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { buildIssueCodeSummary, buildPermissionExportFindings } from '../build-permission-export-findings';
+import { buildIssueCodeSummary, buildPermissionExportFindings, MAX_PERMISSION_EXPORT_FINDINGS } from '../build-permission-export-findings';
 
 describe('buildPermissionExportFindings', () => {
   it('returns empty when there are no permission rows', () => {
@@ -284,10 +284,76 @@ describe('buildPermissionExportFindings — new findings', () => {
         { ParentId: parentId, Name: 'standard-Contact', Visibility: 'DefaultOn' },
         { ParentId: parentId, Name: 'My_VF_Tab', Visibility: 'DefaultOn' },
       ],
+      knownObjectApiNames: ['Account', 'Contact'],
     };
     const findings = buildPermissionExportFindings(objectPermissions, [], context).filter((f) => f.code === 'TAB_VISIBLE_NO_OBJECT_READ');
     expect(findings).toHaveLength(1);
     expect(findings[0].objectApiName).toBe('Account');
+  });
+
+  it('ignores standard tabs that are not backed by an object', () => {
+    const parentId = '0PS1';
+    const context = {
+      permissionSetTabSettings: [
+        { ParentId: parentId, Name: 'standard-home', Visibility: 'DefaultOn' },
+        { ParentId: parentId, Name: 'standard-report', Visibility: 'DefaultOn' },
+        { ParentId: parentId, Name: 'standard-Chatter', Visibility: 'DefaultOn' },
+        { ParentId: parentId, Name: 'standard-File', Visibility: 'DefaultOn' },
+        { ParentId: parentId, Name: 'standard-Account', Visibility: 'DefaultOn' },
+      ],
+      knownObjectApiNames: ['Account', 'Contact'],
+    };
+    const findings = buildPermissionExportFindings([], [], context).filter((f) => f.code === 'TAB_VISIBLE_NO_OBJECT_READ');
+    expect(findings).toHaveLength(1);
+    expect(findings[0].objectApiName).toBe('Account');
+  });
+
+  it('skips the tab pass entirely when the global describe was unavailable', () => {
+    const parentId = '0PS1';
+    const context = {
+      permissionSetTabSettings: [{ ParentId: parentId, Name: 'standard-Account', Visibility: 'DefaultOn' }],
+    };
+    const codes = buildPermissionExportFindings([], [], context).map((f) => f.code);
+    expect(codes).not.toContain('TAB_VISIBLE_NO_OBJECT_READ');
+  });
+
+  it('does not advise deleting managed, standard, or group-backed permission sets', () => {
+    // A real query result carries every selected column on every row, so all three deletability signals
+    // are present here (null where they do not apply).
+    const context = {
+      permissionSets: [
+        { Id: '0PS_MANAGED', Label: 'Packaged', IsOwnedByProfile: false, NamespacePrefix: 'acme', IsCustom: true, Type: 'Regular' },
+        {
+          Id: '0PS_STANDARD',
+          Label: 'Salesforce Provided',
+          IsOwnedByProfile: false,
+          NamespacePrefix: null,
+          IsCustom: false,
+          Type: 'Standard',
+        },
+        { Id: '0PS_GROUP', Label: 'Group Backed', IsOwnedByProfile: false, NamespacePrefix: null, IsCustom: true, Type: 'Group' },
+        { Id: '0PS_SESSION', Label: 'Session', IsOwnedByProfile: false, NamespacePrefix: null, IsCustom: true, Type: 'Session' },
+        { Id: '0PS_CUSTOM', Label: 'Real Orphan', IsOwnedByProfile: false, NamespacePrefix: null, IsCustom: true, Type: 'Regular' },
+      ],
+      permissionSetAssignments: [],
+    };
+    const findings = buildPermissionExportFindings([], [], context).filter((f) => f.code === 'PERMSET_NO_ASSIGNMENTS');
+    expect(findings.map((f) => f.permissionSetId)).toEqual(['0PS_CUSTOM']);
+    expect(String(findings[0].message)).toContain('may be safe to delete');
+  });
+
+  it('drops the deletion advice when the org did not expose the deletability columns', () => {
+    // Older / API-limited orgs where the describe intersection excluded NamespacePrefix / IsCustom / Type.
+    // The permission set really is unassigned, so the finding still surfaces — but without advice we
+    // cannot back up.
+    const context = {
+      permissionSets: [{ Id: '0PS_UNKNOWN', Label: 'Unassigned', IsOwnedByProfile: false }],
+      permissionSetAssignments: [],
+    };
+    const findings = buildPermissionExportFindings([], [], context).filter((f) => f.code === 'PERMSET_NO_ASSIGNMENTS');
+    expect(findings).toHaveLength(1);
+    expect(String(findings[0].message)).not.toContain('may be safe to delete');
+    expect(String(findings[0].message)).toContain('did not expose the columns');
   });
 });
 
@@ -323,6 +389,7 @@ describe('buildPermissionExportFindings — truncation and scope suppression', (
         { ParentId: parentId, Name: 'standard-Contact', Visibility: 'DefaultOn' },
       ],
       objectScope: ['Account'],
+      knownObjectApiNames: ['Account', 'Contact'],
     };
     const findings = buildPermissionExportFindings([], [], context).filter((f) => f.code === 'TAB_VISIBLE_NO_OBJECT_READ');
     // Contact tab is skipped — its ObjectPermissions rows were never fetched, so "no access" cannot be proven.
@@ -337,14 +404,82 @@ describe('buildPermissionExportFindings — truncation and scope suppression', (
   });
 });
 
+describe('buildPermissionExportFindings — effective access across assignments', () => {
+  const objectPermissions = [
+    // 0PS_FIELDS grants no object access; 0PS_OBJECT grants read on Account.
+    { ParentId: '0PS_OBJECT', SobjectType: 'Account', PermissionsRead: true },
+  ];
+  const fieldPermissions = [{ ParentId: '0PS_FIELDS', SobjectType: 'Account', Field: 'Account.Foo__c', PermissionsRead: true }];
+
+  it('suppresses the alignment finding when every assignee gets object access from another permission set', () => {
+    const codes = buildPermissionExportFindings(objectPermissions, fieldPermissions, {
+      permissionSetAssignments: [
+        { PermissionSetId: '0PS_FIELDS', AssigneeId: '005000000000001' },
+        { PermissionSetId: '0PS_OBJECT', AssigneeId: '005000000000001' },
+      ],
+    }).map((finding) => finding.code);
+    expect(codes).not.toContain('FLS_WITHOUT_OLS_ROW');
+  });
+
+  it('still flags when only some assignees get object access elsewhere', () => {
+    const codes = buildPermissionExportFindings(objectPermissions, fieldPermissions, {
+      permissionSetAssignments: [
+        { PermissionSetId: '0PS_FIELDS', AssigneeId: '005000000000001' },
+        { PermissionSetId: '0PS_OBJECT', AssigneeId: '005000000000001' },
+        // This user holds the field permissions but nothing that grants object access.
+        { PermissionSetId: '0PS_FIELDS', AssigneeId: '005000000000002' },
+      ],
+    }).map((finding) => finding.code);
+    expect(codes).toContain('FLS_WITHOUT_OLS_ROW');
+  });
+
+  it('still flags when the permission set has no assignees at all', () => {
+    const codes = buildPermissionExportFindings(objectPermissions, fieldPermissions, {}).map((finding) => finding.code);
+    expect(codes).toContain('FLS_WITHOUT_OLS_ROW');
+  });
+});
+
+describe('buildPermissionExportFindings — truncation keeps exposure findings', () => {
+  it('drops warnings rather than errors when the cap is reached', () => {
+    // Enough warning-only field misalignments to exhaust the warning budget, plus one permission set
+    // granting Modify All Data. Emission order puts the field pass first, so the naive cap would have
+    // dropped the error entirely.
+    const parentId = '0PS_BIG';
+    const objectPermissions = [{ ParentId: parentId, SobjectType: 'Account', PermissionsRead: false }];
+    const fieldPermissions = Array.from({ length: MAX_PERMISSION_EXPORT_FINDINGS + 25 }, (_, index) => ({
+      ParentId: parentId,
+      SobjectType: 'Account',
+      Field: `Account.Field${index}__c`,
+      PermissionsRead: true,
+    }));
+
+    const findings = buildPermissionExportFindings(objectPermissions, fieldPermissions, {
+      permissionSets: [{ Id: '0PS_ADMIN', Label: 'Admin', IsOwnedByProfile: false, PermissionsModifyAllData: true }],
+      permissionSetAssignments: [{ PermissionSetId: '0PS_ADMIN', AssigneeId: '005000000000001' }],
+    });
+
+    expect(findings.filter((finding) => finding.code === 'SYSTEM_PERM_HIGH_RISK')).toHaveLength(1);
+    // Errors sort ahead of warnings so they can never be the rows that get cut.
+    expect(findings[0].severity).toBe('error');
+    expect(findings.some((finding) => finding.code === 'FINDINGS_TRUNCATED')).toBe(true);
+  });
+});
+
 describe('buildIssueCodeSummary', () => {
   it('aggregates counts by code', () => {
     const summary = buildIssueCodeSummary([
-      { code: 'FLS_READ_NO_OBJECT_READ', severity: 'error' },
-      { code: 'FLS_READ_NO_OBJECT_READ', severity: 'error' },
+      { code: 'OBJECT_MODIFY_ALL_RECORDS', severity: 'error' },
+      { code: 'OBJECT_MODIFY_ALL_RECORDS', severity: 'error' },
       { code: 'OLS_READ_NO_FLS_ROWS', severity: 'warning' },
     ]);
-    expect(summary.FLS_READ_NO_OBJECT_READ).toEqual({ count: 2, errors: 2, warnings: 0 });
+    expect(summary.OBJECT_MODIFY_ALL_RECORDS).toEqual({ count: 2, errors: 2, warnings: 0 });
     expect(summary.OLS_READ_NO_FLS_ROWS).toEqual({ count: 1, errors: 0, warnings: 1 });
+  });
+
+  it('trusts the catalog over a stale stored severity', () => {
+    // FLS_READ_NO_OBJECT_READ is a warning in the catalog; a row claiming otherwise must not be counted
+    // as an error, or the stored summary would disagree with the UI's `resolveFindingSeverity`.
+    const summary = buildIssueCodeSummary([{ code: 'FLS_READ_NO_OBJECT_READ', severity: 'error' }]);
+    expect(summary.FLS_READ_NO_OBJECT_READ).toEqual({ count: 1, errors: 0, warnings: 1 });
   });
 });

--- a/libs/features/analysis-shared/src/permission-export/build-permission-export-findings.ts
+++ b/libs/features/analysis-shared/src/permission-export/build-permission-export-findings.ts
@@ -4,12 +4,28 @@ import {
   HIGH_RISK_SYSTEM_PERMISSIONS,
   PERMISSION_EXPORT_FINDING_DEFINITIONS,
   PermissionExportFindingCode,
+  type PermissionExportFindingCodeValue,
+  PermissionExportFindingSeverity,
 } from '@jetstream/shared/constants';
 
-export const MAX_PERMISSION_EXPORT_FINDINGS = 8_000;
+/**
+ * Per-severity cap on emitted issue rows. Bounds the stored (gzipped) job result; the constraint is
+ * browser memory / IndexedDB size, not a Salesforce limit. Errors and warnings are capped independently
+ * so a flood of low-value warnings can never crowd out the exposure findings — see
+ * {@link buildPermissionExportFindings} for the ordering guarantee.
+ */
+export const MAX_PERMISSION_EXPORT_FINDINGS = 50_000;
 
 /** Direct User assignment ids start with `005`; permission set groups / queues do not. */
 const USER_ID_PREFIX = '005';
+
+/**
+ * `PermissionSet.Type` values that are not user-manageable custom permission sets, so
+ * {@link PermissionExportFindingCode.PERMSET_NO_ASSIGNMENTS} ("may be safe to delete") must never fire
+ * for them. `Group` is the permission set backing a permission set group; `Session` is activated per
+ * session rather than assigned; `Profile` is already excluded via `IsOwnedByProfile`.
+ */
+const NON_DELETABLE_PERMISSION_SET_TYPES = new Set(['Group', 'Session', 'Profile']);
 
 export type PermissionExportFindingRecord = Record<string, unknown>;
 
@@ -31,6 +47,14 @@ export interface PermissionExportFindingsContext {
    * must ignore out-of-scope objects to avoid false "no access" calls. Empty/absent = unscoped.
    */
   objectScope?: readonly string[];
+  /**
+   * Every sobject API name in the org (from a global describe). Used to tell a tab that is backed by a
+   * real object from one that is not — `standard-home` / `standard-report` / `standard-Chatter` are tab
+   * names, not objects, and would otherwise each produce a bogus "grants no read access to home" finding.
+   * Absent = the describe was unavailable, in which case the tab-visibility pass is skipped entirely
+   * rather than guessed at.
+   */
+  knownObjectApiNames?: ReadonlySet<string> | readonly string[];
 }
 
 function readTrimmedString(row: Record<string, unknown>, key: string): string {
@@ -119,19 +143,39 @@ function buildGroupContext(context: PermissionExportFindingsContext | undefined)
   return { groupsByMember, membersByGroup, mutingGroupIds, groupMemberIds };
 }
 
-function permissionSetIdsWithDirectUserAssignment(context: PermissionExportFindingsContext | undefined): Set<string> {
-  const assigned = new Set<string>();
+/**
+ * Direct (User) assignment graph. Salesforce effective access is the union across everything assigned to
+ * a user, so this is what lets an alignment finding on one permission set be resolved by another.
+ */
+interface AssignmentContext {
+  /** permissionSetId → assigned User ids. */
+  readonly usersByPermissionSet: Map<string, Set<string>>;
+  /** User id → permissionSetIds assigned to them. */
+  readonly permissionSetsByUser: Map<string, Set<string>>;
+  /** permissionSetIds with at least one direct User assignment. */
+  readonly assignedPermissionSetIds: Set<string>;
+}
+
+function buildAssignmentContext(context: PermissionExportFindingsContext | undefined): AssignmentContext {
+  const usersByPermissionSet = new Map<string, Set<string>>();
+  const permissionSetsByUser = new Map<string, Set<string>>();
+  const assignedPermissionSetIds = new Set<string>();
+
   for (const row of context?.permissionSetAssignments ?? []) {
     if (!row || typeof row !== 'object') {
       continue;
     }
     const permissionSetId = readTrimmedString(row, 'PermissionSetId');
     const assigneeId = readTrimmedString(row, 'AssigneeId');
-    if (permissionSetId && assigneeId.startsWith(USER_ID_PREFIX)) {
-      assigned.add(permissionSetId);
+    if (!permissionSetId || !assigneeId.startsWith(USER_ID_PREFIX)) {
+      continue;
     }
+    assignedPermissionSetIds.add(permissionSetId);
+    addToSetMap(usersByPermissionSet, permissionSetId, assigneeId);
+    addToSetMap(permissionSetsByUser, assigneeId, permissionSetId);
   }
-  return assigned;
+
+  return { usersByPermissionSet, permissionSetsByUser, assignedPermissionSetIds };
 }
 
 function categoryTruncated(context: PermissionExportFindingsContext | undefined, category: string): boolean {
@@ -143,22 +187,21 @@ function categoryTruncated(context: PermissionExportFindingsContext | undefined,
 }
 
 /**
- * Resolves the object API name a PermissionSetTabSetting refers to, or `null` for tabs not backed by a
- * queryable object (Visualforce / web / Lightning page tabs). Standard tabs are `standard-<Object>`;
- * custom-object tabs use the object API name (often `<Name>__c`).
+ * Resolves the object API name a PermissionSetTabSetting refers to, or `null` for tabs not backed by an
+ * object. Standard tabs are `standard-<Object>`; custom-object tabs use the object API name (`<Name>__c`).
+ *
+ * The `standard-` prefix is NOT proof of an object — `standard-home`, `standard-report`,
+ * `standard-Chatter`, `standard-File` and friends are tab names with no sobject behind them. The
+ * candidate is therefore only accepted when it matches a real object from the org's global describe,
+ * and the describe's canonical casing is returned so the `ObjectPermissions.SobjectType` join lines up.
  */
-function tabSettingObjectApiName(tabName: string): string | null {
+function tabSettingObjectApiName(tabName: string, canonicalObjectNamesByLower: ReadonlyMap<string, string>): string | null {
   const name = tabName.trim();
   if (!name) {
     return null;
   }
-  if (name.startsWith('standard-')) {
-    return name.slice('standard-'.length);
-  }
-  if (name.endsWith('__c')) {
-    return name;
-  }
-  return null;
+  const candidate = name.startsWith('standard-') ? name.slice('standard-'.length) : name;
+  return canonicalObjectNamesByLower.get(candidate.toLowerCase()) ?? null;
 }
 
 /**
@@ -175,18 +218,32 @@ export function buildPermissionExportFindings(
   fieldPermissions: Record<string, unknown>[],
   context?: PermissionExportFindingsContext,
 ): PermissionExportFindingRecord[] {
-  const findings: PermissionExportFindingRecord[] = [];
-  let suppressedAfterCap = 0;
+  // Errors and warnings are collected separately and concatenated errors-first. The cap used to drop in
+  // emission order, which meant a warning-heavy org (field permissions are emitted first, and there can
+  // be hundreds of thousands of rows) exhausted the budget before the passes that emit the ONLY two
+  // error codes — an org granting Modify All Data could report zero errors. Exposure findings must
+  // survive truncation; that is the whole point of the report.
+  const errorFindings: PermissionExportFindingRecord[] = [];
+  const warningFindings: PermissionExportFindingRecord[] = [];
+  let suppressedErrors = 0;
+  let suppressedWarnings = 0;
 
   const tryPush = (finding: PermissionExportFindingRecord): void => {
-    if (findings.length < MAX_PERMISSION_EXPORT_FINDINGS) {
-      findings.push(finding);
+    const isError = finding.severity === PermissionExportFindingSeverity.Error;
+    const bucket = isError ? errorFindings : warningFindings;
+    if (bucket.length < MAX_PERMISSION_EXPORT_FINDINGS) {
+      bucket.push(finding);
       return;
     }
-    suppressedAfterCap += 1;
+    if (isError) {
+      suppressedErrors += 1;
+    } else {
+      suppressedWarnings += 1;
+    }
   };
 
   const group = buildGroupContext(context);
+  const assignment = buildAssignmentContext(context);
 
   const objectRowByKey = new Map<string, Record<string, unknown>>();
   for (const row of objectPermissions) {
@@ -236,21 +293,93 @@ export function buildPermissionExportFindings(
   };
 
   /**
-   * Emits an FLS/OLS-alignment finding unless a group sibling already supplies the access. When the
-   * group also contains muting permission sets we cannot be sure, so we emit a softened finding instead
-   * of suppressing it (fail safe — show it, annotated).
+   * Whether EVERY user assigned this permission set also holds another permission set that supplies the
+   * object access. Salesforce effective access is the union across a user's assignments, so in that case
+   * the field access does resolve for every affected user and the finding is a false positive.
+   *
+   * Deliberately all-or-nothing: if even one assignee lacks the access elsewhere, the misalignment is
+   * real for that user and the finding stands. A permission set with no assignees returns false —
+   * nothing is proven (and `PERMSET_NO_ASSIGNMENTS` already covers that case).
    */
-  const pushGroupAwareFlsFinding = (
+  const everyAssigneeCoveredElsewhere = (parentId: string, sobjectType: string, mode: 'read' | 'edit'): boolean => {
+    const assignees = assignment.usersByPermissionSet.get(parentId);
+    if (!assignees || assignees.size === 0) {
+      return false;
+    }
+    for (const userId of assignees) {
+      let covered = false;
+      for (const otherPermissionSetId of assignment.permissionSetsByUser.get(userId) ?? []) {
+        if (otherPermissionSetId === parentId) {
+          continue;
+        }
+        const row = objectRowByKey.get(objectPermissionKey(otherPermissionSetId, sobjectType));
+        if (row && (mode === 'read' ? objectGrantsEffectiveRead(row) : objectGrantsEffectiveEdit(row))) {
+          covered = true;
+          break;
+        }
+      }
+      if (!covered) {
+        return false;
+      }
+    }
+    return true;
+  };
+
+  type AlignmentCoverage =
+    /** No other container we can see supplies the access — the finding stands. */
+    | 'not-covered'
+    /** A group sibling or every assignee's other permission sets supply it — suppress. */
+    | 'covered'
+    /** A group sibling supplies it, but muting sets mean effective access is unproven — soften. */
+    | 'group-covered-but-muted';
+
+  /**
+   * Coverage depends only on (permission set, object, mode) — never on the field — but the alignment
+   * passes ask once per misaligned FIELD row. Without this memo the assignee scan is
+   * O(findings × assignees × their permission sets), which on a wide object with a broadly assigned
+   * permission set means re-walking the whole assignment graph for every column. Cached entries are
+   * bounded by the (parent, object) pairs that actually produce findings.
+   */
+  const alignmentCoverageCache = new Map<string, AlignmentCoverage>();
+
+  const resolveAlignmentCoverage = (parentId: string, sobjectType: string, mode: 'read' | 'edit'): AlignmentCoverage => {
+    const cacheKey = `${parentId}::${sobjectType}::${mode}`;
+    const cached = alignmentCoverageCache.get(cacheKey);
+    if (cached !== undefined) {
+      return cached;
+    }
+    let coverage: AlignmentCoverage;
+    if (siblingSuppliesAccess(parentId, sobjectType, mode)) {
+      coverage = parentInGroupWithMuting(parentId) ? 'group-covered-but-muted' : 'covered';
+    } else {
+      coverage = everyAssigneeCoveredElsewhere(parentId, sobjectType, mode) ? 'covered' : 'not-covered';
+    }
+    alignmentCoverageCache.set(cacheKey, coverage);
+    return coverage;
+  };
+
+  /**
+   * Emits an FLS/OLS-alignment finding unless another container that reaches the same users already
+   * supplies the object access — a permission set group sibling, or another permission set assigned to
+   * every one of this one's assignees. When the group also contains muting permission sets we cannot be
+   * sure, so we emit a softened finding instead of suppressing it (fail safe — show it, annotated).
+   *
+   * Note the remaining blind spot, which is why the messages say "this permission set" rather than
+   * "no effect": the assignees' PROFILE is not visible here (it needs `User.ProfileId`, which the export
+   * does not query), and permission sets outside the exported selection are not visible either.
+   */
+  const pushAlignmentFinding = (
     base: PermissionExportFindingRecord,
     parentId: string,
     sobjectType: string,
     mode: 'read' | 'edit',
   ): void => {
+    const coverage = resolveAlignmentCoverage(parentId, sobjectType, mode);
+    if (coverage === 'covered') {
+      return;
+    }
     const groupId = firstGroupId(parentId);
-    if (siblingSuppliesAccess(parentId, sobjectType, mode)) {
-      if (!parentInGroupWithMuting(parentId)) {
-        return; // satisfied by the group — not a real issue
-      }
+    if (coverage === 'group-covered-but-muted') {
       tryPush({
         ...base,
         ...(groupId ? { partOfGroupId: groupId } : {}),
@@ -298,11 +427,11 @@ export function buildPermissionExportFindings(
     const parentId = key.slice(0, separatorIdx);
     const sobjectType = key.slice(separatorIdx + 2);
     const def = PERMISSION_EXPORT_FINDING_DEFINITIONS[PermissionExportFindingCode.FLS_WITHOUT_OLS_ROW];
-    pushGroupAwareFlsFinding(
+    pushAlignmentFinding(
       {
         severity: def.severity,
         code: PermissionExportFindingCode.FLS_WITHOUT_OLS_ROW,
-        message: `Field permissions exist for ${sobjectType}, but there is no ObjectPermissions row for the same permission set and object.`,
+        message: `Field permissions exist for ${sobjectType}, but this permission set has no object permissions row for it — object access must come from the user's profile or another permission set.`,
         objectApiName: sobjectType,
         parentId,
         permissionSetId: parentId,
@@ -333,11 +462,11 @@ export function buildPermissionExportFindings(
 
     if (editMisaligned) {
       const def = PERMISSION_EXPORT_FINDING_DEFINITIONS[PermissionExportFindingCode.FLS_EDIT_NO_OBJECT_EDIT];
-      pushGroupAwareFlsFinding(
+      pushAlignmentFinding(
         {
           severity: def.severity,
           code: PermissionExportFindingCode.FLS_EDIT_NO_OBJECT_EDIT,
-          message: `Field ${field} on ${sobjectType} has Edit at field level, but the object permission does not grant Edit or Modify All Records.`,
+          message: `Field ${field} on ${sobjectType} has Edit at field level, but this permission set's object permission does not grant Edit or Modify All Records — object access must come from the user's profile or another permission set.`,
           objectApiName: sobjectType,
           fieldApiName: field,
           parentId,
@@ -353,11 +482,11 @@ export function buildPermissionExportFindings(
     // double-counting one misconfiguration as two findings.
     if (readMisaligned && !editMisaligned) {
       const def = PERMISSION_EXPORT_FINDING_DEFINITIONS[PermissionExportFindingCode.FLS_READ_NO_OBJECT_READ];
-      pushGroupAwareFlsFinding(
+      pushAlignmentFinding(
         {
           severity: def.severity,
           code: PermissionExportFindingCode.FLS_READ_NO_OBJECT_READ,
-          message: `Field ${field} on ${sobjectType} has Read at field level, but the object permission does not grant Read, View All Records, or Modify All Records.`,
+          message: `Field ${field} on ${sobjectType} has Read at field level, but this permission set's object permission does not grant Read, View All Records, or Modify All Records — object access must come from the user's profile or another permission set.`,
           objectApiName: sobjectType,
           fieldApiName: field,
           parentId,
@@ -440,7 +569,6 @@ export function buildPermissionExportFindings(
 
   // High-risk system permissions + orphaned permission sets (require the permission set rows).
   const permissionSets = context?.permissionSets ?? [];
-  const assignedSet = permissionSetIdsWithDirectUserAssignment(context);
   const assignmentsTruncated = categoryTruncated(context, 'permissionSetAssignments');
   for (const psRow of permissionSets) {
     if (!psRow || typeof psRow !== 'object') {
@@ -471,14 +599,36 @@ export function buildPermissionExportFindings(
       });
     }
 
-    // Orphaned permission set: not profile-owned, no direct user assignment, and not a member of any group
-    // (a group member may be assigned via its group). Skip when assignment data was truncated.
-    if (!isProfile && !assignmentsTruncated && !assignedSet.has(id) && !group.groupMemberIds.has(id)) {
+    // Orphaned permission set: no direct user assignment and not a member of any group (a group member
+    // may be assigned via its group). Skip when assignment data was truncated.
+    //
+    // Managed-package (`NamespacePrefix`), Salesforce-standard (`IsCustom = false`), and
+    // group/session-backing permission sets are excluded — several cannot be deleted at all, so calling
+    // them "safe to delete" would be wrong advice. Those columns go through the org describe intersection
+    // and could in principle be absent; Salesforce omits unselected fields from the row entirely, so an
+    // `in` check tells us whether we can actually classify deletability. When we cannot, the finding is
+    // still worth surfacing (the set really is unassigned) but the deletion advice is dropped rather than
+    // guessed — same fail-safe posture as the muting-permission-set softening above.
+    const canClassifyDeletability = 'NamespacePrefix' in psRow && 'IsCustom' in psRow && 'Type' in psRow;
+    const isKnownNonDeletable =
+      canClassifyDeletability &&
+      (!!readTrimmedString(psRow, 'NamespacePrefix') ||
+        psRow.IsCustom === false ||
+        NON_DELETABLE_PERMISSION_SET_TYPES.has(readTrimmedString(psRow, 'Type')));
+    if (
+      !isProfile &&
+      !isKnownNonDeletable &&
+      !assignmentsTruncated &&
+      !assignment.assignedPermissionSetIds.has(id) &&
+      !group.groupMemberIds.has(id)
+    ) {
       const def = PERMISSION_EXPORT_FINDING_DEFINITIONS[PermissionExportFindingCode.PERMSET_NO_ASSIGNMENTS];
       tryPush({
         severity: def.severity,
         code: PermissionExportFindingCode.PERMSET_NO_ASSIGNMENTS,
-        message: `Permission set "${label}" has no direct user assignments and is not part of a permission set group — it may be safe to delete.`,
+        message: canClassifyDeletability
+          ? `Permission set "${label}" has no direct user assignments and is not part of a permission set group — it may be safe to delete.`
+          : `Permission set "${label}" has no direct user assignments and is not part of a permission set group. This org did not expose the columns needed to confirm it is a deletable custom permission set, so verify it is not managed or Salesforce-provided before removing it.`,
         parentId: id,
         permissionSetId: id,
         containerId: id,
@@ -488,9 +638,17 @@ export function buildPermissionExportFindings(
 
   // Tab visible without object read. Tab settings are always fetched for ALL tabs, but ObjectPermissions
   // rows are only fetched for in-scope objects — so out-of-scope tabs cannot be evaluated. Skip the whole
-  // pass when ObjectPermissions was truncated (a missing row no longer proves "no access").
+  // pass when ObjectPermissions was truncated (a missing row no longer proves "no access"), or when the
+  // global describe is unavailable (without it a tab name cannot be told apart from an object name).
+  const canonicalObjectNamesByLower = new Map<string, string>();
+  for (const objectApiName of context?.knownObjectApiNames ?? []) {
+    if (typeof objectApiName === 'string' && objectApiName.length > 0) {
+      canonicalObjectNamesByLower.set(objectApiName.toLowerCase(), objectApiName);
+    }
+  }
+  const canEvaluateTabs = !objectPermissionsTruncated && canonicalObjectNamesByLower.size > 0;
   const scopedObjectNames = new Set((context?.objectScope ?? []).map((objectApiName) => objectApiName.toLowerCase()));
-  for (const tabRow of objectPermissionsTruncated ? [] : (context?.permissionSetTabSettings ?? [])) {
+  for (const tabRow of canEvaluateTabs ? (context?.permissionSetTabSettings ?? []) : []) {
     if (!tabRow || typeof tabRow !== 'object') {
       continue;
     }
@@ -500,9 +658,9 @@ export function buildPermissionExportFindings(
     if (!parentId || !tabName || visibility === '' || visibility === 'None' || visibility === 'Hidden') {
       continue;
     }
-    const objectApiName = tabSettingObjectApiName(tabName);
+    const objectApiName = tabSettingObjectApiName(tabName, canonicalObjectNamesByLower);
     if (!objectApiName) {
-      continue; // VF / web / Lightning page tab — no queryable object to check
+      continue; // home / reports / Chatter / VF / web / Lightning page tab — no object behind it
     }
     if (scopedObjectNames.size > 0 && !scopedObjectNames.has(objectApiName.toLowerCase())) {
       continue; // out-of-scope object — its ObjectPermissions rows were never fetched
@@ -523,12 +681,19 @@ export function buildPermissionExportFindings(
     });
   }
 
+  // Errors first — both so truncation drops warnings rather than exposure findings, and so the default
+  // order of the Issues grid leads with what matters. The UI re-sorts on top of this.
+  const findings = [...errorFindings, ...warningFindings];
+
+  const suppressedAfterCap = suppressedErrors + suppressedWarnings;
   if (suppressedAfterCap > 0) {
     const truncatedDef = PERMISSION_EXPORT_FINDING_DEFINITIONS[PermissionExportFindingCode.FINDINGS_TRUNCATED];
+    const errorCoverage =
+      suppressedErrors === 0 ? 'Every error was included' : `${suppressedErrors.toLocaleString()} of the omitted issues are errors`;
     findings.push({
       severity: truncatedDef.severity,
       code: PermissionExportFindingCode.FINDINGS_TRUNCATED,
-      message: `${suppressedAfterCap.toLocaleString()} additional issues were not included so the job result stays under ${MAX_PERMISSION_EXPORT_FINDINGS.toLocaleString()} rows. Narrow the permission set selection and re-run if you need full coverage.`,
+      message: `${suppressedAfterCap.toLocaleString()} additional issues were not included so the job result stays under ${MAX_PERMISSION_EXPORT_FINDINGS.toLocaleString()} rows per severity. ${errorCoverage}. Narrow the permission set or object selection and re-run if you need full coverage.`,
       objectApiName: undefined,
       fieldApiName: undefined,
       parentId: undefined,
@@ -559,10 +724,15 @@ export function buildIssueCodeSummary(findings: PermissionExportFindingRecord[])
     }
     const existing = summary[code] ?? { count: 0, errors: 0, warnings: 0 };
     existing.count += 1;
-    const severity = String(row.severity ?? '').toLowerCase();
-    if (severity === 'error' || severity === 'errors') {
+    // Catalog-first, matching the UI's `resolveFindingSeverity`, so the stored summary and the rendered
+    // rollups can never disagree about the same row.
+    const definition = PERMISSION_EXPORT_FINDING_DEFINITIONS[code as PermissionExportFindingCodeValue] as
+      | (typeof PERMISSION_EXPORT_FINDING_DEFINITIONS)[PermissionExportFindingCodeValue]
+      | undefined;
+    const severity = definition?.severity ?? String(row.severity ?? '').toLowerCase();
+    if (severity === PermissionExportFindingSeverity.Error) {
       existing.errors += 1;
-    } else if (severity === 'warning' || severity === 'warnings') {
+    } else if (severity === PermissionExportFindingSeverity.Warning) {
       existing.warnings += 1;
     }
     summary[code] = existing;

--- a/libs/features/analysis-shared/src/permission-export/run-permission-export.ts
+++ b/libs/features/analysis-shared/src/permission-export/run-permission-export.ts
@@ -1,6 +1,6 @@
 import { logger } from '@jetstream/shared/client-logger';
 import { HIGH_RISK_SYSTEM_PERMISSIONS } from '@jetstream/shared/constants';
-import { describeSObject, queryWithRecordBudget } from '@jetstream/shared/data';
+import { describeGlobal, describeSObject, queryWithRecordBudget } from '@jetstream/shared/data';
 import { sanitizeSobjectApiNames, splitArrayToMaxSize, uniqueSalesforceIds } from '@jetstream/shared/utils';
 import type { PermissionExportFullResult, SalesforceOrgUi } from '@jetstream/types';
 import { buildIssueCodeSummary, buildPermissionExportFindings } from './build-permission-export-findings';
@@ -13,6 +13,7 @@ import {
   buildPermissionSetGroupByIdSoql,
   buildPermissionSetGroupComponentsByPermissionSetSoql,
   buildTabSettingsByParentSoql,
+  OPTIONAL_PERMISSION_SET_METADATA_FIELDS,
 } from './soql-templates';
 
 const PARENT_ID_CHUNK_SIZE = 200;
@@ -23,18 +24,24 @@ const OBJECT_SOBJECT_TYPE_IN_CHUNK_SIZE = 80;
 /**
  * Per-category row caps. Each category has its own independent budget so that one heavy category
  * (e.g. FieldPermissions on a large org) cannot silently starve later categories (Tab settings,
- * Assignments, Groups, MutingPermissionSets) of their budget. Caps sum to ~200K worst case but in
- * practice categories like Groups and TabSettings rarely use more than a few thousand rows.
+ * Assignments, Groups, MutingPermissionSets) of their budget.
+ *
+ * The binding constraint is browser memory (every row is retained and then gzipped into the stored job
+ * result), NOT a Salesforce limit — `queryMore` paging is unmetered beyond normal API call counts. The
+ * caps matter for accuracy, not just size: hitting one marks the category truncated, which DISABLES
+ * whole finding classes (see `truncatedCategories` in `buildPermissionExportFindings`), because a
+ * missing row is then indistinguishable from a row that was cut. So they are set as high as memory
+ * reasonably allows — rows are narrow (3-10 mostly-boolean columns).
  */
 const CATEGORY_BUDGETS = {
-  permissionSets: 10_000,
-  objectPermissions: 50_000,
-  fieldPermissions: 100_000,
-  permissionSetTabSettings: 10_000,
-  permissionSetAssignments: 100_000,
-  permissionSetGroupComponents: 10_000,
-  permissionSetGroups: 10_000,
-  mutingPermissionSets: 10_000,
+  permissionSets: 25_000,
+  objectPermissions: 150_000,
+  fieldPermissions: 250_000,
+  permissionSetTabSettings: 50_000,
+  permissionSetAssignments: 250_000,
+  permissionSetGroupComponents: 50_000,
+  permissionSetGroups: 25_000,
+  mutingPermissionSets: 25_000,
 } as const;
 
 type ExportCategory = keyof typeof CATEGORY_BUDGETS;
@@ -111,21 +118,45 @@ function throwIfCanceled(isCanceled: (() => boolean) | undefined): void {
   }
 }
 
+interface AvailablePermissionSetFields {
+  systemPermissionFields: string[];
+  metadataFields: string[];
+}
+
 /**
- * Many `PermissionSet.Permissions*` columns only exist when the org's edition/licenses/features enable
+ * Many `PermissionSet` columns only exist when the org's edition/licenses/features/API version enable
  * them — selecting a missing one fails the entire query with INVALID_FIELD. Intersect the high-risk
- * catalog with the org's actual PermissionSet fields so the export works in every org. If the describe
- * itself fails we fall back to the full catalog (the query will surface any real error).
+ * catalog and the optional metadata columns with the org's actual PermissionSet fields so the export
+ * works in every org. If the describe itself fails we fall back to the full catalog (the query will
+ * surface any real error).
  */
-async function getAvailableSystemPermissionFields(org: SalesforceOrgUi): Promise<string[]> {
+async function getAvailablePermissionSetFields(org: SalesforceOrgUi): Promise<AvailablePermissionSetFields> {
   const catalogFields = HIGH_RISK_SYSTEM_PERMISSIONS.map((perm) => perm.field);
   try {
     const describeResponse = await describeSObject(org, 'PermissionSet');
     const orgFieldNames = new Set(describeResponse.data.fields.map((field) => field.name));
-    return catalogFields.filter((field) => orgFieldNames.has(field));
+    return {
+      systemPermissionFields: catalogFields.filter((field) => orgFieldNames.has(field)),
+      metadataFields: OPTIONAL_PERMISSION_SET_METADATA_FIELDS.filter((field) => orgFieldNames.has(field)),
+    };
   } catch (ex) {
     logger.warn('[PERMISSION EXPORT] PermissionSet describe failed; selecting the full system permission catalog', ex);
-    return catalogFields;
+    return { systemPermissionFields: catalogFields, metadataFields: [...OPTIONAL_PERMISSION_SET_METADATA_FIELDS] };
+  }
+}
+
+/**
+ * Every sobject API name in the org, used to tell tabs backed by a real object from tabs that are not
+ * (`standard-home`, `standard-report`, …). Returns an empty set when the describe fails, which makes
+ * `buildPermissionExportFindings` skip the tab-visibility pass instead of guessing.
+ */
+async function getKnownObjectApiNames(org: SalesforceOrgUi): Promise<Set<string>> {
+  try {
+    const describeResponse = await describeGlobal(org);
+    return new Set(describeResponse.data.sobjects.map(({ name }) => name).filter((name): name is string => !!name));
+  } catch (ex) {
+    logger.warn('[PERMISSION EXPORT] Global describe failed; skipping tab visibility findings', ex);
+    return new Set();
   }
 }
 
@@ -200,11 +231,15 @@ export async function runPermissionExport(
   emitProgress(`Loading ${parentIds.length} permission set(s)`);
 
   throwIfCanceled(options?.isCanceled);
-  const systemPermissionFields = await getAvailableSystemPermissionFields(org);
+  // Both describes are cached and independent of each other, so run them together.
+  const [{ systemPermissionFields, metadataFields }, knownObjectApiNames] = await Promise.all([
+    getAvailablePermissionSetFields(org),
+    getKnownObjectApiNames(org),
+  ]);
   throwIfCanceled(options?.isCanceled);
   const permSetResult = await queryWithRecordBudget<Record<string, unknown>>(
     org,
-    buildPermissionSetByIdSoql(parentIds, systemPermissionFields),
+    buildPermissionSetByIdSoql(parentIds, systemPermissionFields, metadataFields),
     false,
     budgets.permissionSets,
     (page) => {
@@ -404,6 +439,7 @@ export async function runPermissionExport(
     permissionSetTabSettings,
     truncatedCategories,
     objectScope,
+    knownObjectApiNames,
   });
   const issueCodeSummary = buildIssueCodeSummary(findings);
 

--- a/libs/features/analysis-shared/src/permission-export/soql-templates.ts
+++ b/libs/features/analysis-shared/src/permission-export/soql-templates.ts
@@ -16,12 +16,26 @@ function whereSobjectTypeIn(objectTypes?: string[]): WhereClause | undefined {
 }
 
 /**
+ * Optional `PermissionSet` columns that identify a permission set as NOT an admin-deletable custom one
+ * (managed package, Salesforce-standard, or the set backing a group / session activation). Read by
+ * `buildPermissionExportFindings` to keep `PERMSET_NO_ASSIGNMENTS` from advising deletion of something
+ * that cannot be deleted. Optional because availability varies by API version, so they go through the
+ * same describe intersection as the system permission columns.
+ */
+export const OPTIONAL_PERMISSION_SET_METADATA_FIELDS: readonly string[] = ['NamespacePrefix', 'IsCustom', 'Type'];
+
+/**
  * @param systemPermissionFields `PermissionSet.Permissions*` columns to SELECT. Defaults to the full
  *   {@link HIGH_RISK_SYSTEM_PERMISSIONS} catalog; callers should pass the subset that actually exists in
  *   the target org (many `Permissions*` columns are edition/license/feature dependent and selecting a
  *   missing one fails the whole query with INVALID_FIELD).
+ * @param metadataFields Subset of {@link OPTIONAL_PERMISSION_SET_METADATA_FIELDS} present in the org.
  */
-export function buildPermissionSetByIdSoql(ids: string[], systemPermissionFields?: readonly string[]): string {
+export function buildPermissionSetByIdSoql(
+  ids: string[],
+  systemPermissionFields?: readonly string[],
+  metadataFields: readonly string[] = OPTIONAL_PERMISSION_SET_METADATA_FIELDS,
+): string {
   const permissionFields = systemPermissionFields ?? HIGH_RISK_SYSTEM_PERMISSIONS.map((perm) => perm.field);
   return composeQuery({
     fields: [
@@ -36,6 +50,8 @@ export function buildPermissionSetByIdSoql(ids: string[], systemPermissionFields
       getField('LastModifiedDate'),
       getField('CreatedBy.Name'),
       getField('LastModifiedBy.Name'),
+      // Identify non-deletable permission sets (managed / standard / group / session backed).
+      ...metadataFields.map((field) => getField(field)),
       // High-risk system permissions, surfaced as findings (Modify All Data, View All Data, etc.).
       ...permissionFields.map((field) => getField(field)),
     ],

--- a/libs/features/permission-analysis/src/PermissionAnalysisIssuesTab.tsx
+++ b/libs/features/permission-analysis/src/PermissionAnalysisIssuesTab.tsx
@@ -32,6 +32,7 @@ import {
   formatObjectLabelForModalSummary,
   getFindingCodeDisplayParts,
   getFindingContainerId,
+  resolveFindingSeverity,
   type PermissionAnalysisFinding,
   type PermissionFindingCodeRollup,
   type PermissionFindingObjectRollup,
@@ -52,10 +53,6 @@ export interface PermissionAnalysisIssuesTabProps {
   sobjectExportDetails?: Record<string, SobjectExportDetail>;
 }
 
-function normalizeSeverity(value: string | undefined): string {
-  return (value ?? '').toLowerCase();
-}
-
 function groupIssueFindingsByColumnKey(
   rows: readonly PermissionAnalysisFinding[],
   columnKey: keyof PermissionAnalysisFinding,
@@ -65,8 +62,7 @@ function groupIssueFindingsByColumnKey(
     let key: string;
     switch (columnKey) {
       case 'severity': {
-        const normalized = normalizeSeverity(row.severity as string | undefined);
-        key = normalized.length > 0 ? normalized : '(none)';
+        key = resolveFindingSeverity(row) ?? '(none)';
         break;
       }
       case 'objectApiName': {
@@ -523,7 +519,7 @@ function sortFindings(rows: PermissionAnalysisFinding[], groupBy: IssuesGroupBy)
   const getter = (row: PermissionAnalysisFinding): string => {
     switch (groupBy) {
       case 'severity':
-        return normalizeSeverity(row.severity as string | undefined);
+        return resolveFindingSeverity(row) ?? '';
       case 'object':
         return String(row.objectApiName ?? '');
       case 'code':
@@ -551,14 +547,8 @@ type StandardFindingColumnKey =
 function mapStandardFindingColumn(key: StandardFindingColumnKey): ColumnWithFilter<RowWithKey> {
   const fieldType = key.endsWith('Id') ? 'salesforceId' : 'text';
   const base = setColumnFromType(key, fieldType);
-  const severityCellClass = (row: RowWithKey) => {
-    const finding = row as PermissionAnalysisFinding;
-    const severityValue = finding.severity as string | undefined;
-    if (isWarningSeverity(severityValue) && !isErrorSeverity(severityValue)) {
-      return 'permission-finding-severity-cell--warning';
-    }
-    return undefined;
-  };
+  const severityCellClass = (row: RowWithKey) =>
+    isWarningSeverity(row as PermissionAnalysisFinding) ? 'permission-finding-severity-cell--warning' : undefined;
   const renderCell =
     key === 'message'
       ? ({ row }: RenderCellProps<RowWithKey, unknown>) => (
@@ -670,11 +660,7 @@ const IssuesFindingTreeDataGrid: FunctionComponent<IssuesFindingTreeDataGridProp
       onExpandedGroupIdsChange={(nextExpanded) => setExpandedGroupIds(nextExpanded)}
       onSortedAndFilteredRowsChange={onSortedAndFilteredRowsChange}
       rowClass={(row) => {
-        const severityValue = (row as PermissionAnalysisFinding).severity as string | undefined;
-        if (isErrorSeverity(severityValue)) {
-          return 'permission-finding-row--error';
-        }
-        return undefined;
+        return isErrorSeverity(row as PermissionAnalysisFinding) ? 'permission-finding-row--error' : undefined;
       }}
     />
   );
@@ -1152,11 +1138,7 @@ export const PermissionAnalysisIssuesTab: FunctionComponent<PermissionAnalysisIs
                   context={{ defaultApiVersion }}
                   onSortedAndFilteredRowsChange={handleSortedAndFilteredRowsChange}
                   rowClass={(row) => {
-                    const severityValue = (row as PermissionAnalysisFinding).severity as string | undefined;
-                    if (isErrorSeverity(severityValue)) {
-                      return 'permission-finding-row--error';
-                    }
-                    return undefined;
+                    return isErrorSeverity(row as PermissionAnalysisFinding) ? 'permission-finding-row--error' : undefined;
                   }}
                 />
               ) : (

--- a/libs/features/permission-analysis/src/__tests__/aggregate-permission-findings.spec.ts
+++ b/libs/features/permission-analysis/src/__tests__/aggregate-permission-findings.spec.ts
@@ -9,15 +9,32 @@ describe('aggregatePermissionAnalysisFindings', () => {
 
   it('groups by code and object and excludes FINDINGS_TRUNCATED', () => {
     const rows: PermissionAnalysisFinding[] = [
-      { severity: 'error', code: 'FLS_READ_NO_OBJECT_READ', objectApiName: 'Account', message: 'a' },
-      { severity: 'error', code: 'FLS_READ_NO_OBJECT_READ', objectApiName: 'Contact', message: 'b' },
+      { severity: 'error', code: 'OBJECT_MODIFY_ALL_RECORDS', objectApiName: 'Account', message: 'a' },
+      { severity: 'error', code: 'OBJECT_MODIFY_ALL_RECORDS', objectApiName: 'Contact', message: 'b' },
       { severity: 'warning', code: 'OLS_READ_NO_FLS_ROWS', objectApiName: 'Account', message: 'c' },
       { severity: 'warning', code: PermissionExportFindingCode.FINDINGS_TRUNCATED, message: 'cap' },
     ];
     const agg = aggregatePermissionAnalysisFindings(rows);
-    expect(agg.byCode.map((r) => r.code)).toEqual(['FLS_READ_NO_OBJECT_READ', 'OLS_READ_NO_FLS_ROWS']);
+    expect(agg.byCode.map((r) => r.code)).toEqual(['OBJECT_MODIFY_ALL_RECORDS', 'OLS_READ_NO_FLS_ROWS']);
     expect(agg.byCode[0].count).toBe(2);
     expect(agg.byCode[0].errorCount).toBe(2);
     expect(agg.byObject.find((o) => o.objectApiName === 'Account')?.count).toBe(2);
+  });
+
+  it('counts by the catalog severity, not a stale stored one', () => {
+    // The rollup tiles and the grid highlights must never disagree: both resolve severity from the
+    // catalog, so a row whose stored severity contradicts its code is counted as the catalog says.
+    const rows: PermissionAnalysisFinding[] = [
+      { severity: 'error', code: 'FLS_READ_NO_OBJECT_READ', objectApiName: 'Account', message: 'a' },
+    ];
+    const agg = aggregatePermissionAnalysisFindings(rows);
+    expect(agg.byCode[0].errorCount).toBe(0);
+    expect(agg.byCode[0].warningCount).toBe(1);
+  });
+
+  it('falls back to the stored severity for a code the catalog no longer knows', () => {
+    const rows: PermissionAnalysisFinding[] = [{ severity: 'error', code: 'RETIRED_LEGACY_CODE', objectApiName: 'Account', message: 'a' }];
+    const agg = aggregatePermissionAnalysisFindings(rows);
+    expect(agg.byCode[0].errorCount).toBe(1);
   });
 });

--- a/libs/features/permission-analysis/src/permission-analysis-issues-filters.ts
+++ b/libs/features/permission-analysis/src/permission-analysis-issues-filters.ts
@@ -5,6 +5,7 @@ import {
   type PermissionExportRow,
   getFindingContainerId,
   getPermissionSetIdsWithDirectUserAssignment,
+  resolveFindingSeverity,
 } from './permission-export-result-view';
 
 export type IssuesSeverityFilter = 'all' | 'errors' | 'warnings';
@@ -115,18 +116,18 @@ export function mergePermissionAnalysisSearchParams(
   return next;
 }
 
-function normalizeSeverity(value: string | undefined): string {
-  return (value ?? '').toLowerCase();
+/**
+ * Severity predicates for the issues toolbar, grid, and counters. These take the whole finding (not a
+ * raw `severity` string) so every severity read in the feature resolves the same way — see
+ * {@link resolveFindingSeverity}. Reading `finding.severity` directly anywhere lets the filter counts
+ * drift from the rollup tiles and the cell highlights.
+ */
+export function isErrorSeverity(finding: PermissionAnalysisFinding): boolean {
+  return resolveFindingSeverity(finding) === 'error';
 }
 
-export function isErrorSeverity(value: string | undefined): boolean {
-  const normalized = normalizeSeverity(value);
-  return normalized === 'error' || normalized === 'errors';
-}
-
-export function isWarningSeverity(value: string | undefined): boolean {
-  const normalized = normalizeSeverity(value);
-  return normalized === 'warning' || normalized === 'warnings';
+export function isWarningSeverity(finding: PermissionAnalysisFinding): boolean {
+  return resolveFindingSeverity(finding) === 'warning';
 }
 
 /**
@@ -205,12 +206,11 @@ export function usePermissionAnalysisIssuesFilters({
 
   const filteredFindings = useMemo(() => {
     return findings.filter((finding) => {
-      const severityValue = finding.severity as string | undefined;
-      if (severityFilter === 'errors' && !isErrorSeverity(severityValue)) {
+      if (severityFilter === 'errors' && !isErrorSeverity(finding)) {
         return false;
       }
-      // Warnings-only: keep rows whose severity is warning/warnings (not errors, not unknown/other).
-      if (severityFilter === 'warnings' && !isWarningSeverity(severityValue)) {
+      // Warnings-only: keep warning rows (not errors, and not rows with an unresolvable severity).
+      if (severityFilter === 'warnings' && !isWarningSeverity(finding)) {
         return false;
       }
       if (olsFlsFilter === 'ols' && findingCodeKind(finding.code as string | undefined) !== 'ols') {
@@ -257,16 +257,10 @@ export function usePermissionAnalysisIssuesFilters({
     scopeFilter,
   ]);
 
-  const errorTotal = useMemo(() => findings.filter((f) => isErrorSeverity(f.severity as string | undefined)).length, [findings]);
-  const warningTotal = useMemo(() => findings.filter((f) => isWarningSeverity(f.severity as string | undefined)).length, [findings]);
-  const errorFiltered = useMemo(
-    () => filteredFindings.filter((f) => isErrorSeverity(f.severity as string | undefined)).length,
-    [filteredFindings],
-  );
-  const warningFiltered = useMemo(
-    () => filteredFindings.filter((f) => isWarningSeverity(f.severity as string | undefined)).length,
-    [filteredFindings],
-  );
+  const errorTotal = useMemo(() => findings.filter(isErrorSeverity).length, [findings]);
+  const warningTotal = useMemo(() => findings.filter(isWarningSeverity).length, [findings]);
+  const errorFiltered = useMemo(() => filteredFindings.filter(isErrorSeverity).length, [filteredFindings]);
+  const warningFiltered = useMemo(() => filteredFindings.filter(isWarningSeverity).length, [filteredFindings]);
 
   return useMemo(
     () => ({

--- a/libs/features/permission-analysis/src/permission-export-result-view-modules/export-result-findings.ts
+++ b/libs/features/permission-analysis/src/permission-export-result-view-modules/export-result-findings.ts
@@ -23,6 +23,29 @@ export function objectPermissionFindingRowKey(parentId: string, objectApiName: s
 
 export type PermissionObjectFindingCellSeverity = 'error' | 'warning';
 
+/**
+ * The single severity resolver for issue rows. The catalog is authoritative — the exporter writes each
+ * row's `severity` FROM the catalog definition — but historical job results may hold a code the current
+ * catalog no longer knows, so the stored value is the fallback. Everything that reads severity (summary
+ * rollups, container badges, cell highlights) must go through this, or the counts and the highlights can
+ * disagree about the same row.
+ */
+export function resolveFindingSeverity(finding: PermissionAnalysisFinding): PermissionObjectFindingCellSeverity | null {
+  const code = typeof finding.code === 'string' ? finding.code.trim() : '';
+  const definition = code ? getPermissionExportFindingDefinition(code) : undefined;
+  if (definition) {
+    return definition.severity === 'error' ? 'error' : 'warning';
+  }
+  const stored = String(finding.severity ?? '').toLowerCase();
+  if (stored === 'error') {
+    return 'error';
+  }
+  if (stored === 'warning') {
+    return 'warning';
+  }
+  return null;
+}
+
 const OBJECT_FINDING_READ_PATH_COLUMNS = ['PermissionsRead', 'PermissionsViewAllRecords', 'PermissionsModifyAllRecords'] as const;
 const OBJECT_FINDING_EDIT_PATH_COLUMNS = ['PermissionsEdit', 'PermissionsModifyAllRecords'] as const;
 
@@ -54,14 +77,6 @@ export function getObjectPermissionHighlightColumnKeysForFindingCode(code: strin
     return ['PermissionsViewAllRecords'];
   }
   return [];
-}
-
-function severityForObjectPermissionFindingCode(code: string): PermissionObjectFindingCellSeverity | null {
-  const def = getPermissionExportFindingDefinition(code);
-  if (!def) {
-    return null;
-  }
-  return def.severity === 'error' ? 'error' : 'warning';
 }
 
 /**
@@ -96,6 +111,67 @@ export function listFindingsForObjectPermissionCell(
   return matches;
 }
 
+interface FindingCellHighlightRowContext {
+  finding: PermissionAnalysisFinding;
+  /** Trimmed, non-empty container id (permission set / profile). */
+  parentId: string;
+  /** Trimmed, non-empty object API name. */
+  objectApiName: string;
+  /** Trimmed, non-empty issue code. */
+  code: string;
+}
+
+interface FindingCellHighlightOptions {
+  /** Grid column keys this issue code highlights; empty means the code has no cells on this surface. */
+  columnsForCode: (code: string) => readonly string[];
+  /** Row key the highlight is stored under, or `null` to skip the finding. */
+  rowKeyFor: (context: FindingCellHighlightRowContext) => string | null;
+}
+
+/**
+ * Shared row/column highlight index used by both permission grids. Walks the issue rows once and folds
+ * them into `rowKey → columnKey → severity`, keeping the most severe entry when several issues land on
+ * the same cell. The two surfaces differ only in which columns a code highlights and how the row is
+ * keyed, so those are the only two parameters.
+ */
+function buildFindingCellHighlights(
+  findings: PermissionAnalysisFinding[],
+  { columnsForCode, rowKeyFor }: FindingCellHighlightOptions,
+): Map<string, Map<string, PermissionObjectFindingCellSeverity>> {
+  const result = new Map<string, Map<string, PermissionObjectFindingCellSeverity>>();
+
+  for (const finding of findings) {
+    const code = typeof finding.code === 'string' ? finding.code.trim() : '';
+    const objectApiName = typeof finding.objectApiName === 'string' ? finding.objectApiName.trim() : '';
+    const parentId = getFindingContainerId(finding)?.trim() ?? '';
+    if (!code || !objectApiName || !parentId) {
+      continue;
+    }
+    const highlightColumns = columnsForCode(code);
+    if (highlightColumns.length === 0) {
+      continue;
+    }
+    const severity = resolveFindingSeverity(finding);
+    if (!severity) {
+      continue;
+    }
+    const rowKey = rowKeyFor({ finding, parentId, objectApiName, code });
+    if (!rowKey) {
+      continue;
+    }
+    let columnMap = result.get(rowKey);
+    if (!columnMap) {
+      columnMap = new Map();
+      result.set(rowKey, columnMap);
+    }
+    for (const columnKey of highlightColumns) {
+      columnMap.set(columnKey, columnMap.get(columnKey) === 'error' || severity === 'error' ? 'error' : severity);
+    }
+  }
+
+  return result;
+}
+
 /**
  * Maps object-permission export rows (ParentId + SobjectType) to permission boolean columns that
  * should be highlighted on the Object Permissions tree from analysis issues.
@@ -106,41 +182,10 @@ export function listFindingsForObjectPermissionCell(
 export function buildObjectPermissionFindingCellHighlights(
   findings: PermissionAnalysisFinding[],
 ): Map<string, Map<string, PermissionObjectFindingCellSeverity>> {
-  const result = new Map<string, Map<string, PermissionObjectFindingCellSeverity>>();
-
-  const mergeCell = (rowKey: string, columnKey: string, severity: PermissionObjectFindingCellSeverity): void => {
-    let columnMap = result.get(rowKey);
-    if (!columnMap) {
-      columnMap = new Map();
-      result.set(rowKey, columnMap);
-    }
-    const existing = columnMap.get(columnKey);
-    const next: PermissionObjectFindingCellSeverity = existing === 'error' || severity === 'error' ? 'error' : severity;
-    columnMap.set(columnKey, next);
-  };
-
-  for (const finding of findings) {
-    const codeRaw = typeof finding.code === 'string' ? finding.code.trim() : '';
-    const objectApi = typeof finding.objectApiName === 'string' ? finding.objectApiName.trim() : '';
-    const parentId = getFindingContainerId(finding)?.trim() ?? '';
-    if (!codeRaw || !objectApi || !parentId) {
-      continue;
-    }
-    const highlightColumns = getObjectPermissionHighlightColumnKeysForFindingCode(codeRaw);
-    if (highlightColumns.length === 0) {
-      continue;
-    }
-    const severity = severityForObjectPermissionFindingCode(codeRaw);
-    if (!severity) {
-      continue;
-    }
-    const rowKey = objectPermissionFindingRowKey(parentId, objectApi);
-    for (const columnKey of highlightColumns) {
-      mergeCell(rowKey, columnKey, severity);
-    }
-  }
-
-  return result;
+  return buildFindingCellHighlights(findings, {
+    columnsForCode: getObjectPermissionHighlightColumnKeysForFindingCode,
+    rowKeyFor: ({ parentId, objectApiName }) => objectPermissionFindingRowKey(parentId, objectApiName),
+  });
 }
 
 /**
@@ -172,10 +217,6 @@ export function getFieldPermissionHighlightColumnKeysForFindingCode(code: string
     return [...FIELD_PERMISSION_BOOLEAN_COLUMN_KEYS];
   }
   return [];
-}
-
-function severityForFieldPermissionFindingCode(code: string): PermissionObjectFindingCellSeverity | null {
-  return severityForObjectPermissionFindingCode(code);
 }
 
 /**
@@ -224,50 +265,20 @@ export function listFindingsForFieldPermissionCell(
 export function buildFieldPermissionFindingCellHighlights(
   findings: PermissionAnalysisFinding[],
 ): Map<string, Map<string, PermissionObjectFindingCellSeverity>> {
-  const result = new Map<string, Map<string, PermissionObjectFindingCellSeverity>>();
-
-  const mergeCell = (rowKey: string, columnKey: string, severity: PermissionObjectFindingCellSeverity): void => {
-    let columnMap = result.get(rowKey);
-    if (!columnMap) {
-      columnMap = new Map();
-      result.set(rowKey, columnMap);
-    }
-    const existing = columnMap.get(columnKey);
-    const next: PermissionObjectFindingCellSeverity = existing === 'error' || severity === 'error' ? 'error' : severity;
-    columnMap.set(columnKey, next);
-  };
-
-  for (const finding of findings) {
-    const codeRaw = typeof finding.code === 'string' ? finding.code.trim() : '';
-    const objectApi = typeof finding.objectApiName === 'string' ? finding.objectApiName.trim() : '';
-    const parentId = getFindingContainerId(finding)?.trim() ?? '';
-    if (!codeRaw || !objectApi || !parentId) {
-      continue;
-    }
-    const highlightColumns = getFieldPermissionHighlightColumnKeysForFindingCode(codeRaw);
-    if (highlightColumns.length === 0) {
-      continue;
-    }
-    const severity = severityForFieldPermissionFindingCode(codeRaw);
-    if (!severity) {
-      continue;
-    }
-    const fieldPart =
-      codeRaw === PermissionExportFindingCode.FLS_WITHOUT_OLS_ROW
-        ? FIELD_PERMISSION_OBJECT_SCOPE_MARKER
-        : typeof finding.fieldApiName === 'string'
-          ? finding.fieldApiName.trim()
-          : '';
-    if (!fieldPart) {
-      continue;
-    }
-    const rowKey = fieldPermissionFindingRowKey(parentId, objectApi, fieldPart);
-    for (const columnKey of highlightColumns) {
-      mergeCell(rowKey, columnKey, severity);
-    }
-  }
-
-  return result;
+  return buildFindingCellHighlights(findings, {
+    columnsForCode: getFieldPermissionHighlightColumnKeysForFindingCode,
+    rowKeyFor: ({ finding, parentId, objectApiName, code }) => {
+      // An object-scoped issue highlights every field row for the permission set + object, so it is
+      // stored once under the marker instead of being fanned out across fields we may not have rows for.
+      const fieldSegment =
+        code === PermissionExportFindingCode.FLS_WITHOUT_OLS_ROW
+          ? FIELD_PERMISSION_OBJECT_SCOPE_MARKER
+          : typeof finding.fieldApiName === 'string'
+            ? finding.fieldApiName.trim()
+            : '';
+      return fieldSegment ? fieldPermissionFindingRowKey(parentId, objectApiName, fieldSegment) : null;
+    },
+  });
 }
 
 export function fieldPermissionCellSeverity(
@@ -287,33 +298,6 @@ export function fieldPermissionCellSeverity(
   return fromSpecific ?? fromScope;
 }
 
-function isErrorLikeSeverity(value: unknown): boolean {
-  const normalized = String(value ?? '').toLowerCase();
-  return normalized === 'error' || normalized === 'errors';
-}
-
-function isWarningLikeSeverity(value: unknown): boolean {
-  const normalized = String(value ?? '').toLowerCase();
-  return normalized === 'warning' || normalized === 'warnings';
-}
-
-/**
- * Severity used for container-level badges (permission set / profile rows), from catalog definition or row payload.
- */
-function containerSeverityFromFinding(finding: PermissionAnalysisFinding, codeRaw: string): PermissionObjectFindingCellSeverity | null {
-  const def = getPermissionExportFindingDefinition(codeRaw);
-  if (def) {
-    return def.severity === 'error' ? 'error' : 'warning';
-  }
-  if (isErrorLikeSeverity(finding.severity)) {
-    return 'error';
-  }
-  if (isWarningLikeSeverity(finding.severity)) {
-    return 'warning';
-  }
-  return null;
-}
-
 /**
  * Max severity per permission-set container Id for profile / permission-set / assignment export rows.
  */
@@ -330,7 +314,7 @@ export function buildContainerIdFindingSeverity(
     if (!containerId) {
       continue;
     }
-    const next = containerSeverityFromFinding(finding, codeRaw);
+    const next = resolveFindingSeverity(finding);
     if (!next) {
       continue;
     }
@@ -441,8 +425,9 @@ export function aggregatePermissionAnalysisFindings(findings: PermissionAnalysis
     }
     const objectKeyRaw = String(row.objectApiName ?? '').trim();
     const objectKey = objectKeyRaw.length > 0 ? objectKeyRaw : '(no object)';
-    const isError = isErrorLikeSeverity(row.severity);
-    const isWarning = isWarningLikeSeverity(row.severity);
+    const severity = resolveFindingSeverity(row);
+    const isError = severity === 'error';
+    const isWarning = severity === 'warning';
 
     const codeAgg = byCodeMap.get(code) ?? { count: 0, errors: 0, warnings: 0 };
     codeAgg.count += 1;

--- a/libs/shared/constants/src/lib/permission-export-finding-codes.ts
+++ b/libs/shared/constants/src/lib/permission-export-finding-codes.ts
@@ -5,8 +5,18 @@
  * - `error`   = EXPOSURE: real over-access a user can exploit (Modify All Records, Modify All Data, …).
  * - `warning` = INCONSISTENCY / DEAD-CONFIG / INCOMPLETE-SETUP / CLEANUP. Visible but not alarming.
  *
- * Note: field-level access that the object can never satisfy (FLS without OLS) is INERT — Salesforce
- * silently ignores it — so it is a `warning`, not an `error`. Errors are reserved for true exposure.
+ * Note: field-level access the same container never satisfies (FLS without OLS) is a `warning`, not an
+ * `error`. Errors are reserved for true exposure.
+ *
+ * SCOPE — read this before wording a new alignment code. Salesforce effective access is the UNION of the
+ * user's profile and every permission set assigned to them. The FLS/OLS alignment codes below compare a
+ * field permission against the object permission ON THE SAME CONTAINER, then suppress the finding when
+ * another container that reaches the same users supplies the missing access (permission set group
+ * siblings, and other permission sets sharing every assignee). What they cannot see is the assignees'
+ * PROFILE, and any permission set outside the exported selection. So these codes mean "this container
+ * alone does not grant it" — NEVER "the field access has no effect". Word labels and messages
+ * accordingly; claiming inertness is wrong for the common "object access on the profile, field access in
+ * a permission set" pattern.
  */
 
 export const PermissionExportFindingSeverity = {
@@ -20,7 +30,7 @@ export type PermissionExportFindingSeverityValue = (typeof PermissionExportFindi
  * Stored on each analysis row as `code` and referenced by `issueCodeSummary` keys.
  */
 export const PermissionExportFindingCode = {
-  // Inert / inconsistency (warning) — field access the object can't satisfy.
+  // Inconsistency (warning) — field access this container's own object permission does not satisfy.
   FLS_EDIT_NO_OBJECT_EDIT: 'FLS_EDIT_NO_OBJECT_EDIT',
   FLS_READ_NO_OBJECT_READ: 'FLS_READ_NO_OBJECT_READ',
   FLS_WITHOUT_OLS_ROW: 'FLS_WITHOUT_OLS_ROW',
@@ -51,15 +61,15 @@ export type PermissionExportFindingDefinition = {
 export const PERMISSION_EXPORT_FINDING_DEFINITIONS: Record<PermissionExportFindingCodeValue, PermissionExportFindingDefinition> = {
   [PermissionExportFindingCode.FLS_READ_NO_OBJECT_READ]: {
     severity: PermissionExportFindingSeverity.Warning,
-    label: 'Field read granted, but the object grants no read — field access has no effect.',
+    label: 'Field read granted, but this container grants no object read — access must come from elsewhere.',
   },
   [PermissionExportFindingCode.FLS_EDIT_NO_OBJECT_EDIT]: {
     severity: PermissionExportFindingSeverity.Warning,
-    label: 'Field edit granted, but the object grants no edit — field access has no effect.',
+    label: 'Field edit granted, but this container grants no object edit — access must come from elsewhere.',
   },
   [PermissionExportFindingCode.FLS_WITHOUT_OLS_ROW]: {
     severity: PermissionExportFindingSeverity.Warning,
-    label: 'Field permissions exist for the object, but there is no object permissions row.',
+    label: 'Field permissions exist for the object, but this container has no object permissions row.',
   },
   [PermissionExportFindingCode.OLS_READ_NO_FLS_ROWS]: {
     severity: PermissionExportFindingSeverity.Warning,


### PR DESCRIPTION
Findings from a strict review of the analysis features. All of these are in the permission analysis findings engine; field usage is unchanged.

Truncation no longer discards exposure findings. The 8,000-row cap dropped in emission order, and the two error-severity codes (SYSTEM_PERM_HIGH_RISK, OBJECT_MODIFY_ALL_RECORDS) are emitted in the last passes — so a field-permission heavy org could exhaust the budget on inert warnings and report zero errors while granting Modify All Data. Errors and warnings now collect into independently capped buckets and concatenate errors-first, and the cap is raised to 50,000 per severity. This also makes errors-first the default order of the stored result.

Alignment findings no longer claim inertness they cannot prove. Salesforce effective access is the union of a user's profile and every assigned permission set, but the FLS/OLS checks only compared against the same container, while the catalog label asserted "field access has no effect" — false for the common "object access on the profile, field access in a permission set" pattern. Messages, labels, and docs are now container-scoped, and a finding is suppressed when every assignee gets the missing object access from another permission set (the group-sibling suppression already existed). Profile-level access is still not visible; that needs User.ProfileId and is tracked as follow-up.

TAB_VISIBLE_NO_OBJECT_READ no longer fires on tabs that are not objects. Stripping the `standard-` prefix turned standard-home, standard-report, standard-Chatter, and standard-File into fake object API names, guaranteeing a bogus "grants no read access to home" finding per permission set. Tab names are now resolved against a global describe, which also supplies canonical casing for the SobjectType join. If the describe is unavailable the pass is skipped rather than guessed at.

PERMSET_NO_ASSIGNMENTS no longer advises deleting permission sets that cannot be deleted. NamespacePrefix, IsCustom, and Type are selected through the same describe intersection as the system permission columns (so older orgs degrade gracefully) and managed, Salesforce-standard, group-backed, and session-activated sets are excluded.

Severity now has one resolver. Four divergent implementations existed: the rollups read the stored payload, the cell highlights read the catalog, and the issues filters and grid each had their own plural-tolerant copy — so counts, filters, and highlights could disagree about the same row. All of them now use resolveFindingSeverity (catalog first, stored value as the legacy fallback), which also removes a batch of `as string | undefined` casts and the dead 'errors'/'warnings' branches.

Also collapses the two near-identical cell highlight builders into one parameterized by column-mapper and row-key, and raises the per-category export row budgets ~2-3x. The budget comment now records the real constraint: browser memory and the stored gzip blob, not a Salesforce limit — and that hitting a cap disables whole finding classes, so the caps affect accuracy, not just size.

Two existing test fixtures asserted an error count for FLS_READ_NO_OBJECT_READ, which the catalog defines as a warning; they only passed because of the severity divergence above. Moved to a real error code, with explicit coverage added for catalog-over-payload and the payload fallback.