### PR TITLE
fix: stop permission manager from offering permissions Salesforce won't save

### DIFF
--- a/libs/features/manage-permissions/src/ManagePermissionsEditor.tsx
+++ b/libs/features/manage-permissions/src/ManagePermissionsEditor.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/react';
 import { logger } from '@jetstream/shared/client-logger';
 import { ANALYTICS_KEYS, MIME_TYPES } from '@jetstream/shared/constants';
 import { saveFile, tracker, useGoBackShortcut, usePrimaryActionShortcut } from '@jetstream/shared/ui-utils';
-import { getErrorMessage, groupByFlat, multiWordObjectFilter } from '@jetstream/shared/utils';
+import { getErrorMessage, groupByFlat } from '@jetstream/shared/utils';
 import {
   AsyncJobNew,
   DirtyRow,
@@ -84,6 +84,7 @@ import {
 import {
   clearPermissionErrorMessage,
   collectProfileAndPermissionIds,
+  filterPermissionRows,
   getUpdatedFieldPermissions,
   getUpdatedObjectPermissions,
   getUpdatedSystemPermissions,
@@ -163,6 +164,7 @@ export const ManagePermissionsEditor: FunctionComponent<ManagePermissionsEditorP
   const [visibleObjectRows, setVisibleObjectRows] = useState<PermissionTableObjectCell[] | null>(null);
   const [dirtyObjectRows, setDirtyObjectRows] = useState<Record<string, DirtyRow<PermissionTableObjectCell>>>({});
   const [objectFilter, setObjectFilter] = useState('');
+  const [objectErrorsOnly, setObjectErrorsOnly] = useState(false);
 
   const [tabVisibilityColumns, setTabVisibilityColumns] = useState<
     ColumnWithFilter<PermissionTableTabVisibilityCell, PermissionTableSummaryRow>[]
@@ -171,12 +173,14 @@ export const ManagePermissionsEditor: FunctionComponent<ManagePermissionsEditorP
   const [visibleTabVisibilityRows, setVisibleTabVisibilityRows] = useState<PermissionTableTabVisibilityCell[] | null>(null);
   const [dirtyTabVisibilityRows, setDirtyTabVisibilityRows] = useState<Record<string, DirtyRow<PermissionTableTabVisibilityCell>>>({});
   const [tabVisibilityFilter, setTabVisibilityFilter] = useState('');
+  const [tabVisibilityErrorsOnly, setTabVisibilityErrorsOnly] = useState(false);
 
   const [fieldColumns, setFieldColumns] = useState<ColumnWithFilter<PermissionTableFieldCell, PermissionTableSummaryRow>[]>([]);
   const [fieldRows, setFieldRows] = useState<PermissionTableFieldCell[] | null>(null);
   const [visibleFieldRows, setVisibleFieldRows] = useState<PermissionTableFieldCell[] | null>(null);
   const [dirtyFieldRows, setDirtyFieldRows] = useState<Record<string, DirtyRow<PermissionTableFieldCell>>>({});
   const [fieldFilter, setFieldFilter] = useState('');
+  const [fieldErrorsOnly, setFieldErrorsOnly] = useState(false);
 
   const [systemPermissionColumns, setSystemPermissionColumns] = useState<
     ColumnWithFilter<PermissionTableSystemPermissionCell, PermissionTableSummaryRow>[]
@@ -187,6 +191,7 @@ export const ManagePermissionsEditor: FunctionComponent<ManagePermissionsEditorP
     {},
   );
   const [systemPermissionFilter, setSystemPermissionFilter] = useState('');
+  const [systemPermissionErrorsOnly, setSystemPermissionErrorsOnly] = useState(false);
 
   const [dirtyObjectCount, setDirtyObjectCount] = useState<number>(0);
   const [dirtyFieldCount, setDirtyFieldCount] = useState<number>(0);
@@ -250,10 +255,29 @@ export const ManagePermissionsEditor: FunctionComponent<ManagePermissionsEditorP
 
   useEffect(() => {
     if (objectPermissionMap && fieldPermissionMap && tabVisibilityPermissionMap && systemPermissionMap) {
-      setObjectsHaveErrors(permissionsHaveError(objectPermissionMap));
-      setFieldsHaveErrors(permissionsHaveError(fieldPermissionMap));
-      setTabVisibilityHaveErrors(permissionsHaveError(tabVisibilityPermissionMap));
-      setSystemPermissionsHaveErrors(permissionsHaveError(systemPermissionMap));
+      const objectsHaveError = permissionsHaveError(objectPermissionMap);
+      const fieldsHaveError = permissionsHaveError(fieldPermissionMap);
+      const tabVisibilityHaveError = permissionsHaveError(tabVisibilityPermissionMap);
+      const systemPermissionsHaveError = permissionsHaveError(systemPermissionMap);
+      setObjectsHaveErrors(objectsHaveError);
+      setFieldsHaveErrors(fieldsHaveError);
+      setTabVisibilityHaveErrors(tabVisibilityHaveError);
+      setSystemPermissionsHaveErrors(systemPermissionsHaveError);
+      // The "errors only" toggle is only rendered while a table has errors, so clearing the errors (a successful
+      // re-save or a reset) must also clear the filter - otherwise the table stays filtered to zero rows with no
+      // control left to turn it back off.
+      if (!objectsHaveError) {
+        setObjectErrorsOnly(false);
+      }
+      if (!fieldsHaveError) {
+        setFieldErrorsOnly(false);
+      }
+      if (!tabVisibilityHaveError) {
+        setTabVisibilityErrorsOnly(false);
+      }
+      if (!systemPermissionsHaveError) {
+        setSystemPermissionErrorsOnly(false);
+      }
     }
   }, [objectPermissionMap, fieldPermissionMap, tabVisibilityPermissionMap, systemPermissionMap]);
 
@@ -279,36 +303,20 @@ export const ManagePermissionsEditor: FunctionComponent<ManagePermissionsEditorP
   }, [dirtySystemPermissionRows]);
 
   useEffect(() => {
-    if (fieldRows && fieldFilter) {
-      setVisibleFieldRows(fieldRows.filter(multiWordObjectFilter(['label', 'apiName'], fieldFilter)));
-    } else {
-      setVisibleFieldRows(fieldRows);
-    }
-  }, [fieldFilter, fieldRows]);
+    setVisibleFieldRows(filterPermissionRows(fieldRows, fieldFilter, fieldErrorsOnly));
+  }, [fieldFilter, fieldRows, fieldErrorsOnly]);
 
   useEffect(() => {
-    if (objectRows && objectFilter) {
-      setVisibleObjectRows(objectRows.filter(multiWordObjectFilter(['label', 'apiName'], objectFilter)));
-    } else {
-      setVisibleObjectRows(objectRows);
-    }
-  }, [objectFilter, objectRows]);
+    setVisibleObjectRows(filterPermissionRows(objectRows, objectFilter, objectErrorsOnly));
+  }, [objectFilter, objectRows, objectErrorsOnly]);
 
   useEffect(() => {
-    if (tabVisibilityRows && tabVisibilityFilter) {
-      setVisibleTabVisibilityRows(tabVisibilityRows.filter(multiWordObjectFilter(['label', 'apiName'], tabVisibilityFilter)));
-    } else {
-      setVisibleTabVisibilityRows(tabVisibilityRows);
-    }
-  }, [tabVisibilityFilter, tabVisibilityRows]);
+    setVisibleTabVisibilityRows(filterPermissionRows(tabVisibilityRows, tabVisibilityFilter, tabVisibilityErrorsOnly));
+  }, [tabVisibilityFilter, tabVisibilityRows, tabVisibilityErrorsOnly]);
 
   useEffect(() => {
-    if (systemPermissionRows && systemPermissionFilter) {
-      setVisibleSystemPermissionRows(systemPermissionRows.filter(multiWordObjectFilter(['label', 'apiName'], systemPermissionFilter)));
-    } else {
-      setVisibleSystemPermissionRows(systemPermissionRows);
-    }
-  }, [systemPermissionFilter, systemPermissionRows]);
+    setVisibleSystemPermissionRows(filterPermissionRows(systemPermissionRows, systemPermissionFilter, systemPermissionErrorsOnly));
+  }, [systemPermissionFilter, systemPermissionRows, systemPermissionErrorsOnly]);
 
   const handleObjectBulkRowUpdate = useCallback((rows: PermissionTableObjectCell[], indexes?: number[]) => {
     const rowsByKey = groupByFlat(rows, 'key');
@@ -885,7 +893,10 @@ export const ManagePermissionsEditor: FunctionComponent<ManagePermissionsEditorP
                     rows={visibleObjectRows || []}
                     totalCount={objectRows?.length || 0}
                     filterText={objectFilter}
+                    hasErrors={objectsHaveErrors}
+                    errorsOnly={objectErrorsOnly}
                     onFilter={setObjectFilter}
+                    onToggleErrorsOnly={setObjectErrorsOnly}
                     onBulkUpdate={handleObjectBulkRowUpdate}
                     onDirtyRows={setDirtyObjectRows}
                   />
@@ -915,9 +926,12 @@ export const ManagePermissionsEditor: FunctionComponent<ManagePermissionsEditorP
                     ref={managePermissionsEditorObjectTableRef}
                     columns={tabVisibilityColumns}
                     rows={visibleTabVisibilityRows || []}
-                    totalCount={objectRows?.length || 0}
+                    totalCount={tabVisibilityRows?.length || 0}
                     filterText={tabVisibilityFilter}
+                    hasErrors={tabVisibilityHaveErrors}
+                    errorsOnly={tabVisibilityErrorsOnly}
                     onFilter={setTabVisibilityFilter}
+                    onToggleErrorsOnly={setTabVisibilityErrorsOnly}
                     onBulkUpdate={handleTabVisibilityBulkRowUpdate}
                     onDirtyRows={setDirtyTabVisibilityRows}
                   />
@@ -948,7 +962,10 @@ export const ManagePermissionsEditor: FunctionComponent<ManagePermissionsEditorP
                     rows={visibleFieldRows || []}
                     totalCount={fieldRows?.length || 0}
                     filterText={fieldFilter}
+                    hasErrors={fieldsHaveErrors}
+                    errorsOnly={fieldErrorsOnly}
                     onFilter={setFieldFilter}
+                    onToggleErrorsOnly={setFieldErrorsOnly}
                     onBulkUpdate={handleFieldBulkRowUpdate}
                     onDirtyRows={setDirtyFieldRows}
                   />
@@ -979,7 +996,10 @@ export const ManagePermissionsEditor: FunctionComponent<ManagePermissionsEditorP
                     rows={visibleSystemPermissionRows || []}
                     totalCount={systemPermissionRows?.length || 0}
                     filterText={systemPermissionFilter}
+                    hasErrors={systemPermissionsHaveErrors}
+                    errorsOnly={systemPermissionErrorsOnly}
                     onFilter={setSystemPermissionFilter}
+                    onToggleErrorsOnly={setSystemPermissionErrorsOnly}
                     onBulkUpdate={handleSystemPermissionBulkRowUpdate}
                     onDirtyRows={setDirtySystemPermissionRows}
                   />

--- a/libs/features/manage-permissions/src/ManagePermissionsEditorFieldTable.tsx
+++ b/libs/features/manage-permissions/src/ManagePermissionsEditorFieldTable.tsx
@@ -38,13 +38,17 @@ export interface ManagePermissionsEditorFieldTableProps {
   rows: PermissionTableFieldCell[];
   totalCount: number;
   filterText?: string;
+  /** True when any row has a save error - gates the "errors only" toggle in the filter row */
+  hasErrors?: boolean;
+  errorsOnly?: boolean;
   onFilter: (value: string) => void;
+  onToggleErrorsOnly?: (value: boolean) => void;
   onBulkUpdate: (rows: PermissionTableFieldCell[], indexes?: number[]) => void;
   onDirtyRows?: (values: Record<string, DirtyRow<PermissionTableFieldCell>>) => void;
 }
 
 export const ManagePermissionsEditorFieldTable = forwardRef<any, ManagePermissionsEditorFieldTableProps>(
-  ({ columns, rows, totalCount, filterText, onFilter, onDirtyRows, onBulkUpdate }, ref) => {
+  ({ columns, rows, totalCount, filterText, hasErrors, errorsOnly, onFilter, onToggleErrorsOnly, onDirtyRows, onBulkUpdate }, ref) => {
     const tableRef = useRef<DataTableRef<PermissionTableFieldCell>>(null);
     const [dirtyRows, setDirtyRows] = useState<Record<string, DirtyRow<PermissionTableFieldCell>>>({});
     const [expandedGroupIds, setExpandedGroupIds] = useState(() => new Set<any>(rows.map((row) => row.sobject)));
@@ -88,7 +92,10 @@ export const ManagePermissionsEditorFieldTable = forwardRef<any, ManagePermissio
                 type: 'field',
                 totalCount,
                 filterValue: filterText,
+                hasErrors,
+                errorsOnly,
                 onFilterRows: onFilter,
+                onToggleErrorsOnly,
                 onColumnAction: handleColumnAction,
                 onBulkAction: onBulkUpdate,
               } as PermissionManagerTableContext

--- a/libs/features/manage-permissions/src/ManagePermissionsEditorObjectTable.tsx
+++ b/libs/features/manage-permissions/src/ManagePermissionsEditorObjectTable.tsx
@@ -23,13 +23,17 @@ export interface ManagePermissionsEditorObjectTableProps {
   rows: PermissionTableObjectCell[];
   totalCount: number;
   filterText?: string;
+  /** True when any row has a save error - gates the "errors only" toggle in the filter row */
+  hasErrors?: boolean;
+  errorsOnly?: boolean;
   onFilter: (value: string) => void;
+  onToggleErrorsOnly?: (value: boolean) => void;
   onBulkUpdate: (rows: PermissionTableObjectCell[], indexes?: number[]) => void;
   onDirtyRows?: (values: Record<string, DirtyRow<PermissionTableObjectCell>>) => void;
 }
 
 export const ManagePermissionsEditorObjectTable = forwardRef<any, ManagePermissionsEditorObjectTableProps>(
-  ({ columns, rows, totalCount, filterText, onFilter, onBulkUpdate, onDirtyRows }, ref) => {
+  ({ columns, rows, totalCount, filterText, hasErrors, errorsOnly, onFilter, onToggleErrorsOnly, onBulkUpdate, onDirtyRows }, ref) => {
     const tableRef = useRef<DataTableRef<PermissionTableObjectCell>>(null);
     const [dirtyRows, setDirtyRows] = useState<Record<string, DirtyRow<PermissionTableObjectCell>>>({});
 
@@ -72,7 +76,10 @@ export const ManagePermissionsEditorObjectTable = forwardRef<any, ManagePermissi
                 type: 'object',
                 totalCount,
                 filterValue: filterText,
+                hasErrors,
+                errorsOnly,
                 onFilterRows: onFilter,
+                onToggleErrorsOnly,
                 onColumnAction: handleColumnAction,
                 onBulkAction: onBulkUpdate,
               } as PermissionManagerTableContext

--- a/libs/features/manage-permissions/src/ManagePermissionsEditorSystemPermissionTable.tsx
+++ b/libs/features/manage-permissions/src/ManagePermissionsEditorSystemPermissionTable.tsx
@@ -23,13 +23,17 @@ export interface ManagePermissionsEditorSystemPermissionTableProps {
   rows: PermissionTableSystemPermissionCell[];
   totalCount: number;
   filterText?: string;
+  /** True when any row has a save error - gates the "errors only" toggle in the filter row */
+  hasErrors?: boolean;
+  errorsOnly?: boolean;
   onFilter: (value: string) => void;
+  onToggleErrorsOnly?: (value: boolean) => void;
   onBulkUpdate: (rows: PermissionTableSystemPermissionCell[], indexes?: number[]) => void;
   onDirtyRows?: (values: Record<string, DirtyRow<PermissionTableSystemPermissionCell>>) => void;
 }
 
 export const ManagePermissionsEditorSystemPermissionTable = forwardRef<any, ManagePermissionsEditorSystemPermissionTableProps>(
-  ({ columns, rows, totalCount, filterText, onFilter, onBulkUpdate, onDirtyRows }, ref) => {
+  ({ columns, rows, totalCount, filterText, hasErrors, errorsOnly, onFilter, onToggleErrorsOnly, onBulkUpdate, onDirtyRows }, ref) => {
     const tableRef = useRef<DataTableRef<PermissionTableSystemPermissionCell>>(null);
     const [dirtyRows, setDirtyRows] = useState<Record<string, DirtyRow<PermissionTableSystemPermissionCell>>>({});
 
@@ -74,7 +78,10 @@ export const ManagePermissionsEditorSystemPermissionTable = forwardRef<any, Mana
                 type: 'systemPermission',
                 totalCount,
                 filterValue: filterText,
+                hasErrors,
+                errorsOnly,
                 onFilterRows: onFilter,
+                onToggleErrorsOnly,
                 onColumnAction: handleColumnAction,
                 onBulkAction: onBulkUpdate,
               } as PermissionManagerTableContext

--- a/libs/features/manage-permissions/src/ManagePermissionsEditorTabVisibilityTable.tsx
+++ b/libs/features/manage-permissions/src/ManagePermissionsEditorTabVisibilityTable.tsx
@@ -23,13 +23,17 @@ export interface ManagePermissionsEditorTabVisibilityTableProps {
   rows: PermissionTableTabVisibilityCell[];
   totalCount: number;
   filterText?: string;
+  /** True when any row has a save error - gates the "errors only" toggle in the filter row */
+  hasErrors?: boolean;
+  errorsOnly?: boolean;
   onFilter: (value: string) => void;
+  onToggleErrorsOnly?: (value: boolean) => void;
   onBulkUpdate: (rows: PermissionTableTabVisibilityCell[], indexes?: number[]) => void;
   onDirtyRows?: (values: Record<string, DirtyRow<PermissionTableTabVisibilityCell>>) => void;
 }
 
 export const ManagePermissionsEditorTabVisibilityTable = forwardRef<any, ManagePermissionsEditorTabVisibilityTableProps>(
-  ({ columns, rows, totalCount, filterText, onFilter, onBulkUpdate, onDirtyRows }, ref) => {
+  ({ columns, rows, totalCount, filterText, hasErrors, errorsOnly, onFilter, onToggleErrorsOnly, onBulkUpdate, onDirtyRows }, ref) => {
     const tableRef = useRef<DataTableRef<PermissionTableTabVisibilityCell>>(null);
     const [dirtyRows, setDirtyRows] = useState<Record<string, DirtyRow<PermissionTableTabVisibilityCell>>>({});
 
@@ -72,7 +76,10 @@ export const ManagePermissionsEditorTabVisibilityTable = forwardRef<any, ManageP
                 type: 'tabVisibility',
                 totalCount,
                 filterValue: filterText,
+                hasErrors,
+                errorsOnly,
                 onFilterRows: onFilter,
+                onToggleErrorsOnly,
                 onColumnAction: handleColumnAction,
                 onBulkAction: onBulkUpdate,
               } as PermissionManagerTableContext

--- a/libs/features/manage-permissions/src/ManagePermissionsSelection.tsx
+++ b/libs/features/manage-permissions/src/ManagePermissionsSelection.tsx
@@ -42,7 +42,8 @@ import { useAtom, useAtomValue } from 'jotai';
 import { useResetAtom } from 'jotai/utils';
 import { FunctionComponent, useCallback, useEffect, useMemo, useState } from 'react';
 import { Link, useNavigate } from 'react-router';
-import { filterPermissionsSobjects } from './utils/permission-manager-utils';
+import { usePermissionableSobjects } from './usePermissionableSobjects';
+import { getPermissionsSobjectFilter } from './utils/permission-manager-utils';
 
 const HEIGHT_BUFFER = 170;
 
@@ -110,6 +111,16 @@ export const ManagePermissionsSelection: FunctionComponent<ManagePermissionsSele
 
   const profilesAndPermSetsData = useProfilesAndPermSets(selectedOrg, profiles, permissionSets);
 
+  // Objects that cannot have an ObjectPermissions record (Task, ApexClass, Attachment, ...) fail on save
+  // with INVALID_OR_NULL_FOR_RESTRICTED_PICKLIST, so they are excluded from the picker entirely.
+  const {
+    permissionableSobjects,
+    loading: permissionableSobjectsLoading,
+    refresh: refreshPermissionableSobjects,
+  } = usePermissionableSobjects(selectedOrg);
+
+  const sobjectFilterFn = useMemo(() => getPermissionsSobjectFilter(permissionableSobjects), [permissionableSobjects]);
+
   const hasSelectionsMade = useAtomValue(fromPermissionsState.hasSelectionsMade);
 
   const isAnalysis = selectionMode === 'permission-analysis';
@@ -146,6 +157,15 @@ export const ManagePermissionsSelection: FunctionComponent<ManagePermissionsSele
 
   function handleSobjectChange(sobjects: DescribeGlobalSObjectResult[] | null) {
     setSobjects(sobjects);
+  }
+
+  /**
+   * The object list is reloaded by `ConnectedSobjectListMultiSelect` before this fires, so it used the
+   * previous allow-list. Clearing the objects lets it reload once the refreshed allow-list settles.
+   */
+  function handleSobjectRefresh() {
+    setSobjects(null);
+    refreshPermissionableSobjects();
   }
 
   const handleContinueAnalysis = useCallback(() => {
@@ -378,9 +398,11 @@ export const ManagePermissionsSelection: FunctionComponent<ManagePermissionsSele
               selectedSObjects={selectedSObjects}
               recentItemsEnabled
               recentItemsKey="sobject"
-              filterFn={filterPermissionsSobjects}
+              filterFn={sobjectFilterFn}
+              filterReady={!permissionableSobjectsLoading}
               onSobjects={handleSobjectChange}
               onSelectedSObjects={setSelectedSObjects}
+              onRefresh={handleSobjectRefresh}
             />
           </div>
         </Split>

--- a/libs/features/manage-permissions/src/usePermissionableSobjects.ts
+++ b/libs/features/manage-permissions/src/usePermissionableSobjects.ts
@@ -1,0 +1,49 @@
+import { SalesforceOrgUi } from '@jetstream/types';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { getPermissionableSobjects } from './utils/permission-manager-utils';
+
+/**
+ * Loads the set of objects that can have an `ObjectPermissions` record in the selected org.
+ *
+ * `permissionableSobjects` is `null` when the allow-list could not be determined, which callers treat
+ * as "fall back to the heuristic filter" rather than "no objects". `loading` stays `true` until the
+ * fetch for the current org settles, so the object list is never populated with a stale filter.
+ */
+export function usePermissionableSobjects(selectedOrg: SalesforceOrgUi) {
+  const isMounted = useRef(true);
+  const [refreshCount, setRefreshCount] = useState(0);
+  const [loaded, setLoaded] = useState<{ key: string; permissionableSobjects: Set<string> | null } | null>(null);
+
+  const orgUniqueId = selectedOrg?.uniqueId || null;
+  // Changing the key marks the current results stale without a synchronous state update
+  const key = `${orgUniqueId}:${refreshCount}`;
+
+  useEffect(() => {
+    isMounted.current = true;
+    return () => {
+      isMounted.current = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    let canceled = false;
+    const results = orgUniqueId ? getPermissionableSobjects(selectedOrg) : Promise.resolve(null);
+    results.then((permissionableSobjects) => {
+      if (!canceled && isMounted.current) {
+        setLoaded({ key, permissionableSobjects });
+      }
+    });
+    return () => {
+      canceled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [key]);
+
+  const isLoaded = loaded?.key === key;
+
+  return {
+    permissionableSobjects: isLoaded ? loaded.permissionableSobjects : null,
+    loading: !isLoaded,
+    refresh: useCallback(() => setRefreshCount((count) => count + 1), []),
+  };
+}

--- a/libs/features/manage-permissions/src/utils/__tests__/permission-manager-sobject-filter.spec.ts
+++ b/libs/features/manage-permissions/src/utils/__tests__/permission-manager-sobject-filter.spec.ts
@@ -1,0 +1,93 @@
+import { DescribeGlobalSObjectResult, DescribeSObjectResult, PicklistEntry, SalesforceOrgUi } from '@jetstream/types';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { filterPermissionsSobjects, getPermissionableSobjects, getPermissionsSobjectFilter } from '../permission-manager-utils';
+
+const describeSObject = vi.hoisted(() => vi.fn());
+
+vi.mock('@jetstream/shared/data', () => ({
+  describeSObject,
+  sobjectOperation: vi.fn(),
+  updatePermissionSetRecords: vi.fn(),
+}));
+
+const org = { uniqueId: 'org-1' } as SalesforceOrgUi;
+
+function buildSobject(name: string, overrides: Partial<DescribeGlobalSObjectResult> = {}): DescribeGlobalSObjectResult {
+  return { name, label: name, createable: true, updateable: true, ...overrides } as DescribeGlobalSObjectResult;
+}
+
+function mockSobjectTypePicklist(picklistValues: Partial<PicklistEntry>[] | null | undefined) {
+  describeSObject.mockResolvedValue({
+    data: {
+      fields: [
+        { name: 'ParentId', picklistValues: null },
+        { name: 'SobjectType', picklistValues },
+      ],
+    } as unknown as DescribeSObjectResult,
+  });
+}
+
+describe('getPermissionableSobjects', () => {
+  beforeEach(() => {
+    describeSObject.mockReset();
+  });
+
+  it('returns the SobjectType picklist values', async () => {
+    mockSobjectTypePicklist([
+      { value: 'Account', active: true },
+      { value: 'Contact', active: true },
+    ]);
+
+    const results = await getPermissionableSobjects(org);
+
+    expect(describeSObject).toHaveBeenCalledWith(org, 'ObjectPermissions');
+    expect(results).toEqual(new Set(['Account', 'Contact']));
+  });
+
+  it('omits values explicitly marked inactive but keeps values with no active flag', async () => {
+    mockSobjectTypePicklist([{ value: 'Account', active: true }, { value: 'Retired__c', active: false }, { value: 'Contact' }]);
+
+    expect(await getPermissionableSobjects(org)).toEqual(new Set(['Account', 'Contact']));
+  });
+
+  it.each([
+    ['no picklist values', []],
+    ['a missing picklist', null],
+    ['every value inactive', [{ value: 'Account', active: false }]],
+  ])('returns null when describe returns %s so callers fall back to the heuristic', async (_label, picklistValues) => {
+    mockSobjectTypePicklist(picklistValues);
+
+    expect(await getPermissionableSobjects(org)).toBeNull();
+  });
+
+  it('returns null when describe fails', async () => {
+    describeSObject.mockRejectedValue(new Error('INVALID_SESSION_ID'));
+
+    expect(await getPermissionableSobjects(org)).toBeNull();
+  });
+});
+
+describe('getPermissionsSobjectFilter', () => {
+  it('keeps only objects present in the allow-list', () => {
+    const filterFn = getPermissionsSobjectFilter(new Set(['Account', 'Idea', 'Custom__c']));
+
+    expect(filterPermissionsSobjects(buildSobject('Task'))).toBe(true);
+    expect(filterFn(buildSobject('Account'))).toBe(true);
+    expect(filterFn(buildSobject('Custom__c'))).toBe(true);
+    // Objects that fail on save with INVALID_OR_NULL_FOR_RESTRICTED_PICKLIST despite being createable
+    expect(filterFn(buildSobject('Task'))).toBe(false);
+    expect(filterFn(buildSobject('ApexClass'))).toBe(false);
+    expect(filterFn(buildSobject('Attachment'))).toBe(false);
+    expect(filterFn(null)).toBe(false);
+  });
+
+  it('falls back to the heuristic filter when the allow-list is unavailable', () => {
+    const filterFn = getPermissionsSobjectFilter(null);
+
+    expect(filterFn).toBe(filterPermissionsSobjects);
+    expect(filterFn(buildSobject('Account'))).toBe(true);
+    expect(filterFn(buildSobject('AccountHistory'))).toBe(false);
+    expect(filterFn(buildSobject('ReadOnly__x', { createable: false, updateable: false }))).toBe(false);
+    expect(filterFn(buildSobject('Event__e', { createable: false, updateable: false }))).toBe(true);
+  });
+});

--- a/libs/features/manage-permissions/src/utils/__tests__/permission-manager-table-label-column.spec.ts
+++ b/libs/features/manage-permissions/src/utils/__tests__/permission-manager-table-label-column.spec.ts
@@ -1,0 +1,69 @@
+import { PermissionTableObjectCell, PermissionTableTabVisibilityCell } from '@jetstream/types';
+import { ColumnWithFilter, computeFilterSetValues } from '@jetstream/ui';
+import { describe, expect, it } from 'vitest';
+import { getObjectColumns, getTabVisibilityColumns } from '../permission-manager-table-utils';
+
+/**
+ * Regression coverage for the `tableLabel` column resolving to the literal string `undefined (undefined)`.
+ *
+ * `tableLabel` is already formatted as `Label (ApiName)`, but the object and tab tables defined a
+ * `getValue` that treated `row.tableLabel` as an object and read `.label` / `.apiName` off the string.
+ * The `as any` spread hid it, and the bad value reached the SET filter list, the quick-filter search
+ * index and copy-to-clipboard.
+ */
+
+function buildObjectRow(label: string, apiName: string): PermissionTableObjectCell {
+  return {
+    key: apiName,
+    sobject: apiName,
+    apiName,
+    label,
+    tableLabel: `${label} (${apiName})`,
+    allowEditPermission: true,
+    allowViewAllModifyAllPermission: true,
+    permissions: {},
+  };
+}
+
+function buildTabRow(label: string, apiName: string): PermissionTableTabVisibilityCell {
+  return {
+    key: apiName,
+    sobject: apiName,
+    apiName,
+    label,
+    tableLabel: `${label} (${apiName})`,
+    canSetPermission: true,
+    permissions: {},
+  };
+}
+
+function getTableLabelSetValues<TRow>(columns: ColumnWithFilter<TRow, any>[], rows: TRow[]) {
+  return computeFilterSetValues(columns as ColumnWithFilter<TRow>[], rows)['tableLabel'];
+}
+
+describe('tableLabel column filter values', () => {
+  it('uses the formatted row label for the object table', () => {
+    const columns = getObjectColumns([], [], {}, {});
+    const rows = [buildObjectRow('Account', 'Account'), buildObjectRow('Albright Power', 'AlbrightPower__c')];
+
+    expect(getTableLabelSetValues(columns, rows)).toEqual(['Account (Account)', 'Albright Power (AlbrightPower__c)']);
+  });
+
+  it('uses the formatted row label for the tab visibility table', () => {
+    const columns = getTabVisibilityColumns([], [], {}, {});
+    const rows = [buildTabRow('Account', 'Account'), buildTabRow('Albright Power', 'AlbrightPower__c')];
+
+    expect(getTableLabelSetValues(columns, rows)).toEqual(['Account (Account)', 'Albright Power (AlbrightPower__c)']);
+  });
+
+  it.each([
+    ['object', () => getObjectColumns([], [], {}, {})],
+    ['tab visibility', () => getTabVisibilityColumns([], [], {}, {})],
+  ])('does not override getValue on the %s tableLabel column', (_label, getColumns) => {
+    // A `getValue` here would have to re-derive a value the row already holds - the source of the bug
+    const tableLabelColumn = getColumns().find(({ key }) => key === 'tableLabel');
+
+    expect(tableLabelColumn).toBeDefined();
+    expect(tableLabelColumn?.getValue).toBeUndefined();
+  });
+});

--- a/libs/features/manage-permissions/src/utils/__tests__/permission-manager-view-all-modify-all.spec.ts
+++ b/libs/features/manage-permissions/src/utils/__tests__/permission-manager-view-all-modify-all.spec.ts
@@ -1,0 +1,160 @@
+import {
+  BulkActionCheckbox,
+  ObjectPermissionDefinitionMap,
+  ObjectPermissionItem,
+  PermissionTableObjectCell,
+  PermissionTableObjectCellPermission,
+} from '@jetstream/types';
+import { describe, expect, it } from 'vitest';
+import { OBJECTS_WITHOUT_VIEW_ALL_MODIFY_ALL, supportsViewAllModifyAll } from '../object-permission-support';
+import { getObjectRows, updateRowsFromColumnAction, updateRowsFromRowAction } from '../permission-manager-table-utils';
+import { filterPermissionRows } from '../permission-manager-utils';
+
+const PARENT_ID = 'permSet1';
+
+function buildPermissionItem(overrides: Partial<ObjectPermissionItem> = {}): ObjectPermissionItem {
+  return { create: false, read: false, edit: false, delete: false, viewAll: false, modifyAll: false, viewAllFields: false, ...overrides };
+}
+
+function buildPermissionMap(apiName: string): Record<string, ObjectPermissionDefinitionMap> {
+  return {
+    [apiName]: {
+      apiName,
+      label: apiName,
+      metadata: '',
+      permissionKeys: [PARENT_ID],
+      permissions: { [PARENT_ID]: buildPermissionItem() },
+    },
+  };
+}
+
+function buildRow(apiName: string, permissionOverrides: Partial<PermissionTableObjectCellPermission> = {}): PermissionTableObjectCell {
+  const record = buildPermissionItem();
+  return {
+    key: apiName,
+    sobject: apiName,
+    apiName,
+    label: apiName,
+    tableLabel: `${apiName} (${apiName})`,
+    allowEditPermission: true,
+    allowViewAllModifyAllPermission: supportsViewAllModifyAll(apiName),
+    permissions: {
+      [PARENT_ID]: {
+        rowKey: apiName,
+        parentId: PARENT_ID,
+        sobject: apiName,
+        record,
+        create: false,
+        read: false,
+        edit: false,
+        delete: false,
+        viewAll: false,
+        modifyAll: false,
+        viewAllFields: false,
+        createIsDirty: false,
+        readIsDirty: false,
+        editIsDirty: false,
+        deleteIsDirty: false,
+        viewAllIsDirty: false,
+        modifyAllIsDirty: false,
+        viewAllFieldsIsDirty: false,
+        ...permissionOverrides,
+      },
+    },
+  };
+}
+
+function allCheckboxesOn(): Record<string, BulkActionCheckbox> {
+  return ['create', 'read', 'edit', 'delete', 'viewAll', 'modifyAll', 'viewAllFields'].reduce<Record<string, BulkActionCheckbox>>(
+    (output, id) => {
+      output[id] = { id: id as BulkActionCheckbox['id'], label: id, value: true, disabled: false };
+      return output;
+    },
+    {},
+  );
+}
+
+describe('supportsViewAllModifyAll', () => {
+  it.each(['Idea', 'PendingOrdSumProcEvent', 'Pricebook2', 'Product2', 'PushTopic'])('reports %s as unsupported', (apiName) => {
+    expect(supportsViewAllModifyAll(apiName)).toBe(false);
+    expect(OBJECTS_WITHOUT_VIEW_ALL_MODIFY_ALL.has(apiName)).toBe(true);
+  });
+
+  it.each(['Account', 'Contact', 'PricebookEntry', 'Custom__c'])('reports %s as supported', (apiName) => {
+    expect(supportsViewAllModifyAll(apiName)).toBe(true);
+  });
+});
+
+describe('getObjectRows', () => {
+  it('flags rows for objects that do not support View All / Modify All', () => {
+    const [row] = getObjectRows(['Product2'], buildPermissionMap('Product2'));
+
+    expect(row.allowViewAllModifyAllPermission).toBe(false);
+  });
+
+  it('leaves supported objects editable', () => {
+    const [row] = getObjectRows(['Account'], buildPermissionMap('Account'));
+
+    expect(row.allowViewAllModifyAllPermission).toBe(true);
+  });
+});
+
+describe('updateRowsFromColumnAction', () => {
+  it.each(['viewAll', 'modifyAll'] as const)('does not select %s on an unsupported object', (which) => {
+    const rows = [buildRow('Product2'), buildRow('Account')];
+
+    const [product, account] = updateRowsFromColumnAction('object', 'selectAll', which, PARENT_ID, rows);
+
+    expect(product.permissions[PARENT_ID][which]).toBe(false);
+    expect(product.permissions[PARENT_ID][`${which}IsDirty`]).toBe(false);
+    expect(account.permissions[PARENT_ID][which]).toBe(true);
+  });
+
+  it('still applies other permissions to unsupported objects', () => {
+    const [product] = updateRowsFromColumnAction('object', 'selectAll', 'read', PARENT_ID, [buildRow('Product2')]);
+
+    expect(product.permissions[PARENT_ID].read).toBe(true);
+  });
+
+  it('still allows reset on unsupported objects so a stale value can be restored', () => {
+    const rows = [buildRow('Product2', { viewAll: true, viewAllIsDirty: true })];
+
+    const [product] = updateRowsFromColumnAction('object', 'reset', 'viewAll', PARENT_ID, rows);
+
+    expect(product.permissions[PARENT_ID].viewAll).toBe(false);
+    expect(product.permissions[PARENT_ID].viewAllIsDirty).toBe(false);
+  });
+});
+
+describe('updateRowsFromRowAction', () => {
+  it('applies every permission except View All / Modify All to unsupported objects', () => {
+    const [product, account] = updateRowsFromRowAction('object', allCheckboxesOn(), [buildRow('Product2'), buildRow('Account')]);
+
+    expect(product.permissions[PARENT_ID]).toMatchObject({ create: true, read: true, edit: true, delete: true, viewAllFields: true });
+    expect(product.permissions[PARENT_ID].viewAll).toBe(false);
+    expect(product.permissions[PARENT_ID].modifyAll).toBe(false);
+    expect(account.permissions[PARENT_ID].viewAll).toBe(true);
+    expect(account.permissions[PARENT_ID].modifyAll).toBe(true);
+  });
+});
+
+describe('filterPermissionRows', () => {
+  const rows = [buildRow('Account'), buildRow('Contact', { errorMessage: 'Something went wrong' }), buildRow('Lead')];
+
+  it('returns every row with no filters applied', () => {
+    expect(filterPermissionRows(rows, '', false)).toHaveLength(3);
+  });
+
+  it('keeps only rows with an error when errorsOnly is set', () => {
+    expect(filterPermissionRows(rows, '', true)?.map(({ apiName }) => apiName)).toEqual(['Contact']);
+  });
+
+  it('applies the text filter and errorsOnly together', () => {
+    expect(filterPermissionRows(rows, 'Account', true)).toEqual([]);
+    expect(filterPermissionRows(rows, 'Contact', true)?.map(({ apiName }) => apiName)).toEqual(['Contact']);
+  });
+
+  it('returns null when there are no rows yet', () => {
+    expect(filterPermissionRows(null, '', false)).toBeNull();
+  });
+});

--- a/libs/features/manage-permissions/src/utils/object-permission-support.ts
+++ b/libs/features/manage-permissions/src/utils/object-permission-support.ts
@@ -1,0 +1,19 @@
+/**
+ * Objects that accept an `ObjectPermissions` record but do not support View All Records / Modify All
+ * Records. Salesforce does not reject these - it accepts the DML, reports success, and silently drops
+ * the value, so the checkbox appears to save and then reverts on the next load. There is no describe
+ * flag exposing this, so the list is maintained by hand.
+ *
+ * Salesforce documents ideas, price books, article types and products as unsupported; `PushTopic` and
+ * `PendingOrdSumProcEvent` were confirmed against a live org.
+ *
+ * @see https://help.salesforce.com/s/articleView?id=platform.users_profiles_view_all_mod_all.htm&type=5
+ */
+export const OBJECTS_WITHOUT_VIEW_ALL_MODIFY_ALL = new Set(['Idea', 'PendingOrdSumProcEvent', 'Pricebook2', 'Product2', 'PushTopic']);
+
+export const VIEW_ALL_MODIFY_ALL_UNSUPPORTED_MESSAGE =
+  'Salesforce does not support View All or Modify All for this object. Access is controlled through sharing settings instead.';
+
+export function supportsViewAllModifyAll(sobject: string): boolean {
+  return !OBJECTS_WITHOUT_VIEW_ALL_MODIFY_ALL.has(sobject);
+}

--- a/libs/features/manage-permissions/src/utils/permission-manager-table-utils.tsx
+++ b/libs/features/manage-permissions/src/utils/permission-manager-table-utils.tsx
@@ -51,8 +51,10 @@ import {
   SummaryFilterRenderer,
   Tooltip,
 } from '@jetstream/ui';
+import classNames from 'classnames';
 import startCase from 'lodash/startCase';
 import { Fragment, useContext, useMemo, useRef, useState } from 'react';
+import { supportsViewAllModifyAll, VIEW_ALL_MODIFY_ALL_UNSUPPORTED_MESSAGE } from './object-permission-support';
 import {
   SYSTEM_PERMISSION_DEPENDENCY_TOOLTIP,
   SYSTEM_PERMISSION_DEPENDENT_CLOSURE,
@@ -89,7 +91,22 @@ type PermissionActionAction<T> = T extends 'object'
         ? SystemPermissionTypes
         : never;
 
+/**
+ * True when the permission is View All / Modify All on an object that does not support it. Every path
+ * that writes a permission value routes through this so a bulk action can never set what the checkbox
+ * refuses to set.
+ */
+function isBlockedViewAllModifyAll(which: PermissionTypes, row: PermissionTableCellExtended): boolean {
+  if (which !== 'viewAll' && which !== 'modifyAll') {
+    return false;
+  }
+  return 'allowViewAllModifyAllPermission' in row && !row.allowViewAllModifyAllPermission;
+}
+
 function setObjectValue(which: ObjectPermissionTypes, row: PermissionTableObjectCell, permissionId: string, value: boolean) {
+  if (isBlockedViewAllModifyAll(which, row)) {
+    return row;
+  }
   const newRow = { ...row, permissions: { ...row.permissions, [permissionId]: { ...row.permissions[permissionId] } } };
   const permission = newRow.permissions[permissionId];
   if (which === 'create') {
@@ -360,10 +377,8 @@ export function getObjectColumns(
       key: 'tableLabel',
       frozen: true,
       width: 300,
-      getValue: ({ column, row }) => {
-        const data: PermissionTableFieldCell = row[column.key as keyof PermissionTableObjectCell] as any;
-        return data && `${data.label} (${data.apiName})`;
-      },
+      // No `getValue` — `tableLabel` is already `Label (ApiName)`, so filtering, search and copy all
+      // read the row value directly.
       summaryCellClass: 'bg-color-gray-dark no-outline',
       renderSummaryCell: ({ row }) => {
         if (row.type === 'HEADING') {
@@ -434,11 +449,12 @@ export function getObjectRows(selectedSObjects: string[], objectPermissionMap: R
 
     const currRow: PermissionTableObjectCell = {
       key: sobject,
-      sobject: sobject,
+      sobject,
       apiName: objectPermission.apiName,
       label: objectPermission.label,
       tableLabel: `${objectPermission.label} (${objectPermission.apiName})`,
       allowEditPermission: true,
+      allowViewAllModifyAllPermission: supportsViewAllModifyAll(objectPermission.apiName),
       permissions: {},
     };
 
@@ -716,23 +732,34 @@ function getColumnForProfileOrPermSet<T extends PermissionType>({
         }
       }
 
-      const disabled = actionKey === 'edit' && 'allowEditPermission' in row && !row.allowEditPermission;
+      const unsupportedViewAllModifyAll = isBlockedViewAllModifyAll(actionKey as PermissionTypes, row);
+      const disabled = unsupportedViewAllModifyAll || (actionKey === 'edit' && 'allowEditPermission' in row && !row.allowEditPermission);
+
+      const checkbox = (
+        <input
+          type="checkbox"
+          id={`${row.key}-${id}-${actionKey}`}
+          checked={value}
+          tabIndex={-1}
+          // Stop the click from also reaching the wrapping div's onClick — otherwise a direct click
+          // (or programmatic keyboard activation) toggles via both handlers. onChange owns the toggle.
+          onClick={(ev) => ev.stopPropagation()}
+          onChange={(ev) => {
+            handleChange(ev.target.checked);
+          }}
+          disabled={disabled}
+        ></input>
+      );
 
       return (
         <div className="slds-align_absolute-center h-100" onClick={() => !disabled && handleChange(!value)}>
-          <input
-            type="checkbox"
-            id={`${row.key}-${id}-${actionKey}`}
-            checked={value}
-            tabIndex={-1}
-            // Stop the click from also reaching the wrapping div's onClick — otherwise a direct click
-            // (or programmatic keyboard activation) toggles via both handlers. onChange owns the toggle.
-            onClick={(ev) => ev.stopPropagation()}
-            onChange={(ev) => {
-              handleChange(ev.target.checked);
-            }}
-            disabled={disabled}
-          ></input>
+          {unsupportedViewAllModifyAll ? (
+            <Tooltip ariaRole="label" content={VIEW_ALL_MODIFY_ALL_UNSUPPORTED_MESSAGE}>
+              {checkbox}
+            </Tooltip>
+          ) : (
+            checkbox
+          )}
           {errorMessage && (
             <div
               css={css`
@@ -924,10 +951,8 @@ export function getTabVisibilityColumns(
       key: 'tableLabel',
       frozen: true,
       width: 300,
-      getValue: ({ column, row }) => {
-        const data: PermissionTableTabVisibilityCell = row[column.key as keyof PermissionTableTabVisibilityCell] as any;
-        return data && `${data.label} (${data.apiName})`;
-      },
+      // No `getValue` — `tableLabel` is already `Label (ApiName)`, so filtering, search and copy all
+      // read the row value directly.
       summaryCellClass: 'bg-color-gray-dark no-outline',
       renderSummaryCell: ({ row }) => {
         if (row.type === 'HEADING') {
@@ -1370,6 +1395,10 @@ export function updateRowsFromColumnAction<TRows extends PermissionTableCellExte
 ): TRows[] {
   const newRows = [...rows];
   return newRows.map((row, index) => {
+    // Reset restores the saved value, so it stays allowed even where the permission cannot be set
+    if (action !== 'reset' && isBlockedViewAllModifyAll(which, row)) {
+      return row;
+    }
     row = { ...row };
     let newValue = action === 'selectAll';
     row.permissions = { ...row.permissions };
@@ -1458,8 +1487,10 @@ export function updateRowsFromRowAction<TRows extends PermissionTableCellExtende
 
         permission.edit = checkboxesById['edit'].value;
         permission.delete = checkboxesById['delete'].value;
-        permission.viewAll = checkboxesById['viewAll'].value;
-        permission.modifyAll = checkboxesById['modifyAll'].value;
+        if (!isBlockedViewAllModifyAll('viewAll', row)) {
+          permission.viewAll = checkboxesById['viewAll'].value;
+          permission.modifyAll = checkboxesById['modifyAll'].value;
+        }
         permission.viewAllFields = checkboxesById['viewAllFields'].value;
 
         permission.createIsDirty = permission.create !== permission.record.create;
@@ -1615,15 +1646,21 @@ export const PinnedSelectAllRendererWrapper = ({ column }: RenderSummaryCellProp
   );
 };
 
-function defaultRowActionCheckboxes(type: PermissionType, allowEditPermission: boolean): BulkActionCheckbox[] {
+/**
+ * Checkbox list for the row / bulk action popovers. Omit `row` for the table-wide bulk action, which
+ * spans a mix of rows — per-row restrictions are enforced when the change is applied instead.
+ */
+function defaultRowActionCheckboxes(type: PermissionType, row?: PermissionTableCellExtended): BulkActionCheckbox[] {
+  const allowEditPermission = !row || !('allowEditPermission' in row) || row.allowEditPermission;
+  const allowViewAllModifyAll = !row || !isBlockedViewAllModifyAll('viewAll', row);
   if (type === 'object') {
     return [
       { id: 'create', label: 'Create', value: false, disabled: false },
       { id: 'read', label: 'Read', value: false, disabled: false },
       { id: 'edit', label: 'Edit', value: false, disabled: !allowEditPermission },
       { id: 'delete', label: 'Delete', value: false, disabled: false },
-      { id: 'viewAll', label: 'View All', value: false, disabled: false },
-      { id: 'modifyAll', label: 'Modify All', value: false, disabled: false },
+      { id: 'viewAll', label: 'View All', value: false, disabled: !allowViewAllModifyAll },
+      { id: 'modifyAll', label: 'Modify All', value: false, disabled: !allowViewAllModifyAll },
       { id: 'viewAllFields', label: 'View All Fields', value: false, disabled: false },
     ];
   } else if (type === 'field') {
@@ -1740,7 +1777,7 @@ export const RowActionRenderer = ({ column, commitEdit, row }: RenderCellProps<P
   const { type } = useContext(DataTableGenericContext) as PermissionManagerTableContext;
   const popoverRef = useRef<PopoverRef>(null);
   const [checkboxes, setCheckboxes] = useState<BulkActionCheckbox[]>(() => {
-    return defaultRowActionCheckboxes(type, 'allowEditPermission' in row ? row?.allowEditPermission : true);
+    return defaultRowActionCheckboxes(type, row);
   });
 
   /**
@@ -1781,7 +1818,7 @@ export const RowActionRenderer = ({ column, commitEdit, row }: RenderCellProps<P
 
   function handlePopoverChange(isOpen: boolean) {
     if (!isOpen) {
-      setCheckboxes(defaultRowActionCheckboxes(type, 'allowEditPermission' in row ? row.allowEditPermission : true));
+      setCheckboxes(defaultRowActionCheckboxes(type, row));
     }
   }
 
@@ -1848,8 +1885,44 @@ export const RowActionRenderer = ({ column, commitEdit, row }: RenderCellProps<P
  * This component provides a modal that the user can open to make changes that apply to an entire visible table
  */
 export const ColumnSearchFilter = () => {
-  const { filterValue: initialFilterValue, onFilterRows } = useContext(DataTableGenericContext) as PermissionManagerTableContext;
-  return <SearchInput id="column-filter" value={initialFilterValue || ''} placeholder="Filter..." onChange={onFilterRows} />;
+  const {
+    filterValue: initialFilterValue,
+    hasErrors,
+    errorsOnly,
+    onFilterRows,
+    onToggleErrorsOnly,
+  } = useContext(DataTableGenericContext) as PermissionManagerTableContext;
+  return (
+    <Grid verticalAlign="center">
+      <div className="slds-grow">
+        <SearchInput id="column-filter" value={initialFilterValue || ''} placeholder="Filter..." onChange={onFilterRows} />
+      </div>
+      {/* Only offered once a save has produced errors — otherwise it would always filter to nothing */}
+      {hasErrors && onToggleErrorsOnly && (
+        <Tooltip className="slds-m-left_x-small" content={errorsOnly ? 'Show all rows' : 'Show only rows with errors'}>
+          <button
+            type="button"
+            aria-pressed={!!errorsOnly}
+            className={classNames('slds-button slds-button_icon slds-button_icon-border', {
+              'slds-is-selected': errorsOnly,
+            })}
+            tabIndex={-1}
+            onClick={() => onToggleErrorsOnly(!errorsOnly)}
+          >
+            {/* `slds-is-selected` gives the button a blue background and its own white icon fill, so the
+                error color is only applied while the toggle is off */}
+            <Icon
+              type="utility"
+              icon="error"
+              className={classNames('slds-button__icon slds-button__icon_small', { 'slds-icon-text-error': !errorsOnly })}
+              omitContainer
+            />
+            <span className="slds-assistive-text">{errorsOnly ? 'Show all rows' : 'Show only rows with errors'}</span>
+          </button>
+        </Tooltip>
+      )}
+    </Grid>
+  );
 };
 
 export const ColumnSearchFilterSummary = () => {
@@ -1872,7 +1945,7 @@ export const ColumnSearchFilterSummary = () => {
 export const BulkActionRenderer = () => {
   const { type, rows, onBulkAction } = useContext(DataTableGenericContext) as PermissionManagerTableContext;
   const [isOpen, setIsOpen] = useState(false);
-  const [checkboxes, setCheckboxes] = useState(defaultRowActionCheckboxes(type, true));
+  const [checkboxes, setCheckboxes] = useState(() => defaultRowActionCheckboxes(type));
 
   const rowCount = useMemo(() => rows.filter((row) => !('canSetPermission' in row) || row.canSetPermission).length, [rows]);
 
@@ -1909,7 +1982,7 @@ export const BulkActionRenderer = () => {
   }
 
   function handleOpen() {
-    setCheckboxes(defaultRowActionCheckboxes(type, true));
+    setCheckboxes(defaultRowActionCheckboxes(type));
     setIsOpen(true);
   }
 

--- a/libs/features/manage-permissions/src/utils/permission-manager-utils.ts
+++ b/libs/features/manage-permissions/src/utils/permission-manager-utils.ts
@@ -1,7 +1,7 @@
 import { logger } from '@jetstream/shared/client-logger';
-import { sobjectOperation, updatePermissionSetRecords } from '@jetstream/shared/data';
+import { describeSObject, sobjectOperation, updatePermissionSetRecords } from '@jetstream/shared/data';
 import { isErrorResponse } from '@jetstream/shared/ui-utils';
-import { splitArrayToMaxSize } from '@jetstream/shared/utils';
+import { multiWordObjectFilter, splitArrayToMaxSize } from '@jetstream/shared/utils';
 import {
   DescribeGlobalSObjectResult,
   EntityParticlePermissionsRecord,
@@ -9,6 +9,7 @@ import {
   FieldPermissionDefinitionMap,
   FieldPermissionRecord,
   FieldPermissionRecordForSave,
+  Maybe,
   ObjectPermissionDefinitionMap,
   ObjectPermissionRecord,
   ObjectPermissionRecordForSave,
@@ -20,6 +21,7 @@ import {
   PermissionSetWithProfileRecord,
   PermissionSystemSaveData,
   PermissionTabVisibilitySaveData,
+  PermissionTableCellExtended,
   PermissionTableCellPermission,
   PermissionTableFieldCellPermission,
   PermissionTableObjectCellPermission,
@@ -52,6 +54,46 @@ export function filterPermissionsSobjects(sobject: DescribeGlobalSObjectResult |
     return false;
   }
   return sobject.createable || sobject.updateable || sobject.name.endsWith('__e');
+}
+
+/**
+ * Reads the org's allow-list of objects that can have an `ObjectPermissions` record.
+ *
+ * `ObjectPermissions.SobjectType` is a restricted picklist whose values are exactly those objects.
+ * Objects with no independent CRUD are absent - setup/metadata objects (ApexClass, Profile, RecordType),
+ * children whose access rolls up to a parent (Task/Event, OpportunityLineItem, PricebookEntry, Attachment)
+ * and platform junctions (Group, FeedItem, User). Saving against any of them fails with
+ * `INVALID_OR_NULL_FOR_RESTRICTED_PICKLIST`, so they must never reach the permission editor.
+ *
+ * Returns `null` when the allow-list cannot be determined, which signals callers to fall back to the
+ * name/CRUD heuristic rather than showing an empty object list.
+ */
+export async function getPermissionableSobjects(org: SalesforceOrgUi): Promise<Set<string> | null> {
+  try {
+    const { data } = await describeSObject(org, 'ObjectPermissions');
+    const picklistValues = data.fields.find(({ name }) => name === 'SobjectType')?.picklistValues;
+    if (!picklistValues?.length) {
+      logger.warn('[PERMISSIONS] ObjectPermissions.SobjectType returned no picklist values, falling back to heuristic filter');
+      return null;
+    }
+    // `active` is omitted on some describe responses - only drop values explicitly marked inactive
+    const permissionableSobjects = new Set(picklistValues.filter(({ active }) => active !== false).map(({ value }) => value));
+    return permissionableSobjects.size ? permissionableSobjects : null;
+  } catch (ex) {
+    logger.warn('[PERMISSIONS] Unable to describe ObjectPermissions, falling back to heuristic filter', ex);
+    return null;
+  }
+}
+
+/**
+ * Object list filter for the permission manager. Prefers the org's `ObjectPermissions.SobjectType`
+ * allow-list and falls back to the name/CRUD heuristic when it is unavailable.
+ */
+export function getPermissionsSobjectFilter(permissionableSobjects: Maybe<Set<string>>) {
+  if (!permissionableSobjects) {
+    return filterPermissionsSobjects;
+  }
+  return (sobject: DescribeGlobalSObjectResult | null) => !!sobject && permissionableSobjects.has(sobject.name);
 }
 
 export function getFieldDefinitionKey(record: EntityParticlePermissionsRecord) {
@@ -691,6 +733,32 @@ export function clearPermissionErrorMessage<T extends PermissionDefinitionMap>(p
 
 export function permissionsHaveError<T extends PermissionDefinitionMap>(permissionMap: Record<string, T>): boolean {
   return Object.values(permissionMap).some((item) => Object.values(item.permissions).some((permission) => permission.errorMessage));
+}
+
+export function rowHasError(row: PermissionTableCellExtended): boolean {
+  return Object.values(row.permissions).some((permission) => !!permission.errorMessage);
+}
+
+/**
+ * Row visibility for every permission table: the free-text filter plus the "errors only" toggle, which
+ * is how a user finds the handful of failures after saving a large selection.
+ */
+export function filterPermissionRows<T extends PermissionTableCellExtended>(
+  rows: Maybe<T[]>,
+  filterText: string,
+  errorsOnly: boolean,
+): T[] | null {
+  if (!rows) {
+    return null;
+  }
+  let visibleRows = rows;
+  if (filterText) {
+    visibleRows = visibleRows.filter(multiWordObjectFilter(['label', 'apiName'], filterText));
+  }
+  if (errorsOnly) {
+    visibleRows = visibleRows.filter(rowHasError);
+  }
+  return visibleRows;
 }
 
 /**

--- a/libs/types/src/lib/ui/permission-manager-types.ts
+++ b/libs/types/src/lib/ui/permission-manager-types.ts
@@ -160,6 +160,8 @@ export type PermissionTableCellExtended =
 
 export interface PermissionTableObjectCell extends PermissionTableCell<PermissionTableObjectCellPermission> {
   allowEditPermission: boolean; // TODO: what other permissions may be restricted here??
+  /** False for objects where Salesforce silently drops View All / Modify All (Idea, Product2, ...) */
+  allowViewAllModifyAllPermission: boolean;
 }
 
 export interface PermissionTableFieldCell extends PermissionTableCell<PermissionTableFieldCellPermission> {
@@ -292,7 +294,11 @@ export interface PermissionManagerTableContext {
   rows: PermissionTableCellExtended[];
   totalCount: number;
   filterValue?: string;
+  /** True when any row in the table (not just the visible ones) has a save error */
+  hasErrors?: boolean;
+  errorsOnly?: boolean;
   onFilterRows: (value: string) => void;
+  onToggleErrorsOnly?: (value: boolean) => void;
   onRowAction: (action: 'selectAll' | 'unselectAll' | 'reset', columnKey: string) => void;
   onColumnAction: (action: 'selectAll' | 'unselectAll' | 'reset', columnKey: string) => void;
   onBulkAction: (rows: PermissionTableCellExtended[]) => void;

--- a/libs/ui/src/index.ts
+++ b/libs/ui/src/index.ts
@@ -13,6 +13,7 @@ export * from './lib/data-table/data-table-formatters';
 export type { ColumnWithFilter, ContextAction, ContextMenuActionData, DataTableRef, RowWithKey } from './lib/data-table/data-table-types';
 export {
   TABLE_CONTEXT_MENU_ITEMS,
+  computeFilterSetValues,
   copyGenericTableDataToClipboard,
   getColumnsForGenericTable,
   getRowTypeFromValue,

--- a/libs/ui/src/lib/sobject-list/ConnectedSobjectListMultiSelect.tsx
+++ b/libs/ui/src/lib/sobject-list/ConnectedSobjectListMultiSelect.tsx
@@ -41,6 +41,12 @@ export interface ConnectedSobjectListMultiSelectProps {
   recentItemsEnabled?: boolean;
   recentItemsKey?: RecentHistoryItemType;
   filterFn?: (sobject: DescribeGlobalSObjectResult | null) => boolean;
+  /**
+   * Set to `false` while the caller is still loading data that its `filterFn` depends on (e.g. an async
+   * describe). Objects are not fetched until this is `true`, so the list is never populated using a
+   * filter that is not ready yet.
+   */
+  filterReady?: boolean;
   onSobjects: (sobjects: DescribeGlobalSObjectResult[] | null) => void;
   onSelectedSObjects: (selectedSObjects: string[]) => void;
   onRefresh?: () => void;
@@ -60,6 +66,7 @@ export const ConnectedSobjectListMultiSelect = forwardRef<any, ConnectedSobjectL
       recentItemsEnabled,
       recentItemsKey,
       filterFn = filterSobjectFn,
+      filterReady = true,
       onSobjects,
       onSelectedSObjects,
       onRefresh,
@@ -137,10 +144,10 @@ export const ConnectedSobjectListMultiSelect = forwardRef<any, ConnectedSobjectL
     // Auto-load is independent of `disabled`: a read-only list should still populate its data (the
     // `!sobjects` guard skips the fetch when a caller pre-supplies objects); `disabled` only gates interaction.
     useEffect(() => {
-      if (!disabled && selectedOrg && !loading && !errorMessage && !sobjects) {
+      if (filterReady && selectedOrg && !loading && !errorMessage && !sobjects) {
         loadObjects().then(NOOP);
       }
-    }, [disabled, selectedOrg, loading, errorMessage, sobjects, onSobjects, loadObjects]);
+    }, [filterReady, selectedOrg, loading, errorMessage, sobjects, onSobjects, loadObjects]);
 
     async function handleRefresh() {
       try {
@@ -169,7 +176,7 @@ export const ConnectedSobjectListMultiSelect = forwardRef<any, ConnectedSobjectL
             <Tooltip id={`sobject-list-refresh-tooltip`} content={lastRefreshed}>
               <button
                 className="slds-button slds-button_icon slds-button_icon-container"
-                disabled={disabled || loading}
+                disabled={disabled || loading || !filterReady}
                 onClick={handleRefresh}
               >
                 <Icon type="utility" icon="refresh" description={`Reload objects`} className="slds-button__icon" omitContainer />
@@ -180,7 +187,7 @@ export const ConnectedSobjectListMultiSelect = forwardRef<any, ConnectedSobjectL
         <SobjectListMultiSelect
           sobjects={sobjectsFiltered}
           selectedSObjects={selectedSObjects}
-          loading={loading}
+          loading={loading || !filterReady}
           errorMessage={errorMessage}
           allowSelectAll={allowSelectAll}
           disabled={disabled}


### PR DESCRIPTION
Saving "View All" against every standard object in a real org produced 446 failures out of 580 records, in three distinct classes. Two are fixed here; the third (concurrent save batches breaking cross-object dependencies) is not.

The object picker now filters on the org's own allow-list. 423 of those failures were INVALID_OR_NULL_FOR_RESTRICTED_PICKLIST across 291 distinct objects that cannot hold an ObjectPermissions record at all: setup and metadata objects (ApexClass, Profile, RecordType), children whose access rolls up to a parent (Task/Event, OpportunityLineItem, PricebookEntry, Attachment), and platform junctions (Group, FeedItem, User). ObjectPermissions.SobjectType is a restricted picklist whose values are exactly the permissionable objects, so the picker describes it and filters on the result. That is org-specific and accounts for which features are enabled, unlike the previous name/CRUD heuristic which let anything createable through. The describe is async while the existing filter runs synchronously after describeGlobal, so ConnectedSobjectListMultiSelect gained an optional filterReady prop that defers loading until the caller's filter data is ready; it defaults to true, so no other caller changes behavior. If the describe fails the picker falls back to the old heuristic rather than showing an empty list. Permission Analysis shares the picker and benefits for the same reason — non-permissionable objects produce no export rows either.