### PR TITLE
fix: correct auth redirect, SSO device prompt, and desktop click handling

### DIFF
--- a/apps/api/src/app/controllers/auth.controller.ts
+++ b/apps/api/src/app/controllers/auth.controller.ts
@@ -58,6 +58,7 @@ import {
   Provider,
   ProviderKeysSchema,
   ProvidersSchema,
+  SsoProviderTypeSchema,
   UserProfileSession,
 } from '@jetstream/auth/types';
 import {
@@ -124,6 +125,7 @@ export const routeDefinition = {
       isVerificationExpired: z.boolean(),
       pendingTosAcceptance: z.boolean(),
       currentTosVersion: z.string(),
+      isSsoLogin: z.boolean(),
     }),
     validators: {
       hasSourceOrg: false,
@@ -346,6 +348,10 @@ const getSession = createRoute(routeDefinition.getSession.validators, async (_, 
       isVerificationExpired,
       pendingTosAcceptance: !!req.session.pendingTosAcceptance,
       currentTosVersion: CURRENT_TOS_VERSION,
+      // The SSO callbacks never consult a remembered device, so the verify page uses this to hide the
+      // "Remember this device" option rather than offer a choice that would have no effect. A team that
+      // turns on `ssoRequireMfa` wants the factor every time.
+      isSsoLogin: SsoProviderTypeSchema.safeParse(req.session.provider).success,
     });
   } catch (ex) {
     next(ensureAuthError(ex));
@@ -1587,7 +1593,7 @@ const handleOidcCallback = createRoute(routeDefinition.handleOidcCallback.valida
   }
 });
 
-const acceptTerms = createRoute(routeDefinition.acceptTerms.validators, async ({ body }, req, res, next) => {
+const acceptTerms = createRoute(routeDefinition.acceptTerms.validators, async ({ body, clearCookie }, req, res, next) => {
   try {
     if (!req.session.user) {
       throw new InvalidSession('Not authenticated');
@@ -1613,7 +1619,24 @@ const acceptTerms = createRoute(routeDefinition.acceptTerms.validators, async ({
       success: true,
     });
 
-    const safeRedirectUrl = validateRedirectUrl(null, [ENV.JETSTREAM_CLIENT_URL, ENV.JETSTREAM_SERVER_URL], ENV.JETSTREAM_CLIENT_URL);
+    // ToS acceptance can be the last gate of a flow that started somewhere other than the web app —
+    // the desktop app and web extension both stash their auth-callback URL in the redirectUrl cookie
+    // before sending the user here. Honor it (same as the 2FA and MFA-enrollment steps) or they land
+    // in the web app and never get their token back.
+    const cookieConfig = getCookieConfig(ENV.USE_SECURE_COOKIES);
+    const cookies = req.headers.cookie ? parseCookie(req.headers.cookie) : {};
+    let redirectUrl = ENV.JETSTREAM_CLIENT_URL;
+    const redirectValue = cookies[cookieConfig.redirectUrl.name];
+    if (redirectValue) {
+      redirectUrl = normalizeRedirectCandidate(redirectValue) ?? redirectUrl;
+      clearCookie(cookieConfig.redirectUrl.name, cookieConfig.redirectUrl.options);
+    }
+
+    const safeRedirectUrl = validateRedirectUrl(
+      redirectUrl,
+      [ENV.JETSTREAM_CLIENT_URL, ENV.JETSTREAM_SERVER_URL],
+      ENV.JETSTREAM_CLIENT_URL,
+    );
     sendJson(res, { error: false, redirect: safeRedirectUrl });
   } catch (ex) {
     next(ensureAuthError(ex));

--- a/apps/api/src/app/db/__tests__/feature-flags.db.spec.ts
+++ b/apps/api/src/app/db/__tests__/feature-flags.db.spec.ts
@@ -1,3 +1,4 @@
+import { ALL_FEATURE_FLAG_KEYS, DEFAULT_FEATURE_FLAGS } from '@jetstream/types';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const prismaMock = vi.hoisted(() => ({
@@ -13,8 +14,6 @@ vi.mock('@jetstream/api-config', () => ({
   logger: { error: vi.fn(), warn: vi.fn() },
   prisma: prismaMock,
 }));
-
-import { ALL_FEATURE_FLAG_KEYS, DEFAULT_FEATURE_FLAGS } from '@jetstream/types';
 
 // Drive fixtures off the real registry so renaming/retiring the example flag never breaks these tests.
 const FLAG = ALL_FEATURE_FLAG_KEYS[0];

--- a/apps/jetstream-desktop-client/src/main.css
+++ b/apps/jetstream-desktop-client/src/main.css
@@ -1,3 +1,14 @@
 .slds-global-header {
   app-region: drag;
 }
+
+/*
+ * The header drag region is an OS-level titlebar rect, so anything overlapping the top of the window
+ * has its mouse events consumed by window dragging no matter how it is stacked. Modals render above
+ * the header (z-index 9001 vs 100) and their close button sits at the very top of the container, so
+ * on a tall modal it lands inside that rect and looks clickable but cannot be clicked. Carve the
+ * whole modal back out of the drag region.
+ */
+.slds-modal {
+  app-region: no-drag;
+}

--- a/apps/jetstream-desktop/src/services/ipc.service.ts
+++ b/apps/jetstream-desktop/src/services/ipc.service.ts
@@ -42,6 +42,44 @@ function registerHandler<Key extends keyof ElectronApiRequestResponse>(key: Key,
   ipcMain.handle(key, handler);
 }
 
+/** Abandon an OAuth flow whose callback never arrived, so its listener does not leak */
+const DEEP_LINK_FLOW_TIMEOUT_MS = 900000; // 15 minutes
+
+/** Cancel function for the in-flight flow of each deep-link action, keyed by action name */
+const pendingDeepLinkFlows = new Map<string, () => void>();
+
+/**
+ * Register a one-shot deep-link listener for an OAuth-style flow, cancelling whatever flow was
+ * already pending for the same action.
+ *
+ * A deep-link event is dispatched to EVERY listener registered for its action, so without this a
+ * second "Login" / "Add Org" click (e.g. the first one opened the wrong browser profile) would leave
+ * the abandoned listener registered alongside the new one. When the callback finally arrives both
+ * run: the current flow succeeds while the abandoned one fails its nonce / PKCE check, surfacing a
+ * spurious "error authenticating" toast next to the successful result.
+ */
+function startDeepLinkFlow(action: string, handleCallback: (params: Record<string, string>) => Promise<void>) {
+  pendingDeepLinkFlows.get(action)?.();
+
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  let disposeListener: () => void = () => undefined;
+
+  const cancel = () => {
+    clearTimeout(timeout);
+    disposeListener();
+    // Only clear the map entry if a newer flow has not already replaced this one
+    if (pendingDeepLinkFlows.get(action) === cancel) {
+      pendingDeepLinkFlows.delete(action);
+    }
+  };
+
+  disposeListener = deepLink.once(action, (params) => {
+    handleCallback(params).finally(cancel);
+  });
+  timeout = setTimeout(cancel, DEEP_LINK_FLOW_TIMEOUT_MS);
+  pendingDeepLinkFlows.set(action, cancel);
+}
+
 const handleOpenFile: MainIpcHandler<'openFile'> = async (_event, filePath: string): Promise<void> => {
   try {
     await shell.openPath(filePath);
@@ -168,17 +206,10 @@ const handleLoginEvent: MainIpcHandler<'login'> = async (event) => {
       logger.error('Error handling callback', ex);
       const payload: AuthenticateFailurePayload = { success: false, error: 'There was an unknown error authenticating your account' };
       event.sender.send(IpcEventChannel.authenticate, payload);
-    } finally {
-      clearTimeout(timeout);
     }
   };
 
-  const disposeListener = deepLink.once('auth', handleCallback);
-
-  // Remove the listener if it was not already removed - e.g. auth flow did not completed within 15 minutes
-  const timeout = setTimeout(() => {
-    disposeListener();
-  }, 900000); // 15 minutes in milliseconds
+  startDeepLinkFlow('auth', handleCallback);
 };
 
 // Tracked alongside the logout handler so handleCheckAuthEvent can detect when a logout
@@ -272,17 +303,10 @@ const handleAddOrgEvent: MainIpcHandler<'addOrg'> = async (event, payload) => {
 
       logger.error('Error handling callback', ex);
       event.sender.send(IpcEventChannel.toastMessage, { type: 'error', message });
-    } finally {
-      clearTimeout(timeout);
     }
   };
 
-  const disposeListener = deepLink.once('addOrg', handleCallback);
-
-  // Remove the listener if it was not already removed - e.g. auth flow did not completed within 15 minutes
-  const timeout = setTimeout(() => {
-    disposeListener();
-  }, 900000); // 15 minutes in milliseconds
+  startDeepLinkFlow('addOrg', handleCallback);
 };
 
 const handleOpenGooglePickerEvent: MainIpcHandler<'openGooglePicker'> = async (event, payload) => {

--- a/apps/landing/components/auth/VerifyEmailOr2fa.tsx
+++ b/apps/landing/components/auth/VerifyEmailOr2fa.tsx
@@ -44,9 +44,14 @@ interface VerifyEmailOr2faProps {
   csrfToken: string;
   email?: Maybe<string>;
   pendingVerifications: TwoFactorType[];
+  /**
+   * SSO sessions ignore remembered devices — the SAML/OIDC callbacks always require the configured
+   * factor — so the option is hidden (and never sent) instead of appearing to work.
+   */
+  isSsoLogin?: boolean;
 }
 
-export function VerifyEmailOr2fa({ csrfToken, email, pendingVerifications }: VerifyEmailOr2faProps) {
+export function VerifyEmailOr2fa({ csrfToken, email, pendingVerifications, isSsoLogin }: VerifyEmailOr2faProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
   const [error, setError] = useState<string>();
@@ -67,7 +72,8 @@ export function VerifyEmailOr2fa({ csrfToken, email, pendingVerifications }: Ver
       csrfToken,
       captchaToken: '',
       type: activeFactor,
-      rememberDevice: true,
+      // Never request device remembering for SSO — the record would be written but never honored
+      rememberDevice: !isSsoLogin,
     },
   });
 
@@ -180,7 +186,9 @@ export function VerifyEmailOr2fa({ csrfToken, email, pendingVerifications }: Ver
               }}
             />
 
-            {activeFactor !== 'email' && <Checkbox inputProps={{ ...register('rememberDevice') }}>Remember this device</Checkbox>}
+            {activeFactor !== 'email' && !isSsoLogin && (
+              <Checkbox inputProps={{ ...register('rememberDevice') }}>Remember this device</Checkbox>
+            )}
 
             <div>
               <button

--- a/apps/landing/components/auth/VerifyEmailOr2faWrapper.tsx
+++ b/apps/landing/components/auth/VerifyEmailOr2faWrapper.tsx
@@ -7,7 +7,7 @@ import { VerifyEmailOr2fa } from './VerifyEmailOr2fa';
 
 export function VerifyEmailOr2faWrapper() {
   const router = useRouter();
-  const { isLoading, isVerificationExpired, email, pendingVerifications, isLoggedIn } = useUserProfile();
+  const { isLoading, isVerificationExpired, email, pendingVerifications, isLoggedIn, isSsoLogin } = useUserProfile();
   const { csrfToken, csrfTokenError: error } = useCsrfToken();
 
   useEffect(() => {
@@ -36,5 +36,5 @@ export function VerifyEmailOr2faWrapper() {
     return null;
   }
 
-  return <VerifyEmailOr2fa csrfToken={csrfToken} email={email} pendingVerifications={pendingVerifications} />;
+  return <VerifyEmailOr2fa csrfToken={csrfToken} email={email} pendingVerifications={pendingVerifications} isSsoLogin={isSsoLogin} />;
 }

--- a/apps/landing/hooks/auth.hooks.ts
+++ b/apps/landing/hooks/auth.hooks.ts
@@ -15,6 +15,8 @@ interface AuthState {
   isVerificationExpired: boolean;
   pendingTosAcceptance: boolean;
   currentTosVersion: string;
+  /** Session was established through SAML/OIDC, where a remembered device does not skip MFA */
+  isSsoLogin: boolean;
 }
 
 export function useUserProfile() {
@@ -24,6 +26,7 @@ export function useUserProfile() {
     isVerificationExpired: false,
     pendingTosAcceptance: false,
     currentTosVersion: '',
+    isSsoLogin: false,
   });
   const [isLoading, setIsLoading] = useState(true);
 
@@ -49,6 +52,7 @@ export function useUserProfile() {
             isVerificationExpired: boolean;
             pendingTosAcceptance: boolean;
             currentTosVersion: string;
+            isSsoLogin: boolean;
           };
         }) => {
           setAuthState(data);


### PR DESCRIPTION
- honor the redirectUrl cookie after ToS acceptance so desktop and web extension logins return to their auth callback instead of the web app
- hide "Remember this device" for SSO logins, where the SAML/OIDC callbacks never consult a remembered device
- cancel the pending deep-link flow when a new login or add-org starts, so an abandoned listener stops reporting a bogus auth error
- exclude modals from the desktop header drag region so close buttons overlapping the header are clickable