### PR TITLE
fix: handle feature flag key drift

### DIFF
--- a/libs/shared/ui-utils/src/lib/__tests__/shared-feature-flag-utils.spec.ts
+++ b/libs/shared/ui-utils/src/lib/__tests__/shared-feature-flag-utils.spec.ts
@@ -106,15 +106,45 @@ describe('verifyAndExtractFeatureFlags', () => {
     expect(result).toEqual(DEFAULT_FEATURE_FLAGS);
   });
 
-  it('does not propagate unknown keys even when the signature is valid', async () => {
-    // The canonical payload only covers ALL_FEATURE_FLAG_KEYS, so adding an extra key leaves the
-    // signature valid — the extracted result must still drop the unknown key.
+  it('falls back to code defaults when an unsigned key is injected into the payload', async () => {
+    // The canonical payload covers every transmitted key, so smuggling in an extra one changes the
+    // byte sequence and invalidates the signature rather than riding along unnoticed.
     const signedFlags = { [FLAG]: true } as FeatureFlags;
     const signature = signFlags(userId, signedFlags);
     const tampered = { ...signedFlags, 'evil-injected-flag': true } as unknown as FeatureFlags;
     const result = await verifyAndExtractFeatureFlags({ id: userId, featureFlags: tampered, featureFlagsSignature: signature });
+    expect(result).toEqual(DEFAULT_FEATURE_FLAGS);
     expect(result).not.toHaveProperty('evil-injected-flag');
-    expect(Object.keys(result).sort()).toEqual([...ALL_FEATURE_FLAG_KEYS].sort());
+  });
+
+  // Version skew: the desktop app and browser extension run builds that can be far behind the
+  // server, so the signed payload has to survive a flag registry that differs in either direction.
+  // Keying the payload off the local ALL_FEATURE_FLAG_KEYS instead used to break every one of these,
+  // silently resetting all flags to their code defaults on any out-of-date client.
+  describe('flag registry version skew', () => {
+    it('accepts flags from a server that knows a flag this build does not, ignoring the unknown key', async () => {
+      const serverFlags = { [FLAG]: true, 'flag-added-after-this-build': true } as unknown as FeatureFlags;
+      const result = await verifyAndExtractFeatureFlags({
+        id: userId,
+        featureFlags: serverFlags,
+        featureFlagsSignature: signFlags(userId, serverFlags),
+      });
+      expect(result[FLAG]).toBe(true);
+      expect(result).not.toHaveProperty('flag-added-after-this-build');
+      expect(Object.keys(result).sort()).toEqual([...ALL_FEATURE_FLAG_KEYS].sort());
+    });
+
+    it('accepts flags from a server that omits a flag this build knows, defaulting the missing one', async () => {
+      // An empty payload stands in for "the server sent nothing this build recognizes" and keeps the
+      // test stable no matter how many flags the registry currently holds.
+      const serverFlags = {} as FeatureFlags;
+      const result = await verifyAndExtractFeatureFlags({
+        id: userId,
+        featureFlags: serverFlags,
+        featureFlagsSignature: signFlags(userId, serverFlags),
+      });
+      expect(result).toEqual(DEFAULT_FEATURE_FLAGS);
+    });
   });
 
   it('coerces non-boolean values for known keys to false unless strictly true', async () => {

--- a/libs/shared/ui-utils/src/lib/shared-feature-flag-utils.ts
+++ b/libs/shared/ui-utils/src/lib/shared-feature-flag-utils.ts
@@ -56,7 +56,7 @@ export async function applyVerifiedFeatureFlags<T extends Pick<UserProfileUi, 'i
 export async function verifyAndExtractFeatureFlags(
   profile: Pick<UserProfileUi, 'id' | 'featureFlags' | 'featureFlagsSignature'>,
 ): Promise<FeatureFlags> {
-  const received = (profile.featureFlags ?? {}) as FeatureFlags;
+  const received: Readonly<Record<string, boolean>> = profile.featureFlags ?? {};
   const signature = profile.featureFlagsSignature;
   try {
     if (!signature || !globalThis.crypto?.subtle) {
@@ -72,8 +72,9 @@ export async function verifyAndExtractFeatureFlags(
       logger.warn('[FEATURE FLAGS] Signature verification failed — using code defaults');
       return { ...DEFAULT_FEATURE_FLAGS };
     }
-    // Trust only known flag keys, coerced to booleans. The signature only covers the canonical
-    // known-key payload, so extra or non-boolean values on `received` must not propagate.
+    // The signature covers every transmitted key, so an unsigned key cannot reach this point — but a
+    // server newer than this build legitimately sends flags it does not know. Narrow to the keys this
+    // build understands (anything else stays at its code default) and require a strict boolean.
     const trusted: FeatureFlags = { ...DEFAULT_FEATURE_FLAGS };
     for (const flagKey of ALL_FEATURE_FLAG_KEYS) {
       if (Object.prototype.hasOwnProperty.call(received, flagKey)) {

--- a/libs/types/src/lib/__tests__/feature-flags.spec.ts
+++ b/libs/types/src/lib/__tests__/feature-flags.spec.ts
@@ -1,0 +1,60 @@
+/**
+ * The signed payload is the contract between the server signer and every client verifier, and those
+ * clients ship on their own release cadence — a pinned desktop or browser-extension build can be many
+ * versions behind. These tests pin the two properties that make the byte sequence reproducible across
+ * that skew: it is derived only from what was transmitted, and it is stable regardless of key order.
+ */
+import { describe, expect, it } from 'vitest';
+import { ALL_FEATURE_FLAG_KEYS, serializeFeatureFlagsForSigning } from '../feature-flags';
+
+describe('serializeFeatureFlagsForSigning', () => {
+  const userId = 'user-1';
+
+  it('sorts keys so object insertion order cannot change the signed bytes', () => {
+    const ascending = serializeFeatureFlagsForSigning(userId, { 'flag-a': true, 'flag-b': false });
+    const descending = serializeFeatureFlagsForSigning(userId, { 'flag-b': false, 'flag-a': true });
+    expect(ascending).toBe(descending);
+    expect(ascending).toBe(
+      JSON.stringify({
+        userId,
+        flags: [
+          ['flag-a', true],
+          ['flag-b', false],
+        ],
+      }),
+    );
+  });
+
+  it('covers exactly the transmitted keys, so the local flag registry cannot change the payload', () => {
+    // Neither key exists in FEATURE_FLAGS. When the payload was keyed off ALL_FEATURE_FLAG_KEYS these
+    // would have been dropped and every registry key added at `false`, making the bytes differ between
+    // a server and an older client — which is precisely what broke verification on pinned clients.
+    const payload = serializeFeatureFlagsForSigning(userId, { 'flag-not-in-registry-b': true, 'flag-not-in-registry-a': false });
+    expect(payload).toBe(
+      JSON.stringify({
+        userId,
+        flags: [
+          ['flag-not-in-registry-a', false],
+          ['flag-not-in-registry-b', true],
+        ],
+      }),
+    );
+    for (const registryKey of ALL_FEATURE_FLAG_KEYS) {
+      expect(payload).not.toContain(registryKey);
+    }
+  });
+
+  it('produces an empty flag list when nothing is transmitted', () => {
+    expect(serializeFeatureFlagsForSigning(userId, {})).toBe(JSON.stringify({ userId, flags: [] }));
+  });
+
+  it('binds the payload to the userId', () => {
+    const flags = { 'flag-a': true };
+    expect(serializeFeatureFlagsForSigning(userId, flags)).not.toBe(serializeFeatureFlagsForSigning('user-2', flags));
+  });
+
+  it('coerces values to booleans so a truthy non-boolean cannot alter the byte sequence', () => {
+    const coerced = serializeFeatureFlagsForSigning(userId, { 'flag-a': 'yes' } as unknown as Record<string, boolean>);
+    expect(coerced).toBe(serializeFeatureFlagsForSigning(userId, { 'flag-a': true }));
+  });
+});

--- a/libs/types/src/lib/feature-flags.ts
+++ b/libs/types/src/lib/feature-flags.ts
@@ -37,10 +37,28 @@ export function isFeatureFlagKey(key: string): key is FeatureFlagKey {
 
 /**
  * Canonical, stable serialization of a user's resolved flags. Used by BOTH the server signer and the
- * browser verifier, so the byte sequence must be deterministic regardless of object key order or
- * which keys happen to be present. Keys are sorted and values coerced to booleans.
+ * browser verifier, so the byte sequence must be deterministic regardless of object key order. Keys
+ * are sorted and values coerced to booleans.
+ *
+ * Keys come from `flags` itself, deliberately NOT from `ALL_FEATURE_FLAG_KEYS`. That constant is
+ * compiled into each build, and the desktop app and browser extension run builds that can be many
+ * versions behind the server, so keying off it made the payload depend on the *verifier's* registry:
+ * adding or retiring a single flag changed the byte sequence on the server but not on an older
+ * client, so every signature failed to verify there and the client silently fell back to code
+ * defaults for ALL flags. Deriving the keys from the transmitted object keeps both sides in
+ * agreement in either direction of version skew — a newer server sending an unknown flag, or an
+ * older server omitting one the client knows. The verifier still narrows the result to the flags its
+ * own build understands (see `verifyAndExtractFeatureFlags`).
+ *
+ * Trade-off: a payload signed before a flag existed still verifies, so a user can replay an earlier
+ * set of their own flags rather than it aging out on the next registry change. Flags are client-side
+ * rollout gating with tamper-evidence, not an authorization boundary — server-side `checkFeatureFlag`
+ * stays authoritative — and a replay only restores flags that user was genuinely granted, so that is
+ * the better trade than silently resetting every out-of-date client.
  */
-export function serializeFeatureFlagsForSigning(userId: string, flags: FeatureFlags): string {
-  const entries = [...ALL_FEATURE_FLAG_KEYS].sort().map((key) => [key, !!flags[key]] as const);
+export function serializeFeatureFlagsForSigning(userId: string, flags: Readonly<Record<string, boolean>>): string {
+  const entries = Object.keys(flags)
+    .sort()
+    .map((key) => [key, !!flags[key]] as const);
   return JSON.stringify({ userId, flags: entries });
 }


### PR DESCRIPTION
Ensure signature verification does not fail if client and server are on different versions with different FF shape