### PR TITLE
 fix: align org expiration with Salesforce's 30-day refresh token policy

### DIFF
--- a/apps/api/src/app/db/salesforce-org.db.ts
+++ b/apps/api/src/app/db/salesforce-org.db.ts
@@ -237,6 +237,16 @@ export async function createOrUpdateSalesforceOrg(userId: string, salesforceOrgU
         ? parseISO(salesforceOrgUi.orgTrialExpirationDate)
         : existingOrg.orgTrialExpirationDate,
       connectionError: null,
+      /**
+       * Reconnecting issues a brand new refresh token, which restarts Salesforce's inactivity clock.
+       * The expiration state has to be reset along with it - otherwise the org still matches the
+       * expiration cron's predicate (valid token, no connection error, expiration date in the past)
+       * and gets re-expired on the next run, minutes after the user reconnected it.
+       */
+      lastActivityAt: new Date(),
+      expirationScheduledFor: null,
+      nextExpirationNotificationDate: null,
+      lastExpirationNotificationAt: null,
     };
     data.label = data.label || data.username;
     data.filterText = `${data.username}${data.orgName}${data.label || ''}`;
@@ -280,6 +290,8 @@ export async function createOrUpdateSalesforceOrg(userId: string, salesforceOrgU
         orgNamespacePrefix: salesforceOrgUi.orgNamespacePrefix,
         orgTrialExpirationDate: salesforceOrgUi.orgTrialExpirationDate && parseISO(salesforceOrgUi.orgTrialExpirationDate),
         connectionError: null,
+        // Give a newly connected org a real inactivity base rather than leaving the cron to fall back to updatedAt
+        lastActivityAt: new Date(),
         filterText: `${salesforceOrgUi.username}${salesforceOrgUi.orgName}${salesforceOrgUi.label}`,
       },
     });

--- a/apps/api/src/app/routes/route.middleware.ts
+++ b/apps/api/src/app/routes/route.middleware.ts
@@ -17,7 +17,7 @@ import {
 import { UserProfileSession } from '@jetstream/auth/types';
 import { ApiConnection, exchangeRefreshToken, getApiRequestFactoryFn } from '@jetstream/salesforce-api';
 import { HTTP } from '@jetstream/shared/constants';
-import { ensureBoolean, getErrorMessageAndStackObj } from '@jetstream/shared/utils';
+import { ensureBoolean, getErrorMessageAndStackObj, ORG_INACTIVITY_EXPIRATION_DAYS } from '@jetstream/shared/utils';
 import { parseCookie } from 'cookie';
 import { addDays, getUnixTime, isBefore } from 'date-fns';
 import express, { Request } from 'express';
@@ -349,15 +349,24 @@ export async function getOrgForRequest(
 
   // Early exit if org is expired and the connection is invalid - this avoids updating activity and attempting to call salesforce
   if (accessToken === sfdcEncService.DUMMY_INVALID_ENCRYPTED_TOKEN && org.expirationScheduledFor) {
-    throw new UserFacingError('This org has expired due to inactivity. Reconnect the org to continue using it.');
+    throw new UserFacingError(
+      `Salesforce ended this connection because the org was not used for ${ORG_INACTIVITY_EXPIRATION_DAYS} days. Reconnect the org to continue using it.`,
+    );
   }
 
   // Clear expiration and update last activity when org is accessed
   // This should be done after decryption so that the org stays expired if decryption failed (we use placeholder decryption token)
   if (org.expirationScheduledFor) {
-    salesforceOrgsDb.clearExpiration(org.id, user.id).catch((err) => {
+    /**
+     * Awaited, unlike the activity update below: if this fails silently the org keeps a past
+     * expiration date and the cron scrubs credentials the user is actively using. This branch only
+     * runs for the handful of orgs inside the warning window, not on the hot path.
+     */
+    try {
+      await salesforceOrgsDb.clearExpiration(org.id, user.id);
+    } catch (err) {
       getLogger().error({ orgId: org.id, userId: user.id, err }, '[ORG][UPDATE] Error clearing expirationScheduledFor');
-    });
+    }
   } else {
     // Only update lastActivityAt if it's null or older than 1 day to reduce DB writes
     const oneDayAgo = addDays(new Date(), -1);

--- a/apps/cron-tasks/src/__tests__/salesforce-org-expiration.spec.ts
+++ b/apps/cron-tasks/src/__tests__/salesforce-org-expiration.spec.ts
@@ -2,8 +2,14 @@ import { sendEmail } from '@jetstream/api-config';
 import { createAuditLog } from '@jetstream/audit-logs';
 import { sendOrgExpirationWarningEmail } from '@jetstream/email';
 import { PrismaClient } from '@jetstream/prisma';
+import {
+  ORG_EXPIRATION_CONNECTION_ERROR,
+  ORG_EXPIRATION_WARNING_WINDOW_DAYS,
+  ORG_INACTIVITY_EXPIRATION_DAYS,
+  ORG_SCHEDULE_AFTER_IDLE_DAYS,
+} from '@jetstream/shared/utils';
 import { PrismaPg } from '@prisma/adapter-pg';
-import { addDays, subDays } from 'date-fns';
+import { addDays, endOfDay, subDays } from 'date-fns';
 import * as dotenv from 'dotenv';
 import { v4 as uuid } from 'uuid';
 import { vi } from 'vitest';
@@ -158,65 +164,91 @@ describe('Org Expiration Integration Tests', () => {
     });
     await prisma.$disconnect();
   });
-
   describe('Scheduling orgs for expiration', () => {
-    it('should schedule orgs inactive for 90 days', async () => {
+    it('should schedule an org that just crossed into the warning window', async () => {
       const now = new Date();
-      const inactiveDate = subDays(now, 91); // 91 days ago
 
       await createOrg({
         userId: testUser.id,
-        lastActivityAt: inactiveDate,
+        lastActivityAt: subDays(now, ORG_SCHEDULE_AFTER_IDLE_DAYS),
       });
 
       const result = await manageOrgExpiration(prisma, now);
 
       expect(result.scheduled).toBe(1);
-      expect(result.notified30Days).toBe(1); // Also sends 30-day notification immediately
+      expect(result.realigned).toBe(0);
+      // The first warning goes out on the same run the date is derived
+      expect(result.notifiedByThreshold[7]).toBe(1);
 
-      // Verify DB state
       const org = await prisma.salesforceOrg.findFirst();
-      expect(org?.expirationScheduledFor).toBeTruthy();
+      // Derived from last activity, not granted from today
+      expect(org?.expirationScheduledFor?.toDateString()).toBe(addDays(now, ORG_EXPIRATION_WARNING_WINDOW_DAYS).toDateString());
+      expect(org?.nextExpirationNotificationDate?.toDateString()).toBe(addDays(now, 6).toDateString());
 
-      // Should be scheduled for 30 days from now
-      const expectedExpiration = addDays(now, 30);
-      expect(org?.expirationScheduledFor?.toDateString()).toBe(expectedExpiration.toDateString());
-
-      // Next notification should be 7 days before expiration (since 30-day was just sent)
-      const expectedNextNotification = addDays(expectedExpiration, -7);
-      expect(org?.nextExpirationNotificationDate?.toDateString()).toBe(expectedNextNotification.toDateString());
-
-      // Should have sent email
       expect(mockSendEmail).toHaveBeenCalledTimes(1);
     });
 
-    it('should not schedule orgs with existing expiration', async () => {
+    it('should not schedule an org that is still outside the warning window', async () => {
       const now = new Date();
-      const inactiveDate = subDays(now, 91);
-      const existingExpiration = addDays(now, 10);
 
       await createOrg({
         userId: testUser.id,
-        lastActivityAt: inactiveDate,
-        expirationScheduledFor: existingExpiration,
+        lastActivityAt: subDays(now, ORG_SCHEDULE_AFTER_IDLE_DAYS - 1),
       });
 
       const result = await manageOrgExpiration(prisma, now);
 
       expect(result.scheduled).toBe(0);
+      expect(mockSendEmail).not.toHaveBeenCalled();
 
-      // Expiration date should not change
       const org = await prisma.salesforceOrg.findFirst();
-      expect(org?.expirationScheduledFor?.toDateString()).toBe(existingExpiration.toDateString());
+      expect(org?.expirationScheduledFor).toBeNull();
+    });
+
+    it('should shrink a stale expiration left over from the old inactivity policy', async () => {
+      const now = new Date();
+      // Old policy granted a 30 day grace period on top of 90 days idle, which Salesforce does not honor
+      const staleExpiration = addDays(now, 25);
+
+      await createOrg({
+        userId: testUser.id,
+        lastActivityAt: subDays(now, 200),
+        expirationScheduledFor: staleExpiration,
+      });
+
+      const result = await manageOrgExpiration(prisma, now);
+
+      expect(result.scheduled).toBe(0);
+      expect(result.realigned).toBe(1);
+
+      const org = await prisma.salesforceOrg.findFirst();
+      expect(org?.expirationScheduledFor?.toDateString()).toBe(subDays(now, 170).toDateString());
+    });
+
+    it('should leave an already-correct expiration untouched', async () => {
+      const now = new Date();
+      const lastActivityAt = subDays(now, 25);
+
+      await createOrg({
+        userId: testUser.id,
+        lastActivityAt,
+        expirationScheduledFor: endOfDay(addDays(lastActivityAt, ORG_INACTIVITY_EXPIRATION_DAYS)),
+        nextExpirationNotificationDate: addDays(now, 4),
+      });
+
+      const result = await manageOrgExpiration(prisma, now);
+
+      expect(result.scheduled).toBe(0);
+      expect(result.realigned).toBe(0);
+      expect(mockSendEmail).not.toHaveBeenCalled();
     });
 
     it('should not schedule orgs with connection errors', async () => {
       const now = new Date();
-      const inactiveDate = subDays(now, 91);
 
       await createOrg({
         userId: testUser.id,
-        lastActivityAt: inactiveDate,
+        lastActivityAt: subDays(now, 91),
         connectionError: 'Invalid credentials',
       });
 
@@ -228,49 +260,54 @@ describe('Org Expiration Integration Tests', () => {
       expect(org?.expirationScheduledFor).toBeNull();
     });
 
-    it('should schedule orgs based on updatedAt if lastActivityAt is null', async () => {
+    it('should fall back to updatedAt and pin lastActivityAt when lastActivityAt is null', async () => {
       const now = new Date();
 
-      // Create org and manually set updatedAt to 91 days ago
-      const org = await createOrg({
-        userId: testUser.id,
-        lastActivityAt: null,
-      });
-
+      const org = await createOrg({ userId: testUser.id, lastActivityAt: null });
       await prisma.salesforceOrg.update({
         where: { id: org.id },
-        data: { updatedAt: subDays(now, 91) },
+        data: { updatedAt: subDays(now, 25) },
       });
 
       const result = await manageOrgExpiration(prisma, now);
 
       expect(result.scheduled).toBe(1);
+
+      const updatedOrg = await prisma.salesforceOrg.findUnique({ where: { id: org.id } });
+      expect(updatedOrg?.expirationScheduledFor?.toDateString()).toBe(addDays(now, 5).toDateString());
+      // Pinned so the derived date stops depending on updatedAt, which this cron mutates itself
+      expect(updatedOrg?.lastActivityAt?.toDateString()).toBe(subDays(now, 25).toDateString());
+    });
+
+    it('should not let an unrelated write to updatedAt extend the deadline', async () => {
+      const now = new Date();
+
+      const org = await createOrg({ userId: testUser.id, lastActivityAt: null });
+      await prisma.salesforceOrg.update({
+        where: { id: org.id },
+        data: { updatedAt: subDays(now, 25) },
+      });
+
+      await manageOrgExpiration(prisma, now);
+      const afterFirstRun = await prisma.salesforceOrg.findUnique({ where: { id: org.id } });
+
+      // Simulate a label edit bumping updatedAt long after the expiration was derived
+      vi.clearAllMocks();
+      await prisma.salesforceOrg.update({ where: { id: org.id }, data: { label: 'renamed' } });
+
+      const result = await manageOrgExpiration(prisma, now);
+
+      expect(result.scheduled).toBe(0);
+      expect(result.realigned).toBe(0);
+      expect(mockSendEmail).not.toHaveBeenCalled();
+
+      const afterSecondRun = await prisma.salesforceOrg.findUnique({ where: { id: org.id } });
+      expect(afterSecondRun?.expirationScheduledFor?.getTime()).toBe(afterFirstRun?.expirationScheduledFor?.getTime());
     });
   });
 
   describe('Sending notifications', () => {
-    it('should send 30-day warning notification', async () => {
-      const now = new Date();
-      const expirationDate = addDays(now, 30);
-
-      await createOrg({
-        userId: testUser.id,
-        expirationScheduledFor: expirationDate,
-        nextExpirationNotificationDate: now,
-      });
-
-      const result = await manageOrgExpiration(prisma, now);
-
-      expect(result.notified30Days).toBe(1);
-      expect(mockSendEmail).toHaveBeenCalledTimes(1);
-
-      // Verify next notification date is set to 7 days before expiration
-      const org = await prisma.salesforceOrg.findFirst();
-      const expectedNextNotification = addDays(expirationDate, -7);
-      expect(org?.nextExpirationNotificationDate?.toDateString()).toBe(expectedNextNotification.toDateString());
-    });
-
-    it('should send 7-day warning notification', async () => {
+    it('should send the 7 day warning', async () => {
       const now = new Date();
       const expirationDate = addDays(now, 7);
 
@@ -282,17 +319,16 @@ describe('Org Expiration Integration Tests', () => {
 
       const result = await manageOrgExpiration(prisma, now);
 
-      expect(result.notified7Days).toBe(1);
+      expect(result.notifiedByThreshold[7]).toBe(1);
       expect(mockSendEmail).toHaveBeenCalledTimes(1);
 
       const org = await prisma.salesforceOrg.findFirst();
-      const expectedNextNotification = addDays(expirationDate, -3);
-      expect(org?.nextExpirationNotificationDate?.toDateString()).toBe(expectedNextNotification.toDateString());
+      expect(org?.nextExpirationNotificationDate?.toDateString()).toBe(addDays(expirationDate, -1).toDateString());
     });
 
-    it('should send 3-day warning notification', async () => {
+    it('should send the 1 day warning', async () => {
       const now = new Date();
-      const expirationDate = addDays(now, 3);
+      const expirationDate = addDays(now, 1);
 
       await createOrg({
         userId: testUser.id,
@@ -302,49 +338,62 @@ describe('Org Expiration Integration Tests', () => {
 
       const result = await manageOrgExpiration(prisma, now);
 
-      expect(result.notified3Days).toBe(1);
+      expect(result.notifiedByThreshold[1]).toBe(1);
       expect(mockSendEmail).toHaveBeenCalledTimes(1);
 
       const org = await prisma.salesforceOrg.findFirst();
-      const expectedNextNotification = expirationDate; // Next is 0-day (expiration day)
-      expect(org?.nextExpirationNotificationDate?.toDateString()).toBe(expectedNextNotification.toDateString());
+      expect(org?.nextExpirationNotificationDate?.toDateString()).toBe(expirationDate.toDateString());
+    });
+
+    it('should send the final notice and clear the schedule on the expiration day', async () => {
+      const now = new Date();
+
+      await createOrg({
+        userId: testUser.id,
+        expirationScheduledFor: now,
+        nextExpirationNotificationDate: now,
+      });
+
+      const result = await manageOrgExpiration(prisma, now);
+
+      expect(result.notifiedByThreshold[0]).toBe(1);
+      expect(mockSendEmail).toHaveBeenCalledTimes(1);
+      expect(mockSendEmail.mock.calls[0][0].orgs[0].daysUntilExpiration).toBe(0);
+
+      const org = await prisma.salesforceOrg.findFirst();
+      expect(org?.nextExpirationNotificationDate).toBeNull();
     });
 
     it('should not resend notifications for already-notified thresholds', async () => {
       const now = new Date();
-      const expirationDate = addDays(now, 7);
 
-      // Next notification is in the future, so no notification should be sent
       await createOrg({
         userId: testUser.id,
-        expirationScheduledFor: expirationDate,
-        nextExpirationNotificationDate: addDays(now, 3), // Not due yet
+        expirationScheduledFor: addDays(now, 7),
+        nextExpirationNotificationDate: addDays(now, 6), // Not due yet
       });
 
       const result = await manageOrgExpiration(prisma, now);
 
-      expect(result.notified7Days).toBe(0);
+      expect(result.notifiedByThreshold[7]).toBe(0);
       expect(mockSendEmail).not.toHaveBeenCalled();
     });
 
     it('should catch up on missed notifications', async () => {
       const now = new Date();
-      const expirationDate = addDays(now, 3); // Currently at 3 days
+      const expirationDate = addDays(now, 1);
 
-      // Org scheduled but notification is due (missed notifications don't matter, just send one now)
       await createOrg({
         userId: testUser.id,
         expirationScheduledFor: expirationDate,
-        nextExpirationNotificationDate: subDays(now, 10), // Overdue notification
+        nextExpirationNotificationDate: subDays(now, 10), // Overdue
       });
 
       const result = await manageOrgExpiration(prisma, now);
 
-      // Only counts the actual day threshold
-      expect(result.notified3Days).toBe(1);
-      expect(mockSendEmail).toHaveBeenCalledTimes(1); // One email per user
+      expect(result.notifiedByThreshold[1]).toBe(1);
+      expect(mockSendEmail).toHaveBeenCalledTimes(1);
 
-      // Next notification should be set to expiration day (0-day)
       const org = await prisma.salesforceOrg.findFirst();
       expect(org?.nextExpirationNotificationDate?.toDateString()).toBe(expirationDate.toDateString());
     });
@@ -352,75 +401,45 @@ describe('Org Expiration Integration Tests', () => {
     it('should group multiple orgs by user in single email with different expiration dates', async () => {
       const now = new Date();
 
-      // Create multiple orgs for same user expiring on different days, all due for notification now
-      await createOrg({
-        userId: testUser.id,
-        expirationScheduledFor: addDays(now, 30),
-        nextExpirationNotificationDate: now,
-      });
-
-      await createOrg({
-        userId: testUser.id,
-        expirationScheduledFor: addDays(now, 7),
-        nextExpirationNotificationDate: now,
-      });
-
-      await createOrg({
-        userId: testUser.id,
-        expirationScheduledFor: addDays(now, 3),
-        nextExpirationNotificationDate: now,
-      });
+      await createOrg({ userId: testUser.id, expirationScheduledFor: addDays(now, 7), nextExpirationNotificationDate: now });
+      await createOrg({ userId: testUser.id, expirationScheduledFor: addDays(now, 1), nextExpirationNotificationDate: now });
+      await createOrg({ userId: testUser.id, expirationScheduledFor: now, nextExpirationNotificationDate: now });
 
       await manageOrgExpiration(prisma, now);
 
-      // Should send ONE email with all three orgs showing different expiration days
       expect(mockSendEmail).toHaveBeenCalledTimes(1);
       const emailCall = mockSendEmail.mock.calls[0][0];
       expect(emailCall.orgs).toHaveLength(3);
 
-      // Verify each org shows its own expiration countdown
       const orgExpirations = emailCall.orgs.map((o) => o.daysUntilExpiration).sort((a, b) => a - b);
-      expect(orgExpirations).toEqual([3, 7, 30]);
+      expect(orgExpirations).toEqual([0, 1, 7]);
     });
 
     it('should not email user twice on same cron run', async () => {
       const now = new Date();
 
-      // Create multiple orgs at same threshold
-      await createOrg({
-        userId: testUser.id,
-        expirationScheduledFor: addDays(now, 7),
-        nextExpirationNotificationDate: now,
-      });
-
-      await createOrg({
-        userId: testUser.id,
-        expirationScheduledFor: addDays(now, 7),
-        nextExpirationNotificationDate: now,
-      });
+      await createOrg({ userId: testUser.id, expirationScheduledFor: addDays(now, 7), nextExpirationNotificationDate: now });
+      await createOrg({ userId: testUser.id, expirationScheduledFor: addDays(now, 7), nextExpirationNotificationDate: now });
 
       await manageOrgExpiration(prisma, now);
 
-      // Should send ONE email, not two
       expect(mockSendEmail).toHaveBeenCalledTimes(1);
-      const emailCall = mockSendEmail.mock.calls[0][0];
-      expect(emailCall.orgs).toHaveLength(2);
+      expect(mockSendEmail.mock.calls[0][0].orgs).toHaveLength(2);
     });
 
     it('should skip orgs with connection errors', async () => {
       const now = new Date();
-      const expirationDate = addDays(now, 7);
 
       await createOrg({
         userId: testUser.id,
-        expirationScheduledFor: expirationDate,
+        expirationScheduledFor: addDays(now, 7),
         nextExpirationNotificationDate: now,
         connectionError: 'Invalid credentials',
       });
 
       const result = await manageOrgExpiration(prisma, now);
 
-      expect(result.notified7Days).toBe(0);
+      expect(result.notifiedByThreshold[7]).toBe(0);
       expect(mockSendEmail).not.toHaveBeenCalled();
     });
 
@@ -434,34 +453,94 @@ describe('Org Expiration Integration Tests', () => {
         nextExpirationNotificationDate: now,
       });
 
-      // First run - should send email
       await manageOrgExpiration(prisma, now);
       expect(mockSendEmail).toHaveBeenCalledTimes(1);
 
-      // Second run same day - should NOT send email again (nextExpirationNotificationDate was updated)
       vi.clearAllMocks();
       await manageOrgExpiration(prisma, now);
       expect(mockSendEmail).not.toHaveBeenCalled();
 
-      // Third run same day - still should NOT send
       await manageOrgExpiration(prisma, now);
       expect(mockSendEmail).not.toHaveBeenCalled();
 
-      // Verify next notification date is in the future
       const org = await prisma.salesforceOrg.findFirst();
-      const expectedNextNotification = addDays(expirationDate, -3);
-      expect(org?.nextExpirationNotificationDate?.toDateString()).toBe(expectedNextNotification.toDateString());
+      expect(org?.nextExpirationNotificationDate?.toDateString()).toBe(addDays(expirationDate, -1).toDateString());
+    });
+
+    it('should leave the schedule unadvanced when the email fails so it retries', async () => {
+      const now = new Date();
+
+      const org = await createOrg({
+        userId: testUser.id,
+        expirationScheduledFor: addDays(now, 7),
+        nextExpirationNotificationDate: now,
+      });
+
+      mockSendEmail.mockRejectedValueOnce(new Error('mailgun is down'));
+
+      const result = await manageOrgExpiration(prisma, now);
+
+      expect(result.emailFailures).toBe(1);
+      expect(result.usersNotified).toBe(0);
+      expect(mockCreateAuditLog).not.toHaveBeenCalled();
+
+      const afterFailure = await prisma.salesforceOrg.findUnique({ where: { id: org.id } });
+      expect(afterFailure?.nextExpirationNotificationDate?.toDateString()).toBe(now.toDateString());
+      expect(afterFailure?.lastExpirationNotificationAt).toBeNull();
+
+      // Next run retries rather than silently skipping the threshold
+      vi.clearAllMocks();
+      const retryResult = await manageOrgExpiration(prisma, now);
+      expect(retryResult.emailFailures).toBe(0);
+      expect(mockSendEmail).toHaveBeenCalledTimes(1);
+    });
+
+    it('should still warn a dormant user about an org they can save', async () => {
+      const now = new Date();
+      const dormantUser = await createUser(subDays(now, 200));
+
+      await createOrg({
+        userId: dormantUser.id,
+        lastActivityAt: subDays(now, ORG_SCHEDULE_AFTER_IDLE_DAYS),
+      });
+
+      const result = await manageOrgExpiration(prisma, now);
+
+      expect(result.usersNotified).toBe(1);
+      expect(result.usersSkipped).toBe(0);
+      expect(mockSendEmail).toHaveBeenCalledTimes(1);
+    });
+
+    it('should skip the terminal notice for a dormant user but still scrub the credentials', async () => {
+      const now = new Date();
+      const dormantUser = await createUser(subDays(now, 200));
+
+      const org = await createOrg({
+        userId: dormantUser.id,
+        lastActivityAt: subDays(now, 200),
+        accessToken: 'valid_token',
+      });
+
+      const result = await manageOrgExpiration(prisma, now);
+
+      expect(result.usersSkipped).toBe(1);
+      expect(mockSendEmail).not.toHaveBeenCalled();
+      expect(result.expired).toBe(1);
+
+      const updatedOrg = await prisma.salesforceOrg.findUnique({ where: { id: org.id } });
+      expect(updatedOrg?.accessToken).toBe('v2:EXPIRED_TOKEN_PLACEHOLDER');
+      // The schedule still advances so the skipped user is not reconsidered every run
+      expect(updatedOrg?.nextExpirationNotificationDate).toBeNull();
     });
   });
 
   describe('Expiring credentials', () => {
     it('should expire orgs on expiration day', async () => {
       const now = new Date();
-      const expirationDate = subDays(now, 1); // Yesterday
 
       const org = await createOrg({
         userId: testUser.id,
-        expirationScheduledFor: expirationDate,
+        expirationScheduledFor: subDays(now, 1),
         nextExpirationNotificationDate: null, // All notifications sent
         accessToken: 'valid_token',
       });
@@ -470,22 +549,20 @@ describe('Org Expiration Integration Tests', () => {
 
       expect(result.expired).toBe(1);
 
-      // Verify credentials were invalidated
       const updatedOrg = await prisma.salesforceOrg.findUnique({ where: { id: org.id } });
       expect(updatedOrg?.accessToken).toBe('v2:EXPIRED_TOKEN_PLACEHOLDER');
-      expect(updatedOrg?.connectionError).toBe('Credentials expired due to inactivity');
+      expect(updatedOrg?.connectionError).toBe(ORG_EXPIRATION_CONNECTION_ERROR);
     });
 
     it('should not re-expire already expired orgs', async () => {
       const now = new Date();
-      const expirationDate = subDays(now, 1);
 
       await createOrg({
         userId: testUser.id,
-        expirationScheduledFor: expirationDate,
+        expirationScheduledFor: subDays(now, 1),
         nextExpirationNotificationDate: null,
         accessToken: 'v2:EXPIRED_TOKEN_PLACEHOLDER',
-        connectionError: 'Credentials expired due to inactivity',
+        connectionError: ORG_EXPIRATION_CONNECTION_ERROR,
       });
 
       const result = await manageOrgExpiration(prisma, now);
@@ -495,11 +572,10 @@ describe('Org Expiration Integration Tests', () => {
 
     it('should create audit log for expired orgs', async () => {
       const now = new Date();
-      const expirationDate = subDays(now, 1);
 
       await createOrg({
         userId: testUser.id,
-        expirationScheduledFor: expirationDate,
+        expirationScheduledFor: subDays(now, 1),
         nextExpirationNotificationDate: null,
       });
 
@@ -516,62 +592,105 @@ describe('Org Expiration Integration Tests', () => {
   });
 
   describe('Complete workflow', () => {
-    it('should handle full expiration lifecycle', async () => {
+    it('should schedule, notify, and scrub a long-overdue org in a single run', async () => {
       const now = new Date();
 
-      // Day 0: Org becomes inactive
-      const inactiveDate = subDays(now, 90);
       const org = await createOrg({
         userId: testUser.id,
-        lastActivityAt: inactiveDate,
+        lastActivityAt: subDays(now, 200),
+        expirationScheduledFor: addDays(now, 25), // Stale date from the old policy
+        accessToken: 'valid_token',
       });
 
-      // Run 1: Schedule for expiration and send 30-day warning
+      const result = await manageOrgExpiration(prisma, now);
+
+      expect(result.realigned).toBe(1);
+      expect(result.notifiedByThreshold[0]).toBe(1);
+      expect(result.expired).toBe(1);
+
+      expect(mockSendEmail).toHaveBeenCalledTimes(1);
+      expect(mockSendEmail.mock.calls[0][0].orgs[0].daysUntilExpiration).toBe(0);
+
+      expect(mockCreateAuditLog).toHaveBeenCalledWith(expect.objectContaining({ action: 'ORG_EXPIRED' }));
+      expect(mockCreateAuditLog).toHaveBeenCalledWith(expect.objectContaining({ action: 'ORG_CREDENTIALS_EXPIRED' }));
+
+      const updatedOrg = await prisma.salesforceOrg.findUnique({ where: { id: org.id } });
+      expect(updatedOrg?.expirationScheduledFor?.toDateString()).toBe(subDays(now, 170).toDateString());
+      expect(updatedOrg?.accessToken).toBe('v2:EXPIRED_TOKEN_PLACEHOLDER');
+      expect(updatedOrg?.nextExpirationNotificationDate).toBeNull();
+
+      // Terminal: every subsequent run ignores it
+      vi.clearAllMocks();
+      const secondRun = await manageOrgExpiration(prisma, now);
+      expect(secondRun.realigned).toBe(0);
+      expect(secondRun.expired).toBe(0);
+      expect(mockSendEmail).not.toHaveBeenCalled();
+    });
+
+    it('should handle the full 30 day lifecycle', async () => {
+      const now = new Date();
+
+      // Day 23 of inactivity - the org enters the warning window
+      const org = await createOrg({
+        userId: testUser.id,
+        lastActivityAt: subDays(now, ORG_SCHEDULE_AFTER_IDLE_DAYS),
+      });
+
       let result = await manageOrgExpiration(prisma, now);
       expect(result.scheduled).toBe(1);
-      expect(result.notified30Days).toBe(1); // Sends immediately when scheduled
+      expect(result.notifiedByThreshold[7]).toBe(1);
       expect(mockSendEmail).toHaveBeenCalledTimes(1);
 
       let updatedOrg = await prisma.salesforceOrg.findUnique({ where: { id: org.id } });
-      expect(updatedOrg?.expirationScheduledFor).toBeTruthy();
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const expirationDate = updatedOrg!.expirationScheduledFor!;
+      expect(updatedOrg?.nextExpirationNotificationDate?.toDateString()).toBe(addDays(expirationDate, -1).toDateString());
 
-      // Next notification should be 7 days before expiration
-      let expectedNext = addDays(expirationDate, -7);
-      expect(updatedOrg?.nextExpirationNotificationDate?.toDateString()).toBe(expectedNext.toDateString());
-
-      // Run 2: 7 days before expiration
+      // Day 29 - one day left. Step 1 sees it again but must not rewrite anything.
       vi.clearAllMocks();
-      const day23 = addDays(now, 23);
-      result = await manageOrgExpiration(prisma, day23);
-      expect(result.notified7Days).toBe(1);
+      result = await manageOrgExpiration(prisma, addDays(now, 6));
+      expect(result.scheduled).toBe(0);
+      expect(result.realigned).toBe(0);
+      expect(result.notifiedByThreshold[1]).toBe(1);
+      expect(result.expired).toBe(0);
       expect(mockSendEmail).toHaveBeenCalledTimes(1);
 
       updatedOrg = await prisma.salesforceOrg.findUnique({ where: { id: org.id } });
-      expectedNext = addDays(expirationDate, -3);
-      expect(updatedOrg?.nextExpirationNotificationDate?.toDateString()).toBe(expectedNext.toDateString());
+      expect(updatedOrg?.nextExpirationNotificationDate?.toDateString()).toBe(expirationDate.toDateString());
 
-      // Run 3: 3 days before expiration
+      // Day 30 - final notice and the credentials are scrubbed in the same run
       vi.clearAllMocks();
-      const day27 = addDays(now, 27);
-      result = await manageOrgExpiration(prisma, day27);
-      expect(result.notified3Days).toBe(1);
-      expect(mockSendEmail).toHaveBeenCalledTimes(1);
-
-      updatedOrg = await prisma.salesforceOrg.findUnique({ where: { id: org.id } });
-      expectedNext = expirationDate; // 0-day
-      expect(updatedOrg?.nextExpirationNotificationDate?.toDateString()).toBe(expectedNext.toDateString());
-
-      // Run 4: Expiration day
-      vi.clearAllMocks();
-      const day30 = addDays(now, 30);
-      result = await manageOrgExpiration(prisma, day30);
+      result = await manageOrgExpiration(prisma, addDays(now, 7));
+      expect(result.notifiedByThreshold[0]).toBe(1);
       expect(result.expired).toBe(1);
 
       updatedOrg = await prisma.salesforceOrg.findUnique({ where: { id: org.id } });
       expect(updatedOrg?.accessToken).toBe('v2:EXPIRED_TOKEN_PLACEHOLDER');
-      expect(updatedOrg?.connectionError).toBe('Credentials expired due to inactivity');
+      expect(updatedOrg?.connectionError).toBe(ORG_EXPIRATION_CONNECTION_ERROR);
+      expect(updatedOrg?.nextExpirationNotificationDate).toBeNull();
+    });
+
+    it('should be idempotent when the same day is processed twice', async () => {
+      const now = new Date();
+
+      const org = await createOrg({
+        userId: testUser.id,
+        lastActivityAt: subDays(now, ORG_SCHEDULE_AFTER_IDLE_DAYS),
+      });
+
+      await manageOrgExpiration(prisma, now);
+      const afterFirstRun = await prisma.salesforceOrg.findUnique({ where: { id: org.id } });
+
+      vi.clearAllMocks();
+      const result = await manageOrgExpiration(prisma, now);
+
+      expect(result.scheduled).toBe(0);
+      expect(result.realigned).toBe(0);
+      expect(mockSendEmail).not.toHaveBeenCalled();
+
+      const afterSecondRun = await prisma.salesforceOrg.findUnique({ where: { id: org.id } });
+      expect(afterSecondRun?.expirationScheduledFor?.getTime()).toBe(afterFirstRun?.expirationScheduledFor?.getTime());
+      expect(afterSecondRun?.nextExpirationNotificationDate?.getTime()).toBe(afterFirstRun?.nextExpirationNotificationDate?.getTime());
     });
   });
 
@@ -592,22 +711,21 @@ describe('Org Expiration Integration Tests', () => {
 
     it('should not update database or send user emails in test mode', async () => {
       const now = new Date();
-      const inactiveDate = subDays(now, 91);
 
-      // Create org that would normally be scheduled for expiration
+      // Would be scheduled
       const org1 = await createOrg({
         userId: testUser.id,
-        lastActivityAt: inactiveDate,
+        lastActivityAt: subDays(now, ORG_SCHEDULE_AFTER_IDLE_DAYS),
       });
 
-      // Create org that would normally receive notification
+      // Would receive a notification
       const org2 = await createOrg({
         userId: testUser.id,
         expirationScheduledFor: addDays(now, 7),
         nextExpirationNotificationDate: now,
       });
 
-      // Create org that would normally be expired
+      // Would be expired
       const org3 = await createOrg({
         userId: testUser.id,
         expirationScheduledFor: subDays(now, 1),
@@ -617,9 +735,9 @@ describe('Org Expiration Integration Tests', () => {
 
       const result = await manageOrgExpiration(prisma, now);
 
-      // Results should reflect what WOULD have happened
+      expect(result.testMode).toBe(true);
       expect(result.scheduled).toBe(1);
-      expect(result.notified7Days).toBe(1);
+      expect(result.notifiedByThreshold[7]).toBe(2); // org1 (derived) and org2 (stored)
       expect(result.expired).toBe(1);
 
       // Verify NO database changes occurred
@@ -628,16 +746,13 @@ describe('Org Expiration Integration Tests', () => {
       expect(org1After?.nextExpirationNotificationDate).toBeNull();
 
       const org2After = await prisma.salesforceOrg.findUnique({ where: { id: org2.id } });
-      expect(org2After?.nextExpirationNotificationDate?.toDateString()).toBe(now.toDateString()); // Not updated
+      expect(org2After?.nextExpirationNotificationDate?.toDateString()).toBe(now.toDateString());
 
       const org3After = await prisma.salesforceOrg.findUnique({ where: { id: org3.id } });
-      expect(org3After?.accessToken).toBe('valid_token'); // Not expired
+      expect(org3After?.accessToken).toBe('valid_token');
       expect(org3After?.connectionError).toBeNull();
 
-      // Verify NO user notification emails were sent
       expect(mockSendEmail).not.toHaveBeenCalled();
-
-      // Verify NO audit logs were created
       expect(mockCreateAuditLog).not.toHaveBeenCalled();
 
       // Verify summary email WAS sent
@@ -654,25 +769,21 @@ describe('Org Expiration Integration Tests', () => {
         }),
       );
 
-      // Verify CSV attachments contain expected data
       const summaryCall = mockSendEmailConfig.mock.calls[0][0];
       expect(summaryCall.attachment).toHaveLength(3);
 
-      // Check scheduled orgs CSV
       const scheduledCsv = summaryCall.attachment.find((a: { filename: string }) => a.filename === 'scheduled-orgs.csv');
       expect(scheduledCsv).toBeDefined();
       const scheduledData = scheduledCsv.data.toString('utf-8');
       expect(scheduledData).toContain('orgId');
-      expect(scheduledData).toContain('uniqueId');
+      expect(scheduledData).toContain('realigned');
 
-      // Check notifications CSV
       const notificationsCsv = summaryCall.attachment.find((a: { filename: string }) => a.filename === 'notifications.csv');
       expect(notificationsCsv).toBeDefined();
       const notificationsData = notificationsCsv.data.toString('utf-8');
       expect(notificationsData).toContain('userEmail');
       expect(notificationsData).toContain('daysUntilExpiration');
 
-      // Check expired orgs CSV
       const expiredCsv = summaryCall.attachment.find((a: { filename: string }) => a.filename === 'expired-orgs.csv');
       expect(expiredCsv).toBeDefined();
       const expiredData = expiredCsv.data.toString('utf-8');
@@ -680,27 +791,39 @@ describe('Org Expiration Integration Tests', () => {
       expect(expiredData).toContain('username');
     });
 
-    it('should handle test mode with no changes needed', async () => {
+    it('should report the date it would derive rather than the stale stored date', async () => {
       const now = new Date();
 
-      // Create org that doesn't need any action
       await createOrg({
         userId: testUser.id,
-        lastActivityAt: now, // Active
+        lastActivityAt: subDays(now, 200),
+        expirationScheduledFor: addDays(now, 25),
       });
 
       const result = await manageOrgExpiration(prisma, now);
 
+      expect(result.realigned).toBe(1);
+      // Reported as already past, not as 25 days out
+      expect(result.notifiedByThreshold[0]).toBe(1);
+
+      const summaryCall = mockSendEmailConfig.mock.calls[0][0];
+      const notificationsCsv = summaryCall.attachment.find((a: { filename: string }) => a.filename === 'notifications.csv');
+      expect(notificationsCsv.data.toString('utf-8')).toContain(',0,');
+    });
+
+    it('should handle test mode with no changes needed', async () => {
+      const now = new Date();
+
+      await createOrg({ userId: testUser.id, lastActivityAt: now });
+
+      const result = await manageOrgExpiration(prisma, now);
+
       expect(result.scheduled).toBe(0);
-      expect(result.notified30Days).toBe(0);
-      expect(result.notified7Days).toBe(0);
-      expect(result.notified3Days).toBe(0);
+      expect(result.realigned).toBe(0);
+      expect(result.notifiedByThreshold).toEqual({ 0: 0, 1: 0, 7: 0 });
       expect(result.expired).toBe(0);
 
-      // Summary email should still be sent
       expect(mockSendEmailConfig).toHaveBeenCalledTimes(1);
-
-      // But with no attachments (no CSVs created)
       const summaryCall = mockSendEmailConfig.mock.calls[0][0];
       expect(summaryCall.attachment).toHaveLength(0);
     });

--- a/apps/cron-tasks/src/utils/salesforce-org-expiration.utils.ts
+++ b/apps/cron-tasks/src/utils/salesforce-org-expiration.utils.ts
@@ -3,39 +3,60 @@ import { AuditLogAction, AuditLogResource, createAuditLog } from '@jetstream/aud
 import { sendOrgExpirationWarningEmail } from '@jetstream/email';
 import { Prisma, PrismaClient } from '@jetstream/prisma';
 import { EXPIRED_TOKEN_PLACEHOLDER } from '@jetstream/shared/constants';
+import {
+  computeNextOrgNotificationDate,
+  computeOrgExpirationDate,
+  getDaysUntilOrgExpiration,
+  getErrorMessageAndStackObj,
+  ORG_EXPIRATION_CONNECTION_ERROR,
+  ORG_EXPIRATION_NOTIFICATION_DAYS,
+  ORG_SCHEDULE_AFTER_IDLE_DAYS,
+} from '@jetstream/shared/utils';
 import { addDays, endOfDay } from 'date-fns';
 import Papa from 'papaparse';
 import { logger } from '../config/logger.config';
 
-const INACTIVITY_DAYS = 90;
-const WARNING_PERIOD_DAYS = 30; // Grace period after inactivity before expiration
-const NOTIFICATION_DAYS = [30, 7, 3, 0];
-const USER_INACTIVITY_DAYS = 90; // Skip email if user hasn't logged in for this many days
-const CONNECTION_ERROR_MESSAGE = 'Credentials expired due to inactivity';
+/**
+ * Skip emailing a user who has not logged in for this long. Purely a deliverability guard - mailing
+ * abandoned accounts costs sender reputation without changing anything for them. Deliberately much
+ * longer than the org inactivity window: by the time it fires, the user has been gone several times
+ * longer than an org's entire lifecycle. It never suppresses a warning the user could still act on -
+ * see `hasSavableOrg` below.
+ */
+const USER_INACTIVITY_DAYS = 90;
 
 /**
- * Compute the next notification date based on expiration date and thresholds
- * Returns the smallest threshold date strictly greater than now, or null if none remain
+ * Notification counters keyed by the threshold each org satisfied, rather than by exact day count.
+ * An org notified 5 days out (a catch-up after a skipped cron run) buckets into the `1` threshold.
  */
-function computeNextNotificationDate(expirationDate: Date, now: Date, thresholds: number[]): Date | null {
-  const candidates = thresholds
-    .map((t) => endOfDay(addDays(expirationDate, -t)))
-    .filter((d) => d > now)
-    .sort((a, b) => a.getTime() - b.getTime());
+function bucketByThreshold(daysUntilExpiration: number): number {
+  const descendingThresholds = [...ORG_EXPIRATION_NOTIFICATION_DAYS].sort((a, b) => b - a);
+  // daysUntilExpiration is clamped to >= 0 and 0 is a threshold, so this always matches
+  return descendingThresholds.find((threshold) => daysUntilExpiration >= threshold) ?? 0;
+}
 
-  return candidates.length > 0 ? candidates[0] : null;
+function emptyThresholdCounts(): Record<number, number> {
+  return ORG_EXPIRATION_NOTIFICATION_DAYS.reduce((acc, threshold) => ({ ...acc, [threshold]: 0 }), {} as Record<number, number>);
 }
 
 interface OrgExpirationResult {
+  testMode: boolean;
+  /** Orgs entering the warning window for the first time (`expirationScheduledFor` was null) */
   scheduled: number;
-  notified30Days: number;
-  notified7Days: number;
-  notified3Days: number;
+  /** Orgs whose stored date was shrunk toward the Salesforce-derived date (stale rows from the old policy) */
+  realigned: number;
+  usersNotified: number;
+  /** Users skipped as dormant - see USER_INACTIVITY_DAYS */
+  usersSkipped: number;
+  /** Orgs notified, keyed by the ORG_EXPIRATION_NOTIFICATION_DAYS threshold they satisfied */
+  notifiedByThreshold: Record<number, number>;
+  /** Users whose email failed - their notification schedule was deliberately left unadvanced so it retries */
+  emailFailures: number;
   expired: number;
 }
 
 interface TestModeData {
-  scheduledOrgs: Array<{ orgId: number; uniqueId: string; username: string; expirationDate: Date }>;
+  scheduledOrgs: Array<{ orgId: number; uniqueId: string; username: string; expirationDate: Date; realigned: boolean }>;
   notifications: Array<{
     userEmail: string;
     orgUsername: string;
@@ -47,16 +68,26 @@ interface TestModeData {
   expiredOrgs: Array<{ orgId: number; uniqueId: string; username: string; orgName: string | null }>;
 }
 
+/**
+ * Keep Jetstream's view of an org's credentials in sync with Salesforce's refresh token policy.
+ *
+ * Salesforce invalidates a partner connected app's refresh token after ORG_INACTIVITY_EXPIRATION_DAYS
+ * without use. Jetstream cannot extend that, so `expirationScheduledFor` is *derived* from the last
+ * time the org was used (`lastActivityAt + 30 days`) rather than granted. The three steps run strictly
+ * in order so that a long-overdue org is scheduled, notified, and scrubbed within a single run.
+ */
 export async function manageOrgExpiration(prisma: PrismaClient, initialDate = new Date()): Promise<OrgExpirationResult> {
   const now = endOfDay(initialDate);
-  const inactivityThreshold = addDays(now, -INACTIVITY_DAYS);
   const testMode = process.env.TEST_MODE === 'true';
 
   const result: OrgExpirationResult = {
+    testMode,
     scheduled: 0,
-    notified30Days: 0,
-    notified7Days: 0,
-    notified3Days: 0,
+    realigned: 0,
+    usersNotified: 0,
+    usersSkipped: 0,
+    notifiedByThreshold: emptyThresholdCounts(),
+    emailFailures: 0,
     expired: 0,
   };
 
@@ -70,60 +101,112 @@ export async function manageOrgExpiration(prisma: PrismaClient, initialDate = ne
     logger.info('Running in TEST MODE - no actual updates will be made');
   }
 
-  // 1. Schedule orgs for expiration that haven't been used in 90 days
-  // Set expiration date to WARNING_PERIOD_DAYS in the future to give users time to reactivate
-  const expirationDate = addDays(now, WARNING_PERIOD_DAYS);
-  const firstNotificationDate = endOfDay(addDays(expirationDate, -30)); // 30 days before expiration
+  // 1. Record the derived expiration date for every org at or past the warning window
+  const idleSince = addDays(now, -ORG_SCHEDULE_AFTER_IDLE_DAYS);
 
-  const orgsToScheduleWhere: Prisma.SalesforceOrgWhereInput = {
-    AND: [
-      { connectionError: null },
-      { expirationScheduledFor: null },
-      { OR: [{ lastActivityAt: { lte: inactivityThreshold } }, { lastActivityAt: null, updatedAt: { lte: inactivityThreshold } }] },
-    ],
+  const scheduleCandidateWhere: Prisma.SalesforceOrgWhereInput = {
+    connectionError: null,
+    accessToken: { not: EXPIRED_TOKEN_PLACEHOLDER },
+    OR: [{ lastActivityAt: { lte: idleSince } }, { lastActivityAt: null, updatedAt: { lte: idleSince } }],
   };
 
-  if (testMode) {
-    const orgsToScheduleQuery = await prisma.salesforceOrg.findMany({
-      where: orgsToScheduleWhere,
-      select: { id: true, uniqueId: true, username: true },
-    });
-    result.scheduled = orgsToScheduleQuery.length;
-    testModeData.scheduledOrgs = orgsToScheduleQuery.map((org) => ({
-      orgId: org.id,
-      uniqueId: org.uniqueId,
-      username: org.username,
-      expirationDate,
-    }));
-    logger.info(`[TEST MODE] Would schedule ${orgsToScheduleQuery.length} orgs for expiration`);
-  } else {
-    const orgsToSchedule = await prisma.salesforceOrg.updateMany({
-      where: orgsToScheduleWhere,
-      data: {
-        expirationScheduledFor: expirationDate,
-        nextExpirationNotificationDate: firstNotificationDate,
-      },
-    });
-    result.scheduled = orgsToSchedule.count;
-    logger.info(`Scheduled ${orgsToSchedule.count} orgs for expiration`);
+  const scheduleCandidates = await prisma.salesforceOrg.findMany({
+    where: scheduleCandidateWhere,
+    select: { id: true, uniqueId: true, username: true, lastActivityAt: true, updatedAt: true, expirationScheduledFor: true },
+  });
+
+  /**
+   * Expiration dates for orgs this run has scheduled (or, in test mode, would have scheduled).
+   * Step 2 reads through this so it can notify on the same run the date is computed, without having
+   * to re-read the rows or assume a single shared date across every org.
+   */
+  const scheduledExpirationByOrgId = new Map<number, Date>();
+
+  interface ScheduleGroup {
+    expirationDate: Date;
+    activityBaseDate: Date;
+    needsActivityBackfill: boolean;
+    orgIds: number[];
+  }
+  const scheduleGroups = new Map<string, ScheduleGroup>();
+
+  for (const org of scheduleCandidates) {
+    const activityBaseDate = endOfDay(org.lastActivityAt ?? org.updatedAt);
+    const expirationDate = computeOrgExpirationDate(activityBaseDate);
+
+    /**
+     * Shrink only. `updatedAt` is bumped by any write at all - a label edit, an org move, a token
+     * refresh, even this cron's own updates - so allowing the derived date to move later would hand
+     * orgs a grace period Salesforce never gave them and re-fire notifications every run. Leaving an
+     * already-correct row untouched is also what makes repeat runs on the same day idempotent.
+     */
+    if (org.expirationScheduledFor && org.expirationScheduledFor <= expirationDate) {
+      continue;
+    }
+
+    const realigned = !!org.expirationScheduledFor;
+    if (realigned) {
+      result.realigned++;
+    } else {
+      result.scheduled++;
+    }
+
+    scheduledExpirationByOrgId.set(org.id, expirationDate);
+
+    if (testMode) {
+      testModeData.scheduledOrgs.push({
+        orgId: org.id,
+        uniqueId: org.uniqueId,
+        username: org.username,
+        expirationDate,
+        realigned,
+      });
+      continue;
+    }
+
+    // `lastActivityAt` is only backfilled when it is null, so the group key has to account for it
+    const needsActivityBackfill = !org.lastActivityAt;
+    const key = `${expirationDate.getTime()}:${needsActivityBackfill}`;
+    const existingGroup = scheduleGroups.get(key);
+    if (existingGroup) {
+      existingGroup.orgIds.push(org.id);
+    } else {
+      scheduleGroups.set(key, { expirationDate, activityBaseDate, needsActivityBackfill, orgIds: [org.id] });
+    }
   }
 
-  // 2. Get all orgs due for notification (nextExpirationNotificationDate <= now)
+  if (testMode) {
+    logger.info(`[TEST MODE] Would schedule ${result.scheduled} and realign ${result.realigned} orgs for expiration`);
+  } else {
+    // endOfDay collapses the group key to a calendar day, so steady state is a single statement per run
+    for (const { expirationDate, activityBaseDate, needsActivityBackfill, orgIds } of scheduleGroups.values()) {
+      await prisma.salesforceOrg.updateMany({
+        where: { id: { in: orgIds } },
+        data: {
+          expirationScheduledFor: expirationDate,
+          // The deadline just changed, so notify on this run rather than waiting for the next threshold
+          nextExpirationNotificationDate: now,
+          /**
+           * Pin the inactivity base for legacy rows that predate `lastActivityAt`. Without this the
+           * derived date depends on `updatedAt`, a column this cron mutates itself. Note the pinned
+           * value means "last known write" for those rows, not literally "last used".
+           */
+          ...(needsActivityBackfill ? { lastActivityAt: activityBaseDate } : {}),
+        },
+      });
+    }
+    logger.info(`Scheduled ${result.scheduled} and realigned ${result.realigned} orgs for expiration`);
+  }
+
+  // 2. Notify owners of every org whose next notification has come due
   const userInactivityThreshold = addDays(now, -USER_INACTIVITY_DAYS);
   const orgsToNotifyWhere: Prisma.SalesforceOrgWhereInput = testMode
     ? {
-        // In test mode, include orgs that would be scheduled in this run
+        // No writes happened in test mode, so union in the orgs step 1 would have scheduled
         connectionError: null,
         OR: [
-          {
-            expirationScheduledFor: { not: null },
-            nextExpirationNotificationDate: { not: null, lte: now },
-          },
-          {
-            // Orgs that would be scheduled in this run (these would get firstNotificationDate = now)
-            expirationScheduledFor: null,
-            OR: [{ lastActivityAt: { lte: inactivityThreshold } }, { lastActivityAt: null, updatedAt: { lte: inactivityThreshold } }],
-          },
+          { expirationScheduledFor: { not: null }, nextExpirationNotificationDate: { not: null, lte: now } },
+          { id: { in: [...scheduledExpirationByOrgId.keys()] } },
         ],
       }
     : {
@@ -146,20 +229,24 @@ export async function manageOrgExpiration(prisma: PrismaClient, initialDate = ne
     },
   });
 
-  // Calculate days until expiration for each org
-  const orgsAtThreshold = allScheduledOrgs
-    .map((org) => {
-      // In test mode, orgs without expirationScheduledFor are newly scheduled
-      const effectiveExpirationDate = org.expirationScheduledFor || expirationDate;
-      const daysUntilExpiration = Math.max(0, Math.ceil((effectiveExpirationDate.getTime() - now.getTime()) / (1000 * 60 * 60 * 24)));
-      return { org, daysUntilExpiration };
-    })
-    .filter((item): item is NonNullable<typeof item> => item !== null);
+  const orgsAtThreshold = allScheduledOrgs.flatMap((org) => {
+    // Prefer the date step 1 just derived - in test mode the stored value is still the stale one
+    const effectiveExpirationDate = scheduledExpirationByOrgId.get(org.id) ?? org.expirationScheduledFor;
+    if (!effectiveExpirationDate) {
+      return [];
+    }
+    /**
+     * Clamped at 0 so an org whose derived date is months in the past reads as "connection ended"
+     * rather than a negative countdown. This drives the email wording, the audit action, and the counters.
+     */
+    const daysUntilExpiration = Math.max(0, getDaysUntilOrgExpiration(effectiveExpirationDate, now));
+    return [{ org, effectiveExpirationDate, daysUntilExpiration }];
+  });
 
   if (orgsAtThreshold.length > 0) {
-    // Group orgs by user
+    // Group orgs by user so each user gets a single email covering all of their expiring orgs
     const orgsByUser = orgsAtThreshold.reduce(
-      (acc, { org, daysUntilExpiration }) => {
+      (acc, { org, effectiveExpirationDate, daysUntilExpiration }) => {
         if (!org.jetstreamUser) return acc;
         const userId = org.jetstreamUser.id;
         if (!acc[userId]) {
@@ -168,34 +255,39 @@ export async function manageOrgExpiration(prisma: PrismaClient, initialDate = ne
             orgs: [],
           };
         }
-        acc[userId].orgs.push({ org, daysUntilExpiration });
+        acc[userId].orgs.push({ org, effectiveExpirationDate, daysUntilExpiration });
         return acc;
       },
       {} as Record<
         string,
         {
           user: { id: string; email: string; name: string; lastLoggedIn: Date | null };
-          orgs: Array<{ org: (typeof allScheduledOrgs)[number]; daysUntilExpiration: number }>;
+          orgs: Array<{ org: (typeof allScheduledOrgs)[number]; effectiveExpirationDate: Date; daysUntilExpiration: number }>;
         }
       >,
     );
 
-    // Send notifications per user
     for (const [userId, { user, orgs }] of Object.entries(orgsByUser)) {
       const userInactive = !user.lastLoggedIn || user.lastLoggedIn <= userInactivityThreshold;
-      const shouldSkipEmail = userInactive;
+      // Never let the dormancy guard swallow a warning for a connection the user could still save
+      const hasSavableOrg = orgs.some(({ daysUntilExpiration }) => daysUntilExpiration > 0);
+      const shouldSkipEmail = userInactive && !hasSavableOrg;
+      const orgSummary = orgs.map(({ daysUntilExpiration, org }) => `${org.uniqueId} (${daysUntilExpiration}d)`).join(', ');
+      const testModePrefix = testMode ? '[TEST MODE] Would ' : '';
+
+      if (shouldSkipEmail) {
+        result.usersSkipped++;
+        logger.info(
+          `${testModePrefix}Skip email for inactive user ${user.email} (last login: ${user.lastLoggedIn?.toISOString() || 'never'}) about ${orgs.length} org(s): ${orgSummary}`,
+        );
+      } else {
+        logger.info(`${testModePrefix}Notify user ${user.email} about ${orgs.length} org(s): ${orgSummary}`);
+      }
 
       if (testMode) {
-        if (shouldSkipEmail) {
-          logger.info(
-            `[TEST MODE] Would skip email for inactive user ${user.email} (last login: ${user.lastLoggedIn?.toISOString() || 'never'}) about ${orgs.length} org(s): ${orgs.map(({ daysUntilExpiration, org }) => `${org.uniqueId} (${daysUntilExpiration}d)`).join(', ')}`,
-          );
-        } else {
-          logger.info(
-            `[TEST MODE] Would notify user ${user.email} about ${orgs.length} org(s): ${orgs.map(({ daysUntilExpiration, org }) => `${org.uniqueId} (${daysUntilExpiration}d)`).join(', ')}`,
-          );
+        if (!shouldSkipEmail) {
+          result.usersNotified++;
         }
-        // Track notifications for CSV
         orgs.forEach(({ org, daysUntilExpiration }) => {
           testModeData.notifications.push({
             userEmail: user.email,
@@ -206,17 +298,12 @@ export async function manageOrgExpiration(prisma: PrismaClient, initialDate = ne
             emailSkipped: shouldSkipEmail,
           });
         });
-      } else {
-        if (shouldSkipEmail) {
-          logger.info(
-            `Skipping email for inactive user ${user.email} (last login: ${user.lastLoggedIn?.toISOString() || 'never'}) about ${orgs.length} org(s): ${orgs.map(({ daysUntilExpiration, org }) => `${org.uniqueId} (${daysUntilExpiration}d)`).join(', ')}`,
-          );
-        } else {
-          logger.info(
-            `Notifying user ${user.email} about ${orgs.length} org(s): ${orgs.map(({ daysUntilExpiration, org }) => `${org.uniqueId} (${daysUntilExpiration}d)`).join(', ')}`,
-          );
+        orgs.forEach(({ daysUntilExpiration }) => result.notifiedByThreshold[bucketByThreshold(daysUntilExpiration)]++);
+        continue;
+      }
 
-          // Send email notification
+      if (!shouldSkipEmail) {
+        try {
           await sendOrgExpirationWarningEmail({
             emailAddress: user.email,
             orgs: orgs.map(({ org, daysUntilExpiration }) => ({
@@ -226,52 +313,53 @@ export async function manageOrgExpiration(prisma: PrismaClient, initialDate = ne
               daysUntilExpiration,
             })),
           });
+        } catch (error) {
+          /**
+           * Leave the schedule untouched so the next run retries this user. A duplicate email is a
+           * far better outcome than silently burning one of only three notifications.
+           */
+          result.emailFailures++;
+          logger.error(
+            { userId, ...getErrorMessageAndStackObj(error) },
+            `Failed to send org expiration email to ${user.email} - schedule left unadvanced for retry`,
+          );
+          continue;
         }
-        // Create audit log entry
-        await createAuditLog({
-          userId,
-          action: orgs.some(({ daysUntilExpiration }) => daysUntilExpiration <= 0)
-            ? AuditLogAction.ORG_EXPIRED
-            : AuditLogAction.ORG_EXPIRATION_WARNING,
-          resource: AuditLogResource.SALESFORCE_ORG,
-          metadata: {
-            orgCount: orgs.length,
-            orgDetails: orgs.map(({ org, daysUntilExpiration }) => ({
-              orgId: org.id,
-              daysUntilExpiration,
-            })),
-          },
-        });
+        result.usersNotified++;
       }
 
-      // Update counts and set next notification date
-      for (const { org, daysUntilExpiration } of orgs) {
-        // Map to closest threshold for counting
-        if (daysUntilExpiration >= 30) {
-          result.notified30Days++;
-        } else if (daysUntilExpiration >= 7) {
-          result.notified7Days++;
-        } else if (daysUntilExpiration >= 3) {
-          result.notified3Days++;
-        }
+      await createAuditLog({
+        userId,
+        action: orgs.some(({ daysUntilExpiration }) => daysUntilExpiration <= 0)
+          ? AuditLogAction.ORG_EXPIRED
+          : AuditLogAction.ORG_EXPIRATION_WARNING,
+        resource: AuditLogResource.SALESFORCE_ORG,
+        metadata: {
+          orgCount: orgs.length,
+          emailSkipped: shouldSkipEmail,
+          orgDetails: orgs.map(({ org, daysUntilExpiration }) => ({
+            orgId: org.id,
+            daysUntilExpiration,
+          })),
+        },
+      });
 
-        if (!testMode && org.expirationScheduledFor) {
-          // Compute next notification date
-          const nextNotificationDate = computeNextNotificationDate(org.expirationScheduledFor, now, NOTIFICATION_DAYS);
+      for (const { org, effectiveExpirationDate, daysUntilExpiration } of orgs) {
+        result.notifiedByThreshold[bucketByThreshold(daysUntilExpiration)]++;
 
-          await prisma.salesforceOrg.update({
-            where: { id: org.id },
-            data: {
-              nextExpirationNotificationDate: nextNotificationDate,
-              lastExpirationNotificationAt: now,
-            },
-          });
-        }
+        await prisma.salesforceOrg.update({
+          where: { id: org.id },
+          data: {
+            // null once every threshold has passed, which takes the org out of this query for good
+            nextExpirationNotificationDate: computeNextOrgNotificationDate(effectiveExpirationDate, now),
+            lastExpirationNotificationAt: now,
+          },
+        });
       }
     }
   }
 
-  // 3. Expire orgs (invalidate access tokens)
+  // 3. Scrub credentials Salesforce has already invalidated
   const orgsToExpireWhere: Prisma.SalesforceOrgWhereInput = {
     expirationScheduledFor: { lte: now },
     accessToken: { not: EXPIRED_TOKEN_PLACEHOLDER },
@@ -283,8 +371,8 @@ export async function manageOrgExpiration(prisma: PrismaClient, initialDate = ne
   });
 
   if (orgsToExpire.length > 0) {
+    result.expired = orgsToExpire.length;
     if (testMode) {
-      result.expired = orgsToExpire.length;
       testModeData.expiredOrgs = orgsToExpire.map((org) => ({
         orgId: org.id,
         uniqueId: org.uniqueId,
@@ -299,14 +387,12 @@ export async function manageOrgExpiration(prisma: PrismaClient, initialDate = ne
         },
         data: {
           accessToken: EXPIRED_TOKEN_PLACEHOLDER,
-          connectionError: CONNECTION_ERROR_MESSAGE,
+          connectionError: ORG_EXPIRATION_CONNECTION_ERROR,
         },
       });
 
-      result.expired = orgsToExpire.length;
       logger.info(`Expired ${orgsToExpire.length} org credentials`);
 
-      // Create audit log for expired orgs
       for (const org of orgsToExpire) {
         if (org.jetstreamUserId2) {
           await createAuditLog({
@@ -326,37 +412,11 @@ export async function manageOrgExpiration(prisma: PrismaClient, initialDate = ne
     }
   }
 
-  // In test mode, generate and email CSV summary
   if (testMode) {
     await sendTestModeSummary(testModeData, result);
   }
 
   return result;
-}
-
-export async function clearOrgExpiration(prisma: PrismaClient, orgId: number, userId?: string): Promise<void> {
-  await prisma.salesforceOrg.update({
-    where: { id: orgId },
-    data: {
-      lastActivityAt: new Date(),
-      expirationScheduledFor: null,
-      nextExpirationNotificationDate: null,
-    },
-  });
-
-  if (userId) {
-    await createAuditLog({
-      userId,
-      action: AuditLogAction.ORG_REACTIVATED,
-      resource: AuditLogResource.SALESFORCE_ORG,
-      resourceId: orgId.toString(),
-      metadata: {
-        reactivatedAt: new Date().toISOString(),
-      },
-    });
-  }
-
-  logger.info(`Cleared expiration for org ${orgId}`);
 }
 
 // Test mode helper function
@@ -399,10 +459,9 @@ async function sendTestModeSummary(testModeData: TestModeData, result: OrgExpira
   const emailText = [
     'Org Expiration Test Mode Summary',
     '',
-    `Scheduled for expiration: ${result.scheduled}`,
-    `Notified (30 days): ${result.notified30Days}`,
-    `Notified (7 days): ${result.notified7Days}`,
-    `Notified (3 days): ${result.notified3Days}`,
+    `Newly scheduled for expiration: ${result.scheduled}`,
+    `Realigned to the Salesforce-derived date: ${result.realigned}`,
+    ...Object.entries(result.notifiedByThreshold).map(([threshold, count]) => `Notified (${threshold} days): ${count}`),
     `Expired: ${result.expired}`,
     '',
     `Emails to send: ${uniqueUsersToEmail} users (${emailsToSend} orgs)`,

--- a/libs/email/src/lib/email-templates/org/OrgExpirationWarningEmail.tsx
+++ b/libs/email/src/lib/email-templates/org/OrgExpirationWarningEmail.tsx
@@ -1,4 +1,4 @@
-import { pluralizeFromNumber } from '@jetstream/shared/utils';
+import { ORG_INACTIVITY_EXPIRATION_DAYS, pluralizeFromNumber } from '@jetstream/shared/utils';
 import * as React from 'react';
 import { Body, Button, Container, Head, Heading, Html, Preview, Section, Text } from 'react-email';
 import { EmailFooter } from '../../components/EmailFooter';
@@ -14,9 +14,9 @@ export const OrgExpirationWarningEmail = ({ orgs, loginUrl }: OrgExpirationWarni
   const hasExpired = orgs.some((org) => org.daysUntilExpiration <= 0);
   const hasExpiring = orgs.some((org) => org.daysUntilExpiration > 0);
 
-  const preview = hasExpired ? 'Your Salesforce orgs have expired' : `Your Salesforce orgs are expiring soon`;
+  const preview = hasExpired ? 'Your Salesforce org connections have ended' : `Your Salesforce org connections are ending soon`;
 
-  const heading = hasExpired && !hasExpiring ? 'Salesforce Orgs Expired' : 'Salesforce Orgs Expiring Soon';
+  const heading = hasExpired && !hasExpiring ? 'Salesforce Org Connections Ended' : 'Salesforce Org Connections Ending Soon';
 
   return (
     <Html>
@@ -28,7 +28,10 @@ export const OrgExpirationWarningEmail = ({ orgs, loginUrl }: OrgExpirationWarni
           <Heading style={EMAIL_STYLES.title}>{heading}</Heading>
 
           <Section style={{ marginTop: 16, marginBottom: 16 }}>
-            <Text style={sectionText}>The following Salesforce orgs are scheduled for deactivation due to 90 days of inactivity:</Text>
+            <Text style={sectionText}>
+              Salesforce ends a connection when an org has not been used for {ORG_INACTIVITY_EXPIRATION_DAYS} days. These orgs are at or
+              past that limit:
+            </Text>
 
             {orgs.map((org, index) => (
               <React.Fragment key={index}>
@@ -41,21 +44,26 @@ export const OrgExpirationWarningEmail = ({ orgs, loginUrl }: OrgExpirationWarni
                   <br />
                   <span style={expirationText}>
                     {org.daysUntilExpiration <= 0
-                      ? '⚠️ Expired'
-                      : `Expires in ${org.daysUntilExpiration} ${pluralizeFromNumber('day', org.daysUntilExpiration)}`}
+                      ? '⚠️ Connection ended'
+                      : `Ends in ${org.daysUntilExpiration} ${pluralizeFromNumber('day', org.daysUntilExpiration)}`}
                   </span>
                 </Text>
               </React.Fragment>
             ))}
 
             {hasExpiring && (
-              <Text style={sectionText}>To prevent deactivation, use these orgs in Jetstream before the expiration date.</Text>
+              <Text style={sectionText}>To keep these connections, open each org in Jetstream before the date shown above.</Text>
             )}
 
-            {hasExpired && <Text style={sectionText}>To reactivate expired credentials, log in to Jetstream and reconnect the org.</Text>}
+            {hasExpired && (
+              <Text style={sectionText}>
+                These connections have already ended. Log in to Jetstream and reconnect the org to keep using it.
+              </Text>
+            )}
 
             <Text style={sectionText}>
-              This security measure ensures that unused credentials are automatically removed from Jetstream after 90 days of inactivity.
+              This limit is set by Salesforce for connected apps — it is not a Jetstream policy. Any time you use an org in Jetstream, its{' '}
+              {ORG_INACTIVITY_EXPIRATION_DAYS}-day clock resets.
             </Text>
           </Section>
 
@@ -77,13 +85,13 @@ OrgExpirationWarningEmail.PreviewProps = {
       username: 'admin@acme.com',
       organizationId: '00D000000000000EAA',
       instanceUrl: 'https://acme.my.salesforce.com',
-      daysUntilExpiration: 14,
+      daysUntilExpiration: 7,
     },
     {
       username: 'dev@acme.com.dev',
       organizationId: '00D000000000001EAA',
       instanceUrl: 'https://acme--dev.sandbox.my.salesforce.com',
-      daysUntilExpiration: 3,
+      daysUntilExpiration: 1,
     },
     {
       username: 'old@acme.com',

--- a/libs/email/src/lib/email.tsx
+++ b/libs/email/src/lib/email.tsx
@@ -278,6 +278,12 @@ export async function sendCloudflareSecurityAlertEmail({
   }
 }
 
+/**
+ * Failures propagate rather than being logged and swallowed. The cron only advances an org's
+ * notification schedule once the send succeeds — swallowing the error would silently burn a threshold,
+ * and with only a 7 day warning window that can consume the single actionable warning a user gets
+ * before Salesforce ends the connection.
+ */
 export async function sendOrgExpirationWarningEmail({
   emailAddress,
   orgs,
@@ -285,27 +291,23 @@ export async function sendOrgExpirationWarningEmail({
   emailAddress: string;
   orgs: Array<{ username: string; organizationId: string; instanceUrl: string; daysUntilExpiration: number }>;
 }) {
-  try {
-    const component = <OrgExpirationWarningEmail orgs={orgs} loginUrl={`${ENV.JETSTREAM_SERVER_URL}/app`} />;
-    const [html, text] = await renderComponent(component);
+  const component = <OrgExpirationWarningEmail orgs={orgs} loginUrl={`${ENV.JETSTREAM_SERVER_URL}/app`} />;
+  const [html, text] = await renderComponent(component);
 
-    const hasExpired = orgs.some((org) => org.daysUntilExpiration <= 0);
-    const positiveDays = orgs.map((org) => org.daysUntilExpiration).filter((days) => days > 0);
-    const minDays = positiveDays.length > 0 ? Math.min(...positiveDays) : 0;
+  const hasExpired = orgs.some((org) => org.daysUntilExpiration <= 0);
+  const positiveDays = orgs.map((org) => org.daysUntilExpiration).filter((days) => days > 0);
+  const minDays = positiveDays.length > 0 ? Math.min(...positiveDays) : 0;
 
-    const subject = hasExpired
-      ? 'Salesforce Org Credentials Expired'
-      : `Salesforce Org Credentials Expiring in ${minDays} ${pluralizeFromNumber('Day', minDays)}`;
+  const subject = hasExpired
+    ? 'Salesforce Org Connection Ended'
+    : `Salesforce Org Connection Ending in ${minDays} ${pluralizeFromNumber('Day', minDays)}`;
 
-    await sendEmail({
-      to: emailAddress,
-      subject,
-      text,
-      html,
-    });
-  } catch (error) {
-    logger.error({ ...getErrorMessageAndStackObj(error) }, 'Error sending org expiration warning email');
-  }
+  await sendEmail({
+    to: emailAddress,
+    subject,
+    text,
+    html,
+  });
 }
 
 /**

--- a/libs/features/org-groups/src/lib/SalesforceOrgCardConnectionRefresh.tsx
+++ b/libs/features/org-groups/src/lib/SalesforceOrgCardConnectionRefresh.tsx
@@ -1,6 +1,6 @@
 import { logger } from '@jetstream/shared/client-logger';
 import { checkOrgHealth, getOrgs } from '@jetstream/shared/data';
-import { pluralizeFromNumber } from '@jetstream/shared/utils';
+import { ORG_INACTIVITY_EXPIRATION_DAYS, pluralizeFromNumber } from '@jetstream/shared/utils';
 import { AddOrgHandlerFn, BadgeType, Maybe, SalesforceOrgUi } from '@jetstream/types';
 import { Badge, ConfirmationModalPromise, Grid, Icon, Spinner, Tooltip, fireToast } from '@jetstream/ui';
 import { AddOrg, OrgExpirationStatus, useOrgExpiration, useUpdateOrgs } from '@jetstream/ui-core';
@@ -24,16 +24,16 @@ function getConnectionState(orgExpiration: OrgExpirationStatus, connectionError:
   const connectionState = {
     badge: {
       isVisible: !!orgExpiration.isExpiring,
-      label: orgExpiration.isExpired ? 'Expired' : `Expires ${orgExpiration.expiryDate}`,
+      label: orgExpiration.isExpired ? 'Disconnected' : `Ends ${orgExpiration.expiryDate}`,
       tooltip: orgExpiration.isExpired
-        ? 'This org expired due to 90 days of inactivity. Reconnect the org to continue using it or delete it if it is no longer needed.'
-        : `This org will expire in ${orgExpiration.daysUntilExpiration} ${pluralizeFromNumber('day', orgExpiration.daysUntilExpiration || 0)} due to inactivity. Refresh it or use it to prevent expiration.`,
+        ? `Salesforce ended this connection because the org was not used in Jetstream for ${ORG_INACTIVITY_EXPIRATION_DAYS} days. Reconnect the org to continue using it, or remove it if you no longer need it.`
+        : `Salesforce will end this connection in ${orgExpiration.daysUntilExpiration} ${pluralizeFromNumber('day', orgExpiration.daysUntilExpiration || 0)} unless the org is used. Open or refresh the org in Jetstream to keep it connected.`,
       badgeType: (orgExpiration.severity === 'error' ? 'error' : 'warning') as BadgeType,
     },
     refreshIcon: {
       isVisible: (hasConnectionError && !orgExpiration.isExpired) || orgExpiration.isExpiring,
       tooltip: orgExpiration.isExpiring
-        ? 'Refresh the connection to remove the pending expiration'
+        ? `Refresh the connection now to reset the ${ORG_INACTIVITY_EXPIRATION_DAYS}-day inactivity clock`
         : `There was an error connecting to this org. You can try refreshing the connection otherwise you will need to reconnect the org. Error: ${connectionError}`,
     },
     reconnectOrg: {

--- a/libs/shared/ui-core/src/app/AppHome/AppHomeOrgExpirationBanner.tsx
+++ b/libs/shared/ui-core/src/app/AppHome/AppHomeOrgExpirationBanner.tsx
@@ -1,4 +1,5 @@
 import { APP_ROUTES } from '@jetstream/shared/ui-router';
+import { ORG_INACTIVITY_EXPIRATION_DAYS } from '@jetstream/shared/utils';
 import { ScopedNotification } from '@jetstream/ui';
 import { fromAppState } from '@jetstream/ui/app-state';
 import { useAtomValue } from 'jotai';
@@ -13,8 +14,8 @@ export const AppHomeOrgExpirationBanner = () => {
     return null;
   }
 
-  const expiredText = expired === 1 ? '1 org has expired' : `${expired} orgs have expired`;
-  const expiringSoonText = expiringSoon === 1 ? '1 org is expiring soon' : `${expiringSoon} orgs are expiring soon`;
+  const expiredText = expired === 1 ? '1 org has disconnected' : `${expired} orgs have disconnected`;
+  const expiringSoonText = expiringSoon === 1 ? '1 org will disconnect soon' : `${expiringSoon} orgs will disconnect soon`;
 
   let message: string;
   if (expired > 0 && expiringSoon > 0) {
@@ -26,9 +27,9 @@ export const AppHomeOrgExpirationBanner = () => {
   }
 
   return (
-    <ScopedNotification theme="info" className="slds-m-bottom_x-small">
-      {message} due to 90 days of inactivity. <Link to={APP_ROUTES.SALESFORCE_ORG_GROUPS.ROUTE}>View and manage your orgs</Link> to
-      reactivate them.
+    <ScopedNotification theme={expired > 0 ? 'error' : 'warning'} className="slds-m-bottom_x-small">
+      {message}. Salesforce ends a connection when an org has not been used for {ORG_INACTIVITY_EXPIRATION_DAYS} days, and using an org in
+      Jetstream keeps its connection alive. <Link to={APP_ROUTES.SALESFORCE_ORG_GROUPS.ROUTE}>View and manage your orgs</Link>.
     </ScopedNotification>
   );
 };

--- a/libs/shared/ui-core/src/orgs/OrgsCombobox.tsx
+++ b/libs/shared/ui-core/src/orgs/OrgsCombobox.tsx
@@ -4,6 +4,7 @@ import { ComboboxWithGroupedItems } from '@jetstream/ui';
 import groupBy from 'lodash/groupBy';
 import sortBy from 'lodash/sortBy';
 import { FunctionComponent, useEffect, useState } from 'react';
+import { calculateOrgExpiration } from './useOrgExpiration';
 
 function getSelectedItemLabel(item: ListItem<string, SalesforceOrgUi>) {
   const org = item.meta;
@@ -59,20 +60,14 @@ function orgHasError(org: Maybe<SalesforceOrgUi>): boolean {
 }
 
 function groupOrgs(orgs: SalesforceOrgUi[]): ListItemGroup<string, SalesforceOrgUi>[] {
-  const now = new Date();
   const orgsById = groupBy(sortBy(orgs, ['label']), 'orgName');
   return Object.keys(orgsById).map(
     (key): ListItemGroup => ({
       id: key,
       label: key,
       items: orgsById[key].map((org) => {
-        let expiryMessage: Maybe<string> = undefined;
-        if (org.expirationScheduledFor) {
-          const expirationDate = new Date(org.expirationScheduledFor);
-          const daysUntilExpiration = Math.ceil((expirationDate.getTime() - now.getTime()) / (1000 * 60 * 60 * 24));
-          const isExpired = daysUntilExpiration <= 0;
-          expiryMessage = `${isExpired ? 'Expired' : 'Expires'} on ${new Date(org.expirationScheduledFor).toLocaleDateString()}`;
-        }
+        const { isExpired, expiryDate } = calculateOrgExpiration(org);
+        const expiryMessage: Maybe<string> = expiryDate ? `${isExpired ? 'Ended' : 'Ends'} on ${expiryDate}` : undefined;
 
         return {
           id: org.uniqueId,

--- a/libs/shared/ui-core/src/orgs/useOrgExpiration.ts
+++ b/libs/shared/ui-core/src/orgs/useOrgExpiration.ts
@@ -1,3 +1,4 @@
+import { getDaysUntilOrgExpiration } from '@jetstream/shared/utils';
 import { SalesforceOrgUi } from '@jetstream/types';
 import { useMemo } from 'react';
 
@@ -6,7 +7,7 @@ export interface OrgExpirationStatus {
   isExpired: boolean;
   expiryDate: string | null;
   daysUntilExpiration: number | null;
-  severity: 'error' | 'warning' | 'info' | null;
+  severity: 'error' | 'warning' | null;
 }
 
 export interface ExpiringOrgsSummary {
@@ -30,23 +31,17 @@ export function calculateOrgExpiration(org: SalesforceOrgUi | null | undefined):
     };
   }
 
-  const now = new Date();
   const expirationDate = new Date(org.expirationScheduledFor);
-  const daysUntilExpiration = Math.ceil((expirationDate.getTime() - now.getTime()) / (1000 * 60 * 60 * 24));
+  const daysUntilExpiration = getDaysUntilOrgExpiration(expirationDate, new Date());
 
   const isExpired = daysUntilExpiration <= 0;
   const isExpiring = true;
 
-  let severity: 'error' | 'warning' | 'info' | null = null;
-  if (isExpired) {
-    severity = 'error';
-  } else if (daysUntilExpiration <= 3) {
-    severity = 'error';
-  } else if (daysUntilExpiration <= 7) {
-    severity = 'warning';
-  } else if (isExpiring) {
-    severity = 'info';
-  }
+  /**
+   * An org only has an expiration date once it is inside the warning window, so the range here is
+   * capped at ORG_EXPIRATION_WARNING_WINDOW_DAYS - there is no "far off" band to represent.
+   */
+  const severity: 'error' | 'warning' = daysUntilExpiration <= 3 ? 'error' : 'warning';
 
   return {
     isExpiring,

--- a/libs/shared/utils/src/index.ts
+++ b/libs/shared/utils/src/index.ts
@@ -3,6 +3,7 @@ export * from './lib/custom-field-tooling-names';
 export * from './lib/dedupe-field-usage-where-used';
 export * from './lib/password-validation';
 export * from './lib/regex';
+export * from './lib/salesforce-org-expiration';
 export * from './lib/sobject-api-name-utils';
 export * from './lib/sso-certificate-expiration';
 export * from './lib/utils';

--- a/libs/shared/utils/src/lib/__tests__/salesforce-org-expiration.spec.ts
+++ b/libs/shared/utils/src/lib/__tests__/salesforce-org-expiration.spec.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest';
+import {
+  computeNextOrgNotificationDate,
+  computeOrgExpirationDate,
+  getDaysUntilOrgExpiration,
+  ORG_EXPIRATION_NOTIFICATION_DAYS,
+  ORG_INACTIVITY_EXPIRATION_DAYS,
+  ORG_SCHEDULE_AFTER_IDLE_DAYS,
+} from '../salesforce-org-expiration';
+
+/**
+ * Expiration dates resolve to end-of-day in the server's local timezone (matching the cron), so every
+ * date here is constructed and asserted in local time to keep the suite timezone-independent.
+ */
+function localDate(year: number, month: number, day: number, hour = 0) {
+  return new Date(year, month - 1, day, hour);
+}
+
+/** The cron normalizes `now` to end-of-day before computing thresholds — mirror that here. */
+function localEndOfDay(year: number, month: number, day: number) {
+  return new Date(year, month - 1, day, 23, 59, 59, 999);
+}
+
+function toDateString(date: Date | null) {
+  if (!date) {
+    return null;
+  }
+  const month = `${date.getMonth() + 1}`.padStart(2, '0');
+  const day = `${date.getDate()}`.padStart(2, '0');
+  return `${date.getFullYear()}-${month}-${day}`;
+}
+
+describe('constants', () => {
+  it('warns far enough ahead that the first email lands inside the Salesforce window', () => {
+    expect(ORG_SCHEDULE_AFTER_IDLE_DAYS).toBe(23);
+    expect(ORG_SCHEDULE_AFTER_IDLE_DAYS + ORG_EXPIRATION_NOTIFICATION_DAYS[0]).toBe(ORG_INACTIVITY_EXPIRATION_DAYS);
+  });
+});
+
+describe('computeOrgExpirationDate', () => {
+  it('derives the expiration 30 days after the last activity', () => {
+    expect(toDateString(computeOrgExpirationDate(localDate(2026, 6, 1, 9)))).toBe('2026-07-01');
+  });
+
+  it('normalizes to end of day so the time of the last activity does not shift the date', () => {
+    const earlyMorning = computeOrgExpirationDate(localDate(2026, 6, 1, 0));
+    const lateNight = computeOrgExpirationDate(localDate(2026, 6, 1, 23));
+    expect(earlyMorning.getTime()).toBe(lateNight.getTime());
+  });
+
+  it('is idempotent when recomputed from an already normalized base', () => {
+    // The cron pins lastActivityAt to endOfDay(base), then re-derives from it on later runs.
+    const base = localDate(2026, 6, 1, 9);
+    const fromRawBase = computeOrgExpirationDate(base);
+    const fromPinnedBase = computeOrgExpirationDate(new Date(base.getFullYear(), base.getMonth(), base.getDate(), 23, 59, 59, 999));
+    expect(fromPinnedBase.getTime()).toBe(fromRawBase.getTime());
+  });
+});
+
+describe('computeNextOrgNotificationDate', () => {
+  const EXPIRES_AT = computeOrgExpirationDate(localDate(2026, 6, 1));
+
+  it('returns the 7 day threshold when the org just entered the warning window', () => {
+    expect(toDateString(computeNextOrgNotificationDate(EXPIRES_AT, localDate(2026, 6, 20)))).toBe('2026-06-24');
+  });
+
+  it('skips thresholds that have already passed', () => {
+    expect(toDateString(computeNextOrgNotificationDate(EXPIRES_AT, localDate(2026, 6, 26)))).toBe('2026-06-30');
+  });
+
+  it('returns the expiration-day threshold as the final notification', () => {
+    expect(toDateString(computeNextOrgNotificationDate(EXPIRES_AT, localEndOfDay(2026, 6, 30)))).toBe('2026-07-01');
+  });
+
+  it('returns null once every threshold has passed so the org leaves the cron query', () => {
+    expect(computeNextOrgNotificationDate(EXPIRES_AT, localEndOfDay(2026, 7, 1))).toBeNull();
+  });
+
+  it('returns null for a long-overdue org rather than replaying every threshold', () => {
+    // The realignment path derives expiration dates far in the past for orgs idle for months.
+    expect(computeNextOrgNotificationDate(computeOrgExpirationDate(localDate(2025, 1, 1)), localDate(2026, 7, 1))).toBeNull();
+  });
+
+  it('advances through every configured threshold exactly once', () => {
+    let now = localDate(2026, 6, 20);
+    const scheduled: string[] = [];
+
+    let next = computeNextOrgNotificationDate(EXPIRES_AT, now);
+    while (next) {
+      scheduled.push(toDateString(next) as string);
+      // Simulate the cron running at the moment the notification came due
+      now = next;
+      next = computeNextOrgNotificationDate(EXPIRES_AT, now);
+    }
+
+    expect(scheduled).toEqual(['2026-06-24', '2026-06-30', '2026-07-01']);
+    expect(scheduled).toHaveLength(ORG_EXPIRATION_NOTIFICATION_DAYS.length);
+  });
+});
+
+describe('getDaysUntilOrgExpiration', () => {
+  const EXPIRES_AT = computeOrgExpirationDate(localDate(2026, 6, 1));
+
+  it('does not depend on the time of day it is evaluated', () => {
+    // The banner passes a live `new Date()`; a millisecond delta would report 8 in the morning
+    // and 7 in the evening for the same calendar day.
+    expect(getDaysUntilOrgExpiration(EXPIRES_AT, localDate(2026, 6, 24, 0))).toBe(7);
+    expect(getDaysUntilOrgExpiration(EXPIRES_AT, localDate(2026, 6, 24, 23))).toBe(7);
+  });
+
+  it('returns 0 on the day the connection expires', () => {
+    expect(getDaysUntilOrgExpiration(EXPIRES_AT, localDate(2026, 7, 1, 8))).toBe(0);
+  });
+
+  it('goes negative once expired', () => {
+    expect(getDaysUntilOrgExpiration(EXPIRES_AT, localDate(2026, 7, 8))).toBe(-7);
+  });
+});

--- a/libs/shared/utils/src/lib/salesforce-org-expiration.ts
+++ b/libs/shared/utils/src/lib/salesforce-org-expiration.ts
@@ -1,0 +1,80 @@
+import { addDays } from 'date-fns/addDays';
+import { differenceInCalendarDays } from 'date-fns/differenceInCalendarDays';
+import { endOfDay } from 'date-fns/endOfDay';
+
+/**
+ * Salesforce invalidates a partner connected app's refresh token once an org has gone this many days
+ * without the token being used. Salesforce owns this cutoff — Jetstream cannot extend it, it can only
+ * predict it and warn ahead of time.
+ */
+export const ORG_INACTIVITY_EXPIRATION_DAYS = 30;
+
+/**
+ * Days-before-expiration at which the org owner is emailed. `0` is the notification sent on/after the
+ * day the connection dies.
+ */
+export const ORG_EXPIRATION_NOTIFICATION_DAYS = [7, 1, 0];
+
+/**
+ * The window in which the in-app banner and org card badge warn about an upcoming expiration. Matches
+ * the first email threshold so the banner and the first email appear at the same time.
+ */
+export const ORG_EXPIRATION_WARNING_WINDOW_DAYS = ORG_EXPIRATION_NOTIFICATION_DAYS[0];
+
+/**
+ * Idle days at which an org enters the warning window and the cron records an expiration date for it.
+ */
+export const ORG_SCHEDULE_AFTER_IDLE_DAYS = ORG_INACTIVITY_EXPIRATION_DAYS - ORG_EXPIRATION_WARNING_WINDOW_DAYS;
+
+/**
+ * Written to `connectionError` when the cron scrubs credentials that Salesforce has already invalidated.
+ * Surfaced verbatim to the user on the org card and the org selection screen.
+ */
+export const ORG_EXPIRATION_CONNECTION_ERROR = `Connection ended by Salesforce after ${ORG_INACTIVITY_EXPIRATION_DAYS} days of inactivity`;
+
+/**
+ * The date Salesforce is expected to invalidate an org's refresh token, derived from the last time the
+ * org was used through Jetstream.
+ *
+ * Derived, never granted: Jetstream used to hand out its own grace period on top of an inactivity
+ * threshold, which is no longer possible now that Salesforce enforces the lifetime. Normalized to
+ * end-of-day so it lines up with the notification thresholds and so recomputing it from an already
+ * normalized base is a no-op.
+ */
+export function computeOrgExpirationDate(activityBaseDate: Date): Date {
+  return endOfDay(addDays(activityBaseDate, ORG_INACTIVITY_EXPIRATION_DAYS));
+}
+
+/**
+ * Compute the next date an org expiration warning is due.
+ *
+ * Returns the earliest threshold date strictly after `now`, or null once every notification has been
+ * sent — null is the terminal state that takes the org out of the cron's notification query entirely.
+ * An org whose expiration is already in the past returns null immediately rather than replaying every
+ * threshold.
+ */
+export function computeNextOrgNotificationDate(
+  expirationDate: Date,
+  now: Date,
+  thresholds = ORG_EXPIRATION_NOTIFICATION_DAYS,
+): Date | null {
+  const upcoming = thresholds
+    .map((daysBefore) => endOfDay(addDays(expirationDate, -daysBefore)))
+    .filter((notificationDate) => notificationDate > now)
+    .sort((a, b) => a.getTime() - b.getTime());
+
+  return upcoming[0] ?? null;
+}
+
+/**
+ * Calendar days from `now` until the connection expires. Negative once expired, which lets callers
+ * distinguish "expires today" (0) from "expired last week" (-7) when choosing wording.
+ *
+ * Deliberately a calendar-day difference rather than a millisecond delta: every consumer is
+ * day-threshold based, and expiration dates are stored at end-of-day, so a raw delta makes the result
+ * depend on time-of-day — an org expiring at 23:59 reports 8 ("outside the warning window") when
+ * checked at 09:00 seven days earlier.
+ */
+export function getDaysUntilOrgExpiration(expirationDate: Date, now: Date): number {
+  return differenceInCalendarDays(expirationDate, now);
+}


### PR DESCRIPTION
Salesforce now enforces a 30-day inactivity-based refresh token expiration on
partner connected apps. Jetstream's own policy (90 days idle, then a
Jetstream-granted 30-day grace period, scrub at day 120) told users their org
was fine for months after Salesforce had already invalidated the credentials.

expirationScheduledFor is now derived rather than granted: lastActivityAt + 30
days, Jetstream's best estimate of Salesforce's cutoff. Orgs enter the warning
window at 23 days idle and are notified at 7, 1, and 0 days out.