### PR TITLE
Data table: default copy context menu + drag-select auto-scroll

### DIFF
--- a/libs/ui/src/lib/data-table/DataTable.tsx
+++ b/libs/ui/src/lib/data-table/DataTable.tsx
@@ -37,7 +37,8 @@ export interface DataTableProps<T extends object = RowWithKey, TContext = Record
   contextMenuItems?: ContextMenuItems<T>;
   // `any` so call sites may type their handler against a narrower row type without variance errors.
   contextMenuAction?: (item: ContextMenuItem, data: ContextMenuActionData<any>) => void;
-  /** Consumer-supplied builder for extra per-column header menu items (must be stable). */
+  /** Consumer-supplied builder for extra per-column header menu items (must be stable). Items dispatch
+   * through `contextMenuAction`; they are omitted from the menu without one. */
   getColumnHeaderMenuItems?: (columnId: string) => ContextMenuItem[];
   initialSortColumns?: SortColumn[];
   rowAlwaysVisible?: (row: T) => boolean;

--- a/libs/ui/src/lib/data-table/DataTable.tsx
+++ b/libs/ui/src/lib/data-table/DataTable.tsx
@@ -32,6 +32,8 @@ export interface DataTableProps<T extends object = RowWithKey, TContext = Record
   quickFilterText?: string | null;
   includeQuickFilter?: boolean;
   context?: TContext;
+  /** Omit to get the standard copy cell/row/column/table actions, which the grid resolves and dispatches
+   * itself; supply a list/builder (plus `contextMenuAction`) to replace them, or `[]` to opt out. */
   contextMenuItems?: ContextMenuItems<T>;
   // `any` so call sites may type their handler against a narrower row type without variance errors.
   contextMenuAction?: (item: ContextMenuItem, data: ContextMenuActionData<any>) => void;

--- a/libs/ui/src/lib/data-table/grid/DataTableV2.tsx
+++ b/libs/ui/src/lib/data-table/grid/DataTableV2.tsx
@@ -80,9 +80,11 @@ export interface DataTableV2Props<TRow extends object = RowWithKey, TContext = R
    * the standard copy cell/row/column/table actions, which the grid resolves and dispatches itself;
    * pass `[]` to opt out of them. */
   contextMenuItems?: ContextMenuItems<TRow>;
-  /** Right-click context menu action handler (must be stable). Required only alongside `contextMenuItems`. */
+  /** Right-click context menu action handler (must be stable). Required whenever consumer-supplied items
+   * can be selected — alongside `contextMenuItems` and/or `getColumnHeaderMenuItems`. */
   contextMenuAction?: (item: ContextMenuItem, data: ContextMenuActionData<TRow>) => void;
-  /** Consumer-supplied builder for extra per-column header menu items (must be stable). */
+  /** Consumer-supplied builder for extra per-column header menu items (must be stable). Items dispatch
+   * through `contextMenuAction`; they are omitted from the menu without one. */
   getColumnHeaderMenuItems?: (columnId: string) => ContextMenuItem[];
   /** Opt-in: rows wrap and size to their content (DOM-measured); disables column virtualization so every
    * row's height accounts for all cells. Use only for grids whose columns fit without horizontal scroll. */

--- a/libs/ui/src/lib/data-table/grid/DataTableV2.tsx
+++ b/libs/ui/src/lib/data-table/grid/DataTableV2.tsx
@@ -76,9 +76,11 @@ export interface DataTableV2Props<TRow extends object = RowWithKey, TContext = R
   summaryRows?: unknown[];
   /** Fixed height (px) for each pinned summary row; content-sized when omitted. */
   summaryRowHeight?: number;
-  /** Right-click context menu items — a static list or a per-cell builder (must be stable). */
+  /** Right-click context menu items — a static list or a per-cell builder (must be stable). Omit to get
+   * the standard copy cell/row/column/table actions, which the grid resolves and dispatches itself;
+   * pass `[]` to opt out of them. */
   contextMenuItems?: ContextMenuItems<TRow>;
-  /** Right-click context menu action handler (must be stable). */
+  /** Right-click context menu action handler (must be stable). Required only alongside `contextMenuItems`. */
   contextMenuAction?: (item: ContextMenuItem, data: ContextMenuActionData<TRow>) => void;
   /** Consumer-supplied builder for extra per-column header menu items (must be stable). */
   getColumnHeaderMenuItems?: (columnId: string) => ContextMenuItem[];

--- a/libs/ui/src/lib/data-table/grid/__tests__/grid-auto-scroll.spec.ts
+++ b/libs/ui/src/lib/data-table/grid/__tests__/grid-auto-scroll.spec.ts
@@ -1,0 +1,163 @@
+import { describe, expect, test, vi } from 'vitest';
+import {
+  AutoScrollScheduler,
+  computeEdgeScrollVelocity,
+  createEdgeAutoScroller,
+  DEFAULT_EDGE_SIZE,
+  DEFAULT_MAX_SPEED,
+  EdgeScrollBox,
+} from '../grid-auto-scroll';
+
+const box: EdgeScrollBox = { top: 100, right: 900, bottom: 500, left: 100 };
+
+describe('computeEdgeScrollVelocity', () => {
+  test('is idle in the middle of the box', () => {
+    expect(computeEdgeScrollVelocity({ box, clientX: 500, clientY: 300 })).toEqual({ x: 0, y: 0 });
+  });
+
+  test('ramps linearly from the edge inward', () => {
+    // Half of the ramp width in from the bottom edge → half speed.
+    const halfway = computeEdgeScrollVelocity({ box, clientX: 500, clientY: box.bottom - DEFAULT_EDGE_SIZE / 2 });
+    expect(halfway.y).toBeCloseTo(DEFAULT_MAX_SPEED / 2);
+    expect(halfway.x).toBe(0);
+  });
+
+  test('clamps at max speed once the pointer is outside the box', () => {
+    expect(computeEdgeScrollVelocity({ box, clientX: 500, clientY: box.bottom + 5000 }).y).toBe(DEFAULT_MAX_SPEED);
+    expect(computeEdgeScrollVelocity({ box, clientX: box.right + 5000, clientY: 300 }).x).toBe(DEFAULT_MAX_SPEED);
+  });
+
+  test('scrolls back toward the origin above/left of the box', () => {
+    expect(computeEdgeScrollVelocity({ box, clientX: 500, clientY: box.top - 20 }).y).toBe(-DEFAULT_MAX_SPEED);
+    expect(computeEdgeScrollVelocity({ box, clientX: box.left - 20, clientY: 300 }).x).toBe(-DEFAULT_MAX_SPEED);
+  });
+
+  test('drives both axes in the corners', () => {
+    const corner = computeEdgeScrollVelocity({ box, clientX: box.right - 1, clientY: box.bottom - 1 });
+    expect(corner.x).toBeGreaterThan(0);
+    expect(corner.y).toBeGreaterThan(0);
+  });
+
+  test('splits a box narrower than two ramps so the opposing ramps never overlap', () => {
+    // A 40px-tall box with a 48px ramp: each half owns 20px, so the exact centre is still idle.
+    const narrow: EdgeScrollBox = { top: 0, right: 1000, bottom: 40, left: 0 };
+    expect(computeEdgeScrollVelocity({ box: narrow, clientX: 500, clientY: 20 }).y).toBe(0);
+    expect(computeEdgeScrollVelocity({ box: narrow, clientX: 500, clientY: 35 }).y).toBeGreaterThan(0);
+    expect(computeEdgeScrollVelocity({ box: narrow, clientX: 500, clientY: 5 }).y).toBeLessThan(0);
+  });
+
+  test('is idle for a degenerate (zero-size) box', () => {
+    expect(computeEdgeScrollVelocity({ box: { top: 0, right: 0, bottom: 0, left: 0 }, clientX: 0, clientY: 0 })).toEqual({ x: 0, y: 0 });
+  });
+});
+
+/** rAF/clock stand-in: frames only advance when the test says so, each by `frameMs`. */
+function createTestScheduler() {
+  let time = 0;
+  let nextHandle = 1;
+  const pending = new Map<number, () => void>();
+  const scheduler: AutoScrollScheduler = {
+    now: () => time,
+    request: vi.fn((callback: () => void) => {
+      const handle = nextHandle++;
+      pending.set(handle, callback);
+      return handle;
+    }),
+    cancel: vi.fn((handle: number) => {
+      pending.delete(handle);
+    }),
+  };
+  return {
+    scheduler,
+    /** Run every queued frame, advancing the clock by `frameMs` first (mirrors rAF's timestamp). */
+    advanceFrames(count: number, frameMs: number) {
+      for (let index = 0; index < count; index++) {
+        const callbacks = Array.from(pending.values());
+        pending.clear();
+        time += frameMs;
+        callbacks.forEach((callback) => callback());
+      }
+    },
+    hasPendingFrame: () => pending.size > 0,
+  };
+}
+
+describe('createEdgeAutoScroller', () => {
+  test('scrolls at the requested px/sec regardless of frame rate', () => {
+    const element = document.createElement('div');
+    const slow = createTestScheduler();
+    createEdgeAutoScroller({ getScrollElement: () => element, scheduler: slow.scheduler }).setVelocity({ x: 0, y: 1000 });
+    slow.advanceFrames(3, 16);
+    expect(element.scrollTop).toBe(48);
+
+    // The same elapsed time at 120Hz must cover the same distance — a fixed px-per-frame step doubles it.
+    const element120 = document.createElement('div');
+    const fast = createTestScheduler();
+    createEdgeAutoScroller({ getScrollElement: () => element120, scheduler: fast.scheduler }).setVelocity({ x: 0, y: 1000 });
+    fast.advanceFrames(6, 8);
+    expect(element120.scrollTop).toBe(48);
+  });
+
+  test('accumulates sub-pixel movement instead of truncating it away', () => {
+    const element = document.createElement('div');
+    const { scheduler, advanceFrames } = createTestScheduler();
+    // 32px/sec over a 16ms frame is ~0.5px — a naive `scrollTop += 0.5` would never move at all.
+    createEdgeAutoScroller({ getScrollElement: () => element, scheduler }).setVelocity({ x: 0, y: 32 });
+    advanceFrames(1, 16);
+    expect(element.scrollTop).toBe(0);
+    advanceFrames(1, 16);
+    expect(element.scrollTop).toBe(1);
+  });
+
+  test('clamps a long frame gap so a background tab does not jump the scroll position', () => {
+    const element = document.createElement('div');
+    const { scheduler, advanceFrames } = createTestScheduler();
+    createEdgeAutoScroller({ getScrollElement: () => element, scheduler }).setVelocity({ x: 0, y: 900 });
+    advanceFrames(1, 2000);
+    // 900px/sec × the 0.05s cap, not × the 2s that actually elapsed.
+    expect(element.scrollTop).toBe(45);
+  });
+
+  test('scrolls horizontally and negatively', () => {
+    const element = document.createElement('div');
+    element.scrollLeft = 500;
+    const { scheduler, advanceFrames } = createTestScheduler();
+    createEdgeAutoScroller({ getScrollElement: () => element, scheduler }).setVelocity({ x: -1000, y: 0 });
+    advanceFrames(3, 16);
+    expect(element.scrollLeft).toBe(452);
+  });
+
+  test('reports the px actually applied to onFrame', () => {
+    const element = document.createElement('div');
+    const onFrame = vi.fn();
+    const { scheduler, advanceFrames } = createTestScheduler();
+    createEdgeAutoScroller({ getScrollElement: () => element, onFrame, scheduler }).setVelocity({ x: 0, y: 1000 });
+    advanceFrames(1, 16);
+    expect(onFrame).toHaveBeenCalledWith({ x: 0, y: 16 });
+  });
+
+  test('a zero velocity and stop() both cancel the pending frame', () => {
+    const element = document.createElement('div');
+    const { scheduler, advanceFrames, hasPendingFrame } = createTestScheduler();
+    const scroller = createEdgeAutoScroller({ getScrollElement: () => element, scheduler });
+
+    scroller.setVelocity({ x: 0, y: 600 });
+    expect(hasPendingFrame()).toBe(true);
+    scroller.setVelocity({ x: 0, y: 0 });
+    expect(hasPendingFrame()).toBe(false);
+
+    scroller.setVelocity({ x: 0, y: 600 });
+    advanceFrames(1, 16);
+    const scrolled = element.scrollTop;
+    scroller.stop();
+    advanceFrames(2, 16);
+    expect(element.scrollTop).toBe(scrolled);
+  });
+
+  test('stops quietly when the scroll element goes away', () => {
+    const { scheduler, advanceFrames, hasPendingFrame } = createTestScheduler();
+    createEdgeAutoScroller({ getScrollElement: () => null, scheduler }).setVelocity({ x: 0, y: 600 });
+    expect(() => advanceFrames(1, 1000 / 60)).not.toThrow();
+    expect(hasPendingFrame()).toBe(false);
+  });
+});

--- a/libs/ui/src/lib/data-table/grid/__tests__/grid-clipboard.spec.tsx
+++ b/libs/ui/src/lib/data-table/grid/__tests__/grid-clipboard.spec.tsx
@@ -1,0 +1,144 @@
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { useJetstreamTable } from '../core/useJetstreamTable';
+import { copyGridDataToClipboard, copyGridGroupRowsToClipboard } from '../grid-clipboard';
+import { ColumnWithFilter, TanstackTable } from '../grid-types';
+
+const copyRecordsToClipboard = vi.hoisted(() => vi.fn());
+vi.mock('@jetstream/shared/ui-utils', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@jetstream/shared/ui-utils')>()),
+  copyRecordsToClipboard,
+}));
+
+interface Row {
+  _key: string;
+  Type: string;
+  Name: string;
+  'Account.Name': string;
+  Detail: { count: number };
+}
+
+const columns: ColumnWithFilter<Row>[] = [
+  { key: 'select-row', name: '' },
+  { key: 'Type', name: 'Type' },
+  { key: 'Name', name: 'Record Name' },
+  { key: 'Account.Name', name: 'Account Name' },
+  { key: 'Detail', name: 'Detail', getValue: ({ row }) => `${row.Detail.count} items` },
+];
+
+const data: Row[] = [
+  { _key: '1', Type: 'Alpha', Name: 'One', 'Account.Name': 'Acme', Detail: { count: 1 } },
+  { _key: '2', Type: 'Beta', Name: 'Two', 'Account.Name': 'Initech', Detail: { count: 2 } },
+  { _key: '3', Type: 'Alpha', Name: 'Three', 'Account.Name': 'Hooli', Detail: { count: 3 } },
+];
+
+function setup(overrides: Partial<Parameters<typeof useJetstreamTable<Row>>[0]> = {}) {
+  const { result } = renderHook(() => useJetstreamTable<Row>({ data, columns, getRowKey: (row) => row._key, ...overrides }));
+  act(() => undefined);
+  return result.current.table as TanstackTable<Row>;
+}
+
+/** The records handed to the clipboard, re-keyed by their header row so assertions stay readable. */
+function copiedRecords() {
+  const [records, , fields] = copyRecordsToClipboard.mock.calls[0];
+  return { records, fields };
+}
+
+describe('copyGridDataToClipboard', () => {
+  beforeEach(() => copyRecordsToClipboard.mockClear());
+
+  test('COPY_CELL copies only the clicked cell, no header', () => {
+    const table = setup();
+    const result = copyGridDataToClipboard({
+      table,
+      action: 'COPY_CELL',
+      row: table.getRowModel().rows[1],
+      column: table.getColumn('Name'),
+    });
+
+    expect(result).toEqual({ rowCount: 1, columnCount: 1 });
+    const { records, fields } = copiedRecords();
+    expect(fields).toEqual(['c0']);
+    expect(records).toEqual([{ c0: 'Two' }]);
+  });
+
+  test('COPY_ROW_EXCEL copies every data column with a display-name header, excluding the select column', () => {
+    const table = setup();
+    copyGridDataToClipboard({ table, action: 'COPY_ROW_EXCEL', row: table.getRowModel().rows[0] });
+
+    const { records, fields } = copiedRecords();
+    expect(fields).toEqual(['c0', 'c1', 'c2', 'c3']);
+    expect(records).toEqual([
+      { c0: 'Type', c1: 'Record Name', c2: 'Account Name', c3: 'Detail' },
+      { c0: 'Alpha', c1: 'One', c2: 'Acme', c3: '1 items' },
+    ]);
+  });
+
+  test('a column key containing a dot is copied as a literal key, not a nested lodash path', () => {
+    const table = setup();
+    copyGridDataToClipboard({ table, action: 'COPY_COL_NO_HEADER', column: table.getColumn('Account.Name') });
+
+    const { records, fields } = copiedRecords();
+    // Synthetic field names are the guard: passing 'Account.Name' downstream would resolve as a path.
+    expect(fields).toEqual(['c0']);
+    expect(records).toEqual([{ c0: 'Acme' }, { c0: 'Initech' }, { c0: 'Hooli' }]);
+  });
+
+  test('copies through the column getValue rather than the raw row property', () => {
+    const table = setup();
+    copyGridDataToClipboard({ table, action: 'COPY_COL_NO_HEADER', column: table.getColumn('Detail') });
+
+    expect(copiedRecords().records).toEqual([{ c0: '1 items' }, { c0: '2 items' }, { c0: '3 items' }]);
+  });
+
+  test('COPY_TABLE follows the filtered + sorted row order the user is looking at', () => {
+    const table = setup({
+      initialSortColumns: [{ columnKey: 'Name', direction: 'ASC' }],
+      includeQuickFilter: true,
+      quickFilterText: 'Alpha',
+    });
+    const result = copyGridDataToClipboard({ table, action: 'COPY_TABLE' });
+
+    expect(result).toEqual({ rowCount: 2, columnCount: 4 });
+    expect(copiedRecords().records.slice(1)).toEqual([
+      { c0: 'Alpha', c1: 'One', c2: 'Acme', c3: '1 items' },
+      { c0: 'Alpha', c1: 'Three', c2: 'Hooli', c3: '3 items' },
+    ]);
+  });
+
+  test('JSON keeps the real column ids and un-stringified values', () => {
+    const table = setup();
+    copyGridDataToClipboard({ table, action: 'COPY_ROW_JSON', row: table.getRowModel().rows[0] });
+
+    const [records, format] = copyRecordsToClipboard.mock.calls[0];
+    expect(format).toBe('json');
+    expect(records).toEqual([{ Type: 'Alpha', Name: 'One', 'Account.Name': 'Acme', Detail: '1 items' }]);
+  });
+
+  test('an action with no row/column to act on copies nothing', () => {
+    const table = setup();
+    expect(copyGridDataToClipboard({ table, action: 'COPY_CELL' })).toBeNull();
+    expect(copyRecordsToClipboard).not.toHaveBeenCalled();
+  });
+});
+
+describe('copyGridGroupRowsToClipboard', () => {
+  beforeEach(() => copyRecordsToClipboard.mockClear());
+
+  test('copies only the rows beneath the group, optionally with a header', () => {
+    const table = setup({ grouping: ['Type'] });
+    const groupRow = table.getRowModel().rows.find((row) => row.getIsGrouped() && row.groupingValue === 'Alpha');
+
+    const result = copyGridGroupRowsToClipboard(table, groupRow!, false);
+
+    expect(result).toEqual({ rowCount: 2, columnCount: 4 });
+    expect(copiedRecords().records).toEqual([
+      { c0: 'Alpha', c1: 'One', c2: 'Acme', c3: '1 items' },
+      { c0: 'Alpha', c1: 'Three', c2: 'Hooli', c3: '3 items' },
+    ]);
+
+    copyRecordsToClipboard.mockClear();
+    copyGridGroupRowsToClipboard(table, groupRow!, true);
+    expect(copiedRecords().records[0]).toEqual({ c0: 'Type', c1: 'Record Name', c2: 'Account Name', c3: 'Detail' });
+  });
+});

--- a/libs/ui/src/lib/data-table/grid/__tests__/grid-context-menu-interaction.spec.tsx
+++ b/libs/ui/src/lib/data-table/grid/__tests__/grid-context-menu-interaction.spec.tsx
@@ -1,0 +1,175 @@
+import { ContextMenuItem } from '@jetstream/types';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
+import { DataTable, DataTableProps } from '../../DataTable';
+import { DataTree } from '../../DataTree';
+import { SELECT_COLUMN_KEY } from '../grid-constants';
+import { ColumnWithFilter, ContextMenuActionData } from '../grid-types';
+import { SelectColumn } from '../renderers/CellRenderers';
+
+const copyRecordsToClipboard = vi.hoisted(() => vi.fn());
+vi.mock('@jetstream/shared/ui-utils', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@jetstream/shared/ui-utils')>()),
+  copyRecordsToClipboard,
+}));
+
+interface Row {
+  _key: string;
+  Type: string;
+  Name: string;
+}
+
+const columns: ColumnWithFilter<Row>[] = [
+  { key: 'Type', name: 'Type' },
+  { key: 'Name', name: 'Record Name' },
+];
+
+const data: Row[] = [
+  { _key: '1', Type: 'Alpha', Name: 'One' },
+  { _key: '2', Type: 'Beta', Name: 'Two' },
+  { _key: '3', Type: 'Alpha', Name: 'Three' },
+];
+
+// The row/column virtualizers measure the scroll container, which jsdom reports as 0x0 — nothing would
+// render. Give every element a viewport-sized box so the grid mounts real rows to right-click.
+beforeAll(() => {
+  for (const property of ['clientHeight', 'clientWidth', 'offsetHeight', 'offsetWidth'] as const) {
+    Object.defineProperty(HTMLElement.prototype, property, { configurable: true, value: 600 });
+  }
+  HTMLElement.prototype.getBoundingClientRect = () =>
+    ({ width: 800, height: 600, top: 0, left: 0, bottom: 600, right: 800, x: 0, y: 0, toJSON: () => ({}) }) as DOMRect;
+});
+
+function renderTable(props: Partial<DataTableProps<Row>> = {}) {
+  return render(<DataTable columns={columns} data={data} getRowKey={(row) => row._key} {...props} />);
+}
+
+function getCell(rowId: string, columnId: string): HTMLElement {
+  const cell = document.querySelector(`[data-row-id="${rowId}"][data-col-id="${columnId}"]`);
+  if (!cell) {
+    throw new Error(`No cell rendered for row ${rowId} / column ${columnId}`);
+  }
+  return cell as HTMLElement;
+}
+
+/** Right-click the element and return the menu's item labels (empty when no menu opened). */
+async function openMenu(element: HTMLElement): Promise<string[]> {
+  fireEvent.contextMenu(element);
+  try {
+    const items = await screen.findAllByRole('menuitem', {}, { timeout: 250 });
+    return items.map((item) => item.textContent ?? '');
+  } catch {
+    return [];
+  }
+}
+
+describe('context menu — a table that supplies no items of its own', () => {
+  beforeEach(() => copyRecordsToClipboard.mockClear());
+
+  test('right-clicking a data cell offers the standard copy actions', async () => {
+    renderTable();
+
+    expect(await openMenu(getCell('1', 'Name'))).toEqual([
+      'Copy cell to clipboard',
+      'Copy row to clipboard (Excel)',
+      'Copy row to clipboard (JSON)',
+      'Copy column to values clipboard',
+      'Copy column to clipboard (Excel)',
+      'Copy column to clipboard (JSON)',
+      'Copy table to clipboard (Excel)',
+      'Copy table to clipboard (CSV)',
+      'Copy table to clipboard (JSON)',
+    ]);
+  });
+
+  test('picking an action copies the right cell, without a consumer handler', async () => {
+    renderTable();
+    await openMenu(getCell('2', 'Name'));
+
+    fireEvent.click(screen.getByText('Copy cell to clipboard'));
+
+    await waitFor(() => expect(copyRecordsToClipboard).toHaveBeenCalled());
+    const [records] = copyRecordsToClipboard.mock.calls[0];
+    expect(records).toEqual([{ c0: 'Two' }]);
+  });
+
+  test('a column header offers only the column/table-scoped actions', async () => {
+    renderTable();
+
+    expect(await openMenu(getCell('__jgrid_header__', 'Type'))).toEqual([
+      'Copy column to values clipboard',
+      'Copy column to clipboard (Excel)',
+      'Copy column to clipboard (JSON)',
+      'Copy table to clipboard (Excel)',
+      'Copy table to clipboard (CSV)',
+      'Copy table to clipboard (JSON)',
+    ]);
+  });
+
+  test('the row-selection column keeps the native menu — it has no data to copy', async () => {
+    renderTable({
+      columns: [{ ...SelectColumn, key: SELECT_COLUMN_KEY }, ...columns],
+      selectedRows: new Set<string>(),
+      onSelectedRowsChange: vi.fn(),
+    });
+
+    expect(await openMenu(getCell('1', SELECT_COLUMN_KEY))).toEqual([]);
+  });
+
+  test('an explicit empty list opts out of the copy actions', async () => {
+    renderTable({ contextMenuItems: [] });
+
+    expect(await openMenu(getCell('1', 'Name'))).toEqual([]);
+  });
+});
+
+describe('context menu — a table with its own items', () => {
+  beforeEach(() => copyRecordsToClipboard.mockClear());
+
+  test('a per-cell BUILDER still gets a column-scoped header menu', async () => {
+    // Regression: header right-click previously required a static array, so builder-driven tables
+    // (Deploy, Manage Permissions fields) had no header menu at all.
+    const contextMenuItems = (actionData: ContextMenuActionData<Row>): ContextMenuItem[] => [
+      { label: `Copy column (${actionData.row.Type})`, value: 'COPY_COL_TYPE' },
+      { label: 'Copy column (All Types)', value: 'COPY_COL' },
+    ];
+    renderTable({ contextMenuItems, contextMenuAction: vi.fn() });
+
+    expect(await openMenu(getCell('__jgrid_header__', 'Name'))).toEqual(['Copy column (All Types)']);
+  });
+
+  test('consumer items are dispatched to the consumer, not the grid', async () => {
+    const contextMenuAction = vi.fn();
+    renderTable({ contextMenuItems: [{ label: 'Do a thing', value: 'CUSTOM' }], contextMenuAction });
+    await openMenu(getCell('1', 'Name'));
+
+    fireEvent.click(screen.getByText('Do a thing'));
+
+    expect(contextMenuAction).toHaveBeenCalledWith(
+      expect.objectContaining({ value: 'CUSTOM' }),
+      expect.objectContaining({ row: data[0], rowIdx: 0 }),
+    );
+    expect(copyRecordsToClipboard).not.toHaveBeenCalled();
+  });
+});
+
+describe('context menu — group header rows', () => {
+  beforeEach(() => copyRecordsToClipboard.mockClear());
+
+  test('offers to copy the group’s own rows, with or without a header', async () => {
+    render(<DataTree columns={columns} data={data} getRowKey={(row) => row._key} groupBy={['Type']} defaultExpanded />);
+    const groupCell = document.querySelector('.jgrid-group-cell') as HTMLElement;
+
+    expect(await openMenu(groupCell)).toEqual(['Copy rows in group', 'Copy rows in group with header']);
+
+    fireEvent.click(screen.getByText('Copy rows in group with header'));
+
+    await waitFor(() => expect(copyRecordsToClipboard).toHaveBeenCalled());
+    const [records] = copyRecordsToClipboard.mock.calls[0];
+    expect(records).toEqual([
+      { c0: 'Type', c1: 'Record Name' },
+      { c0: 'Alpha', c1: 'One' },
+      { c0: 'Alpha', c1: 'Three' },
+    ]);
+  });
+});

--- a/libs/ui/src/lib/data-table/grid/__tests__/grid-context-menu.spec.ts
+++ b/libs/ui/src/lib/data-table/grid/__tests__/grid-context-menu.spec.ts
@@ -1,0 +1,69 @@
+import { ContextMenuItem } from '@jetstream/types';
+import { describe, expect, test, vi } from 'vitest';
+import { TABLE_CONTEXT_MENU_ITEMS } from '../grid-constants';
+import { resolveHeaderContextMenuItems } from '../grid-context-menu';
+import { ColumnWithFilter, ContextMenuActionData } from '../grid-types';
+
+interface Row {
+  _key: string;
+  typeLabel: string;
+  Name: string;
+}
+
+const column: ColumnWithFilter<Row> = { key: 'Name', name: 'Name' };
+
+function actionData(rows: Row[]): ContextMenuActionData<Row> {
+  return {
+    row: rows[0],
+    rows,
+    rowIdx: rows.length ? 0 : -1,
+    column,
+    columns: [column],
+  };
+}
+
+const rows: Row[] = [{ _key: '1', typeLabel: 'Apex Class', Name: 'One' }];
+
+describe('resolveHeaderContextMenuItems', () => {
+  test('keeps only the column/table-scoped actions from a static list', () => {
+    const items = resolveHeaderContextMenuItems(TABLE_CONTEXT_MENU_ITEMS, actionData(rows));
+
+    expect(items.map(({ value }) => value)).toEqual([
+      'COPY_COL_NO_HEADER',
+      'COPY_COL',
+      'COPY_COL_JSON',
+      'COPY_TABLE',
+      'COPY_TABLE_CSV',
+      'COPY_TABLE_JSON',
+    ]);
+  });
+
+  test('evaluates a per-cell BUILDER against the header row and keeps its column-scoped items', () => {
+    // Regression: builder-driven tables (Deploy, Manage Permissions fields) previously got no header
+    // menu at all, because only a static array was considered.
+    const builder = (data: ContextMenuActionData<Row>): ContextMenuItem[] => [
+      { label: `Copy column (${data.row.typeLabel})`, value: 'COPY_COL_TYPE' },
+      { label: 'Copy column (All Types)', value: 'COPY_COL' },
+      { label: 'Copy row to clipboard (Excel)', value: 'COPY_ROW_EXCEL' },
+      { label: 'Copy Table to clipboard (Excel)', value: 'COPY_TABLE' },
+    ];
+
+    const items = resolveHeaderContextMenuItems(builder, actionData(rows));
+
+    // The row-scoped items ("this row's type", "this row") are dropped — a header has no single row.
+    expect(items.map(({ value }) => value)).toEqual(['COPY_COL', 'COPY_TABLE']);
+  });
+
+  test('does not call a builder when the table has no rows to hand it', () => {
+    // Builders dereference `data.row` (e.g. `data.row.typeLabel`), so calling one with no row would throw.
+    const builder = vi.fn(() => []);
+
+    expect(resolveHeaderContextMenuItems(builder, actionData([]))).toEqual([]);
+    expect(resolveHeaderContextMenuItems(builder, null)).toEqual([]);
+    expect(builder).not.toHaveBeenCalled();
+  });
+
+  test('a table that opts out with an empty list gets no header menu', () => {
+    expect(resolveHeaderContextMenuItems([], actionData(rows))).toEqual([]);
+  });
+});

--- a/libs/ui/src/lib/data-table/grid/__tests__/useGridKeyboardNavigation.spec.tsx
+++ b/libs/ui/src/lib/data-table/grid/__tests__/useGridKeyboardNavigation.spec.tsx
@@ -1,11 +1,17 @@
 import { useTable } from '@tanstack/react-table';
 import { act, renderHook } from '@testing-library/react';
-import { describe, expect, test } from 'vitest';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { SELECT_COLUMN_KEY } from '../grid-constants';
 import { jetstreamTableFeatures } from '../grid-features';
 import { TanstackColumnDef, TanstackTable } from '../grid-types';
 import { useGridKeyboardNavigation } from '../keyboard/useGridKeyboardNavigation';
 import { getSelectionBounds } from '../selection/grid-selection';
+
+const copyRecordsToClipboard = vi.hoisted(() => vi.fn());
+vi.mock('@jetstream/shared/ui-utils', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@jetstream/shared/ui-utils')>()),
+  copyRecordsToClipboard,
+}));
 
 interface Row {
   _key: string;
@@ -46,6 +52,66 @@ const frozenDataColumns: TanstackColumnDef<Row>[] = [
   { id: 'Name', accessorKey: 'Name', meta: { jetstream: { frozen: true } } as TanstackColumnDef<Row>['meta'] },
   { id: 'Amount', accessorKey: 'Amount' },
 ];
+
+describe('useGridKeyboardNavigation — copying a range', () => {
+  beforeEach(() => copyRecordsToClipboard.mockClear());
+
+  /** Deploy's metadata table: a "No metadata found" child row renders a message through a row-level
+   * colSpan and has no cell values. Row '2' is an ordinary row that happens to be blank. */
+  const spannerColumns: TanstackColumnDef<Row>[] = [
+    {
+      id: 'Name',
+      accessorKey: 'Name',
+      meta: {
+        jetstream: { colSpan: ({ type, row }) => (type === 'ROW' && (row as Row)?.Name === '' ? 2 : 1) },
+      } as TanstackColumnDef<Row>['meta'],
+    },
+    { id: 'Amount', accessorKey: 'Amount' },
+  ];
+  const spannerData: Row[] = [
+    { _key: '1', Name: 'Alpha', Amount: '10' },
+    { _key: '2', Name: '', Amount: '' },
+    { _key: '3', Name: '', Amount: '' },
+    { _key: '4', Name: 'Delta', Amount: '40' },
+  ];
+
+  function copyRange(columns: TanstackColumnDef<Row>[], data: Row[], from: [string, string], to: [string, string]) {
+    const { result } = renderHook(() => {
+      const table = useTable({
+        features: jetstreamTableFeatures,
+        data,
+        columns,
+        getRowId: (row) => row._key,
+      }) as unknown as TanstackTable<Row>;
+      return useGridKeyboardNavigation({ table, getRootElement: () => null });
+    });
+    act(() => result.current.handleCellMouseDown(from[0], from[1], false));
+    act(() => result.current.handleCellMouseEnter(to[0], to[1]));
+    act(() => result.current.copySelection());
+    return copyRecordsToClipboard.mock.calls[0][0] as Record<string, string>[];
+  }
+
+  test('skips placeholder spanner rows so they do not land as blank lines mid-range', () => {
+    // Rows '2' and '3' are spanners with nothing to copy; '4' must still follow '1' with no gap.
+    expect(copyRange(spannerColumns, spannerData, ['1', 'Name'], ['4', 'Amount'])).toEqual([
+      { c0: 'Alpha', c1: '10' },
+      { c0: 'Delta', c1: '40' },
+    ]);
+  });
+
+  test('keeps genuinely empty DATA rows — dropping them would misalign everything below', () => {
+    const emptyData: Row[] = [
+      { _key: '1', Name: 'Alpha', Amount: '10' },
+      { _key: '2', Name: '', Amount: '' },
+      { _key: '3', Name: 'Charlie', Amount: '30' },
+    ];
+    expect(copyRange(columns, emptyData, ['1', 'Name'], ['3', 'Amount'])).toEqual([
+      { c1: 'Alpha', c2: '10' },
+      { c1: '', c2: '' },
+      { c1: 'Charlie', c2: '30' },
+    ]);
+  });
+});
 
 describe('useGridKeyboardNavigation — mouse range drag', () => {
   test('mouseenter without a mousedown does not extend anything', () => {

--- a/libs/ui/src/lib/data-table/grid/__tests__/useGridKeyboardNavigation.spec.tsx
+++ b/libs/ui/src/lib/data-table/grid/__tests__/useGridKeyboardNavigation.spec.tsx
@@ -1,0 +1,135 @@
+import { useTable } from '@tanstack/react-table';
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, test } from 'vitest';
+import { SELECT_COLUMN_KEY } from '../grid-constants';
+import { jetstreamTableFeatures } from '../grid-features';
+import { TanstackColumnDef, TanstackTable } from '../grid-types';
+import { useGridKeyboardNavigation } from '../keyboard/useGridKeyboardNavigation';
+import { getSelectionBounds } from '../selection/grid-selection';
+
+interface Row {
+  _key: string;
+  Name: string;
+  Amount: string;
+}
+
+// Mirrors the real column order: the frozen select/action columns come FIRST and are never selectable.
+const columns: TanstackColumnDef<Row>[] = [
+  { id: SELECT_COLUMN_KEY, enableCellSelection: false },
+  { id: 'Name', accessorKey: 'Name' },
+  { id: 'Amount', accessorKey: 'Amount' },
+];
+
+const data: Row[] = [
+  { _key: '1', Name: 'Alpha', Amount: '10' },
+  { _key: '2', Name: 'Bravo', Amount: '20' },
+  { _key: '3', Name: 'Charlie', Amount: '30' },
+];
+
+function renderNav(options: { columns?: TanstackColumnDef<Row>[]; scrollLeft?: number } = {}) {
+  const scroller = document.createElement('div');
+  scroller.scrollLeft = options.scrollLeft ?? 0;
+  return renderHook(() => {
+    const table = useTable({
+      features: jetstreamTableFeatures,
+      data,
+      columns: options.columns ?? columns,
+      getRowId: (row) => row._key,
+    }) as unknown as TanstackTable<Row>;
+    const keyboardNav = useGridKeyboardNavigation({ table, getRootElement: () => null, getScrollElement: () => scroller });
+    return { table, keyboardNav };
+  });
+}
+
+/** The permission-manager shape: a frozen DATA column pinned at the far left, ahead of scrollable ones. */
+const frozenDataColumns: TanstackColumnDef<Row>[] = [
+  { id: 'Name', accessorKey: 'Name', meta: { jetstream: { frozen: true } } as TanstackColumnDef<Row>['meta'] },
+  { id: 'Amount', accessorKey: 'Amount' },
+];
+
+describe('useGridKeyboardNavigation — mouse range drag', () => {
+  test('mouseenter without a mousedown does not extend anything', () => {
+    const { result } = renderNav();
+    act(() => result.current.keyboardNav.handleCellMouseEnter('3', 'Amount'));
+
+    expect(result.current.keyboardNav.activeCell).toBeNull();
+    expect(getSelectionBounds(result.current.table)).toHaveLength(0);
+  });
+
+  test('mousedown then mouseenter grows the rectangle from the mousedown cell', () => {
+    const { result } = renderNav();
+    act(() => result.current.keyboardNav.handleCellMouseDown('1', 'Name', false));
+    act(() => result.current.keyboardNav.handleCellMouseEnter('3', 'Amount'));
+
+    expect(result.current.keyboardNav.activeCell).toEqual({ rowId: '3', columnId: 'Amount' });
+    expect(getSelectionBounds(result.current.table)).toEqual([{ minRowIndex: 0, maxRowIndex: 2, minColumnIndex: 1, maxColumnIndex: 2 }]);
+  });
+
+  test('dragging over a non-selectable column changes nothing at all', () => {
+    const { result } = renderNav();
+    act(() => result.current.keyboardNav.handleCellMouseDown('1', 'Amount', false));
+    act(() => result.current.keyboardNav.handleCellMouseEnter('3', 'Name'));
+    act(() => result.current.keyboardNav.handleCellMouseEnter('3', SELECT_COLUMN_KEY));
+
+    // The select/action columns are frozen at the far left and can never join a range. The active cell
+    // must not move there either: the active-column scroll-into-view effect would follow it and yank
+    // the viewport back to column 0, and every cell the drag then passed over would join the range.
+    expect(result.current.keyboardNav.activeCell).toEqual({ rowId: '3', columnId: 'Name' });
+    expect(getSelectionBounds(result.current.table)).toEqual([{ minRowIndex: 0, maxRowIndex: 2, minColumnIndex: 1, maxColumnIndex: 2 }]);
+  });
+
+  test('dragging onto a frozen data column is ignored while it covers scrolled-away content', () => {
+    const { result } = renderNav({ columns: frozenDataColumns, scrollLeft: 400 });
+    act(() => result.current.keyboardNav.handleCellMouseDown('1', 'Amount', false));
+    act(() => result.current.keyboardNav.handleCellMouseEnter('3', 'Name'));
+
+    // Permission manager pins a wide `tableLabel` column. Scrolled right, it sits on top of the columns
+    // the drag is reaching for, so a hit there means "keep going left", not "select the pinned column".
+    expect(result.current.keyboardNav.activeCell).toEqual({ rowId: '1', columnId: 'Amount' });
+    expect(getSelectionBounds(result.current.table)).toEqual([{ minRowIndex: 0, maxRowIndex: 0, minColumnIndex: 1, maxColumnIndex: 1 }]);
+  });
+
+  test('a frozen data column is an ordinary drag target once the grid is scrolled home', () => {
+    const { result } = renderNav({ columns: frozenDataColumns, scrollLeft: 0 });
+    act(() => result.current.keyboardNav.handleCellMouseDown('1', 'Amount', false));
+    act(() => result.current.keyboardNav.handleCellMouseEnter('3', 'Name'));
+
+    expect(result.current.keyboardNav.activeCell).toEqual({ rowId: '3', columnId: 'Name' });
+    expect(getSelectionBounds(result.current.table)).toEqual([{ minRowIndex: 0, maxRowIndex: 2, minColumnIndex: 0, maxColumnIndex: 1 }]);
+  });
+
+  test('a mouseenter back onto the current focus corner is a no-op, not a re-render', () => {
+    const { result } = renderNav();
+    act(() => result.current.keyboardNav.handleCellMouseDown('1', 'Name', false));
+    act(() => result.current.keyboardNav.handleCellMouseEnter('2', 'Amount'));
+    const activeCell = result.current.keyboardNav.activeCell;
+
+    act(() => result.current.keyboardNav.handleCellMouseEnter('2', 'Amount'));
+
+    // Identity, not equality: auto-scroll re-fires mouseenter for scroll-induced hover changes, and a
+    // fresh active-cell object would re-render the grid AND reset the interaction source away from
+    // 'drag-autoscroll' (which is what keeps the virtualizers' scroll-into-view suppressed).
+    expect(result.current.keyboardNav.activeCell).toBe(activeCell);
+  });
+
+  test('right-click never starts a drag', () => {
+    const { result } = renderNav();
+    act(() => result.current.keyboardNav.handleCellMouseDown('1', 'Name', false, 2));
+    act(() => result.current.keyboardNav.handleCellMouseEnter('3', 'Amount'));
+
+    expect(result.current.keyboardNav.activeCell).toEqual({ rowId: '1', columnId: 'Name' });
+    expect(getSelectionBounds(result.current.table)).toEqual([{ minRowIndex: 0, maxRowIndex: 0, minColumnIndex: 1, maxColumnIndex: 1 }]);
+  });
+
+  test('releasing the mouse anywhere ends the drag', () => {
+    const { result } = renderNav();
+    act(() => result.current.keyboardNav.handleCellMouseDown('1', 'Name', false));
+    act(() => {
+      window.dispatchEvent(new MouseEvent('mouseup'));
+    });
+    act(() => result.current.keyboardNav.handleCellMouseEnter('3', 'Amount'));
+
+    expect(result.current.keyboardNav.activeCell).toEqual({ rowId: '1', columnId: 'Name' });
+    expect(getSelectionBounds(result.current.table)).toEqual([{ minRowIndex: 0, maxRowIndex: 0, minColumnIndex: 1, maxColumnIndex: 1 }]);
+  });
+});

--- a/libs/ui/src/lib/data-table/grid/__tests__/useRangeDragAutoScroll.spec.tsx
+++ b/libs/ui/src/lib/data-table/grid/__tests__/useRangeDragAutoScroll.spec.tsx
@@ -1,0 +1,278 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { ActiveCell } from '../components/GridRow';
+import { getSummaryRowId, HEADER_ROW_ID } from '../grid-constants';
+import { useRangeDragAutoScroll, UseRangeDragAutoScrollOptions } from '../keyboard/useRangeDragAutoScroll';
+
+const SCROLLER_RECT = { top: 100, left: 200, width: 600, height: 400 };
+const HEADER_HEIGHT = 60;
+const FROZEN_WIDTH = 120;
+
+/**
+ * jsdom reports 0 for every layout measurement, so the scroller's geometry is stubbed. It does keep
+ * whatever number is assigned to scrollTop/scrollLeft (unclamped), which is exactly what the rAF loop
+ * writes — so the scrolling itself is observable.
+ */
+function renderFixture(overrides: Partial<UseRangeDragAutoScrollOptions> = {}) {
+  const scroller = document.createElement('div');
+  scroller.className = 'jgrid-scroller';
+  const root = document.createElement('div');
+  root.className = 'jgrid';
+  const header = document.createElement('div');
+  header.className = 'jgrid-header';
+  const body = document.createElement('div');
+  body.className = 'jgrid-body';
+  root.append(header, body);
+  scroller.append(root);
+  document.body.append(scroller);
+
+  vi.spyOn(scroller, 'getBoundingClientRect').mockReturnValue({
+    ...SCROLLER_RECT,
+    right: SCROLLER_RECT.left + SCROLLER_RECT.width,
+    bottom: SCROLLER_RECT.top + SCROLLER_RECT.height,
+  } as DOMRect);
+  Object.defineProperty(scroller, 'clientWidth', { value: SCROLLER_RECT.width });
+  Object.defineProperty(scroller, 'clientHeight', { value: SCROLLER_RECT.height });
+  vi.spyOn(header, 'getBoundingClientRect').mockReturnValue({
+    top: SCROLLER_RECT.top,
+    bottom: SCROLLER_RECT.top + HEADER_HEIGHT,
+    left: SCROLLER_RECT.left,
+    right: SCROLLER_RECT.left + SCROLLER_RECT.width,
+    height: HEADER_HEIGHT,
+    width: SCROLLER_RECT.width,
+  } as DOMRect);
+
+  /** A cell that belongs to the fixture's grid. `left` defaults to inside the scrollable area — cells
+   * positioned left of the frozen band stand in for the sticky columns overlaying it. */
+  const makeCell = (rowId: string, columnId: string, container: HTMLElement = body, left = SCROLLER_RECT.left + FROZEN_WIDTH + 50) => {
+    const cell = document.createElement('div');
+    cell.setAttribute('data-row-id', rowId);
+    cell.setAttribute('data-col-id', columnId);
+    vi.spyOn(cell, 'getBoundingClientRect').mockReturnValue({ left, right: left + 100, top: 0, bottom: 20 } as DOMRect);
+    container.append(cell);
+    return cell;
+  };
+
+  const hitTest = vi.fn<(clientX: number, clientY: number) => Element | null>(() => makeCell('r5', 'Name'));
+  const onExtendToCell = vi.fn();
+  const onDragEnd = vi.fn();
+  let activeCell: ActiveCell | null = null;
+
+  const { result, unmount } = renderHook(() =>
+    useRangeDragAutoScroll({
+      getScrollElement: () => scroller,
+      getRootElement: () => root,
+      getLeftInset: () => FROZEN_WIDTH,
+      getActiveCell: () => activeCell,
+      onExtendToCell,
+      onDragEnd,
+      hitTest,
+      ...overrides,
+    }),
+  );
+
+  return {
+    autoScroll: result.current,
+    scroller,
+    root,
+    body,
+    makeCell,
+    hitTest,
+    onExtendToCell,
+    onDragEnd,
+    unmount,
+    setActiveCell: (cell: ActiveCell | null) => {
+      activeCell = cell;
+    },
+  };
+}
+
+/** Dispatch a drag-in-progress pointer move (button still held). */
+function moveMouseTo(clientX: number, clientY: number, buttons = 1) {
+  act(() => {
+    window.dispatchEvent(new MouseEvent('mousemove', { clientX, clientY, buttons }));
+  });
+}
+
+function advanceFrames(count: number) {
+  for (let index = 0; index < count; index++) {
+    act(() => {
+      vi.advanceTimersByTime(16);
+    });
+  }
+}
+
+describe('useRangeDragAutoScroll', () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ toFake: ['requestAnimationFrame', 'cancelAnimationFrame', 'performance'] });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    document.body.innerHTML = '';
+  });
+
+  test('does nothing until a drag starts', () => {
+    const { scroller, onExtendToCell } = renderFixture();
+    moveMouseTo(400, 495);
+    advanceFrames(3);
+
+    expect(scroller.scrollTop).toBe(0);
+    expect(onExtendToCell).not.toHaveBeenCalled();
+  });
+
+  test('scrolls down and extends to the cell that moves under the pointer', () => {
+    const { autoScroll, scroller, onExtendToCell } = renderFixture();
+    act(() => autoScroll.start());
+    // 5px above the scroller's bottom edge — deep inside the ramp.
+    moveMouseTo(400, SCROLLER_RECT.top + SCROLLER_RECT.height - 5);
+    advanceFrames(3);
+
+    expect(scroller.scrollTop).toBeGreaterThan(0);
+    expect(onExtendToCell).toHaveBeenCalledWith('r5', 'Name');
+  });
+
+  test('scrolls up when the pointer sits over the sticky header, hit-testing below it', () => {
+    const { autoScroll, scroller, hitTest } = renderFixture();
+    scroller.scrollTop = 500;
+    act(() => autoScroll.start());
+    moveMouseTo(400, SCROLLER_RECT.top + 10);
+    advanceFrames(3);
+
+    expect(scroller.scrollTop).toBeLessThan(500);
+    // Load-bearing clamp: a hit on a header cell would write a sentinel row id as the range's focus
+    // corner, and the whole rectangle would resolve to nothing.
+    const [, hitY] = hitTest.mock.calls[hitTest.mock.calls.length - 1];
+    expect(hitY).toBe(SCROLLER_RECT.top + HEADER_HEIGHT + 1);
+  });
+
+  test('scrolls left, hit-testing past the unselectable frozen band', () => {
+    const { autoScroll, scroller, hitTest } = renderFixture();
+    scroller.scrollLeft = 500;
+    act(() => autoScroll.start());
+    moveMouseTo(SCROLLER_RECT.left + 10, 300);
+    advanceFrames(3);
+
+    expect(scroller.scrollLeft).toBeLessThan(500);
+    // The frozen action/select columns sit at index 0 and can never join a range — resolving onto one
+    // would snap the rectangle's left edge there and select every column in between.
+    const [hitX] = hitTest.mock.calls[hitTest.mock.calls.length - 1];
+    expect(hitX).toBe(SCROLLER_RECT.left + FROZEN_WIDTH + 1);
+  });
+
+  test('walks past a hit that landed on the sticky-left band to the first uncovered cell', () => {
+    const fixture = renderFixture();
+    // One row: a pinned cell overlaying the band, then the scrollable cell the drag is reaching for.
+    const row = document.createElement('div');
+    fixture.body.append(row);
+    const pinnedCell = fixture.makeCell('r5', 'tableLabel', row, SCROLLER_RECT.left + 10);
+    fixture.makeCell('r5', 'Permission', row, SCROLLER_RECT.left + FROZEN_WIDTH);
+    fixture.hitTest.mockImplementation(() => pinnedCell);
+
+    act(() => fixture.autoScroll.start());
+    moveMouseTo(SCROLLER_RECT.left + 10, 300);
+    advanceFrames(3);
+
+    // Without the walk the pinned cell would be rejected downstream and the drag would scroll forever
+    // without ever selecting anything — which is what a wide pinned band (permission manager) produces.
+    expect(fixture.onExtendToCell).toHaveBeenCalledWith('r5', 'Permission');
+  });
+
+  test('scrolls both axes at once in a corner', () => {
+    const { autoScroll, scroller } = renderFixture();
+    act(() => autoScroll.start());
+    moveMouseTo(SCROLLER_RECT.left + SCROLLER_RECT.width - 2, SCROLLER_RECT.top + SCROLLER_RECT.height - 2);
+    advanceFrames(3);
+
+    expect(scroller.scrollTop).toBeGreaterThan(0);
+    expect(scroller.scrollLeft).toBeGreaterThan(0);
+  });
+
+  test('stays idle while the pointer is in the middle of the grid', () => {
+    const { autoScroll, scroller, onExtendToCell } = renderFixture();
+    act(() => autoScroll.start());
+    moveMouseTo(SCROLLER_RECT.left + 300, SCROLLER_RECT.top + 200);
+    advanceFrames(3);
+
+    expect(scroller.scrollTop).toBe(0);
+    expect(onExtendToCell).not.toHaveBeenCalled();
+  });
+
+  test('never re-extends to the cell that is already the focus corner', () => {
+    const { autoScroll, onExtendToCell, setActiveCell } = renderFixture();
+    setActiveCell({ rowId: 'r5', columnId: 'Name' });
+    act(() => autoScroll.start());
+    moveMouseTo(400, SCROLLER_RECT.top + SCROLLER_RECT.height - 5);
+    advanceFrames(5);
+
+    expect(onExtendToCell).not.toHaveBeenCalled();
+  });
+
+  test('ignores header and summary sentinel rows', () => {
+    const fixture = renderFixture();
+    fixture.hitTest.mockImplementation(() => fixture.makeCell(HEADER_ROW_ID, 'Name'));
+    act(() => fixture.autoScroll.start());
+    moveMouseTo(400, SCROLLER_RECT.top + SCROLLER_RECT.height - 5);
+    advanceFrames(2);
+    expect(fixture.onExtendToCell).not.toHaveBeenCalled();
+
+    fixture.hitTest.mockImplementation(() => fixture.makeCell(getSummaryRowId(0), 'Name'));
+    advanceFrames(2);
+    expect(fixture.onExtendToCell).not.toHaveBeenCalled();
+  });
+
+  test('ignores cells belonging to another grid', () => {
+    const fixture = renderFixture();
+    const otherGrid = document.createElement('div');
+    otherGrid.className = 'jgrid';
+    document.body.append(otherGrid);
+    fixture.hitTest.mockImplementation(() => fixture.makeCell('r5', 'Name', otherGrid));
+
+    act(() => fixture.autoScroll.start());
+    moveMouseTo(400, SCROLLER_RECT.top + SCROLLER_RECT.height - 5);
+    advanceFrames(3);
+
+    expect(fixture.onExtendToCell).not.toHaveBeenCalled();
+  });
+
+  test('ends the drag when the button is released outside the window', () => {
+    const { autoScroll, scroller, onDragEnd } = renderFixture();
+    act(() => autoScroll.start());
+    moveMouseTo(400, SCROLLER_RECT.top + SCROLLER_RECT.height - 5);
+    advanceFrames(2);
+    const scrolled = scroller.scrollTop;
+
+    moveMouseTo(400, SCROLLER_RECT.top + SCROLLER_RECT.height - 5, 0);
+    advanceFrames(3);
+
+    expect(onDragEnd).toHaveBeenCalledTimes(1);
+    expect(scroller.scrollTop).toBe(scrolled);
+  });
+
+  test('stop() detaches the pointer listener and halts the loop', () => {
+    const { autoScroll, scroller } = renderFixture();
+    act(() => autoScroll.start());
+    moveMouseTo(400, SCROLLER_RECT.top + SCROLLER_RECT.height - 5);
+    advanceFrames(2);
+    const scrolled = scroller.scrollTop;
+
+    act(() => autoScroll.stop());
+    moveMouseTo(400, SCROLLER_RECT.top + SCROLLER_RECT.height - 5);
+    advanceFrames(3);
+
+    expect(scroller.scrollTop).toBe(scrolled);
+  });
+
+  test('unmounting mid-drag cancels the loop', () => {
+    const { autoScroll, scroller, unmount } = renderFixture();
+    act(() => autoScroll.start());
+    moveMouseTo(400, SCROLLER_RECT.top + SCROLLER_RECT.height - 5);
+    advanceFrames(2);
+    const scrolled = scroller.scrollTop;
+
+    unmount();
+    expect(() => advanceFrames(3)).not.toThrow();
+    expect(scroller.scrollTop).toBe(scrolled);
+  });
+});

--- a/libs/ui/src/lib/data-table/grid/components/GridBody.tsx
+++ b/libs/ui/src/lib/data-table/grid/components/GridBody.tsx
@@ -6,7 +6,7 @@ import { CSSProperties, RefObject, useEffect, useMemo, useRef } from 'react';
 import { DEFAULT_ROW_HEIGHT, HEADER_ROW_ID, isSummaryRowId } from '../grid-constants';
 import { selectRowModelInputs } from '../grid-context';
 import { TanstackTable } from '../grid-types';
-import { GridMode } from '../keyboard/useGridKeyboardNavigation';
+import { GridInteractionSource, GridMode } from '../keyboard/useGridKeyboardNavigation';
 import { getRowSelectionSpans } from '../selection/grid-selection';
 import { GridGroupRow } from './GridGroupRow';
 import { ActiveCell, GridRow } from './GridRow';
@@ -35,9 +35,10 @@ export interface GridBodyProps<TRow extends object> {
   activeCell?: ActiveCell | null;
   mode?: GridMode;
   /** Whether the active cell last changed via mouse vs keyboard — on mouse we skip auto-focusing the
-   * cell so popovers/controls opened by the click keep focus; on 'select-all' we additionally skip
-   * scroll-into-view (Ctrl+A must not jump the viewport to the last row). */
-  getLastInteractionSource?: () => 'mouse' | 'keyboard' | 'select-all';
+   * cell so popovers/controls opened by the click keep focus; on 'select-all' and 'drag-autoscroll' we
+   * additionally skip scroll-into-view (Ctrl+A must not jump the viewport to the last row, and a range
+   * drag's own auto-scroll loop owns the scroll offset). */
+  getLastInteractionSource?: () => GridInteractionSource;
   /** The cell currently being edited (its editor owns focus, so the body must not steal it). */
   editingCell?: ActiveCell | null;
   /** Resolved cell-selection rectangles (inclusive display-index bounds; empty when collapsed). */
@@ -151,9 +152,11 @@ export function GridBody<TRow extends object>({
     if (!activeCell) {
       return;
     }
+    const interactionSource = getLastInteractionSource?.();
     // Select-all moves the active corner to the last cell purely as selection bookkeeping — never
-    // scroll or move focus for it.
-    if (getLastInteractionSource?.() === 'select-all') {
+    // scroll or move focus for it. A drag's edge auto-scroll owns the scroll offset while it runs, and
+    // `align: 'auto'` would snap the partially-visible edge row fully into view on every extend.
+    if (interactionSource === 'select-all' || interactionSource === 'drag-autoscroll') {
       return;
     }
     // The column header and pinned summary rows are virtual rows in the sticky header block (always
@@ -176,7 +179,7 @@ export function GridBody<TRow extends object>({
     // A mouse click already placed focus correctly — on the cell, or on an interactive control / portaled
     // popover rendered inside it. Re-focusing the cell here would steal focus back and close those
     // popovers, so only keyboard / programmatic activation drives cell focus.
-    if (getLastInteractionSource?.() === 'mouse') {
+    if (interactionSource === 'mouse') {
       return;
     }
 
@@ -277,6 +280,7 @@ export function GridBody<TRow extends object>({
               height={virtualRow.size}
               activeCell={rowActiveCell}
               onCellMouseDown={onCellMouseDown}
+              onCellMouseEnter={onCellMouseEnter}
               onContextMenu={onGroupContextMenu}
               autoHeight={autoRowHeight}
               measureRef={measureRowRef}

--- a/libs/ui/src/lib/data-table/grid/components/GridBody.tsx
+++ b/libs/ui/src/lib/data-table/grid/components/GridBody.tsx
@@ -45,6 +45,8 @@ export interface GridBodyProps<TRow extends object> {
   onCellMouseDown?: (rowId: string, columnId: string, shiftKey: boolean, button?: number, ctrlOrMetaKey?: boolean) => void;
   onCellMouseEnter?: (rowId: string, columnId: string) => void;
   onCellContextMenu?: (event: React.MouseEvent, rowId: string, columnId: string) => void;
+  /** Right-click on a GROUP header row — a separate menu from the data-cell one (see GridContainer). */
+  onGroupContextMenu?: (event: React.MouseEvent, rowId: string, columnId: string) => void;
   rowClass?: (row: TRow) => string | undefined;
   onStartEdit?: (rowId: string, columnId: string) => void;
   onCommitRow?: (updatedRow: TRow, rowId: string, columnId: string) => void;
@@ -82,6 +84,7 @@ export function GridBody<TRow extends object>({
   onCellMouseDown,
   onCellMouseEnter,
   onCellContextMenu,
+  onGroupContextMenu,
   rowClass,
   onStartEdit,
   onCommitRow,
@@ -274,6 +277,7 @@ export function GridBody<TRow extends object>({
               height={virtualRow.size}
               activeCell={rowActiveCell}
               onCellMouseDown={onCellMouseDown}
+              onContextMenu={onGroupContextMenu}
               autoHeight={autoRowHeight}
               measureRef={measureRowRef}
             />

--- a/libs/ui/src/lib/data-table/grid/components/GridContainer.tsx
+++ b/libs/ui/src/lib/data-table/grid/components/GridContainer.tsx
@@ -6,13 +6,26 @@ import classNames from 'classnames';
 import { CSSProperties, ReactNode, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { ContextMenu } from '../../../form/context-menu/ContextMenu';
 import { EditorHost } from '../editors/EditorHost';
+import { copyGridDataToClipboard, copyGridGroupRowsToClipboard, GridCopyResult } from '../grid-clipboard';
 import { reorderColumnOrder } from '../grid-column-utils';
-import { HEADER_ROW_ID, isSummaryRowId, NON_DATA_COLUMN_KEYS } from '../grid-constants';
+import { HEADER_ROW_ID, isSummaryRowId, NON_DATA_COLUMN_KEYS, TABLE_CONTEXT_MENU_ITEMS } from '../grid-constants';
 import { GridRuntime, GridRuntimeContext, selectRowModelInputs } from '../grid-context';
+import {
+  COPY_GROUP_ACTION,
+  COPY_GROUP_WITH_HEADER_ACTION,
+  COPY_RANGE_ACTION,
+  COPY_RANGE_WITH_HEADER_ACTION,
+  GRID_OWNED_COPY_ACTIONS,
+  GROUP_CONTEXT_MENU_ITEMS,
+  PASTE_RANGE_ACTION,
+  resolveHeaderContextMenuItems,
+  REVERT_RANGE_ACTION,
+} from '../grid-context-menu';
 import { computePasteTargets, flashPastedCells, parsePastedText } from '../grid-paste';
 import { getSortedFilteredLeafRows } from '../grid-row-utils';
 import {
   ColumnWithFilter,
+  ContextAction,
   ContextMenuActionData,
   ContextMenuItems,
   DataTableHeaderProps,
@@ -28,35 +41,20 @@ import { GridHeader } from './GridHeader';
 import { ActiveCell } from './GridRow';
 import { getGridTemplateColumns } from './grid-layout';
 
-const COPY_RANGE_ACTION = '__COPY_RANGE__';
-const COPY_RANGE_WITH_HEADER_ACTION = '__COPY_RANGE_WITH_HEADER__';
-const PASTE_RANGE_ACTION = '__PASTE_RANGE__';
-const REVERT_RANGE_ACTION = '__REVERT_RANGE__';
 // Hard bound on cells examined when deciding whether to show the "Revert" context-menu item, so opening
 // the menu over a huge selection (e.g. select-all) can never stall. ~50k O(1) dirty checks is a few ms.
 const REVERT_SCAN_CELL_BUDGET = 50_000;
 
-/** Context-menu actions that operate on a column/table (no specific row) — the subset offered when
- * right-clicking a column HEADER. Matches the `ContextAction` values used by the standard
- * TABLE_CONTEXT_MENU_ITEMS; consumer items outside this set are cell-scoped and excluded. */
-const COLUMN_SCOPED_CONTEXT_ACTIONS = new Set<unknown>([
-  'COPY_COL',
-  'COPY_COL_JSON',
-  'COPY_COL_NO_HEADER',
-  'COPY_TABLE',
-  'COPY_TABLE_JSON',
-  'COPY_TABLE_CSV',
-]);
-
 interface ContextMenuState<TRow extends object = any> {
-  area: 'cell' | 'header';
-  /** Set for cell menus; absent for header menus. */
+  area: 'cell' | 'header' | 'group';
+  /** Set for cell/group menus; absent for header menus. */
   rowId?: string;
   columnId: string;
   element: HTMLElement;
   /** Items resolved when the menu opened (a per-cell builder may have produced these). */
   items: ContextMenuItem[];
-  /** Cell action data captured at open time, passed to `contextMenuAction` on selection. */
+  /** Cell action data captured at open time, passed to `contextMenuAction` on selection. Always null for
+   * a group menu — that payload is leaf-row-scoped, and a group header has no single row. */
   actionData: ContextMenuActionData<TRow> | null;
 }
 
@@ -91,7 +89,9 @@ export interface GridContainerProps<TRow extends object> {
   summaryRows?: unknown[];
   /** Fixed height (px) for each pinned summary row; content-sized when omitted. */
   summaryRowHeight?: number;
-  /** Right-click context menu items — a static list or a per-cell builder (must be stable). */
+  /** Right-click context menu items — a static list or a per-cell builder (must be stable). Omit to get
+   * the standard copy actions dispatched by the grid itself; pass `[]` to opt out of them. (The
+   * selection-aware items — copy range / paste / revert / copy group — are always available.) */
   contextMenuItems?: ContextMenuItems<TRow>;
   /** Right-click context menu action handler (must be stable). */
   contextMenuAction?: (item: ContextMenuItem, data: ContextMenuActionData<TRow>) => void;
@@ -651,12 +651,18 @@ export function GridContainer<TRow extends object = RowWithKey>({
     [table, orderedColumns],
   );
 
+  // A table that supplies no `contextMenuItems` gets the standard copy actions for free, dispatched by
+  // the grid (`copyGridDataToClipboard`) rather than a consumer handler. An explicit `[]` opts out.
+  const usesGridOwnedMenu = contextMenuItems === undefined;
+  const resolvedContextMenuItems: ContextMenuItems<TRow> = contextMenuItems ?? TABLE_CONTEXT_MENU_ITEMS;
+  const canDispatchMenuItems = usesGridOwnedMenu || !!contextMenuAction;
+
   // A static list, or a per-cell builder evaluated against the right-clicked cell (e.g. group-aware
   // "Copy column (Apex Classes)"). The builder returning `[]` suppresses the menu for that cell.
   const resolveCellMenuItems = useCallback(
     (data: ContextMenuActionData<TRow>): ContextMenuItem[] =>
-      typeof contextMenuItems === 'function' ? contextMenuItems(data) : Array.isArray(contextMenuItems) ? contextMenuItems : [],
-    [contextMenuItems],
+      typeof resolvedContextMenuItems === 'function' ? resolvedContextMenuItems(data) : resolvedContextMenuItems,
+    [resolvedContextMenuItems],
   );
 
   const handleCellContextMenu = useCallback(
@@ -664,7 +670,10 @@ export function GridContainer<TRow extends object = RowWithKey>({
       if (event.ctrlKey || event.metaKey) {
         return;
       }
-      const actionData = contextMenuAction ? buildCellActionData(rowId, columnId) : null;
+      // The grid-owned menu is pure copy actions, so it has nothing to offer on the select/action columns
+      // (a consumer's own items may still be meaningful there, so this only applies to the grid's).
+      const isGridMenuOnNonDataColumn = usesGridOwnedMenu && table.getColumn(columnId)?.columnDef.meta?.jetstream?.cellKind !== 'data';
+      const actionData = canDispatchMenuItems && !isGridMenuOnNonDataColumn ? buildCellActionData(rowId, columnId) : null;
       const items = actionData ? resolveCellMenuItems(actionData) : [];
       // Ctrl/Meta lets the native browser menu through; so does an empty menu with no selection and no
       // paste affordance (the rectangular copy + paste items are injected when the menu renders). Paste
@@ -680,31 +689,30 @@ export function GridContainer<TRow extends object = RowWithKey>({
       setContextMenu(null);
       setTimeout(() => setContextMenu({ area: 'cell', rowId, columnId, element, items, actionData }));
     },
-    [contextMenuAction, buildCellActionData, resolveCellMenuItems, hasRangeSelection, onPaste, activeCell],
+    [table, canDispatchMenuItems, usesGridOwnedMenu, buildCellActionData, resolveCellMenuItems, hasRangeSelection, onPaste, activeCell],
   );
 
-  // Right-clicking a column HEADER offers the column/table-scoped copy actions — only for a static item
-  // list (per-cell builders are cell-scoped). Non-data columns (select/action) keep the native menu.
-  const headerContextMenuItems = useMemo(
-    () =>
-      Array.isArray(contextMenuItems) && contextMenuAction
-        ? contextMenuItems.filter((item) => COLUMN_SCOPED_CONTEXT_ACTIONS.has(item.value))
-        : [],
-    [contextMenuItems, contextMenuAction],
-  );
+  // Right-clicking a GROUP header row copies that group's data rows. Always grid-owned: a consumer's
+  // items are built from (and act on) a single leaf row, which a group header doesn't have.
+  const handleGroupContextMenu = useCallback((event: React.MouseEvent, rowId: string, columnId: string) => {
+    if (event.ctrlKey || event.metaKey) {
+      return;
+    }
+    event.preventDefault();
+    const element = event.currentTarget as HTMLElement;
+    setContextMenu(null);
+    setTimeout(() => setContextMenu({ area: 'group', rowId, columnId, element, items: GROUP_CONTEXT_MENU_ITEMS, actionData: null }));
+  }, []);
+
+  // Right-clicking a column HEADER offers the column/table-scoped copy actions (see
+  // `resolveHeaderContextMenuItems`). Non-data columns keep the native menu.
   const handleHeaderContextMenu = useCallback(
     (event: React.MouseEvent, columnId: string) => {
-      // Append any consumer-supplied per-column items (e.g. "View field metadata") to the static
-      // column-scoped copy actions.
-      const extraItems = getColumnHeaderMenuItems?.(columnId) ?? [];
-      const items = [...headerContextMenuItems, ...extraItems];
-      // Every header item is dispatched through `contextMenuAction` on selection — without it the menu
-      // would open but be unusable (selections become no-ops), so don't present it.
-      if (event.ctrlKey || event.metaKey || !contextMenuAction || !items.length || NON_DATA_COLUMN_KEYS.has(columnId)) {
+      // Every header item is dispatched on selection — by the grid, or through `contextMenuAction`.
+      // Without either the menu would open but be unusable (selections become no-ops), so don't present it.
+      if (event.ctrlKey || event.metaKey || !canDispatchMenuItems || NON_DATA_COLUMN_KEYS.has(columnId)) {
         return;
       }
-      event.preventDefault();
-      const element = event.currentTarget as HTMLElement;
       // Column/table actions operate over the whole column — anchor on the first leaf row when present.
       // Build the payload directly (rather than via buildCellActionData) so header-only actions like
       // "View field metadata", which read just the column, still fire when the table has no rows.
@@ -719,10 +727,49 @@ export function GridContainer<TRow extends object = RowWithKey>({
             columns: orderedColumns,
           }
         : null;
+      // Append any consumer-supplied per-column items (e.g. "View field metadata") to the copy actions.
+      const items = [
+        ...resolveHeaderContextMenuItems(resolvedContextMenuItems, actionData),
+        ...(getColumnHeaderMenuItems?.(columnId) ?? []),
+      ];
+      if (!items.length) {
+        return;
+      }
+      event.preventDefault();
+      const element = event.currentTarget as HTMLElement;
       setContextMenu(null);
       setTimeout(() => setContextMenu({ area: 'header', columnId, element, items, actionData }));
     },
-    [headerContextMenuItems, table, orderedColumns, getColumnHeaderMenuItems, contextMenuAction],
+    [canDispatchMenuItems, resolvedContextMenuItems, table, orderedColumns, getColumnHeaderMenuItems],
+  );
+
+  // ── Grid-owned copy dispatch (the default menu + the group-row menu) ────────────────────────────
+  const announceCopy = useCallback(
+    (result: GridCopyResult | null) => {
+      if (!result) {
+        announce('Nothing to copy.');
+        return;
+      }
+      const { rowCount, columnCount } = result;
+      announce(`Copied ${rowCount} ${rowCount === 1 ? 'row' : 'rows'} by ${columnCount} ${columnCount === 1 ? 'column' : 'columns'}`);
+    },
+    [announce],
+  );
+
+  const copyMenuTarget = useCallback(
+    (menu: ContextMenuState<TRow>, action: ContextAction) => {
+      const row = menu.rowId ? rowModelRows.find((modelRow) => modelRow.id === menu.rowId) : null;
+      announceCopy(copyGridDataToClipboard({ table, action, row, column: table.getColumn(menu.columnId) }));
+    },
+    [table, rowModelRows, announceCopy],
+  );
+
+  const copyGroupRows = useCallback(
+    (rowId: string | undefined, includeHeader: boolean) => {
+      const groupRow = rowId ? rowModelRows.find((modelRow) => modelRow.id === rowId) : null;
+      announceCopy(groupRow ? copyGridGroupRowsToClipboard(table, groupRow, includeHeader) : null);
+    },
+    [table, rowModelRows, announceCopy],
   );
 
   // Closing the menu can strand DOM focus on <body> (the menu auto-focuses its items and unmounts on
@@ -733,7 +780,7 @@ export function GridContainer<TRow extends object = RowWithKey>({
     setContextMenu(null);
     requestAnimationFrame(() => {
       const focused = document.activeElement;
-      if ((!focused || focused === document.body) && menu?.area === 'cell' && menu.rowId) {
+      if ((!focused || focused === document.body) && menu?.area !== 'header' && menu?.rowId) {
         focusCellEl({ rowId: menu.rowId, columnId: menu.columnId });
       }
     });
@@ -862,6 +909,7 @@ export function GridContainer<TRow extends object = RowWithKey>({
               onCellMouseDown={keyboardNav.handleCellMouseDown}
               onCellMouseEnter={keyboardNav.handleCellMouseEnter}
               onCellContextMenu={handleCellContextMenu}
+              onGroupContextMenu={handleGroupContextMenu}
               rowClass={rowClass}
               onStartEdit={handleStartEdit}
               onCommitRow={handleCellCommit}
@@ -905,7 +953,10 @@ export function GridContainer<TRow extends object = RowWithKey>({
                     { label: 'Copy selected cells with header', value: COPY_RANGE_WITH_HEADER_ACTION } as ContextMenuItem,
                   ]
                 : []),
-              ...(onPaste && keyboardNav.activeCell ? [{ label: 'Paste', value: PASTE_RANGE_ACTION } as ContextMenuItem] : []),
+              // A group header row has no editable cells to anchor a paste on.
+              ...(onPaste && keyboardNav.activeCell && contextMenu.area !== 'group'
+                ? [{ label: 'Paste', value: PASTE_RANGE_ACTION } as ContextMenuItem]
+                : []),
               ...(revertableCount
                 ? [
                     {
@@ -933,10 +984,14 @@ export function GridContainer<TRow extends object = RowWithKey>({
                     keyboardNav.copySelection();
                   } else if (item.value === COPY_RANGE_WITH_HEADER_ACTION) {
                     keyboardNav.copySelection(true);
+                  } else if (item.value === COPY_GROUP_ACTION || item.value === COPY_GROUP_WITH_HEADER_ACTION) {
+                    copyGroupRows(contextMenu.rowId, item.value === COPY_GROUP_WITH_HEADER_ACTION);
                   } else if (item.value === PASTE_RANGE_ACTION) {
                     handleContextMenuPaste();
                   } else if (item.value === REVERT_RANGE_ACTION) {
                     revertSelection(getRevertableSelectionCells());
+                  } else if (usesGridOwnedMenu && GRID_OWNED_COPY_ACTIONS.has(item.value)) {
+                    copyMenuTarget(contextMenu, item.value as ContextAction);
                   } else if (contextMenuAction && contextMenu.actionData) {
                     // Action data (leaf rows only; group rows excluded) was captured when the menu opened.
                     contextMenuAction(item, contextMenu.actionData);

--- a/libs/ui/src/lib/data-table/grid/components/GridContainer.tsx
+++ b/libs/ui/src/lib/data-table/grid/components/GridContainer.tsx
@@ -6,6 +6,7 @@ import classNames from 'classnames';
 import { CSSProperties, ReactNode, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { ContextMenu } from '../../../form/context-menu/ContextMenu';
 import { EditorHost } from '../editors/EditorHost';
+import { computeEdgeScrollVelocity, createEdgeAutoScroller } from '../grid-auto-scroll';
 import { copyGridDataToClipboard, copyGridGroupRowsToClipboard, GridCopyResult } from '../grid-clipboard';
 import { reorderColumnOrder } from '../grid-column-utils';
 import { HEADER_ROW_ID, isSummaryRowId, NON_DATA_COLUMN_KEYS, TABLE_CONTEXT_MENU_ITEMS } from '../grid-constants';
@@ -271,6 +272,7 @@ export function GridContainer<TRow extends object = RowWithKey>({
   const keyboardNav = useGridKeyboardNavigation({
     table,
     getRootElement: () => gridRef.current,
+    getScrollElement: () => scrollRef.current,
     onRequestEdit: startEdit,
     shouldRetainFocusOnBlur,
     summaryRowCount: summaryRows?.length ?? 0,
@@ -355,9 +357,12 @@ export function GridContainer<TRow extends object = RowWithKey>({
   const visibleColumnIndexes = autoRowHeight ? allColumnIndexes : windowedColumnIndexes;
 
   // Scroll the active column into view (mirrors the active-row logic in GridBody) so keyboard
-  // navigation to off-screen columns brings them into the window before focus resolves.
+  // navigation to off-screen columns brings them into the window before focus resolves. Skipped while
+  // a range drag auto-scrolls: `align: 'auto'` resolves to `'end'` for the partially-visible edge
+  // column, so it would snap a full column width on every extend and override the velocity ramp.
   useEffect(() => {
-    if (!keyboardNav.activeCell || keyboardNav.getLastInteractionSource() === 'select-all') {
+    const interactionSource = keyboardNav.getLastInteractionSource();
+    if (!keyboardNav.activeCell || interactionSource === 'select-all' || interactionSource === 'drag-autoscroll') {
       return;
     }
     const index = leafColumns.findIndex((column) => column.id === keyboardNav.activeCell!.columnId);
@@ -795,62 +800,34 @@ export function GridContainer<TRow extends object = RowWithKey>({
   );
 
   // Edge auto-scroll: because columns are horizontally virtualized, the drop target may be off-screen.
-  // While a column drag is active and the cursor nears the scroller's left/right edge, nudge the
-  // horizontal scroll so more columns (and drop targets) render. The rAF loop runs only during a drag.
-  const autoScrollFrameRef = useRef<number | null>(null);
-  const autoScrollStepRef = useRef(0);
-
-  const stopAutoScroll = useCallback(() => {
-    if (autoScrollFrameRef.current !== null) {
-      cancelAnimationFrame(autoScrollFrameRef.current);
-      autoScrollFrameRef.current = null;
-    }
-    autoScrollStepRef.current = 0;
-  }, []);
-
-  const runAutoScroll = useCallback(() => {
-    const scroller = scrollRef.current;
-    if (!scroller || autoScrollStepRef.current === 0) {
-      autoScrollFrameRef.current = null;
-      return;
-    }
-    scroller.scrollLeft += autoScrollStepRef.current;
-    autoScrollFrameRef.current = requestAnimationFrame(runAutoScroll);
-  }, []);
+  // While a column drag is active and the cursor nears the scroller's left/right edge, scroll
+  // horizontally so more columns (and drop targets) render. Shares the range drag's scroller, so the
+  // speed is in px/sec and stays the same on a 120Hz display.
+  const [columnDragAutoScroll] = useState(() => createEdgeAutoScroller({ getScrollElement: () => scrollRef.current }));
 
   const handleColumnDragOverScroller = useCallback(
     (event: React.DragEvent<HTMLDivElement>) => {
       if (!draggingColumnId) {
         return;
       }
-      const EDGE_SIZE = 60;
-      const SCROLL_STEP = 12;
       const rect = event.currentTarget.getBoundingClientRect();
-      const distanceFromLeft = event.clientX - rect.left;
-      const distanceFromRight = rect.right - event.clientX;
-      let step = 0;
-      if (distanceFromLeft < EDGE_SIZE) {
-        step = -SCROLL_STEP;
-      } else if (distanceFromRight < EDGE_SIZE) {
-        step = SCROLL_STEP;
-      }
-      autoScrollStepRef.current = step;
-      if (step !== 0 && autoScrollFrameRef.current === null) {
-        autoScrollFrameRef.current = requestAnimationFrame(runAutoScroll);
-      } else if (step === 0) {
-        stopAutoScroll();
-      }
+      const { x } = computeEdgeScrollVelocity({
+        box: { top: rect.top, right: rect.left + event.currentTarget.clientWidth, bottom: rect.bottom, left: rect.left },
+        clientX: event.clientX,
+        clientY: event.clientY,
+      });
+      columnDragAutoScroll.setVelocity({ x, y: 0 });
     },
-    [draggingColumnId, runAutoScroll, stopAutoScroll],
+    [columnDragAutoScroll, draggingColumnId],
   );
 
   const handleColumnDragEnd = useCallback(() => {
     setDraggingColumnId(null);
-    stopAutoScroll();
-  }, [stopAutoScroll]);
+    columnDragAutoScroll.stop();
+  }, [columnDragAutoScroll]);
 
   // Stop any in-flight auto-scroll frame when the grid unmounts mid-drag.
-  useEffect(() => stopAutoScroll, [stopAutoScroll]);
+  useEffect(() => columnDragAutoScroll.stop, [columnDragAutoScroll]);
 
   return (
     <GridRuntimeContext.Provider value={runtime as GridRuntime}>

--- a/libs/ui/src/lib/data-table/grid/components/GridContainer.tsx
+++ b/libs/ui/src/lib/data-table/grid/components/GridContainer.tsx
@@ -733,9 +733,10 @@ export function GridContainer<TRow extends object = RowWithKey>({
           }
         : null;
       // Append any consumer-supplied per-column items (e.g. "View field metadata") to the copy actions.
+      // These dispatch only through `contextMenuAction`, so without it they'd render but no-op on select.
       const items = [
         ...resolveHeaderContextMenuItems(resolvedContextMenuItems, actionData),
-        ...(getColumnHeaderMenuItems?.(columnId) ?? []),
+        ...(contextMenuAction ? (getColumnHeaderMenuItems?.(columnId) ?? []) : []),
       ];
       if (!items.length) {
         return;
@@ -745,7 +746,7 @@ export function GridContainer<TRow extends object = RowWithKey>({
       setContextMenu(null);
       setTimeout(() => setContextMenu({ area: 'header', columnId, element, items, actionData }));
     },
-    [canDispatchMenuItems, resolvedContextMenuItems, table, orderedColumns, getColumnHeaderMenuItems],
+    [canDispatchMenuItems, resolvedContextMenuItems, table, orderedColumns, getColumnHeaderMenuItems, contextMenuAction],
   );
 
   // ── Grid-owned copy dispatch (the default menu + the group-row menu) ────────────────────────────
@@ -921,7 +922,9 @@ export function GridContainer<TRow extends object = RowWithKey>({
           (() => {
             // Capped count of modified editable cells under the right-clicked selection; gates the "Revert"
             // item and picks its label without enumerating the whole selection (full list computed on click).
-            const revertableCount = contextMenu.area === 'cell' ? countRevertableSelectionCells(2) : 0;
+            // Selection-scoped like the copy items, so group-header menus get it too (revert skips group
+            // rows); header menus render no grid items at all.
+            const revertableCount = contextMenu.area !== 'header' ? countRevertableSelectionCells(2) : 0;
             // Grid-injected, selection-aware actions (copy/paste/revert), shown above the consumer's items.
             const gridItems: ContextMenuItem[] = [
               ...(hasRangeSelection

--- a/libs/ui/src/lib/data-table/grid/components/GridGroupRow.tsx
+++ b/libs/ui/src/lib/data-table/grid/components/GridGroupRow.tsx
@@ -20,6 +20,9 @@ export interface GridGroupRowProps<TRow extends object> {
   height: number;
   activeCell?: ActiveCell | null;
   onCellMouseDown?: (rowId: string, columnId: string, shiftKey: boolean, button?: number, ctrlOrMetaKey?: boolean) => void;
+  /** Mouse enters a group cell while dragging — lets a range drag sweep THROUGH group header rows
+   * instead of stalling on them (the rectangle passes over them; they render and copy nothing). */
+  onCellMouseEnter?: (rowId: string, columnId: string) => void;
   onContextMenu?: (event: React.MouseEvent, rowId: string, columnId: string) => void;
   /** When true the group row sizes to its content instead of being pinned to `height`. */
   autoHeight?: boolean;
@@ -58,6 +61,7 @@ export function GridGroupRow<TRow extends object>({
   height,
   activeCell,
   onCellMouseDown,
+  onCellMouseEnter,
   onContextMenu,
   autoHeight,
   measureRef,
@@ -107,6 +111,7 @@ export function GridGroupRow<TRow extends object>({
           data-col-id={firstColumnId}
           tabIndex={isActive ? 0 : -1}
           onMouseDown={(event) => firstColumnId && onCellMouseDown?.(row.id, firstColumnId, event.shiftKey, event.button)}
+          onMouseEnter={() => firstColumnId && onCellMouseEnter?.(row.id, firstColumnId)}
           onContextMenu={(event) => firstColumnId && onContextMenu?.(event, row.id, firstColumnId)}
         >
           <button
@@ -160,6 +165,7 @@ export function GridGroupRow<TRow extends object>({
           data-col-id={column.id}
           tabIndex={isActive && activeCell?.columnId === column.id ? 0 : -1}
           onMouseDown={(event) => onCellMouseDown?.(row.id, column.id, event.shiftKey, event.button)}
+          onMouseEnter={() => onCellMouseEnter?.(row.id, column.id)}
           onContextMenu={(event) => onContextMenu?.(event, row.id, column.id)}
           style={{ gridColumn: `${startCol} / span ${span}`, ...getFrozenCellStyle(columns, index) }}
         >

--- a/libs/ui/src/lib/data-table/grid/components/GridGroupRow.tsx
+++ b/libs/ui/src/lib/data-table/grid/components/GridGroupRow.tsx
@@ -20,6 +20,7 @@ export interface GridGroupRowProps<TRow extends object> {
   height: number;
   activeCell?: ActiveCell | null;
   onCellMouseDown?: (rowId: string, columnId: string, shiftKey: boolean, button?: number, ctrlOrMetaKey?: boolean) => void;
+  onContextMenu?: (event: React.MouseEvent, rowId: string, columnId: string) => void;
   /** When true the group row sizes to its content instead of being pinned to `height`. */
   autoHeight?: boolean;
   /** Virtualizer `measureElement` ref; attached in auto-height mode so the row's real height is measured. */
@@ -57,6 +58,7 @@ export function GridGroupRow<TRow extends object>({
   height,
   activeCell,
   onCellMouseDown,
+  onContextMenu,
   autoHeight,
   measureRef,
 }: GridGroupRowProps<TRow>) {
@@ -105,6 +107,7 @@ export function GridGroupRow<TRow extends object>({
           data-col-id={firstColumnId}
           tabIndex={isActive ? 0 : -1}
           onMouseDown={(event) => firstColumnId && onCellMouseDown?.(row.id, firstColumnId, event.shiftKey, event.button)}
+          onContextMenu={(event) => firstColumnId && onContextMenu?.(event, row.id, firstColumnId)}
         >
           <button
             type="button"
@@ -157,6 +160,7 @@ export function GridGroupRow<TRow extends object>({
           data-col-id={column.id}
           tabIndex={isActive && activeCell?.columnId === column.id ? 0 : -1}
           onMouseDown={(event) => onCellMouseDown?.(row.id, column.id, event.shiftKey, event.button)}
+          onContextMenu={(event) => onContextMenu?.(event, row.id, column.id)}
           style={{ gridColumn: `${startCol} / span ${span}`, ...getFrozenCellStyle(columns, index) }}
         >
           {meta?.renderGroupCell && groupCellProps ? meta.renderGroupCell(groupCellProps) : null}

--- a/libs/ui/src/lib/data-table/grid/components/GridGroupRow.tsx
+++ b/libs/ui/src/lib/data-table/grid/components/GridGroupRow.tsx
@@ -4,7 +4,7 @@ import { CSSProperties } from 'react';
 import Icon from '../../../widgets/Icon';
 import { DataTableGroupCellProps, TanstackColumn, TanstackRow, TanstackTable } from '../grid-types';
 import { ActiveCell } from './GridRow';
-import { getFrozenCellStyle } from './grid-layout';
+import { getGroupCellStickyStyle } from './grid-layout';
 
 export interface GridGroupRowProps<TRow extends object> {
   table: TanstackTable<TRow>;
@@ -167,7 +167,7 @@ export function GridGroupRow<TRow extends object>({
           onMouseDown={(event) => onCellMouseDown?.(row.id, column.id, event.shiftKey, event.button)}
           onMouseEnter={() => onCellMouseEnter?.(row.id, column.id)}
           onContextMenu={(event) => onContextMenu?.(event, row.id, column.id)}
-          style={{ gridColumn: `${startCol} / span ${span}`, ...getFrozenCellStyle(columns, index) }}
+          style={{ gridColumn: `${startCol} / span ${span}`, ...getGroupCellStickyStyle(columns, index, span) }}
         >
           {meta?.renderGroupCell && groupCellProps ? meta.renderGroupCell(groupCellProps) : null}
         </div>,

--- a/libs/ui/src/lib/data-table/grid/components/grid-layout.ts
+++ b/libs/ui/src/lib/data-table/grid/components/grid-layout.ts
@@ -34,3 +34,22 @@ export function getFrozenCellStyle<TRow extends object>(columns: TanstackColumn<
     zIndex: 1,
   };
 }
+
+/**
+ * Sticky-left style for a GROUP row cell, which spans columns and so can straddle the frozen band.
+ * A group cell is pinned when its span covers ANY frozen column, not only when its own column is
+ * frozen: the permission manager's field table starts the expand/collapse cell on a scrollable column
+ * and spans it across the two pinned ones, so without this the toggle scrolls away underneath the
+ * frozen cells (which paint above it) and the group becomes impossible to collapse when scrolled right.
+ */
+export function getGroupCellStickyStyle<TRow extends object>(columns: TanstackColumn<TRow>[], index: number, span: number): CSSProperties {
+  const spansFrozenColumn = columns.slice(index, index + span).some(isFrozenColumn);
+  if (!spansFrozenColumn) {
+    return {};
+  }
+  return {
+    position: 'sticky',
+    left: getFrozenLeftOffset(columns, index),
+    zIndex: 1,
+  };
+}

--- a/libs/ui/src/lib/data-table/grid/grid-auto-scroll.ts
+++ b/libs/ui/src/lib/data-table/grid/grid-auto-scroll.ts
@@ -1,0 +1,183 @@
+/**
+ * Edge auto-scroll primitives shared by the grid's drag interactions (range drag-select, column
+ * reorder): a pure velocity ramp plus a single time-based rAF loop that applies it to a scroll
+ * container.
+ *
+ * Velocity is expressed in px/SECOND and applied against the real frame delta, so the scroll speed is
+ * identical on a 60Hz and a 120Hz display (a fixed px-per-frame step scrolls twice as fast on
+ * ProMotion hardware).
+ */
+
+/** Ramp width (px) measured inward from each edge of the content viewport. */
+export const DEFAULT_EDGE_SIZE = 48;
+/** Speed (px/sec) reached at — and beyond — the outer edge of the ramp (≈32 rows/sec at the default row height). */
+export const DEFAULT_MAX_SPEED = 900;
+/** Frame deltas are clamped to this so a tab-switch/GC pause can't scroll the grid in one giant jump. */
+const MAX_FRAME_SECONDS = 0.05;
+
+/**
+ * The client-coordinate box the pointer is measured against — the scroll container's CONTENT viewport.
+ * Callers exclude scrollbar tracks (via clientWidth/clientHeight) and any sticky overlay that would
+ * otherwise swallow the whole ramp (the grid's sticky header block, the frozen column band).
+ */
+export interface EdgeScrollBox {
+  top: number;
+  right: number;
+  bottom: number;
+  left: number;
+}
+
+export interface EdgeScrollVelocityOptions {
+  box: EdgeScrollBox;
+  clientX: number;
+  clientY: number;
+  edgeSize?: number;
+  maxSpeed?: number;
+}
+
+/** Linear 0→maxSpeed ramp over the last `edgeSize` px before `edgeStart`, clamped past the edge. */
+function axisVelocity(position: number, start: number, end: number, edgeSize: number, maxSpeed: number): number {
+  const size = end - start;
+  if (size <= 0) {
+    return 0;
+  }
+  // Never let opposing ramps overlap in a box narrower than two full ramps — each takes half.
+  const ramp = Math.min(edgeSize, size / 2);
+  if (ramp <= 0) {
+    return 0;
+  }
+  const distanceFromStart = position - start;
+  if (distanceFromStart < ramp) {
+    return -maxSpeed * Math.min(1, (ramp - distanceFromStart) / ramp);
+  }
+  const distanceFromEnd = end - position;
+  if (distanceFromEnd < ramp) {
+    return maxSpeed * Math.min(1, (ramp - distanceFromEnd) / ramp);
+  }
+  return 0;
+}
+
+/**
+ * Scroll velocity (px/sec, positive = right/down) for a pointer measured against `box`: zero in the
+ * middle, ramping linearly to `maxSpeed` at the edge and staying pinned there once the pointer is
+ * outside the box entirely.
+ */
+export function computeEdgeScrollVelocity({
+  box,
+  clientX,
+  clientY,
+  edgeSize = DEFAULT_EDGE_SIZE,
+  maxSpeed = DEFAULT_MAX_SPEED,
+}: EdgeScrollVelocityOptions): { x: number; y: number } {
+  return {
+    x: axisVelocity(clientX, box.left, box.right, edgeSize, maxSpeed),
+    y: axisVelocity(clientY, box.top, box.bottom, edgeSize, maxSpeed),
+  };
+}
+
+/** Injectable clock/scheduler — the loop uses rAF + performance.now() unless a test supplies its own. */
+export interface AutoScrollScheduler {
+  now: () => number;
+  request: (callback: () => void) => number;
+  cancel: (handle: number) => void;
+}
+
+export interface EdgeAutoScrollerOptions {
+  getScrollElement: () => HTMLElement | null;
+  /** Fired after each frame's write with the px actually applied per axis (0 when clamped at either end). */
+  onFrame?: (applied: { x: number; y: number }) => void;
+  scheduler?: AutoScrollScheduler;
+}
+
+export interface EdgeAutoScroller {
+  /** px/sec. A non-zero velocity starts the loop; `{ x: 0, y: 0 }` cancels the pending frame. */
+  setVelocity: (velocity: { x: number; y: number }) => void;
+  stop: () => void;
+}
+
+const defaultScheduler: AutoScrollScheduler = {
+  now: () => performance.now(),
+  request: (callback) => requestAnimationFrame(callback),
+  cancel: (handle) => cancelAnimationFrame(handle),
+};
+
+/**
+ * A single rAF loop that scrolls an element at a settable velocity.
+ *
+ * Sub-pixel movement is accumulated in a carry rather than truncated, so slow ramp velocities still
+ * scroll (assigning a fractional delta to `scrollTop` rounds away in some engines). The loop keeps
+ * running while the velocity is non-zero even once the element is clamped at 0 or at its maximum —
+ * the pointer may move back toward the middle, and `onFrame` reports the zero movement so callers can
+ * skip per-frame work.
+ */
+export function createEdgeAutoScroller({
+  getScrollElement,
+  onFrame,
+  scheduler = defaultScheduler,
+}: EdgeAutoScrollerOptions): EdgeAutoScroller {
+  let frameHandle: number | null = null;
+  let lastFrameTime = 0;
+  let velocity = { x: 0, y: 0 };
+  let carryX = 0;
+  let carryY = 0;
+
+  const cancelFrame = () => {
+    if (frameHandle !== null) {
+      scheduler.cancel(frameHandle);
+      frameHandle = null;
+    }
+  };
+
+  const runFrame = () => {
+    frameHandle = null;
+    const element = getScrollElement();
+    if (!element || (velocity.x === 0 && velocity.y === 0)) {
+      return;
+    }
+    const now = scheduler.now();
+    const deltaSeconds = Math.min((now - lastFrameTime) / 1000, MAX_FRAME_SECONDS);
+    lastFrameTime = now;
+
+    carryX += velocity.x * deltaSeconds;
+    carryY += velocity.y * deltaSeconds;
+    const stepX = Math.trunc(carryX);
+    const stepY = Math.trunc(carryY);
+    carryX -= stepX;
+    carryY -= stepY;
+
+    const beforeLeft = element.scrollLeft;
+    const beforeTop = element.scrollTop;
+    if (stepX !== 0) {
+      element.scrollLeft = beforeLeft + stepX;
+    }
+    if (stepY !== 0) {
+      element.scrollTop = beforeTop + stepY;
+    }
+    // Schedule before notifying so an `onFrame` callback that calls `stop()` cancels the next frame
+    // instead of being overwritten by it.
+    frameHandle = scheduler.request(runFrame);
+    onFrame?.({ x: element.scrollLeft - beforeLeft, y: element.scrollTop - beforeTop });
+  };
+
+  return {
+    setVelocity(next) {
+      velocity = next;
+      if (next.x === 0 && next.y === 0) {
+        cancelFrame();
+        carryX = 0;
+        carryY = 0;
+        return;
+      }
+      if (frameHandle === null) {
+        lastFrameTime = scheduler.now();
+        frameHandle = scheduler.request(runFrame);
+      }
+    },
+    stop() {
+      cancelFrame();
+      velocity = { x: 0, y: 0 };
+      carryX = 0;
+      carryY = 0;
+    },
+  };
+}

--- a/libs/ui/src/lib/data-table/grid/grid-clipboard.ts
+++ b/libs/ui/src/lib/data-table/grid/grid-clipboard.ts
@@ -1,12 +1,176 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { copyRecordsToClipboard } from '@jetstream/shared/ui-utils';
-import { ContextAction, ContextMenuActionData, RowWithKey } from './grid-types';
+import { getSortedFilteredLeafRows } from './grid-row-utils';
+import { ContextAction, ContextMenuActionData, RowWithKey, TanstackColumn, TanstackRow, TanstackTable } from './grid-types';
 
 /**
- * Clipboard copy helpers for the table context menu. Ported verbatim from the legacy data-table-utils
- * (no react-data-grid dependency). `copyGenericTableDataToClipboard` works with plain row data;
- * `copySalesforceRecordTableDataToClipboard` assumes a `_record` indirection on each row.
+ * Clipboard copy helpers for the table context menu.
+ *
+ * Two families live here:
+ *  - `copyGridDataToClipboard` — the grid's own implementation, driven by the TanStack table model. Used
+ *    for the copy menu every table gets by default, and for the group-row menu.
+ *  - `copyGenericTableDataToClipboard` / `copySalesforceRecordTableDataToClipboard` — the consumer-facing
+ *    helpers (ported verbatim from the legacy data-table-utils), driven by the plain row objects handed
+ *    to a `contextMenuAction`. The Salesforce variant assumes a `_record` indirection on each row.
  */
+
+/**
+ * A cell's value as the grid understands it: the author column's `getValue` when provided (the same
+ * accessor the cell renders from), otherwise the raw row property.
+ */
+export function getCellValue<TRow extends object>(row: TanstackRow<TRow>, column: TanstackColumn<TRow>): unknown {
+  // Synthetic group header rows have no original row data.
+  if (row.original === null || row.original === undefined) {
+    return null;
+  }
+  const authorColumn = column.columnDef.meta?.jetstream?.column;
+  return authorColumn?.getValue
+    ? authorColumn.getValue({ row: row.original, column: authorColumn })
+    : (row.original as Record<string, unknown>)[column.id];
+}
+
+/** A cell's copyable text — `getCellValue` stringified (objects/arrays as JSON, nullish as empty). */
+export function getCellText<TRow extends object>(row: TanstackRow<TRow>, column: TanstackColumn<TRow>): string {
+  const value = getCellValue(row, column);
+  if (value === null || value === undefined) {
+    return '';
+  }
+  if (Array.isArray(value) || typeof value === 'object') {
+    return JSON.stringify(value);
+  }
+  return String(value);
+}
+
+/** Display label for a column header. Falls back to the string header / column id when the author's
+ * `name` is a ReactNode. */
+export function getColumnHeaderText<TRow extends object>(column: TanstackColumn<TRow>): string {
+  const name = column.columnDef.meta?.jetstream?.column?.name;
+  if (typeof name === 'string') {
+    return name;
+  }
+  const header = column.columnDef.header;
+  if (typeof header === 'string') {
+    return header;
+  }
+  return column.id;
+}
+
+/** What a grid-owned copy actually put on the clipboard, for the polite live-region announcement. */
+export interface GridCopyResult {
+  rowCount: number;
+  columnCount: number;
+}
+
+/** Visible columns carrying copyable data — the select/action columns hold controls, not values. */
+function getCopyableColumns<TRow extends object>(table: TanstackTable<TRow>): TanstackColumn<TRow>[] {
+  return table.getVisibleLeafColumns().filter((column) => column.columnDef.meta?.jetstream?.cellKind === 'data');
+}
+
+/**
+ * Copy a rows × columns region.
+ *
+ * Excel/CSV records are keyed by synthetic field names (`c0`, `c1`, …) because the downstream copy
+ * utilities resolve field names as lodash paths — a real column id like `Account.Name` would be read as
+ * a nested path instead of a literal key. That also rules out letting them emit the header row, so the
+ * header is prepended as a normal record. JSON does no path resolution, so it keeps the real column ids
+ * as keys and the un-stringified values.
+ */
+function copyRegion<TRow extends object>(
+  rows: TanstackRow<TRow>[],
+  columns: TanstackColumn<TRow>[],
+  format: 'excel' | 'csv' | 'json',
+  includeHeader: boolean,
+): GridCopyResult | null {
+  if (!rows.length || !columns.length) {
+    return null;
+  }
+  const result: GridCopyResult = { rowCount: rows.length, columnCount: columns.length };
+
+  if (format === 'json') {
+    const records = rows.map((row) =>
+      columns.reduce<Record<string, unknown>>((record, column) => {
+        record[column.id] = getCellValue(row, column);
+        return record;
+      }, {}),
+    );
+    void copyRecordsToClipboard(records, 'json');
+    return result;
+  }
+
+  const fields = columns.map((_, index) => `c${index}`);
+  const records: Record<string, string>[] = [];
+  if (includeHeader) {
+    records.push(
+      columns.reduce<Record<string, string>>((record, column, index) => {
+        record[fields[index]] = getColumnHeaderText(column);
+        return record;
+      }, {}),
+    );
+  }
+  for (const row of rows) {
+    records.push(
+      columns.reduce<Record<string, string>>((record, column, index) => {
+        record[fields[index]] = getCellText(row, column);
+        return record;
+      }, {}),
+    );
+  }
+  void copyRecordsToClipboard(records, format, fields, false);
+  return result;
+}
+
+export interface GridCopyRequest<TRow extends object> {
+  table: TanstackTable<TRow>;
+  action: ContextAction;
+  /** The right-clicked row — required by the cell/row-scoped actions. */
+  row?: TanstackRow<TRow> | null;
+  /** The right-clicked column — required by the cell/column-scoped actions. */
+  column?: TanstackColumn<TRow> | null;
+}
+
+/**
+ * The grid's own implementation of the standard `TABLE_CONTEXT_MENU_ITEMS` actions, used for the copy
+ * menu a table gets when it supplies no `contextMenuItems` of its own.
+ *
+ * Unlike the consumer-facing helpers, which index raw row objects by column key, this reads through the
+ * table model — so it honors `getValue`, column reordering and visibility, and the filtered + sorted row
+ * order the user is actually looking at.
+ */
+export function copyGridDataToClipboard<TRow extends object>({ table, action, row, column }: GridCopyRequest<TRow>): GridCopyResult | null {
+  const columns = getCopyableColumns(table);
+  const rows = getSortedFilteredLeafRows(table);
+  switch (action) {
+    case 'COPY_CELL':
+      return row && column ? copyRegion([row], [column], 'excel', false) : null;
+    case 'COPY_ROW_EXCEL':
+      return row ? copyRegion([row], columns, 'excel', true) : null;
+    case 'COPY_ROW_JSON':
+      return row ? copyRegion([row], columns, 'json', false) : null;
+    case 'COPY_COL':
+      return column ? copyRegion(rows, [column], 'excel', true) : null;
+    case 'COPY_COL_NO_HEADER':
+      return column ? copyRegion(rows, [column], 'excel', false) : null;
+    case 'COPY_COL_JSON':
+      return column ? copyRegion(rows, [column], 'json', false) : null;
+    case 'COPY_TABLE':
+      return copyRegion(rows, columns, 'excel', true);
+    case 'COPY_TABLE_CSV':
+      return copyRegion(rows, columns, 'csv', true);
+    case 'COPY_TABLE_JSON':
+      return copyRegion(rows, columns, 'json', false);
+    default:
+      return null;
+  }
+}
+
+/** Copy every data row beneath a group header row — the grid-owned action on a group row right-click. */
+export function copyGridGroupRowsToClipboard<TRow extends object>(
+  table: TanstackTable<TRow>,
+  groupRow: TanstackRow<TRow>,
+  includeHeader: boolean,
+): GridCopyResult | null {
+  return copyRegion(groupRow.getLeafRows(), getCopyableColumns(table), 'excel', includeHeader);
+}
 
 export function copyGenericTableDataToClipboard<T extends Record<string, any>>(
   action: ContextAction,

--- a/libs/ui/src/lib/data-table/grid/grid-context-menu.ts
+++ b/libs/ui/src/lib/data-table/grid/grid-context-menu.ts
@@ -1,0 +1,59 @@
+import { ContextMenuItem } from '@jetstream/types';
+import { TABLE_CONTEXT_MENU_ITEMS } from './grid-constants';
+import { ContextMenuActionData, ContextMenuItems } from './grid-types';
+
+/**
+ * The right-click menu's grid-owned pieces: the sentinel action values the grid dispatches itself, and
+ * the pure item-resolution rules. `GridContainer` owns the interaction; this owns what ends up in the list.
+ */
+
+/** Sentinel values for actions the grid implements itself (never routed to a `contextMenuAction`). */
+export const COPY_RANGE_ACTION = '__COPY_RANGE__';
+export const COPY_RANGE_WITH_HEADER_ACTION = '__COPY_RANGE_WITH_HEADER__';
+export const COPY_GROUP_ACTION = '__COPY_GROUP__';
+export const COPY_GROUP_WITH_HEADER_ACTION = '__COPY_GROUP_WITH_HEADER__';
+export const PASTE_RANGE_ACTION = '__PASTE_RANGE__';
+export const REVERT_RANGE_ACTION = '__REVERT_RANGE__';
+
+/** Grid-owned actions on a group header row: the group's own data rows, with or without a header line.
+ * Consumer items never appear here — their `ContextMenuActionData` is leaf-row-scoped. */
+export const GROUP_CONTEXT_MENU_ITEMS: ContextMenuItem[] = [
+  { label: 'Copy rows in group', value: COPY_GROUP_ACTION },
+  { label: 'Copy rows in group with header', value: COPY_GROUP_WITH_HEADER_ACTION },
+];
+
+/** Item values the grid dispatches itself when it owns the menu (i.e. the table supplied no items). */
+export const GRID_OWNED_COPY_ACTIONS = new Set<unknown>(TABLE_CONTEXT_MENU_ITEMS.map(({ value }) => value));
+
+/** Context-menu actions that operate on a column/table (no specific row) — the subset offered when
+ * right-clicking a column HEADER. Matches the `ContextAction` values used by the standard
+ * TABLE_CONTEXT_MENU_ITEMS; items outside this set are cell-scoped and excluded. */
+const COLUMN_SCOPED_CONTEXT_ACTIONS = new Set<unknown>([
+  'COPY_COL',
+  'COPY_COL_JSON',
+  'COPY_COL_NO_HEADER',
+  'COPY_TABLE',
+  'COPY_TABLE_JSON',
+  'COPY_TABLE_CSV',
+]);
+
+/**
+ * The items to show when a column HEADER is right-clicked.
+ *
+ * A per-cell builder is evaluated against the header's own action data (anchored on the first data row)
+ * so builder-driven tables get a header menu too; the column-scoped filter then drops whatever items it
+ * produced for that row specifically. Builders read the row they are handed, so one is only called when
+ * the table actually has a row to give it.
+ */
+export function resolveHeaderContextMenuItems<TRow extends object>(
+  items: ContextMenuItems<TRow>,
+  actionData: ContextMenuActionData<TRow> | null,
+): ContextMenuItem[] {
+  if (typeof items !== 'function') {
+    return items.filter((item) => COLUMN_SCOPED_CONTEXT_ACTIONS.has(item.value));
+  }
+  if (!actionData || actionData.rowIdx < 0) {
+    return [];
+  }
+  return items(actionData).filter((item) => COLUMN_SCOPED_CONTEXT_ACTIONS.has(item.value));
+}

--- a/libs/ui/src/lib/data-table/grid/keyboard/useGridKeyboardNavigation.ts
+++ b/libs/ui/src/lib/data-table/grid/keyboard/useGridKeyboardNavigation.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { copyRecordsToClipboard, transformTabularDataToExcelStr } from '@jetstream/shared/ui-utils';
 import { FocusEvent as ReactFocusEvent, KeyboardEvent as ReactKeyboardEvent, useCallback, useEffect, useRef, useState } from 'react';
+import { isFrozenColumn } from '../components/grid-layout';
 import { ActiveCell } from '../components/GridRow';
 import { getCellText, getColumnHeaderText } from '../grid-clipboard';
 import { getSummaryRowId, getSummaryRowIndex, HEADER_ROW_ID, isSummaryRowId, SELECT_COLUMN_KEY } from '../grid-constants';
@@ -14,8 +15,19 @@ import {
   hasMultiCellSelection,
   isCellInSelectionBounds,
 } from '../selection/grid-selection';
+import { useRangeDragAutoScroll } from './useRangeDragAutoScroll';
 
 export type GridMode = 'navigation' | 'actionable';
+
+/**
+ * What drove the most recent active-cell change. Consumers use it to decide whether to move DOM focus
+ * and whether to scroll the cell into view:
+ *  - `mouse` — a click/hover already placed focus; don't steal it back.
+ *  - `select-all` — Ctrl+A moves the focus corner as bookkeeping only; never scroll or focus.
+ *  - `drag-autoscroll` — a range drag's own rAF loop owns the scroll offset; a `scrollToIndex` here
+ *    would snap the partially-visible edge row/column fully into view every frame and override it.
+ */
+export type GridInteractionSource = 'mouse' | 'keyboard' | 'select-all' | 'drag-autoscroll';
 
 /** Rows to jump on PageUp/PageDown (approximate viewport page). */
 const PAGE_SIZE = 12;
@@ -32,6 +44,16 @@ const ACTIVATABLE_SELECTOR =
 /** A rectangular cell-selection in display-index space (inclusive bounds). */
 function clamp(value: number, min: number, max: number): number {
   return Math.max(min, Math.min(max, value));
+}
+
+/**
+ * Combined width of the sticky-left band. Every frozen column stacks at the left edge in column order
+ * (`getFrozenLeftOffset`) whether or not the frozen columns are contiguous — the permission manager's
+ * field table pins columns 1 and 2 while column 0 scrolls underneath them — so this sums all of them,
+ * not just a leading run.
+ */
+function getFrozenBandWidth<TRow extends object>(table: TanstackTable<TRow>): number {
+  return table.getVisibleLeafColumns().reduce((width, column) => (isFrozenColumn(column) ? width + column.getSize() : width), 0);
 }
 
 /**
@@ -80,6 +102,9 @@ export interface UseGridKeyboardNavigationOptions<TRow extends object> {
   table: TanstackTable<TRow>;
   /** Returns the grid root element so DOM focus/copy queries are scoped to this grid instance. */
   getRootElement: () => HTMLElement | null;
+  /** Returns the scroll container (`.jgrid-scroller`, owner of BOTH axes) that a range drag edge
+   * auto-scrolls. Omit it and drags simply stop extending at the viewport edge, as they did before. */
+  getScrollElement?: () => HTMLElement | null;
   /** Enter/F2 hook: if it starts editing the cell (returns true), the grid stays out of Actionable mode. */
   onRequestEdit?: (cell: ActiveCell) => boolean;
   /** Return true to keep the active cell/selection when focus leaves the grid root — used when focus
@@ -110,8 +135,8 @@ export interface GridKeyboardNavigation {
   handleRootFocus: (event: ReactFocusEvent<HTMLElement>) => void;
   /** Whether the last active-cell change came from the mouse or keyboard — lets GridBody skip stealing
    * focus back to the cell on mouse clicks (which would close popovers opened from a cell). The
-   * 'select-all' source additionally suppresses scroll-into-view (Ctrl+A must not jump the viewport). */
-  getLastInteractionSource: () => 'mouse' | 'keyboard' | 'select-all';
+   * 'select-all' and 'drag-autoscroll' sources additionally suppress scroll-into-view. */
+  getLastInteractionSource: () => GridInteractionSource;
   /** When focus leaves the grid entirely (e.g. Tab/Shift+Tab out), clear the active cell so the next
    * focus event re-seeds and the grid root re-enters the tab order. */
   handleRootBlur: (event: ReactFocusEvent<HTMLElement>) => void;
@@ -143,6 +168,7 @@ export interface GridKeyboardNavigation {
 export function useGridKeyboardNavigation<TRow extends object>({
   table,
   getRootElement,
+  getScrollElement,
   onRequestEdit,
   shouldRetainFocusOnBlur,
   summaryRowCount = 0,
@@ -155,7 +181,7 @@ export function useGridKeyboardNavigation<TRow extends object>({
   const [mode, setMode] = useState<GridMode>('navigation');
   const isDraggingRef = useRef(false);
   // Tracks whether the most recent active-cell change was mouse- or keyboard-driven (see interface doc).
-  const interactionSourceRef = useRef<'mouse' | 'keyboard' | 'select-all'>('keyboard');
+  const interactionSourceRef = useRef<GridInteractionSource>('keyboard');
   // The cell an activation opened a popover/modal from — focus is returned here once the overlay closes.
   const pendingReturnFocusCellRef = useRef<ActiveCell | null>(null);
   // Live mirror of activeCell for the document focus listeners (avoids re-subscribing on every move).
@@ -168,14 +194,31 @@ export function useGridKeyboardNavigation<TRow extends object>({
   // spreadsheet "sticky column" behavior.
   const desiredColRef = useRef<number | null>(null);
 
-  // Stop drag-select when the mouse is released anywhere.
-  useEffect(() => {
-    const onMouseUp = () => {
-      isDraggingRef.current = false;
-    };
-    window.addEventListener('mouseup', onMouseUp);
-    return () => window.removeEventListener('mouseup', onMouseUp);
-  }, []);
+  /** False for the select/action columns — they can never join a cell range (see buildColumnDefs). */
+  const isColumnCellSelectable = useCallback(
+    (columnId: string): boolean =>
+      table.getVisibleLeafColumns().find((column) => column.id === columnId)?.columnDef.enableCellSelection !== false,
+    [table],
+  );
+
+  /**
+   * Whether a MOUSE drag may extend onto this column. Stricter than `isColumnCellSelectable`: a
+   * sticky-left column that is currently covering scrolled-away content is not what the pointer is
+   * reaching for — the user is dragging toward whatever sits underneath it. Extending there would
+   * anchor the rectangle at the far-left column (selecting everything in between) and drag the
+   * active-column scroll-into-view effect back to the start of the table with it. Once the grid is
+   * scrolled home the band covers nothing, so its columns become ordinary drag targets again.
+   */
+  const isDragExtendTarget = useCallback(
+    (columnId: string): boolean => {
+      const column = table.getVisibleLeafColumns().find((candidate) => candidate.id === columnId);
+      if (!column || column.columnDef.enableCellSelection === false) {
+        return false;
+      }
+      return !isFrozenColumn(column) || (getScrollElement?.()?.scrollLeft ?? 0) === 0;
+    },
+    [table, getScrollElement],
+  );
 
   // Apply a new active cell. `extend` grows the ACTIVE cell-selection range toward the target
   // (v9 keeps the range's anchor corner fixed); otherwise the selection collapses onto the new cell.
@@ -192,16 +235,22 @@ export function useGridKeyboardNavigation<TRow extends object>({
       }
       setActiveCellState({ rowId, columnId });
       setMode('navigation');
-      // Cell selection (v9 state): extends may sweep any coordinate (group rows / non-data columns
-      // render nothing and copy nothing, but the rectangle passes through them — legacy behavior).
+      const columnSelectable = isColumnCellSelectable(columnId);
+      // Cell selection (v9 state): an extend may sweep any ROW (group rows render nothing and copy
+      // nothing, but the rectangle passes through them), never a non-selectable COLUMN. The select and
+      // action columns are frozen at indexes 0/1, so letting Shift+Arrow anchor an edge there would snap
+      // the rectangle to column 0 and swallow every column in between. Keyboard focus still moves onto
+      // them so navigation can pass through; a MOUSE drag ignores them entirely (handleCellMouseEnter),
+      // since moving the active cell there would drag the viewport back to column 0 with it.
       // A plain move participates only for body DATA cells on selectable columns; header/summary
       // sentinels, group header rows, and the select/action columns are focus-only and clear it.
       if (extend) {
-        extendActiveSelectionTo(table, rowId, columnId);
+        if (columnSelectable) {
+          extendActiveSelectionTo(table, rowId, columnId);
+        }
         return;
       }
       const isSentinel = rowId === HEADER_ROW_ID || isSummaryRowId(rowId);
-      const columnSelectable = columns.find((column) => column.id === columnId)?.columnDef.enableCellSelection !== false;
       const row = isSentinel ? undefined : table.getRowModel().rows.find((candidate) => candidate.id === rowId);
       if (isSentinel || !columnSelectable || !row || row.getIsGrouped()) {
         clearCellSelection(table);
@@ -209,8 +258,43 @@ export function useGridKeyboardNavigation<TRow extends object>({
         collapseSelectionTo(table, rowId, columnId);
       }
     },
-    [table],
+    [table, isColumnCellSelectable],
   );
+
+  // Edge auto-scroll: once the cursor leaves the scroll viewport there are no cells left to fire
+  // `mouseenter`, so a drag would stop growing. This scrolls the container while the pointer sits at
+  // (or beyond) an edge and extends the range to whatever cell scrolls under it.
+  const rangeDragAutoScroll = useRangeDragAutoScroll({
+    getScrollElement: getScrollElement ?? (() => null),
+    getRootElement,
+    getLeftInset: () => getFrozenBandWidth(table),
+    getActiveCell: () => activeCellRef.current,
+    onExtendToCell: (rowId, columnId) => {
+      if (!isDragExtendTarget(columnId)) {
+        return;
+      }
+      interactionSourceRef.current = 'drag-autoscroll';
+      applySelection(rowId, columnId, true);
+    },
+    onDragEnd: () => {
+      isDraggingRef.current = false;
+    },
+  });
+
+  const beginRangeDrag = useCallback(() => {
+    isDraggingRef.current = true;
+    rangeDragAutoScroll.start();
+  }, [rangeDragAutoScroll]);
+
+  // Stop drag-select when the mouse is released anywhere.
+  useEffect(() => {
+    const onMouseUp = () => {
+      isDraggingRef.current = false;
+      rangeDragAutoScroll.stop();
+    };
+    window.addEventListener('mouseup', onMouseUp);
+    return () => window.removeEventListener('mouseup', onMouseUp);
+  }, [rangeDragAutoScroll]);
 
   const setActiveCell = useCallback(
     (cell: ActiveCell | null) => {
@@ -484,7 +568,7 @@ export function useGridKeyboardNavigation<TRow extends object>({
         applySelection(rowId, columnId, true);
         // Keep dragging after a shift-extend (Excel behavior): mouseenter continues growing the SAME
         // active range, since extend moves the focus corner while the anchor stays fixed.
-        isDraggingRef.current = true;
+        beginRangeDrag();
         return;
       }
       // Ctrl/Cmd+click on a selectable data cell starts a NEW rectangle that adds to (unselected cell)
@@ -500,23 +584,31 @@ export function useGridKeyboardNavigation<TRow extends object>({
         setActiveCellState({ rowId, columnId });
         setMode('navigation');
         addOrExcludeCellRange(table, rowId, columnId);
-        isDraggingRef.current = true;
+        beginRangeDrag();
         return;
       }
       applySelection(rowId, columnId, false);
-      isDraggingRef.current = true;
+      beginRangeDrag();
     },
-    [applySelection, isCellInSelection, table],
+    [applySelection, beginRangeDrag, isCellInSelection, table],
   );
 
   const handleCellMouseEnter = useCallback(
     (rowId: string, columnId: string) => {
-      if (isDraggingRef.current) {
-        interactionSourceRef.current = 'mouse';
-        applySelection(rowId, columnId, true);
+      if (!isDraggingRef.current || !isDragExtendTarget(columnId)) {
+        return;
       }
+      // Auto-scrolling re-fires `mouseenter` for hover changes the scroll itself caused. Ignoring the
+      // ones that land back on the current focus corner keeps the source at 'drag-autoscroll' (so the
+      // virtualizers' scroll-into-view stays suppressed) and avoids a render that changes nothing.
+      const current = activeCellRef.current;
+      if (current && current.rowId === rowId && current.columnId === columnId) {
+        return;
+      }
+      interactionSourceRef.current = 'mouse';
+      applySelection(rowId, columnId, true);
     },
-    [applySelection],
+    [applySelection, isDragExtendTarget],
   );
 
   // Mouse-down on a header cell makes it the keyboard-active cell so arrow nav continues from the header.

--- a/libs/ui/src/lib/data-table/grid/keyboard/useGridKeyboardNavigation.ts
+++ b/libs/ui/src/lib/data-table/grid/keyboard/useGridKeyboardNavigation.ts
@@ -83,6 +83,15 @@ function getRowSegmentStarts<TRow extends object>(row: TanstackRow<TRow>, column
   return starts;
 }
 
+/**
+ * True when the row renders at least one cell wider than a single column. Consumers use a row-level
+ * colSpan for message/placeholder rows ("No metadata found", "no rows found") — the tell that a row
+ * carries a rendered message rather than per-column data.
+ */
+function isSpannerRow<TRow extends object>(row: TanstackRow<TRow>, columns: TanstackColumn<TRow>[]): boolean {
+  return getRowSegmentStarts(row, columns).length < columns.length;
+}
+
 /** The segment owner (start index) of the cell that covers `targetColIndex` in `row`. For a row with no
  * spans this is `targetColIndex` itself; for a spanned cell it's the column that renders it. */
 function resolveColumnStart<TRow extends object>(row: TanstackRow<TRow>, columns: TanstackColumn<TRow>[], targetColIndex: number): number {
@@ -665,8 +674,18 @@ export function useGridKeyboardNavigation<TRow extends object>({
             continue;
           }
           const record: Record<string, string> = {};
+          let hasText = false;
           for (let colIndex = rect.minColumnIndex; colIndex <= rect.maxColumnIndex; colIndex++) {
-            record[`c${colIndex}`] = getCellText(rows[rowIndex], columns[colIndex]);
+            const text = getCellText(rows[rowIndex], columns[colIndex]);
+            hasText ||= text !== '';
+            record[`c${colIndex}`] = text;
+          }
+          // Placeholder rows (deploy's "No metadata found" child) render a message through a row-level
+          // colSpan and carry no cell values, so they'd land as a blank line mid-range. A genuinely
+          // empty DATA row has no span and must still be copied — dropping it would shift every row
+          // below it out of alignment with the source.
+          if (!hasText && isSpannerRow(rows[rowIndex], columns)) {
+            continue;
           }
           records.push(record);
         }

--- a/libs/ui/src/lib/data-table/grid/keyboard/useGridKeyboardNavigation.ts
+++ b/libs/ui/src/lib/data-table/grid/keyboard/useGridKeyboardNavigation.ts
@@ -2,6 +2,7 @@
 import { copyRecordsToClipboard, transformTabularDataToExcelStr } from '@jetstream/shared/ui-utils';
 import { FocusEvent as ReactFocusEvent, KeyboardEvent as ReactKeyboardEvent, useCallback, useEffect, useRef, useState } from 'react';
 import { ActiveCell } from '../components/GridRow';
+import { getCellText, getColumnHeaderText } from '../grid-clipboard';
 import { getSummaryRowId, getSummaryRowIndex, HEADER_ROW_ID, isSummaryRowId, SELECT_COLUMN_KEY } from '../grid-constants';
 import { ColSpanArgs, TanstackColumn, TanstackRow, TanstackTable } from '../grid-types';
 import {
@@ -73,38 +74,6 @@ function resolveColumnStart<TRow extends object>(row: TanstackRow<TRow>, columns
     }
   }
   return owner;
-}
-
-function cellText<TRow extends object>(row: TanstackRow<TRow>, column: TanstackColumn<TRow>): string {
-  // Synthetic group header rows have no original row data.
-  if (row.original === null || row.original === undefined) {
-    return '';
-  }
-  const authorColumn = column.columnDef.meta?.jetstream?.column;
-  const value: unknown = authorColumn?.getValue
-    ? authorColumn.getValue({ row: row.original, column: authorColumn })
-    : (row.original as Record<string, unknown>)[column.id];
-  if (value === null || value === undefined) {
-    return '';
-  }
-  if (Array.isArray(value) || typeof value === 'object') {
-    return JSON.stringify(value);
-  }
-  return String(value);
-}
-
-/** Display label for a column header, used when copying a selection "with header". Falls back to the
- * string header / column id when the author's `name` is a ReactNode. */
-function headerText<TRow extends object>(column: TanstackColumn<TRow>): string {
-  const name = column.columnDef.meta?.jetstream?.column?.name;
-  if (typeof name === 'string') {
-    return name;
-  }
-  const header = column.columnDef.header;
-  if (typeof header === 'string') {
-    return header;
-  }
-  return column.id;
 }
 
 export interface UseGridKeyboardNavigationOptions<TRow extends object> {
@@ -595,7 +564,7 @@ export function useGridKeyboardNavigation<TRow extends object>({
         if (includeHeader) {
           const headerRecord: Record<string, string> = {};
           for (let colIndex = rect.minColumnIndex; colIndex <= rect.maxColumnIndex; colIndex++) {
-            headerRecord[`c${colIndex}`] = headerText(columns[colIndex]);
+            headerRecord[`c${colIndex}`] = getColumnHeaderText(columns[colIndex]);
           }
           records.push(headerRecord);
         }
@@ -605,7 +574,7 @@ export function useGridKeyboardNavigation<TRow extends object>({
           }
           const record: Record<string, string> = {};
           for (let colIndex = rect.minColumnIndex; colIndex <= rect.maxColumnIndex; colIndex++) {
-            record[`c${colIndex}`] = cellText(rows[rowIndex], columns[colIndex]);
+            record[`c${colIndex}`] = getCellText(rows[rowIndex], columns[colIndex]);
           }
           records.push(record);
         }

--- a/libs/ui/src/lib/data-table/grid/keyboard/useRangeDragAutoScroll.ts
+++ b/libs/ui/src/lib/data-table/grid/keyboard/useRangeDragAutoScroll.ts
@@ -1,0 +1,216 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { ActiveCell } from '../components/GridRow';
+import { computeEdgeScrollVelocity, createEdgeAutoScroller, EdgeScrollBox } from '../grid-auto-scroll';
+import { HEADER_ROW_ID, isSummaryRowId } from '../grid-constants';
+
+export interface UseRangeDragAutoScrollOptions {
+  /** The `.jgrid-scroller` element — it owns BOTH the vertical and horizontal scroll. */
+  getScrollElement: () => HTMLElement | null;
+  /** The `.jgrid` root. Hit-test results belonging to a different grid (a portaled overlay, a nested
+   * grid) are ignored — their foreign row ids would make the whole selection rectangle unresolvable. */
+  getRootElement: () => HTMLElement | null;
+  /** Width (px) of the sticky-left frozen band at the START of the grid. It overlays the scroller's
+   * left edge, so both the ramp and the hit test begin after it: a band wider than the ramp would
+   * swallow it, and a hit landing on the band resolves to a far-left column — snapping the rectangle's
+   * edge there and selecting every column in between, when what the pointer is actually reaching for is
+   * the scrolled-away content underneath. */
+  getLeftInset: () => number;
+  /** The current focus corner — used to skip extends that wouldn't change anything (one render each). */
+  getActiveCell: () => ActiveCell | null;
+  /** Extend the active selection range to the cell resolved under the pointer. */
+  onExtendToCell: (rowId: string, columnId: string) => void;
+  /** The pointer was released (or the window lost focus) — the caller clears its own drag state. */
+  onDragEnd: () => void;
+  /** Test seam: jsdom does not implement `document.elementFromPoint`. */
+  hitTest?: (clientX: number, clientY: number) => Element | null;
+}
+
+export interface RangeDragAutoScroll {
+  /** Begin pointer tracking + edge auto-scrolling for a range drag. Idempotent. */
+  start: () => void;
+  /** Detach listeners and cancel any in-flight frame. Idempotent. */
+  stop: () => void;
+}
+
+const defaultHitTest = (clientX: number, clientY: number): Element | null => document.elementFromPoint?.(clientX, clientY) ?? null;
+
+const clamp = (value: number, min: number, max: number): number => Math.min(Math.max(value, min), max);
+
+/**
+ * The drag lifecycle, built once per grid and driven through `getOptions` (which always resolves to the
+ * latest render's callbacks). Kept outside the component body so the listeners have stable identities
+ * without a web of `useCallback`s.
+ */
+function createRangeDragAutoScroller(getOptions: () => UseRangeDragAutoScrollOptions): RangeDragAutoScroll {
+  let isActive = false;
+  let pointer: { x: number; y: number } | null = null;
+  let pointerMoved = false;
+
+  /** The content viewport the pointer is measured against, with the sticky overlays subtracted. */
+  const getScrollBox = (element: HTMLElement): EdgeScrollBox => {
+    const { getRootElement, getLeftInset } = getOptions();
+    const rect = element.getBoundingClientRect();
+    const headerRect = getRootElement()?.querySelector('.jgrid-header')?.getBoundingClientRect();
+    return {
+      top: headerRect ? headerRect.bottom : rect.top,
+      left: rect.left + getLeftInset(),
+      // clientWidth/clientHeight rather than the rect, so a classic (non-overlay) scrollbar track —
+      // which the pointer can never hover — doesn't sit inside the ramp.
+      right: rect.left + element.clientWidth,
+      bottom: rect.top + element.clientHeight,
+    };
+  };
+
+  /**
+   * The hit landed on (or behind) the sticky-left band, so it names a column the drag isn't reaching
+   * for. Walk right through the same row to the first cell the band isn't covering. Resolving this
+   * geometrically rather than trusting the hit point's clamp matters with a wide pinned band: a
+   * sub-pixel column boundary can still return a pinned cell, and the drag would then scroll without
+   * ever selecting anything (nothing under the pointer is a legal target).
+   */
+  const resolveUncoveredCell = (cellEl: Element, box: EdgeScrollBox): Element | null => {
+    if (cellEl.getBoundingClientRect().left >= box.left - 0.5) {
+      return cellEl;
+    }
+    const siblings = cellEl.parentElement?.querySelectorAll<HTMLElement>(':scope > [data-row-id][data-col-id]') ?? [];
+    for (const sibling of siblings) {
+      if (sibling.getBoundingClientRect().left >= box.left - 0.5) {
+        return sibling;
+      }
+    }
+    return null;
+  };
+
+  /** Resolve the cell under the pointer and extend to it, skipping redundant and invalid targets. */
+  const extendToPointerCell = (element: HTMLElement, box: EdgeScrollBox) => {
+    const { getRootElement, getActiveCell, onExtendToCell, hitTest = defaultHitTest } = getOptions();
+    const root = getRootElement();
+    if (!pointer || !root) {
+      return;
+    }
+    const rect = element.getBoundingClientRect();
+    // Clamp into the region a range can actually cover: below the sticky header and to the right of the
+    // sticky-left band (see the hook doc), and inside the scroller on both axes. Pushing past the band
+    // is what makes a leftward drag march column by column instead of jumping to the first column.
+    const hitX = clamp(clamp(pointer.x, box.left + 1, rect.left + element.clientWidth - 1), 0, window.innerWidth - 1);
+    const hitY = clamp(clamp(pointer.y, box.top + 1, rect.top + element.clientHeight - 1), 0, window.innerHeight - 1);
+    const hitEl = hitTest(hitX, hitY)?.closest('[data-row-id][data-col-id]');
+    if (!hitEl || hitEl.closest('.jgrid') !== root) {
+      return;
+    }
+    const cellEl = resolveUncoveredCell(hitEl, box);
+    if (!cellEl) {
+      return;
+    }
+    const rowId = cellEl.getAttribute('data-row-id');
+    const columnId = cellEl.getAttribute('data-col-id');
+    if (!rowId || !columnId || rowId === HEADER_ROW_ID || isSummaryRowId(rowId)) {
+      return;
+    }
+    const activeCell = getActiveCell();
+    if (activeCell?.rowId === rowId && activeCell.columnId === columnId) {
+      return;
+    }
+    onExtendToCell(rowId, columnId);
+  };
+
+  const scroller = createEdgeAutoScroller({
+    getScrollElement: () => getOptions().getScrollElement(),
+    onFrame: (applied) => {
+      const element = getOptions().getScrollElement();
+      if (!element) {
+        return;
+      }
+      // Nothing moved and the pointer is where it was — the cell under it can't have changed.
+      if (applied.x === 0 && applied.y === 0 && !pointerMoved) {
+        return;
+      }
+      pointerMoved = false;
+      extendToPointerCell(element, getScrollBox(element));
+    },
+  });
+
+  const stop = () => {
+    if (!isActive) {
+      return;
+    }
+    isActive = false;
+    pointer = null;
+    pointerMoved = false;
+    scroller.stop();
+    window.removeEventListener('mousemove', handleMouseMove);
+    window.removeEventListener('blur', handleWindowBlur);
+  };
+
+  function handleMouseMove(event: MouseEvent) {
+    // A `mouseup` over browser chrome or an OS menu never reaches us, but the released button does.
+    if (event.buttons === 0) {
+      stop();
+      getOptions().onDragEnd();
+      return;
+    }
+    const element = getOptions().getScrollElement();
+    if (!element) {
+      return;
+    }
+    pointer = { x: event.clientX, y: event.clientY };
+    pointerMoved = true;
+    const box = getScrollBox(element);
+    scroller.setVelocity(computeEdgeScrollVelocity({ box, clientX: event.clientX, clientY: event.clientY }));
+  }
+
+  function handleWindowBlur() {
+    stop();
+    getOptions().onDragEnd();
+  }
+
+  return {
+    start() {
+      if (isActive) {
+        return;
+      }
+      isActive = true;
+      pointer = null;
+      pointerMoved = false;
+      window.addEventListener('mousemove', handleMouseMove, { passive: true });
+      window.addEventListener('blur', handleWindowBlur);
+    },
+    stop,
+  };
+}
+
+/**
+ * Edge auto-scroll for mouse range drag-selection.
+ *
+ * Cell-range extension is normally driven by each cell's `onMouseEnter`, which stops working the moment
+ * the cursor leaves the scroll viewport — there are no more cells under it. While a drag is active this
+ * hook tracks the pointer on `window`, scrolls the container when the pointer nears (or passes) an edge,
+ * and after each frame's scroll resolves whichever cell has moved under the pointer and extends to it.
+ * Nothing is listening or looping while no drag is in progress.
+ *
+ * The hit point is clamped into the region a selection rectangle can actually cover, which is what keeps
+ * this path in agreement with `onMouseEnter` (neither the header nor the action/select columns have a
+ * meaningful hover target). Both clamps are load-bearing:
+ *  - Above: a header/summary sentinel row id as the focus corner makes `getCellSelectionBounds()` drop
+ *    the range entirely (unresolvable corners are omitted, not clamped) — the selection would vanish.
+ *  - Left: the sticky-left frozen band covers the scrolled-away columns the drag is reaching for, so
+ *    resolving onto it snaps the rectangle's left edge to a far-left column and selects everything in
+ *    between.
+ */
+export function useRangeDragAutoScroll(options: UseRangeDragAutoScrollOptions): RangeDragAutoScroll {
+  // Live mirror so the drag controller (built once) always reads the current callbacks.
+  const optionsRef = useRef(options);
+  // eslint-disable-next-line react-hooks/refs
+  optionsRef.current = options;
+  const getOptions = useCallback(() => optionsRef.current, []);
+
+  // False positive: the initializer only stores `getOptions` on closures that run from event handlers
+  // and rAF frames — nothing reads the ref during render.
+  // eslint-disable-next-line react-hooks/refs
+  const [autoScroll] = useState(() => createRangeDragAutoScroller(getOptions));
+
+  // Never leave a rAF loop or a window listener behind if the grid unmounts mid-drag.
+  useEffect(() => autoScroll.stop, [autoScroll]);
+
+  return autoScroll;
+}


### PR DESCRIPTION
Follow-on polish to the TanStack v9 grid. Three related pieces:

## Copy context menu is now opt-out

An audit found only 11 of 31 grid instances offered a context menu — the other 20
fell through to the native browser menu because copy actions were opt-in and each
table had to wire up `contextMenuItems` plus a near-identical handler.

Omitting `contextMenuItems` now gives a table the standard copy cell/row/column/table
actions, dispatched by the grid. Passing a list or builder still replaces them; `[]`
opts out. Because the grid-owned implementation reads through the table model instead
of indexing raw rows by column key, it picks up filtered/sorted order, column
visibility and reorder for free — and copies `true`/`false` rather than
`[object Object]` from the permission editors.

Also fixed: header menus were ignored for tables that pass a *builder* (Deploy,
Manage Permissions → Fields), and group header rows now offer "Copy rows in group".

## Auto-scroll while drag-selecting a range

Drag-select only extended via per-cell `mouseenter`, so the selection stopped growing
at the edge of the viewport — you couldn't select beyond one screenful. Range drags now
edge-auto-scroll in both axes and both directions, extending the rectangle to whichever
cell moves under the pointer.

The scroll loop is time-based (px/sec), so speed is identical on 60Hz and 120Hz
displays; the column-reorder drag was folded onto the same scroller, which fixes its
long-standing 2×-on-ProMotion bug. Frozen columns and the sticky header are excluded as
drag targets — resolving onto either one used to snap the rectangle to the first column
and swallow everything in between.

## Two fixes found while testing

- Permission manager's expand/collapse toggle slid underneath the pinned columns when
  scrolled right, leaving no way to collapse a group.
- Deploy's "No metadata found" placeholder row copied as a blank line mid-range.

## Testing

~190 unit tests across the data table, including new coverage for the velocity ramp,
the rAF scroll loop, the drag hit test, and the right-click → menu → clipboard path.
The grid is now testable end-to-end: stubbing element layout makes the virtualizers
mount real rows under jsdom, which previously rendered nothing.

Worth exercising by hand: drag-select past each edge in query results and permission
manager, and the column-reorder drag.