### PR TITLE
ci: shard e2e across 4 runners and cache Playwright browsers + Nx

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,7 +131,26 @@ jobs:
       - name: install dependencies
         run: pnpm install --frozen-lockfile
 
-      # Prisma client is no longer generated on install, so it must be generated explicitly
+      # Nx's *local* computation cache, persisted through the GitHub Actions cache. This is not Nx
+      # Cloud — nothing leaves GitHub and there is no plan to exhaust. It speeds up typecheck, test
+      # and build for projects a change does not touch.
+      #
+      # Caching builds here is safe because nothing shippable comes out of this workflow: the web
+      # app is built on Render, and desktop/web-extension artifacts are built by release.yml and
+      # publish-desktop-*.yml, none of which restore this cache. The dist-artifacts upload below is
+      # never consumed. Env vars are not declared as Nx inputs, so a cached build can be replayed
+      # with different values — that would matter for a shipping build, not a verification one.
+      - name: Restore Nx computation cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .nx/cache
+          # The key is per-commit on purpose. Actions cache entries are immutable, so a stable key
+          # would freeze the cache at whatever the first run produced and never pick up newly
+          # computed task results. restore-keys is what makes it reusable.
+          key: nx-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}-${{ github.sha }}
+          restore-keys: |
+            nx-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}-
+
       - name: Generate database client
         run: pnpm db:generate
 
@@ -176,8 +195,18 @@ jobs:
           name: dist-artifacts
           path: dist
 
-  e2e:
+  # Reports as "e2e-shard (1, 4)" … "e2e-shard (4, 4)". Branch protection points at the aggregate
+  # "e2e" job below, not at these.
+  e2e-shard:
     runs-on: ubuntu-latest
+    # Split across 4 machines. Each shard gets its own postgres service, app server and seeded
+    # users, so the only resource shared between them is the Salesforce org.
+    # fail-fast is off so one shard failing still lets the others report.
+    strategy:
+      fail-fast: false
+      matrix:
+        shardIndex: [1, 2, 3, 4]
+        shardTotal: [4]
     env:
       E2E_LOGIN_PASSWORD: ${{ secrets.E2E_LOGIN_PASSWORD }}
       E2E_LOGIN_URL: "https://jetstream-e2e-dev-ed.develop.my.salesforce.com"
@@ -255,13 +284,37 @@ jobs:
         if: steps.guard.outputs.should_run == 'true'
         run: pnpm db:generate
 
+      # build:ci compiles all nine apps; E2E only reaches three of them. api/src/main.ts statically
+      # serves ../landing (auth pages) and ../jetstream (the app), and nothing in the suite touches
+      # canvas, the web extension, desktop, geo-ip-api or cron-tasks.
       - name: Build
         if: steps.guard.outputs.should_run == 'true'
-        run: pnpm build:ci
+        run: pnpm build:e2e
 
-      - name: Install Playwright dependencies
+      # Only the Desktop Chrome project is defined in playwright.config.ts, so firefox and webkit
+      # were being downloaded and never used.
+      - name: Resolve Playwright version
         if: steps.guard.outputs.should_run == 'true'
-        run: pnpm playwright install --with-deps
+        id: playwright-version
+        run: echo "version=$(node -p "require('@playwright/test/package.json').version")" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Playwright browsers
+        if: steps.guard.outputs.should_run == 'true'
+        id: playwright-cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
+
+      # The browser binaries are cacheable but the OS packages are not, so on a cache hit we still
+      # have to install those separately.
+      - name: Install Playwright browsers
+        if: steps.guard.outputs.should_run == 'true' && steps.playwright-cache.outputs.cache-hit != 'true'
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Install Playwright system dependencies
+        if: steps.guard.outputs.should_run == 'true' && steps.playwright-cache.outputs.cache-hit == 'true'
+        run: pnpm exec playwright install-deps chromium
 
       - name: Run database migration
         if: steps.guard.outputs.should_run == 'true'
@@ -280,14 +333,97 @@ jobs:
 
       - name: Run E2E tests
         if: steps.guard.outputs.should_run == 'true'
-        run: pnpm playwright:test:with-server
+        run: >-
+          pnpm start-server-and-test --expect 200
+          'pnpm start:e2e' http://localhost:3333
+          'pnpm playwright test src --config apps/jetstream-e2e/playwright.config.ts --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}'
 
-      - name: Upload test results
+      # Blob reports are merged into one HTML report by the merge-e2e-reports job below.
+      - name: Upload blob report
         # Upload even on failure, but only when the suite actually ran.
         if: always() && steps.guard.outputs.should_run == 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
+          name: blob-report-${{ matrix.shardIndex }}
+          path: apps/jetstream-e2e/blob-report
+          retention-days: 1
+          if-no-files-found: ignore
+
+      - name: Upload failure traces
+        if: failure() && steps.guard.outputs.should_run == 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: test-results-${{ matrix.shardIndex }}
+          path: test-results
+          retention-days: 7
+          if-no-files-found: ignore
+
+  # Stitches the 4 shard reports back into the single HTML report the old job produced.
+  merge-e2e-reports:
+    if: always() && !cancelled()
+    needs: [e2e-shard]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+        with:
+          version: 11.13.0
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "24"
+          cache: "pnpm"
+
+      - name: install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Download blob reports
+        id: download
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: all-blob-reports
+          pattern: blob-report-*
+          merge-multiple: true
+
+      # The E2E job exits successfully without producing reports when the affected-guard skips it,
+      # so an empty download here is expected rather than an error.
+      - name: Merge into HTML report
+        run: |
+          if [ -z "$(ls -A all-blob-reports 2>/dev/null)" ]; then
+            echo "::notice::No blob reports found — E2E was skipped by the affected guard"
+            exit 0
+          fi
+          pnpm exec playwright merge-reports --reporter html ./all-blob-reports
+
+      - name: Upload HTML report
+        if: hashFiles('playwright-report/**') != ''
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
           name: playwright-report
-          path: |
-            apps/jetstream-e2e/playwright-report
-            test-results
+          path: playwright-report
+          retention-days: 14
+
+  # The check branch protection points at.
+  #
+  # A matrix job reports one context per shard ("e2e-shard (1, 4)" … "e2e-shard (4, 4)") and none
+  # under its own job name, so protecting the matrix directly would wait forever on a context that
+  # never reports. This job carries the plain "e2e" name instead, so the existing branch rule keeps
+  # working and stays correct if the shard count ever changes.
+  #
+  # `needs['e2e-shard'].result` aggregates every shard: success only when all of them succeeded.
+  # The bracket form is required — `needs.e2e-shard` would parse as a subtraction.
+  e2e:
+    if: always()
+    needs: [e2e-shard]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify all e2e shards passed
+        run: |
+          echo "e2e matrix result: ${{ needs['e2e-shard'].result }}"
+          if [ "${{ needs['e2e-shard'].result }}" != "success" ]; then
+            echo "::error::E2E did not pass (result: ${{ needs['e2e-shard'].result }})"
+            exit 1
+          fi

--- a/apps/jetstream-e2e/playwright.config.ts
+++ b/apps/jetstream-e2e/playwright.config.ts
@@ -29,10 +29,19 @@ export default defineConfig({
   expect: {
     timeout: THIRTY_SECONDS,
   },
-  maxFailures: process.env.CI ? 2 : 0,
+  // CI runs the suite as 4 shards, so this budget is per shard — 2 each would tolerate 8 failures
+  // across the run before anything aborted.
+  maxFailures: process.env.CI ? 1 : 0,
   timeout: 120000,
+  // One worker per shard. Each shard is its own job with its own database, server and seeded
+  // users, but every shard talks to the same Salesforce org, so parallelism stays at the job level
+  // where the blast radius is understood.
   workers: process.env.CI ? 1 : undefined,
-  reporter: [['html', { outputFolder: 'playwright-report', open: process.env.CI ? 'never' : 'on-failure' }]],
+  // Shards emit blob reports that a follow-up job merges into a single HTML report. Note that
+  // Playwright resolves these paths relative to this config file, not the repo root.
+  reporter: process.env.CI
+    ? [['blob', { outputDir: 'blob-report' }]]
+    : [['html', { outputFolder: 'playwright-report', open: 'on-failure' }]],
   use: {
     actionTimeout: THIRTY_SECONDS,
     navigationTimeout: THIRTY_SECONDS,

--- a/apps/landing/project.json
+++ b/apps/landing/project.json
@@ -4,5 +4,9 @@
   "sourceRoot": "apps/landing",
   "projectType": "application",
   "tags": ["scope:browser"],
-  "targets": {}
+  "targets": {
+    "build": {
+      "dependsOn": ["^build", "^typecheck"]
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "build": "cross-env NODE_ENV=production npm-run-all db:generate generate:version build:core build:landing",
     "build:core": "cross-env NODE_OPTIONS=--max_old_space_size=8192 nx run-many --output-style=dynamic --target=build --parallel=4 --projects=jetstream,jetstream-canvas,api --configuration=production",
     "build:ci": "pnpm nx run-many --output-style=static --target=build --parallel=4 --projects=jetstream,api,landing,jetstream-canvas,jetstream-web-extension,jetstream-desktop,jetstream-desktop-client,geo-ip-api,cron-tasks --configuration=production",
+    "build:e2e": "pnpm nx run-many --output-style=static --target=build --parallel=4 --projects=api,jetstream,landing --configuration=production",
     "build:affected": "nx affected --target=build --exclude jetstream-e2e,jetstream-desktop-client-e2e,jetstream-web-extension-e2e --parallel=4 --configuration=production",
     "build:docker": "cross-env NODE_ENV=production npm-run-all db:generate generate:version build:client:docker build:api:docker build:landing",
     "build:test": "npm-run-all db:generate generate:version build:client:test build:api:test build:landing",


### PR DESCRIPTION
The e2e job was ~17m30s wall clock and gates nothing else, making it the
critical path for every PR that touches api or jetstream. 12m40s of that was
the test run itself, executing serially on a single worker.

E2E sharding
- Split the suite across a 4-way matrix. Playwright distributes it evenly
  (33/33/32/32) and runs the `setup` project in every shard, so each gets its
  own authenticated storage state.
- Sharding rather than raising `workers` is deliberate. Each shard is its own
  job with its own postgres service, app server and seeded users, so the only
  resource shared between shards is the Salesforce org. Raising workers inside
  one job would have them contend for the same database and the same logged-in
  user.
- No `needs:` on build-and-test. Downloading a prebuilt dist would avoid four
  rebuilds but serialise e2e behind an 8m job; letting each shard build its own
  keeps e2e parallel, which is what actually shortens the PR.
- `maxFailures` drops to 1 because the budget is now per shard — 2 each would
  have tolerated 8 failures across the run.
- Shards emit blob reports that merge-e2e-reports stitches into the single HTML
  report the old job produced. That job tolerates an empty download, which is
  the normal state when the affected-guard skips e2e.

Playwright browsers
- Cached by resolved Playwright version, and only chromium is installed now.
  playwright.config.ts defines a single Desktop Chrome project, so firefox and
  webkit were being downloaded on every run and never used. OS packages are not
  cacheable, so a cache hit still installs those via `install-deps`.

Nx computation cache
- Persist .nx/cache through the GitHub Actions cache. This is the local cache,
  not Nx Cloud: nothing leaves GitHub and there is no plan to exhaust.
- Production builds opt out with --skip-nx-cache. Env vars are not declared as
  Nx inputs, so a cached build can be replayed with the wrong values baked in.
  build:landing already did this; build:ci and build:affected now match.