### PR TITLE
feat(load): support loading JSON files

### DIFF
--- a/apps/docs/docs/load/load.mdx
+++ b/apps/docs/docs/load/load.mdx
@@ -37,8 +37,10 @@ After choosing which object you want to make changes to, you will need to provid
 **Jetstream supports the following file formats**:
 
 1. CSV (.csv)
-2. Excel (.xslx)
-3. Google Sheet
+2. Excel (.xlsx)
+3. JSON (.json)
+   1. Records downloaded as JSON from the Query tool can be uploaded as-is - nested relationship fields are converted to columns like `Owner.Name`
+4. Google Sheet
    1. Choose the "Google Drive" tab to connect your Google account
 
 Once you choose your file, you will be shown a preview of the data in a table, confirm that the data looks good.

--- a/apps/jetstream-desktop-client/src/app/components/core/useElectronActionLoader.tsx
+++ b/apps/jetstream-desktop-client/src/app/components/core/useElectronActionLoader.tsx
@@ -1,6 +1,7 @@
 import { DesktopAction } from '@jetstream/desktop/types';
 import { logger } from '@jetstream/shared/client-logger';
 import { parseFile } from '@jetstream/shared/ui-utils';
+import { getErrorMessage } from '@jetstream/shared/utils';
 import { fireToast, XlsxSheetSelectionModalPromise } from '@jetstream/ui';
 import { fromLoadRecordsState } from '@jetstream/ui-core';
 import { useSetAtom } from 'jotai';
@@ -51,6 +52,8 @@ export const useElectronActionLoader = () => {
         }
       } catch (ex) {
         logger.error('Error handling electron action:', ex);
+        // parseFile throws on unreadable content (e.g. malformed JSON), which would otherwise look like the app ignored the file
+        fireToast({ message: `There was an error reading your file. ${getErrorMessage(ex)}`, type: 'error' });
       }
     },
     [setInputFileData, setInputFileHeader, setInputFilename, setInputFilenameType],

--- a/apps/jetstream-desktop/src/services/protocol.service.ts
+++ b/apps/jetstream-desktop/src/services/protocol.service.ts
@@ -161,6 +161,8 @@ export function registerDownloadHandler() {
 export function registerFileOpenHandler() {
   app.on('open-file', async (event, filePath) => {
     event.preventDefault();
+    // Must stay in sync with mac.extendInfo.CFBundleDocumentTypes in electron-builder.config.js - macOS only
+    // routes open-file events for the types declared there
     function isAllowedExtension(extension?: string): boolean {
       switch (extension) {
         case '.csv':
@@ -176,11 +178,14 @@ export function registerFileOpenHandler() {
       if (!isAllowedExtension(extension)) {
         return;
       }
+      // Node reads files under 32KB into a shared pool, so `.buffer` is the entire 64KB pool rather than
+      // this file's bytes - slice out the view or every small file arrives surrounded by unrelated data.
+      const fileBuffer = readFileSync(filePath);
       const fileData: DesktopActionLoadRecord = {
         action: 'LOAD_RECORD',
         payload: {
           fileContent: {
-            content: readFileSync(filePath).buffer as ArrayBuffer,
+            content: fileBuffer.buffer.slice(fileBuffer.byteOffset, fileBuffer.byteOffset + fileBuffer.byteLength),
             filename: name,
             extension,
             isPasteFromClipboard: false,
@@ -194,7 +199,7 @@ export function registerFileOpenHandler() {
           newWindow.webContents.send(IpcEventChannel.action, fileData);
         });
       } else if (newWindow) {
-        newWindow.webContents.send(IpcEventChannel.fileDropped, fileData);
+        newWindow.webContents.send(IpcEventChannel.action, fileData);
       }
     } catch (ex) {
       logger.error('Error opening file:', getErrorMessageAndStackObj(ex));

--- a/libs/features/load-records/src/LoadRecords.tsx
+++ b/libs/features/load-records/src/LoadRecords.tsx
@@ -39,8 +39,6 @@ import { useSearchParams } from 'react-router';
 import LoadRecordsDataPreview from './components/LoadRecordsDataPreview';
 import LoadRecordsProgress from './components/LoadRecordsProgress';
 import LoadRecordsFieldMapping from './steps/FieldMapping';
-import LoadRecordsLoadAutomationDeploy from './steps/LoadRecordsAutomationDeploy';
-import LoadRecordsLoadAutomationRollback from './steps/LoadRecordsAutomationRollback';
 import PerformLoad from './steps/PerformLoad';
 import PerformLoadCustomMetadata from './steps/PerformLoadCustomMetadata';
 import LoadRecordsSelectObjectAndFile from './steps/SelectObjectAndFile';
@@ -48,15 +46,10 @@ import LoadRecordsSelectObjectAndFile from './steps/SelectObjectAndFile';
 const HEIGHT_BUFFER = 170;
 
 const steps: Step[] = [
-  { idx: 0, name: 'sobjectAndFile', label: 'Choose Object and Load File', active: true, enabled: true },
-  { idx: 1, name: 'fieldMapping', label: 'Map Fields', active: false, enabled: true },
-  { idx: 2, name: 'automationDeploy', label: 'Disable Automation (optional)', active: false, enabled: false },
-  { idx: 3, name: 'loadRecords', label: 'Load Data', active: false, enabled: true },
-  { idx: 4, name: 'automationRollback', label: 'Rollback Automation (optional)', active: false, enabled: false },
+  { name: 'sobjectAndFile', label: 'Choose Object and Load File' },
+  { name: 'fieldMapping', label: 'Map Fields' },
+  { name: 'loadRecords', label: 'Load Data' },
 ];
-
-const enabledSteps: Step[] = steps.filter((step) => step.enabled);
-const finalStep: Step = enabledSteps[enabledSteps.length - 1];
 
 export const LoadRecords = () => {
   useTitle(TITLES.LOAD);
@@ -67,7 +60,7 @@ export const LoadRecords = () => {
   // Capture pre-fill params (e.g. from browser extension popover) once on mount
   const [initialObjectName] = useState(() => searchParams.get('objectName'));
   const [hasAppliedInitialObjectName, setHasAppliedInitialObjectName] = useState(false);
-  const { defaultApiVersion, serverUrl, google_apiKey, google_appId, google_clientId } = useAtomValue(applicationCookieState);
+  const { google_apiKey, google_appId, google_clientId } = useAtomValue(applicationCookieState);
   const { hasGoogleDriveAccess, googleShowUpgradeToPro } = useAtomValue(googleDriveAccessState);
   const googleApiConfig = useMemo(
     () => ({ apiKey: google_apiKey, appId: google_appId, clientId: google_clientId }),
@@ -75,8 +68,7 @@ export const LoadRecords = () => {
   );
   const selectedOrg = useAtomValue(selectedOrgState);
   const orgType = useAtomValue(selectedOrgType);
-  // TODO: probably need this to know when to reset state
-  const [priorSelectedOrg, setPriorSelectedOrg] = useAtom(fromLoadRecordsState.priorSelectedOrg);
+  const [priorSelectedOrg, setPriorSelectedOrg] = useState<string | null>(null);
   const [sobjects, setSobjects] = useAtom(fromLoadRecordsState.sObjectsState);
   const [selectedSObject, setSelectedSObject] = useAtom(fromLoadRecordsState.selectedSObjectState);
   const isCustomMetadataObject = useAtomValue(fromLoadRecordsState.isCustomMetadataObject);
@@ -106,8 +98,8 @@ export const LoadRecords = () => {
   const [loadingFields, setLoadingFields] = useState<boolean>(false);
   const [didPerformDataLoad, setDidPerformDataLoad] = useState<boolean>(false);
 
-  const [currentStep, setCurrentStep] = useState<Step>(steps[0]);
-  const [currentStepIdx, setCurrentStepIdx] = useState<number>(0);
+  const [currentStepIdx, setCurrentStepIdx] = useState(0);
+  const currentStep = steps[currentStepIdx];
   const [currentStepText, setCurrentStepText] = useState<string>('');
   const [nextStepDisabled, setNextStepDisabled] = useState<boolean>(true);
   const [loadSummaryText, setLoadSummaryText] = useState<string>('');
@@ -158,7 +150,6 @@ export const LoadRecords = () => {
   }, [
     inputFileData,
     inputZipFileData,
-    resetBatchSizeState,
     resetTrialRunSizeState,
     resetTrialRunState,
     resetInsertNullsState,
@@ -212,7 +203,7 @@ export const LoadRecords = () => {
   useEffect(() => {
     if (priorSelectedOrg && selectedOrg && selectedOrg.uniqueId !== priorSelectedOrg) {
       setPriorSelectedOrg(selectedOrg.uniqueId);
-      setCurrentStep(steps[0]);
+      setCurrentStepIdx(0);
       resetLoadExistingRecordCount();
     } else {
       setPriorSelectedOrg(selectedOrg.uniqueId);
@@ -237,10 +228,6 @@ export const LoadRecords = () => {
       );
     }
   }, [hasAppliedInitialObjectName, initialObjectName, sobjects, setSelectedSObject, setSearchParams]);
-
-  useEffect(() => {
-    setCurrentStepIdx(enabledSteps.findIndex((step) => step.idx === currentStep.idx));
-  }, [currentStep]);
 
   const fetchFieldMetadata = useCallback(async () => {
     if (!selectedSObject) {
@@ -296,7 +283,6 @@ export const LoadRecords = () => {
   useEffect(() => {
     let currStepButtonText = '';
     let isNextStepDisabled = true;
-    let hasNextStep = true;
     switch (currentStep.name) {
       case 'sobjectAndFile':
         currStepButtonText = 'Continue to Map Fields';
@@ -307,10 +293,8 @@ export const LoadRecords = () => {
           !loadType ||
           (loadType === 'UPSERT' && !externalId) ||
           loadingFields;
-        hasNextStep = true;
         break;
       case 'fieldMapping':
-        // currStepButtonText = 'Continue to Disable Automation';
         currStepButtonText = 'Continue to Load Records';
         // Ensure at least one field is mapped
         isNextStepDisabled = !fieldMapping || Object.values(fieldMapping).filter((field) => field.targetField).length === 0;
@@ -332,30 +316,10 @@ export const LoadRecords = () => {
         if (!isNextStepDisabled && allowBinaryAttachment && inputZipFilename) {
           isNextStepDisabled = !Object.values(fieldMapping).find((field) => field.targetField === binaryAttachmentBodyField);
         }
-        hasNextStep = true;
-        break;
-      case 'automationDeploy':
-        currStepButtonText = 'Continue to Load Records';
-        isNextStepDisabled = false;
-        hasNextStep = true;
         break;
       case 'loadRecords':
-        // TODO: Only show this if automation was disabled
-        // currStepButtonText = 'Continue to Rollback Automation';
         currStepButtonText = 'No More Steps';
         isNextStepDisabled = true;
-        hasNextStep = false;
-        break;
-      // TODO: if we decide to add this back in, enable
-      // case 'automationRollback':
-      //   // TODO: Only show this if automation was disabled
-      //   currStepButtonText = 'No More Steps';
-      //   isNextStepDisabled = true;
-      //   hasNextStep = false;
-      //   break;
-      default:
-        currStepButtonText = currentStepText;
-        isNextStepDisabled = nextStepDisabled;
         break;
     }
     setCurrentStepText(currStepButtonText);
@@ -412,7 +376,7 @@ export const LoadRecords = () => {
   }
 
   function changeStep(changeBy: number) {
-    setCurrentStep(enabledSteps[currentStepIdx + changeBy]);
+    setCurrentStepIdx((priorStepIdx) => Math.min(Math.max(priorStepIdx + changeBy, 0), steps.length - 1));
     if (currentStepIdx === 0 && selectedSObject?.name) {
       recentHistoryItemsDb
         .addItemToRecentHistoryItems(selectedOrg.uniqueId, 'sobject', [selectedSObject.name])
@@ -423,7 +387,7 @@ export const LoadRecords = () => {
   // Cmd/Ctrl+Enter advances to the next step; mirrors the next-step button's disabled condition
   usePrimaryActionShortcut(() => changeStep(1), { disabled: nextStepDisabled || loading });
   // Cmd/Ctrl+Shift+Enter goes back one step; mirrors the go-back button's disabled condition
-  useGoBackShortcut(handleGoBackToPrev, { disabled: currentStep.idx === 0 || loading });
+  useGoBackShortcut(handleGoBackToPrev, { disabled: currentStepIdx === 0 || loading });
 
   const handleIsLoading = useCallback((isLoading: boolean) => {
     setLoading(isLoading);
@@ -431,7 +395,7 @@ export const LoadRecords = () => {
   }, []);
 
   function handleStartOver() {
-    setCurrentStep(enabledSteps[0]);
+    setCurrentStepIdx(0);
     resetSelectedSObjectState();
     resetLoadTypeState();
     resetInputFileDataState();
@@ -466,7 +430,7 @@ export const LoadRecords = () => {
             <button
               data-testid="start-over-button"
               className="slds-button slds-button_neutral collapsible-button collapsible-button-md"
-              disabled={(currentStep.idx === 0 && !inputFileData && !selectedSObject) || loading}
+              disabled={(currentStepIdx === 0 && !inputFileData && !selectedSObject) || loading}
               onClick={() => handleStartOver()}
             >
               <Icon type="utility" icon="refresh" className="slds-button__icon slds-button__icon_left" />
@@ -483,7 +447,7 @@ export const LoadRecords = () => {
               <button
                 data-testid="prev-step-button"
                 className="slds-button slds-button_neutral"
-                disabled={currentStep.idx === 0 || loading}
+                disabled={currentStepIdx === 0 || loading}
                 onClick={() => handleGoBackToPrev()}
               >
                 <Icon type="utility" icon="back" className="slds-button__icon slds-button__icon_left" />
@@ -578,11 +542,6 @@ export const LoadRecords = () => {
                 />
               </span>
             )}
-            {currentStep.name === 'automationDeploy' && selectedSObject && (
-              <span>
-                <LoadRecordsLoadAutomationDeploy />
-              </span>
-            )}
             {currentStep.name === 'loadRecords' && selectedSObject && inputFileData && (
               <span>
                 {!isCustomMetadataObject ? (
@@ -600,8 +559,6 @@ export const LoadRecords = () => {
                   />
                 ) : (
                   <PerformLoadCustomMetadata
-                    apiVersion={defaultApiVersion}
-                    serverUrl={serverUrl}
                     selectedOrg={selectedOrg}
                     orgType={orgType}
                     selectedSObject={selectedSObject.name}
@@ -614,14 +571,9 @@ export const LoadRecords = () => {
                 )}
               </span>
             )}
-            {currentStep.name === 'automationRollback' && (
-              <span>
-                <LoadRecordsLoadAutomationRollback />
-              </span>
-            )}
           </GridCol>
           <GridCol size={2}>
-            <LoadRecordsProgress currentStepIdx={currentStepIdx} enabledSteps={enabledSteps} />
+            <LoadRecordsProgress currentStepIdx={currentStepIdx} steps={steps} />
           </GridCol>
         </Grid>
       </AutoFullHeightContainer>

--- a/libs/features/load-records/src/components/LoadRecordsAssignmentRules.tsx
+++ b/libs/features/load-records/src/components/LoadRecordsAssignmentRules.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/react';
 import { queryWithCache } from '@jetstream/shared/data';
 import { useNonInitialEffect } from '@jetstream/shared/ui-utils';
-import { ApiMode, ListItem, Maybe, SalesforceOrgUi } from '@jetstream/types';
+import { ListItem, Maybe, SalesforceOrgUi } from '@jetstream/types';
 import { Checkbox, Grid, Picklist, Spinner } from '@jetstream/ui';
 import { Fragment, FunctionComponent, useCallback, useEffect, useRef, useState } from 'react';
 
@@ -15,14 +15,12 @@ const allowedObjects = new Set(['lead', 'case']);
 let currKey = 0;
 export interface LoadRecordsAssignmentRulesProps {
   selectedOrg: SalesforceOrgUi;
-  apiMode: ApiMode;
   selectedSObject: string;
   onAssignmentRule: (assignmentRuleId: Maybe<string>) => void;
 }
 
 export const LoadRecordsAssignmentRules: FunctionComponent<LoadRecordsAssignmentRulesProps> = ({
   selectedOrg,
-  apiMode,
   selectedSObject,
   onAssignmentRule,
 }) => {
@@ -70,7 +68,7 @@ export const LoadRecordsAssignmentRules: FunctionComponent<LoadRecordsAssignment
         currKey++;
         setPickListKey(currKey);
       }
-    } catch (ex) {
+    } catch {
       if (isMounted.current) {
         setLoading(false);
       }

--- a/libs/features/load-records/src/components/LoadRecordsDataPreview.tsx
+++ b/libs/features/load-records/src/components/LoadRecordsDataPreview.tsx
@@ -4,6 +4,7 @@ import { query } from '@jetstream/shared/data';
 import { formatNumber } from '@jetstream/shared/ui-utils';
 import { REGEX, groupByFlat } from '@jetstream/shared/utils';
 import { ContextMenuItem, DescribeGlobalSObjectResult, InsertUpdateUpsertDelete, Maybe, SalesforceOrgUi } from '@jetstream/types';
+import type { Column } from '@jetstream/ui';
 import {
   AutoFullHeightContainer,
   ContextAction,
@@ -23,7 +24,6 @@ import { applicationCookieState, selectSkipFrontdoorAuth } from '@jetstream/ui/a
 import { useAtom, useAtomValue } from 'jotai';
 import isNil from 'lodash/isNil';
 import { FunctionComponent, useCallback, useEffect, useRef, useState } from 'react';
-import type { Column } from '@jetstream/ui';
 import { ErrorBoundary } from 'react-error-boundary';
 
 const MAX_RECORD_FOR_PREVIEW = 100_000;
@@ -38,8 +38,6 @@ export interface LoadRecordsDataPreviewProps {
   data: Maybe<any[]>;
   header: Maybe<string[]>;
 }
-
-// function valueGetter: ((params: ValueGetterParams) => any) | string;
 
 function getLoadDescription(loadType: InsertUpdateUpsertDelete, totalRecordCount: number, omitTotalRecordCount: boolean, data: any[]) {
   let action: string;

--- a/libs/features/load-records/src/components/LoadRecordsDuplicateWarning.tsx
+++ b/libs/features/load-records/src/components/LoadRecordsDuplicateWarning.tsx
@@ -13,7 +13,7 @@ import {
   getColumnsForGenericTable,
 } from '@jetstream/ui';
 import { checkForDuplicateRecords } from '@jetstream/ui-core';
-import { FunctionComponent, useCallback, useEffect, useRef, useState } from 'react';
+import { FunctionComponent, useCallback, useEffect, useState } from 'react';
 
 const DUPE_COLUMN = '_DUPLICATE';
 
@@ -45,20 +45,12 @@ export const LoadRecordsDuplicateWarning: FunctionComponent<LoadRecordsDuplicate
   isCustomMetadata = false,
   externalId,
 }) => {
-  const isMounted = useRef(true);
   const [columns, setColumns] = useState<Maybe<Column<RowWithKey>[]>>(null);
   const [fields, setFields] = useState<string[]>([]);
   const [rows, setRows] = useState<Maybe<RowWithKey[]>>(null);
   const [isOpen, setIsOpen] = useState(false);
 
   const [duplicates] = useState(() => checkForDuplicateRecords(fieldMapping, inputFileData, loadType, isCustomMetadata, externalId));
-
-  useEffect(() => {
-    isMounted.current = true;
-    return () => {
-      isMounted.current = false;
-    };
-  }, []);
 
   useEffect(() => {
     if (duplicates && inputFileHeader) {

--- a/libs/features/load-records/src/components/LoadRecordsFieldMappingRelatedObject.tsx
+++ b/libs/features/load-records/src/components/LoadRecordsFieldMappingRelatedObject.tsx
@@ -4,11 +4,8 @@ import { FieldMappingItem, FieldMappingItemCsv, FieldRelatedEntity, ListItem, Sa
 import { ComboboxWithItems, Grid, Icon, Tooltip } from '@jetstream/ui';
 import { fetchRelatedFields, SELF_LOOKUP_KEY } from '@jetstream/ui-core';
 import { Fragment, FunctionComponent, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { getComboboxFieldName } from '../utils/field-mapping-utils';
 import LoadRecordsFieldMappingRowLookupOption from './LoadRecordsFieldMappingRowLookupOption';
-
-function getComboboxFieldName(item: ListItem) {
-  return `${item.label} (${item.value})`;
-}
 
 export interface LoadRecordsFieldMappingRelatedObjectProps {
   org: SalesforceOrgUi;

--- a/libs/features/load-records/src/components/LoadRecordsFieldMappingRow.tsx
+++ b/libs/features/load-records/src/components/LoadRecordsFieldMappingRow.tsx
@@ -5,6 +5,7 @@ import { Checkbox, ComboboxWithItems, Icon } from '@jetstream/ui';
 import classNames from 'classnames';
 import isNil from 'lodash/isNil';
 import { Fragment, FunctionComponent, useState } from 'react';
+import { getComboboxFieldName, getComboboxFieldTitle, getFieldListItems } from '../utils/field-mapping-utils';
 import { LoadRecordsFieldMappingRelatedObject } from './LoadRecordsFieldMappingRelatedObject';
 
 function getPreviewData(csvRowData: string | Date | boolean | number | null): string {
@@ -17,14 +18,6 @@ function getPreviewData(csvRowData: string | Date | boolean | number | null): st
   return `${csvRowData}`;
 }
 
-function getComboboxFieldName(item: ListItem) {
-  return `${item.label} (${item.value})`;
-}
-
-function getComboboxFieldTitle(item: ListItem) {
-  return `${item.label} (${item.value}) - ${item.secondaryLabel}`;
-}
-
 export interface LoadRecordsFieldMappingRowProps {
   org: SalesforceOrgUi;
   isCustomMetadataObject: boolean;
@@ -32,20 +25,8 @@ export interface LoadRecordsFieldMappingRowProps {
   fieldMappingItem: FieldMappingItemCsv;
   csvField: string;
   csvRowData: string;
-  binaryAttachmentBodyField?: string;
+  binaryAttachmentBodyField?: Maybe<string>;
   onSelectionChanged: (csvField: string, fieldMappingItem: FieldMappingItemCsv) => void;
-}
-
-function getFieldListItems(fields: FieldWithRelatedEntities[]) {
-  return fields.map((field): ListItem<string, FieldWithRelatedEntities> => ({
-    id: field.name,
-    label: field.label,
-    value: field.name,
-    secondaryLabel: field.name,
-    secondaryLabelOnNewLine: true,
-    tertiaryLabel: field.typeLabel,
-    meta: field,
-  }));
 }
 
 export const LoadRecordsFieldMappingRow: FunctionComponent<LoadRecordsFieldMappingRowProps> = ({

--- a/libs/features/load-records/src/components/LoadRecordsFieldMappingStaticRow.tsx
+++ b/libs/features/load-records/src/components/LoadRecordsFieldMappingStaticRow.tsx
@@ -4,6 +4,7 @@ import { useNonInitialEffect } from '@jetstream/shared/ui-utils';
 import { FieldMappingItemStatic, FieldWithRelatedEntities, ListItem, Maybe, PicklistFieldValues, SalesforceOrgUi } from '@jetstream/types';
 import { ComboboxWithItems, Icon, Picklist } from '@jetstream/ui';
 import { FunctionComponent, useEffect, useId, useMemo, useState } from 'react';
+import { getComboboxFieldName, getComboboxFieldTitle, getFieldListItems } from '../utils/field-mapping-utils';
 
 type ValueInputMode = NonNullable<FieldMappingItemStatic['valueInputMode']>;
 
@@ -15,14 +16,6 @@ const VALUE_INPUT_MODE_OPTIONS: ListItem[] = [
 // Salesforce caps a multipicklist write at 100 selected values, each up to 255 chars
 const MULTIPICKLIST_MAX_TEXT_LENGTH = 100 * 255;
 
-function getComboboxFieldName(item: ListItem) {
-  return `${item.label} (${item.value})`;
-}
-
-function getComboboxFieldTitle(item: ListItem) {
-  return `${item.label} (${item.value}) - ${item.secondaryLabel}`;
-}
-
 export interface LoadRecordsFieldMappingStaticRowProps {
   org: SalesforceOrgUi;
   fields: FieldWithRelatedEntities[];
@@ -30,18 +23,6 @@ export interface LoadRecordsFieldMappingStaticRowProps {
   isCustomMetadata?: boolean;
   onSelectionChanged: (fieldMappingItem: FieldMappingItemStatic) => void;
   onRemoveRow: () => void;
-}
-
-function getFieldListItems(fields: FieldWithRelatedEntities[]) {
-  return fields.map((field) => ({
-    id: field.name,
-    label: field.label,
-    value: field.name,
-    secondaryLabel: field.name,
-    secondaryLabelOnNewLine: true,
-    tertiaryLabel: field.typeLabel,
-    meta: field,
-  }));
 }
 
 export const LoadRecordsFieldMappingStaticRow: FunctionComponent<LoadRecordsFieldMappingStaticRowProps> = ({

--- a/libs/features/load-records/src/components/LoadRecordsProgress.tsx
+++ b/libs/features/load-records/src/components/LoadRecordsProgress.tsx
@@ -4,13 +4,13 @@ import { FunctionComponent } from 'react';
 
 export interface LoadRecordsProgressProps {
   currentStepIdx: number;
-  enabledSteps: Step[];
+  steps: Step[];
 }
 
-export const LoadRecordsProgress: FunctionComponent<LoadRecordsProgressProps> = ({ currentStepIdx, enabledSteps }) => {
+export const LoadRecordsProgress: FunctionComponent<LoadRecordsProgressProps> = ({ currentStepIdx, steps }) => {
   return (
     <ProgressStepIndicator currentStep={currentStepIdx} isVertical>
-      {enabledSteps.map((step, i) => (
+      {steps.map((step, i) => (
         <ProgressStepIndicatorListItem
           key={step.name}
           step={i}

--- a/libs/features/load-records/src/components/load-results/LoadRecordsBatchApiResults.tsx
+++ b/libs/features/load-records/src/components/load-results/LoadRecordsBatchApiResults.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/react';
 import { logger } from '@jetstream/shared/client-logger';
 import { ANALYTICS_KEYS } from '@jetstream/shared/constants';
-import { convertDateToLocale, formatNumber, useBrowserNotifications, tracker } from '@jetstream/shared/ui-utils';
+import { convertDateToLocale, formatNumber, tracker, useBrowserNotifications } from '@jetstream/shared/ui-utils';
 import { decodeHtmlEntity, flattenRecord, getErrorMessage, getSuccessOrFailureChar, pluralizeFromNumber } from '@jetstream/shared/utils';
 import {
   ApiMode,
@@ -164,6 +164,10 @@ export const LoadRecordsBatchApiResults = ({
         throw new Error('Aborted');
       }
 
+      if (!isMounted.current) {
+        return;
+      }
+
       const dateString = convertDateToLocale(new Date(), { timeStyle: 'medium' });
 
       if (!preparedDataResponse?.data.length) {
@@ -191,9 +195,11 @@ export const LoadRecordsBatchApiResults = ({
       }
     } catch (ex) {
       logger.error('ERROR', ex);
-      setStatus(STATUSES.ERROR);
-      setFatalError(getErrorMessage(ex));
-      onFinishRef.current({ success: 0, failure: inputFileData.length, failedRecords: [] });
+      if (isMounted.current) {
+        setStatus(STATUSES.ERROR);
+        setFatalError(getErrorMessage(ex));
+        onFinishRef.current({ success: 0, failure: inputFileData.length, failedRecords: [] });
+      }
       notifyUser(`Your ${LoadTypeDisplayNames[loadType]} data load failed`, {
         body: `❌ ${getErrorMessage(ex)}`,
         tag: 'load-records',
@@ -243,6 +249,10 @@ export const LoadRecordsBatchApiResults = ({
         () => isAborted.current,
       );
 
+      if (!isMounted.current) {
+        return;
+      }
+
       const dateString = convertDateToLocale(new Date(), { timeStyle: 'medium' });
       const failedRecords = processedRecordsRef.current.filter((record) => !record.success).map((record) => record.record);
       // Compute counts directly from the ref — processingStatusRef may be stale since it's updated in a useEffect
@@ -256,9 +266,11 @@ export const LoadRecordsBatchApiResults = ({
     } catch (ex) {
       const dateString = convertDateToLocale(new Date(), { timeStyle: 'medium' });
       logger.error('ERROR', ex);
-      setStatus(STATUSES.ERROR);
-      onFinishRef.current({ success: 0, failure: inputFileData.length, failedRecords: [] });
-      setEndTime(dateString);
+      if (isMounted.current) {
+        setStatus(STATUSES.ERROR);
+        onFinishRef.current({ success: 0, failure: inputFileData.length, failedRecords: [] });
+        setEndTime(dateString);
+      }
       notifyUser(`Your ${LoadTypeDisplayNames[loadType]} data load failed`, {
         body: `❌ ${getErrorMessage(ex)}`,
         tag: 'load-records',

--- a/libs/features/load-records/src/components/load-results/retry-record-map.ts
+++ b/libs/features/load-records/src/components/load-results/retry-record-map.ts
@@ -14,10 +14,6 @@ export function registerRetryRecord<TRow extends object, TRecord>(row: TRow, ori
   return row;
 }
 
-export function getRetryRecord<TRecord = unknown>(row: object): TRecord | undefined {
-  return retryRecordMap.get(row) as TRecord | undefined;
-}
-
 /**
  * Extract the original prepared records for a set of selected result rows. Rows without a
  * registered original record are skipped (and logged by the caller if needed).

--- a/libs/features/load-records/src/steps/FieldMapping.tsx
+++ b/libs/features/load-records/src/steps/FieldMapping.tsx
@@ -401,6 +401,7 @@ export const LoadRecordsFieldMapping = memo<LoadRecordsFieldMappingProps>(
                     fieldMappingItem={mappingItem}
                     csvField={header}
                     csvRowData={activeRow?.[header]}
+                    binaryAttachmentBodyField={binaryAttachmentBodyField}
                     onSelectionChanged={handleFieldMappingChange}
                   />
                 );

--- a/libs/features/load-records/src/steps/LoadRecordsAutomationDeploy.tsx
+++ b/libs/features/load-records/src/steps/LoadRecordsAutomationDeploy.tsx
@@ -1,9 +1,0 @@
-import { FunctionComponent } from 'react';
-
-export interface LoadRecordsLoadAutomationDeployProps {}
-
-export const LoadRecordsLoadAutomationDeploy: FunctionComponent<LoadRecordsLoadAutomationDeployProps> = () => {
-  return <div>Deploy Automation</div>;
-};
-
-export default LoadRecordsLoadAutomationDeploy;

--- a/libs/features/load-records/src/steps/LoadRecordsAutomationRollback.tsx
+++ b/libs/features/load-records/src/steps/LoadRecordsAutomationRollback.tsx
@@ -1,9 +1,0 @@
-import { FunctionComponent } from 'react';
-
-export interface LoadRecordsLoadAutomationRollbackProps {}
-
-export const LoadRecordsLoadAutomationRollback: FunctionComponent<LoadRecordsLoadAutomationRollbackProps> = () => {
-  return <div>Rollback Automation</div>;
-};
-
-export default LoadRecordsLoadAutomationRollback;

--- a/libs/features/load-records/src/steps/PerformLoad.tsx
+++ b/libs/features/load-records/src/steps/PerformLoad.tsx
@@ -458,12 +458,7 @@ export const LoadRecordsPerformLoad: FunctionComponent<LoadRecordsPerformLoadPro
           onChange={setSerialMode}
         />
 
-        <LoadRecordsAssignmentRules
-          selectedOrg={selectedOrg}
-          apiMode={apiMode}
-          selectedSObject={selectedSObject}
-          onAssignmentRule={setAssignmentRuleId}
-        />
+        <LoadRecordsAssignmentRules selectedOrg={selectedOrg} selectedSObject={selectedSObject} onAssignmentRule={setAssignmentRuleId} />
 
         <Input
           id="batch-size"

--- a/libs/features/load-records/src/steps/PerformLoadCustomMetadata.tsx
+++ b/libs/features/load-records/src/steps/PerformLoadCustomMetadata.tsx
@@ -30,7 +30,7 @@ import { ChangeEvent, Fragment, useCallback, useState } from 'react';
 import LoadRecordsDuplicateWarning from '../components/LoadRecordsDuplicateWarning';
 import LoadRecordsCustomMetadataResultsTable from '../components/load-results/LoadRecordsCustomMetadataResultsTable';
 
-export function getDeploymentStatusUrl(id: string) {
+function getDeploymentStatusUrl(id: string) {
   const address = encodeURIComponent(
     `/changemgmt/monitorDeploymentsDetails.apexp?asyncId=${id}&retURL=${encodeURIComponent('/changemgmt/monitorDeployment.apexp')}`,
   );
@@ -39,8 +39,6 @@ export function getDeploymentStatusUrl(id: string) {
 
 export interface PerformLoadCustomMetadataProps {
   selectedOrg: SalesforceOrgUi;
-  apiVersion: string;
-  serverUrl: string;
   orgType: Maybe<SalesforceOrgUiType>;
   selectedSObject: string;
   inputFileHeader: string[] | null;

--- a/libs/features/load-records/src/steps/SelectObjectAndFile.tsx
+++ b/libs/features/load-records/src/steps/SelectObjectAndFile.tsx
@@ -226,9 +226,14 @@ export const LoadRecordsSelectObjectAndFile = ({
                     id: 'load-record-file',
                     label: 'File to Load',
                     filename: inputFileType === 'local' ? inputFilename : undefined,
-                    accept: [INPUT_ACCEPT_FILETYPES.CSV, INPUT_ACCEPT_FILETYPES.TSV, INPUT_ACCEPT_FILETYPES.EXCEL],
+                    accept: [
+                      INPUT_ACCEPT_FILETYPES.CSV,
+                      INPUT_ACCEPT_FILETYPES.TSV,
+                      INPUT_ACCEPT_FILETYPES.EXCEL,
+                      INPUT_ACCEPT_FILETYPES.JSON,
+                    ],
                     allowFromClipboard: true,
-                    userHelpText: 'Choose CSV or XLSX file to upload',
+                    userHelpText: 'Choose a CSV, XLSX, or JSON file to upload',
                     onReadFile: handleFile,
                   }}
                   googleSelectorProps={{

--- a/libs/features/load-records/src/utils/field-mapping-utils.ts
+++ b/libs/features/load-records/src/utils/field-mapping-utils.ts
@@ -1,0 +1,21 @@
+import { FieldWithRelatedEntities, ListItem } from '@jetstream/types';
+
+export function getComboboxFieldName(item: ListItem) {
+  return `${item.label} (${item.value})`;
+}
+
+export function getComboboxFieldTitle(item: ListItem) {
+  return `${item.label} (${item.value}) - ${item.secondaryLabel}`;
+}
+
+export function getFieldListItems(fields: FieldWithRelatedEntities[]) {
+  return fields.map((field): ListItem<string, FieldWithRelatedEntities> => ({
+    id: field.name,
+    label: field.label,
+    value: field.name,
+    secondaryLabel: field.name,
+    secondaryLabelOnNewLine: true,
+    tertiaryLabel: field.typeLabel,
+    meta: field,
+  }));
+}

--- a/libs/features/load-records/src/utils/load-records-process.ts
+++ b/libs/features/load-records/src/utils/load-records-process.ts
@@ -380,7 +380,6 @@ export async function loadBatchApiData(
             record: originalBatchRecords[i],
           })) || [];
       } finally {
-        // replyToMessage('loadDataStatus', { records: responseWithRecord });
         statusCallback(responseWithRecord);
       }
     }

--- a/libs/shared/constants/src/lib/shared-constants.ts
+++ b/libs/shared/constants/src/lib/shared-constants.ts
@@ -1,6 +1,7 @@
 import type {
   InputAcceptTypeCsv,
   InputAcceptTypeExcel,
+  InputAcceptTypeJson,
   InputAcceptTypeTsv,
   InputAcceptTypeXml,
   InputAcceptTypeZip,
@@ -26,12 +27,14 @@ export const INPUT_ACCEPT_FILETYPES: {
   CSV: InputAcceptTypeCsv;
   TSV: InputAcceptTypeTsv;
   EXCEL: InputAcceptTypeExcel;
+  JSON: InputAcceptTypeJson;
   XML: InputAcceptTypeXml;
 } = {
   ZIP: '.zip',
   CSV: '.csv',
   TSV: '.tsv',
   EXCEL: '.xlsx',
+  JSON: '.json',
   XML: '.xml',
 };
 

--- a/libs/shared/ui-core/src/state-management/load-records.state.ts
+++ b/libs/shared/ui-core/src/state-management/load-records.state.ts
@@ -13,8 +13,6 @@ SUPPORTED_ATTACHMENT_OBJECTS.set('Document', { bodyField: 'Body' });
 SUPPORTED_ATTACHMENT_OBJECTS.set('ContentVersion', { bodyField: 'VersionData' });
 const DATE_FIELDS = new Set(['date', 'datetime']);
 
-export const priorSelectedOrg = atom<string | null>(null);
-
 export const sObjectsState = atomWithReset<DescribeGlobalSObjectResult[] | null>(null);
 
 export const selectedSObjectState = atomWithReset<DescribeGlobalSObjectResult | null>(null);

--- a/libs/shared/ui-utils/src/index.ts
+++ b/libs/shared/ui-utils/src/index.ts
@@ -20,6 +20,7 @@ export * from './lib/hooks/useNonInitialEffect';
 export * from './lib/hooks/useObservable';
 export * from './lib/hooks/useProfilesAndPermSets';
 export * from './lib/hooks/useTitle';
+export * from './lib/parse-json';
 export * from './lib/queries';
 export * from './lib/shared-browser-extension-helpers';
 export * from './lib/shared-browser-utils';

--- a/libs/shared/ui-utils/src/lib/__tests__/parse-file-json.spec.ts
+++ b/libs/shared/ui-utils/src/lib/__tests__/parse-file-json.spec.ts
@@ -1,0 +1,157 @@
+import { parseJson } from '../parse-json';
+import { parseFile } from '../shared-ui-utils';
+
+describe('parseJson', () => {
+  it('should parse a top-level array of records', () => {
+    const result = parseJson(JSON.stringify([{ Id: '001', Name: 'Acme' }]));
+    expect(result.data).toEqual([{ Id: '001', Name: 'Acme' }]);
+    expect(result.headers).toEqual(['Id', 'Name']);
+    expect(result.errors).toEqual([]);
+  });
+
+  it('should unwrap a records wrapper', () => {
+    const result = parseJson(JSON.stringify({ totalSize: 1, done: true, records: [{ Id: '001', Name: 'Acme' }] }));
+    expect(result.data).toEqual([{ Id: '001', Name: 'Acme' }]);
+    expect(result.headers).toEqual(['Id', 'Name']);
+  });
+
+  it('should treat a single object as one record', () => {
+    const result = parseJson(JSON.stringify({ Id: '001', Name: 'Acme' }));
+    expect(result.data).toEqual([{ Id: '001', Name: 'Acme' }]);
+  });
+
+  it('should return no data for an empty array', () => {
+    const result = parseJson('[]');
+    expect(result.data).toEqual([]);
+    expect(result.headers).toEqual([]);
+    expect(result.errors).toEqual([]);
+  });
+
+  it('should strip the Salesforce attributes envelope', () => {
+    const result = parseJson(
+      JSON.stringify([{ attributes: { type: 'Account', url: '/services/data/v64.0/sobjects/Account/001' }, Id: '001' }]),
+    );
+    expect(result.data).toEqual([{ Id: '001' }]);
+    expect(result.headers).toEqual(['Id']);
+  });
+
+  it('should keep an attributes key that is not a Salesforce envelope', () => {
+    const result = parseJson(JSON.stringify([{ Id: '001', attributes: { color: 'red' } }]));
+    expect(result.data).toEqual([{ Id: '001', 'attributes.color': 'red' }]);
+    expect(result.headers).toEqual(['Id', 'attributes.color']);
+  });
+
+  it('should keep an attributes key that has a type but extra keys beyond the envelope', () => {
+    const result = parseJson(JSON.stringify([{ Id: '001', attributes: { type: 'premium', tier: 'gold' } }]));
+    expect(result.data).toEqual([{ Id: '001', 'attributes.type': 'premium', 'attributes.tier': 'gold' }]);
+  });
+
+  it('should strip an AggregateResult envelope, which has no url', () => {
+    const result = parseJson(JSON.stringify([{ attributes: { type: 'AggregateResult' }, expr0: 5 }]));
+    expect(result.data).toEqual([{ expr0: 5 }]);
+    expect(result.headers).toEqual(['expr0']);
+  });
+
+  it('should drop the bare parent header left behind by an empty lookup', () => {
+    const result = parseJson(
+      JSON.stringify([
+        { Id: '1', Parent: null },
+        { Id: '2', Parent: { Name: 'Acme' } },
+      ]),
+    );
+    expect(result.headers).toEqual(['Id', 'Parent.Name']);
+    expect(result.data).toEqual([{ Id: '1' }, { Id: '2', 'Parent.Name': 'Acme' }]);
+  });
+
+  it('should drop bare parent headers at every nesting level', () => {
+    const result = parseJson(JSON.stringify([{ Owner: null }, { Owner: { Profile: null } }, { Owner: { Profile: { Name: 'Admin' } } }]));
+    expect(result.headers).toEqual(['Owner.Profile.Name']);
+  });
+
+  it('should keep a bare parent header when some row holds a real value there', () => {
+    const result = parseJson(JSON.stringify([{ Parent: 'a005' }, { Parent: { Name: 'Acme' } }]));
+    expect(result.headers).toEqual(['Parent', 'Parent.Name']);
+    expect(result.data).toEqual([{ Parent: 'a005' }, { 'Parent.Name': 'Acme' }]);
+  });
+
+  it('should flatten nested relationship records to dot-notation and strip their attributes', () => {
+    const result = parseJson(
+      JSON.stringify([
+        {
+          Id: '001',
+          Owner: { attributes: { type: 'User', url: '/services/data/v64.0/sobjects/User/005' }, Name: 'Bob', Profile: { Name: 'Admin' } },
+        },
+      ]),
+    );
+    expect(result.data).toEqual([{ Id: '001', 'Owner.Name': 'Bob', 'Owner.Profile.Name': 'Admin' }]);
+    expect(result.headers).toEqual(['Id', 'Owner.Name', 'Owner.Profile.Name']);
+  });
+
+  it('should serialize subquery records', () => {
+    const contacts = [{ Id: '003a' }, { Id: '003b' }];
+    const result = parseJson(JSON.stringify([{ Id: '001', Contacts: { totalSize: 2, done: true, records: contacts } }]));
+    expect(result.data).toEqual([{ Id: '001', Contacts: JSON.stringify(contacts) }]);
+  });
+
+  it('should serialize array values', () => {
+    const result = parseJson(JSON.stringify([{ Id: '001', Tags: ['a', 'b'] }]));
+    expect(result.data).toEqual([{ Id: '001', Tags: '["a","b"]' }]);
+  });
+
+  it('should build headers from every record, not just the first', () => {
+    const result = parseJson(JSON.stringify([{ Id: '001' }, { Name: 'Acme', Id: '002' }, { Website: 'example.com' }]));
+    expect(result.headers).toEqual(['Id', 'Name', 'Website']);
+  });
+
+  it('should preserve value types', () => {
+    const result = parseJson(JSON.stringify([{ Name: 'Acme', Amount: 12.5, IsActive: false, Description: null }]));
+    expect(result.data).toEqual([{ Name: 'Acme', Amount: 12.5, IsActive: false, Description: null }]);
+  });
+
+  it('should skip entries that are not records and report them', () => {
+    const result = parseJson(JSON.stringify([{ Id: '001' }, 'nope', 42, null]));
+    expect(result.data).toEqual([{ Id: '001' }]);
+    expect(result.errors).toEqual(['3 items were skipped because they are not records.']);
+  });
+
+  it('should serialize objects nested beyond the max flatten depth', () => {
+    // 12 levels deep, which is past the depth limit of 10
+    let deeplyNested: Record<string, unknown> = { value: 'found' };
+    for (let i = 0; i < 12; i++) {
+      deeplyNested = { nested: deeplyNested };
+    }
+    const result = parseJson(JSON.stringify([deeplyNested]));
+    expect(result.headers).toHaveLength(1);
+    expect(result.headers[0].split('.')).toHaveLength(11);
+    expect(result.data[0][result.headers[0]]).toEqual(JSON.stringify({ nested: { value: 'found' } }));
+  });
+
+  it('should throw for invalid JSON', () => {
+    expect(() => parseJson('{ not json')).toThrow(/not valid JSON/);
+  });
+
+  it('should throw when the content is not a record or array of records', () => {
+    expect(() => parseJson('"just a string"')).toThrow(/must contain a record/);
+    expect(() => parseJson('null')).toThrow(/must contain a record/);
+  });
+});
+
+describe('parseFile with JSON', () => {
+  it('should parse JSON when the extension is json', async () => {
+    const result = await parseFile(JSON.stringify([{ Id: '001', Name: 'Acme' }]), { extension: '.json' });
+    expect(result.data).toEqual([{ Id: '001', Name: 'Acme' }]);
+    expect(result.headers).toEqual(['Id', 'Name']);
+  });
+
+  it('should parse JSON provided as an ArrayBuffer', async () => {
+    const content = new TextEncoder().encode(JSON.stringify([{ Id: '001', Name: 'Acme' }]));
+    const result = await parseFile(content.buffer as ArrayBuffer, { extension: '.json' });
+    expect(result.data).toEqual([{ Id: '001', Name: 'Acme' }]);
+    expect(result.headers).toEqual(['Id', 'Name']);
+  });
+
+  it('should still parse csv content as csv', async () => {
+    const result = await parseFile('Id,Name\n001,Acme', { extension: '.csv' });
+    expect(result.data).toEqual([{ Id: '001', Name: 'Acme' }]);
+  });
+});

--- a/libs/shared/ui-utils/src/lib/parse-json.ts
+++ b/libs/shared/ui-utils/src/lib/parse-json.ts
@@ -1,0 +1,110 @@
+import { getErrorMessage } from '@jetstream/shared/utils';
+import isNil from 'lodash/isNil';
+import isPlainObject from 'lodash/isPlainObject';
+import isString from 'lodash/isString';
+
+/** Recursion guard against pathologically nested JSON - anything deeper is serialized instead of flattened */
+const MAX_JSON_FLATTEN_DEPTH = 10;
+
+/**
+ * Salesforce records carry a metadata envelope that is not loadable data. Matched on the exact key set so a
+ * user's own `attributes` column is left alone - `url` is optional because AggregateResult omits it.
+ */
+function isSalesforceAttributes(value: unknown): boolean {
+  if (!isPlainObject(value) || !isString((value as Record<string, unknown>).type)) {
+    return false;
+  }
+  return Object.keys(value as object).every((key) => key === 'type' || key === 'url');
+}
+
+/**
+ * Flatten a JSON record into the shape a CSV or XLSX row would have - nested objects become dot-notation keys
+ * (`Owner.Name`) and anything list-like is serialized, which mirrors how `flattenRecord()` builds a download.
+ */
+function flattenJsonRecord(record: Record<string, any>, output: Record<string, any> = {}, prefix = '', depth = 0): Record<string, any> {
+  for (const [key, value] of Object.entries(record)) {
+    if (key === 'attributes' && isSalesforceAttributes(value)) {
+      continue;
+    }
+    const path = prefix ? `${prefix}.${key}` : key;
+    if (Array.isArray(value)) {
+      output[path] = JSON.stringify(value);
+    } else if (isPlainObject(value)) {
+      if (Array.isArray(value.records)) {
+        // Subquery results are wrapped in `{ totalSize, done, records }` - only the records are meaningful
+        output[path] = JSON.stringify(value.records);
+      } else if (depth >= MAX_JSON_FLATTEN_DEPTH) {
+        output[path] = JSON.stringify(value);
+      } else {
+        flattenJsonRecord(value, output, path, depth + 1);
+      }
+    } else {
+      output[path] = value;
+    }
+  }
+  return output;
+}
+
+/**
+ * Parse JSON file content into flat rows for the data loader.
+ *
+ * Accepts a top-level array of records, a `{ records: [] }` wrapper (the shape the Salesforce API and Jetstream's
+ * multi-sheet downloads use), or a single record object. Throws if the content cannot be read as records at all,
+ * since unlike a CSV there is no partial result worth showing the user.
+ */
+export function parseJson(content: string): {
+  data: any[];
+  headers: string[];
+  errors: string[];
+} {
+  let parsedContent: unknown;
+  try {
+    parsedContent = JSON.parse(content);
+  } catch (ex) {
+    throw new Error(`The file is not valid JSON. ${getErrorMessage(ex)}`);
+  }
+
+  let parsedRecords: unknown[];
+  if (Array.isArray(parsedContent)) {
+    parsedRecords = parsedContent;
+  } else if (isPlainObject(parsedContent) && Array.isArray((parsedContent as { records?: unknown[] }).records)) {
+    parsedRecords = (parsedContent as { records: unknown[] }).records;
+  } else if (isPlainObject(parsedContent)) {
+    parsedRecords = [parsedContent];
+  } else {
+    throw new Error('The file must contain a record or an array of records.');
+  }
+
+  const errors: string[] = [];
+  const data: Record<string, any>[] = [];
+  let skippedCount = 0;
+
+  parsedRecords.forEach((record) => {
+    if (!isPlainObject(record)) {
+      skippedCount++;
+      return;
+    }
+    data.push(flattenJsonRecord(record as Record<string, any>));
+  });
+
+  if (skippedCount > 0) {
+    errors.push(`${skippedCount} item${skippedCount === 1 ? ' was' : 's were'} skipped because they are not records.`);
+  }
+
+  // Records are allowed to omit keys, so every row contributes to the header list instead of just the first
+  const headerSet = new Set<string>();
+  data.forEach((record) => Object.keys(record).forEach((header) => headerSet.add(header)));
+  const headers = Array.from(headerSet);
+
+  // An empty lookup (`"Owner": null`) leaves a bare `Owner` header beside the `Owner.Name` that populated rows
+  // flatten to. That bare column holds nothing loadable, so it is dropped - but only when it is empty on every
+  // row, since a real value there is a scalar/object conflict the user should see rather than lose silently.
+  const emptyParentHeaders = new Set(
+    headers.filter(
+      (header) => headers.some((otherHeader) => otherHeader.startsWith(`${header}.`)) && data.every((record) => isNil(record[header])),
+    ),
+  );
+  data.forEach((record) => emptyParentHeaders.forEach((header) => delete record[header]));
+
+  return { data, headers: headers.filter((header) => !emptyParentHeaders.has(header)), errors };
+}

--- a/libs/shared/ui-utils/src/lib/shared-ui-utils.ts
+++ b/libs/shared/ui-utils/src/lib/shared-ui-utils.ts
@@ -63,6 +63,7 @@ import isUndefined from 'lodash/isUndefined';
 import type { IDisposable, editor } from 'monaco-editor';
 import { UnparseConfig, parse as parseCsv, unparse, unparse as unparseCsv } from 'papaparse';
 import * as XLSX from 'xlsx';
+import { parseJson } from './parse-json';
 
 initXlsx(XLSX);
 
@@ -1253,7 +1254,7 @@ export function readFile(file: File, type: 'text' | 'array_buffer' | 'data_url' 
 
 /**
  * Parse file
- * Supported Types: CSV / XLSX
+ * Supported Types: CSV / TSV / XLSX / JSON
  *
  * TODO: support other filetypes (.zip)
  *
@@ -1274,6 +1275,10 @@ export async function parseFile(
   errors: string[];
 }> {
   options = options || {};
+  if (options.extension === INPUT_ACCEPT_FILETYPES.JSON) {
+    // FileSelector reads .json as text, but the signature permits an ArrayBuffer, so decode rather than assume
+    return parseJson(isString(content) ? content : new TextDecoder().decode(content));
+  }
   if (!options.isBinaryString && isString(content)) {
     // csv - read from papaparse
     let csvResult = parseCsv(content, {

--- a/libs/types/src/lib/ui/load-records-types.ts
+++ b/libs/types/src/lib/ui/load-records-types.ts
@@ -27,14 +27,11 @@ export interface FieldRelatedEntity {
 }
 
 export interface Step {
-  idx: number;
   name: StepName;
   label: string;
-  active: boolean;
-  enabled: boolean;
 }
 
-export type StepName = 'sobjectAndFile' | 'fieldMapping' | 'automationDeploy' | 'loadRecords' | 'automationRollback';
+export type StepName = 'sobjectAndFile' | 'fieldMapping' | 'loadRecords';
 
 type RecordAttributesWithRelatedRecords = RecordAttributes & { relatedRecords: EntityParticleRecord[] };
 

--- a/libs/types/src/lib/ui/types.ts
+++ b/libs/types/src/lib/ui/types.ts
@@ -209,12 +209,14 @@ export type InputAcceptType =
   | InputAcceptTypeCsv
   | InputAcceptTypeTsv
   | InputAcceptTypeExcel
+  | InputAcceptTypeJson
   | InputAcceptTypeXml
   | InputAcceptTypeImage;
 export type InputAcceptTypeZip = '.zip';
 export type InputAcceptTypeCsv = '.csv';
 export type InputAcceptTypeTsv = '.tsv';
 export type InputAcceptTypeExcel = '.xlsx';
+export type InputAcceptTypeJson = '.json';
 export type InputAcceptTypeXml = '.xml';
 export type InputAcceptTypeImage = '.png' | '.jpg' | '.jpeg' | '.gif' | '.webp' | '.svg';
 

--- a/libs/ui/src/lib/form/file-selector/FileSelector.tsx
+++ b/libs/ui/src/lib/form/file-selector/FileSelector.tsx
@@ -8,7 +8,11 @@ import isString from 'lodash/isString';
 import { FunctionComponent, useCallback, useRef, useState } from 'react';
 import HelpText from '../../widgets/HelpText';
 import Icon from '../../widgets/Icon';
+import { getPastedFile } from './getPastedFile';
 import { useFilename } from './useFilename';
+
+/** Everything else is read as an ArrayBuffer, which is what the xlsx/zip parsers expect */
+const TEXT_FILE_EXTENSIONS: InputAcceptType[] = ['.csv', '.tsv', '.xml', '.json'];
 
 export interface FileSelectorProps {
   className?: string;
@@ -105,11 +109,12 @@ export const FileSelector: FunctionComponent<FileSelectorProps> = ({
           setSystemErrorMessage(null);
           setManagedFilename(null);
           handleFile(item.getAsFile());
-        } else if (item.kind === 'string' && accept?.includes('.csv')) {
+        } else if (item.kind === 'string') {
           item.getAsString((content) => {
-            if (content && content.split('\n').length > 1) {
-              setManagedFilename('Clipboard-Paste.csv');
-              onReadFile({ filename: 'Clipboard-Paste.csv', extension: '.csv', content, isPasteFromClipboard: true });
+            const pastedFile = getPastedFile(content, accept);
+            if (pastedFile) {
+              setManagedFilename(pastedFile.filename);
+              onReadFile({ ...pastedFile, isPasteFromClipboard: true });
             }
           });
         }
@@ -161,8 +166,7 @@ export const FileSelector: FunctionComponent<FileSelectorProps> = ({
 
       setManagedFilename(file.name);
 
-      const readAsArrayBuffer = extension !== '.csv' && extension !== '.tsv' && extension !== '.xml';
-      const content = await (readAsArrayBuffer ? readFile(file, 'array_buffer') : readFile(file, 'text'));
+      const content = await (TEXT_FILE_EXTENSIONS.includes(extension) ? readFile(file, 'text') : readFile(file, 'array_buffer'));
 
       onReadFile({ filename: file.name, extension, content });
     } catch (ex) {

--- a/libs/ui/src/lib/form/file-selector/__tests__/getPastedFile.spec.ts
+++ b/libs/ui/src/lib/form/file-selector/__tests__/getPastedFile.spec.ts
@@ -1,0 +1,44 @@
+import { getPastedFile } from '../getPastedFile';
+
+describe('getPastedFile', () => {
+  it('should return null for empty content', () => {
+    expect(getPastedFile('', ['.csv', '.json'])).toBeNull();
+  });
+
+  it('should return null when nothing is accepted', () => {
+    expect(getPastedFile('[{"Id":"001"}]', undefined)).toBeNull();
+    expect(getPastedFile('[{"Id":"001"}]', ['.xlsx'])).toBeNull();
+  });
+
+  it('should detect a JSON array', () => {
+    expect(getPastedFile('[{"Id":"001"}]', ['.csv', '.json'])).toEqual({
+      filename: 'Clipboard-Paste.json',
+      extension: '.json',
+      content: '[{"Id":"001"}]',
+    });
+  });
+
+  it('should detect a JSON object and tolerate leading whitespace', () => {
+    expect(getPastedFile('\n  {"Id":"001"}', ['.json'])?.extension).toEqual('.json');
+  });
+
+  it('should detect multi-line CSV', () => {
+    expect(getPastedFile('Id,Name\n001,Acme', ['.csv'])).toEqual({
+      filename: 'Clipboard-Paste.csv',
+      extension: '.csv',
+      content: 'Id,Name\n001,Acme',
+    });
+  });
+
+  it('should not treat a single-line string as CSV', () => {
+    expect(getPastedFile('just some text', ['.csv'])).toBeNull();
+  });
+
+  it('should not detect JSON when json is not accepted', () => {
+    expect(getPastedFile('[{"Id":"001"}]', ['.csv'])).toBeNull();
+  });
+
+  it('should fall back to CSV when json is accepted but the content is not json', () => {
+    expect(getPastedFile('Id,Name\n001,Acme', ['.csv', '.json'])?.extension).toEqual('.csv');
+  });
+});

--- a/libs/ui/src/lib/form/file-selector/getPastedFile.ts
+++ b/libs/ui/src/lib/form/file-selector/getPastedFile.ts
@@ -1,0 +1,21 @@
+import { InputAcceptType } from '@jetstream/types';
+
+/**
+ * Identify pasted clipboard text as a supported file, or null if the caller does not accept anything it looks like.
+ * JSON is checked first because it is valid on a single line, which the CSV heuristic would reject.
+ */
+export function getPastedFile(
+  content: string,
+  accept?: InputAcceptType[],
+): { filename: string; extension: InputAcceptType; content: string } | null {
+  if (!content) {
+    return null;
+  }
+  if (accept?.includes('.json') && ['[', '{'].includes(content.trim().charAt(0))) {
+    return { filename: 'Clipboard-Paste.json', extension: '.json', content };
+  }
+  if (accept?.includes('.csv') && content.split('\n').length > 1) {
+    return { filename: 'Clipboard-Paste.csv', extension: '.csv', content };
+  }
+  return null;
+}


### PR DESCRIPTION
The Query tool downloads records as JSON but the data loader only accepted CSV/TSV/XLSX and Google Sheets, so that download could not be loaded back.

parseFile now handles .json. It accepts a top-level array, a `{ records: [] }` wrapper, or a single object; strips the Salesforce `attributes` envelope; and flattens nested relationships to dot-notation headers (`Owner.Name`) so rows match the shape CSV and XLSX already produce. Headers are the union of keys across all records since JSON rows may omit fields, and the bare header left behind by an empty lookup is dropped unless some row holds a real value there. JSON can also be pasted from the clipboard.

Desktop "Open With" is deliberately unchanged: macOS only routes open-file events for types declared in CFBundleDocumentTypes, which lists csv and xlsx.

Fix two pre-existing bugs on that desktop file-open path, found while scoping the above:

- readFileSync(path).buffer handed off Node's shared 64KB pool rather than the file's bytes, corrupting every file under 32KB. Now sliced to the buffer's own view, which also repairs the existing csv and xlsx paths.
- The non-loading branch sent on IpcEventChannel.fileDropped, which nothing subscribes to; it now sends on `action` like its sibling. Read failures also surface a toast instead of only a console log.

Fix the attachment body field being lost on a manual remap: FieldMapping never passed binaryAttachmentBodyField to the mapping row, so isBinaryBodyField always resolved false and the zip contents were never attached.

Clean up cruft left by the feature-library migration (3dbed4b07): drop the never-enabled automationDeploy/automationRollback steps and their placeholder components, the write-only `finalStep` and `hasNextStep` locals, props that were passed but never read, and an unused retry-map export. Step state now holds an index rather than the step object, so `Step` loses `idx`, `active`, and `enabled`. Field-mapping combobox helpers are deduped into utils/field-mapping-utils.