### PR TITLE
fix: show error message if fetching profile fails

### DIFF
--- a/libs/shared/data/src/lib/__tests__/client-data-data-helper.spec.ts
+++ b/libs/shared/data/src/lib/__tests__/client-data-data-helper.spec.ts
@@ -1,0 +1,98 @@
+import { HTTP } from '@jetstream/shared/constants';
+import { AxiosError, type AxiosResponse, type InternalAxiosRequestConfig } from 'axios';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { AxiosAdapterConfig, handleRequest } from '../client-data-data-helper';
+import { ApiRequestError, isAuthenticationFailure } from '../client-data-errors';
+
+const mockedAdapter = vi.fn<(config: InternalAxiosRequestConfig) => Promise<AxiosResponse>>();
+
+function successResponse(config: InternalAxiosRequestConfig, data: unknown): AxiosResponse {
+  return { config, data: { data }, status: 200, statusText: 'OK', headers: {}, request: {} };
+}
+
+function networkError(): AxiosError {
+  return new AxiosError('Network Error', AxiosError.ERR_NETWORK, {} as InternalAxiosRequestConfig, {});
+}
+
+function errorResponse(status: number, message: string): AxiosError {
+  const config = { method: 'get', url: '/api/me' } as InternalAxiosRequestConfig;
+  return new AxiosError(`Request failed with status code ${status}`, AxiosError.ERR_BAD_RESPONSE, config, {}, {
+    config,
+    data: { error: true, message },
+    status,
+    statusText: '',
+    headers: {},
+  } as AxiosResponse);
+}
+
+/** Attach the rejection handler up front so advancing timers cannot surface an unhandled rejection. */
+function captureResult<T>(promise: Promise<T>): Promise<T | Error> {
+  return promise.catch((ex: Error) => ex);
+}
+
+describe('handleRequest', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockedAdapter.mockReset();
+    AxiosAdapterConfig.adapter = mockedAdapter;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    AxiosAdapterConfig.adapter = undefined;
+  });
+
+  // The retried request is issued by a nested axios instance that does not itself carry the retry
+  // interceptor, so the chain stops after one retry regardless of `RETRY_CONFIG.retry`.
+  it('retries GET /api/me when the request never reaches the server, then reports the failure', async () => {
+    mockedAdapter.mockRejectedValue(networkError());
+
+    const result = captureResult(handleRequest({ method: 'GET', url: '/api/me' }));
+    await vi.runAllTimersAsync();
+    const error = await result;
+
+    expect(mockedAdapter).toHaveBeenCalledTimes(2);
+    // The retry must go back through the configured adapter, which is the only transport the
+    // desktop, extension and canvas apps have
+    expect(mockedAdapter.mock.calls[1][0].headers[HTTP.HEADERS.X_RETRY]).toBe('1');
+    // A failure with no response must stay distinguishable from one the server rejected
+    expect(error).toBeInstanceOf(ApiRequestError);
+    expect((error as ApiRequestError).status).toBeNull();
+    expect(isAuthenticationFailure(error)).toBe(false);
+  });
+
+  it('retries GET /api/me on a server error and returns the retried response', async () => {
+    mockedAdapter
+      .mockRejectedValueOnce(errorResponse(503, 'Service Unavailable'))
+      .mockImplementationOnce((config) => Promise.resolve(successResponse(config, { id: 'user-1' })));
+
+    const result = captureResult(handleRequest({ method: 'GET', url: '/api/me' }));
+    await vi.runAllTimersAsync();
+
+    expect(await result).toEqual({ data: { id: 'user-1' } });
+    expect(mockedAdapter).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not retry GET /api/me when the server says the user is not authenticated', async () => {
+    mockedAdapter.mockRejectedValue(errorResponse(401, 'Unauthorized'));
+
+    const result = captureResult(handleRequest({ method: 'GET', url: '/api/me' }));
+    await vi.runAllTimersAsync();
+    const error = await result;
+
+    expect(mockedAdapter).toHaveBeenCalledTimes(1);
+    expect((error as ApiRequestError).status).toBe(401);
+    expect(isAuthenticationFailure(error)).toBe(true);
+  });
+
+  it('leaves endpoints outside the retry allowlist alone', async () => {
+    mockedAdapter.mockRejectedValue(networkError());
+
+    const result = captureResult(handleRequest({ method: 'GET', url: '/api/orgs' }));
+    await vi.runAllTimersAsync();
+    const error = await result;
+
+    expect(mockedAdapter).toHaveBeenCalledTimes(1);
+    expect(isAuthenticationFailure(error)).toBe(false);
+  });
+});

--- a/libs/shared/data/src/lib/client-data-data-helper.ts
+++ b/libs/shared/data/src/lib/client-data-data-helper.ts
@@ -27,7 +27,7 @@ import isString from 'lodash/isString';
 import { v4 as uuid } from 'uuid';
 import { getCacheItemHttp, saveCacheItemHttp } from './client-data-cache';
 import { SOBJECT_DESCRIBE_CACHED_RESPONSES } from './client-data-data-cached-responses';
-import { StepUpRequiredError } from './client-data-errors';
+import { ApiRequestError, StepUpRequiredError } from './client-data-errors';
 import { errorMiddleware } from './middleware';
 
 interface RequestOptions {
@@ -56,6 +56,9 @@ const RETRY_CONFIG = {
     /^\/api\/bulk\/([a-zA-Z0-9]+)\/([a-zA-Z0-9]+)$/,
     // Idempotent pagination — a transient failure mid-loop otherwise discards all previously fetched pages
     /^\/api\/query-more$/,
+    // Fetched once during app boot and there is no second chance at it — a blip here costs the user
+    // their entire session (see `fetchUserProfile`)
+    /^\/api\/me$/,
   ],
   methods: new Set(['GET']),
   statusCodes: new Set([429, 500, 502, 503, 504]),
@@ -269,7 +272,9 @@ function retryInterceptor(config: AxiosRequestConfig, options: RequestOptions = 
 
       options = { ...options, retryCount };
       config.headers = { ...config.headers, [HTTP.HEADERS.X_RETRY]: String(retryCount) };
-      const axiosInstance = axios.create({ ...config });
+      // The adapter must be carried over from `handleRequest`, otherwise the retry falls back to the
+      // browser transport and skips the desktop/extension/canvas message-passing bridge entirely.
+      const axiosInstance = axios.create({ ...config, adapter: AxiosAdapterConfig.adapter });
       axiosInstance.interceptors.request.use(requestInterceptor(options));
       axiosInstance.interceptors.response.use(responseInterceptor(options), responseErrorInterceptor(options));
       return await axiosInstance.request(config);
@@ -397,7 +402,9 @@ function responseErrorInterceptor(options: {
           ? 'A network error occurred - check your connection and try again.'
           : error.message || message;
     }
-    throw new Error(message);
+    // Carries the status so callers can distinguish a rejection by the server from a request that
+    // never completed — a plain `Error` in every other respect.
+    throw new ApiRequestError(message, error.response?.status ?? null);
   };
 }
 

--- a/libs/shared/data/src/lib/client-data-errors.ts
+++ b/libs/shared/data/src/lib/client-data-errors.ts
@@ -18,6 +18,38 @@ export class StepUpRequiredError extends Error {
 }
 
 /**
+ * A failed API request, carrying the HTTP status the server responded with (null when the request
+ * never completed — connection drop, offline, proxy kill). Call sites that must tell "the server
+ * rejected this" from "this never made it to the server" read {@link ApiRequestError.status};
+ * everything else keeps treating it as the plain `Error` it replaced.
+ *
+ * `name` is intentionally left as `Error`: every request failure used to be a plain `Error` and the
+ * error tracker groups by name, so overriding it would re-bucket every existing API error.
+ */
+export class ApiRequestError extends Error {
+  /** Marker so {@link isApiRequestError} holds across module instances, the way `isAxiosError` does. */
+  readonly isApiRequestError = true;
+  readonly status: number | null;
+
+  constructor(message: string, status: number | null = null) {
+    super(message);
+    this.status = status;
+  }
+}
+
+export function isApiRequestError(error: unknown): error is ApiRequestError {
+  return error instanceof Error && (error as Partial<ApiRequestError>).isApiRequestError === true;
+}
+
+/**
+ * True when the server explicitly rejected the request as unauthenticated or forbidden, as opposed
+ * to a network failure or a server error, which say nothing about whether the user is signed in.
+ */
+export function isAuthenticationFailure(error: unknown): boolean {
+  return isApiRequestError(error) && (error.status === 401 || error.status === 403);
+}
+
+/**
  * The user dismissed the re-authentication prompt. Not a failure - call sites should swallow this
  * silently rather than surfacing an error toast.
  */

--- a/libs/shared/ui-app-state/src/lib/__tests__/ui-app-state.spec.ts
+++ b/libs/shared/ui-app-state/src/lib/__tests__/ui-app-state.spec.ts
@@ -1,0 +1,116 @@
+import { ApiRequestError } from '@jetstream/shared/data';
+import type { UserProfileUi } from '@jetstream/types';
+import { createStore } from 'jotai';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockedGetUserProfile, mockedIsBrowserExtension, mockedIsCanvasApp, mockedIsDesktop, mockedApplyVerifiedFeatureFlags } = vi.hoisted(
+  () => ({
+    mockedGetUserProfile: vi.fn(),
+    mockedIsBrowserExtension: vi.fn(() => false),
+    mockedIsCanvasApp: vi.fn(() => false),
+    mockedIsDesktop: vi.fn(() => false),
+    mockedApplyVerifiedFeatureFlags: vi.fn((profile: UserProfileUi) => Promise.resolve(profile)),
+  }),
+);
+
+vi.mock('@jetstream/shared/data', async (importOriginal) => {
+  // The real error classification (`ApiRequestError` / `isAuthenticationFailure`) is what decides
+  // signed-out vs. transient failure, so it stays under test — only the network calls are replaced.
+  const actual = await importOriginal<typeof import('@jetstream/shared/data')>();
+  return {
+    ...actual,
+    getUserProfile: mockedGetUserProfile,
+    checkHeartbeat: vi.fn(() => Promise.resolve({ appInfo: {}, version: 'test', announcements: [] })),
+    getOrgs: vi.fn(() => Promise.resolve([])),
+    getOrgGroups: vi.fn(() => Promise.resolve([])),
+    getLocalStore: vi.fn(() => ({ getItem: vi.fn(() => Promise.resolve(null)), setItem: vi.fn() })),
+  };
+});
+
+vi.mock('@jetstream/shared/ui-utils', () => ({
+  applyVerifiedFeatureFlags: mockedApplyVerifiedFeatureFlags,
+  isBrowserExtension: mockedIsBrowserExtension,
+  isCanvasApp: mockedIsCanvasApp,
+  isDesktop: mockedIsDesktop,
+  getBrowserExtensionVersion: vi.fn(() => 'test'),
+  getOrgType: vi.fn(),
+  setItemInLocalStorage: vi.fn(),
+  setItemInSessionStorage: vi.fn(),
+}));
+
+const PROFILE = { id: 'user-1', userId: 'user-1', email: 'user@example.com' } as UserProfileUi;
+
+/**
+ * The profile fetch fires at module evaluation, so every scenario needs the module re-evaluated with
+ * the mocks already set up for it.
+ */
+async function loadAppState() {
+  vi.resetModules();
+  return await import('../ui-app-state');
+}
+
+describe('userProfileState', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedIsBrowserExtension.mockReturnValue(false);
+    mockedIsCanvasApp.mockReturnValue(false);
+    mockedIsDesktop.mockReturnValue(false);
+    mockedApplyVerifiedFeatureFlags.mockImplementation((profile: UserProfileUi) => Promise.resolve(profile));
+  });
+
+  it('resolves to the profile returned by the server', async () => {
+    mockedGetUserProfile.mockResolvedValue(PROFILE);
+
+    const { userProfileState } = await loadAppState();
+
+    await expect(createStore().get(userProfileState)).resolves.toEqual(PROFILE);
+    expect(mockedApplyVerifiedFeatureFlags).toHaveBeenCalledWith(PROFILE);
+  });
+
+  it.each([401, 403])('falls back to the logged out profile when the server rejects with %i', async (status) => {
+    mockedGetUserProfile.mockRejectedValue(new ApiRequestError('Unauthorized', status));
+
+    const { userProfileState, DEFAULT_PROFILE } = await loadAppState();
+
+    await expect(createStore().get(userProfileState)).resolves.toEqual(DEFAULT_PROFILE);
+  });
+
+  it.each([
+    ['a network failure', null],
+    ['a server error', 500],
+    ['rate limiting', 429],
+  ])('fails the boot rather than presenting the session as logged out after %s', async (_scenario, status) => {
+    const cause = new ApiRequestError('Request failed', status);
+    mockedGetUserProfile.mockRejectedValue(cause);
+
+    const { userProfileState, UserProfileUnavailableError } = await loadAppState();
+
+    const error = await Promise.resolve(createStore().get(userProfileState)).then(
+      () => null,
+      (ex) => ex,
+    );
+    expect(error).toBeInstanceOf(UserProfileUnavailableError);
+    expect(error.cause).toBe(cause);
+  });
+
+  it('keeps the logged out profile on desktop, where the main process supplies the real profile', async () => {
+    mockedIsDesktop.mockReturnValue(true);
+    mockedGetUserProfile.mockRejectedValue(new ApiRequestError('Network Error', null));
+
+    const { userProfileState, DEFAULT_PROFILE } = await loadAppState();
+
+    await expect(createStore().get(userProfileState)).resolves.toEqual(DEFAULT_PROFILE);
+  });
+
+  it.each([
+    ['browser extension', mockedIsBrowserExtension],
+    ['canvas app', mockedIsCanvasApp],
+  ])('uses the default profile for the %s without calling the server', async (_scenario, isCurrentApp) => {
+    isCurrentApp.mockReturnValue(true);
+
+    const { userProfileState, DEFAULT_PROFILE } = await loadAppState();
+
+    await expect(createStore().get(userProfileState)).resolves.toEqual(DEFAULT_PROFILE);
+    expect(mockedGetUserProfile).not.toHaveBeenCalled();
+  });
+});

--- a/libs/shared/ui-app-state/src/lib/ui-app-state.ts
+++ b/libs/shared/ui-app-state/src/lib/ui-app-state.ts
@@ -1,7 +1,7 @@
 import { getUserAbility } from '@jetstream/acl';
 import { logger } from '@jetstream/shared/client-logger';
 import { INDEXED_DB } from '@jetstream/shared/constants';
-import { checkHeartbeat, getLocalStore, getOrgGroups, getOrgs, getUserProfile } from '@jetstream/shared/data';
+import { checkHeartbeat, getLocalStore, getOrgGroups, getOrgs, getUserProfile, isAuthenticationFailure } from '@jetstream/shared/data';
 import {
   applyVerifiedFeatureFlags,
   getBrowserExtensionVersion,
@@ -209,11 +209,38 @@ async function fetchAppInfo(): Promise<AppInfo> {
   }
 }
 
+/**
+ * `GET /api/me` failed for a reason that does not mean the user is signed out — a network failure,
+ * a server error, a request that never completed.
+ *
+ * Falling back to {@link DEFAULT_PROFILE} in that case is not harmless: the app presents the session
+ * as logged out, which leaves the per-user Dexie and localforage stores unscoped for the rest of the
+ * page session, and every read or write against them throws (query history, api request history,
+ * recent items, saved mappings, preferences). Failing the boot instead puts the user in front of an
+ * error they can act on rather than an app that silently keeps no history.
+ */
+export class UserProfileUnavailableError extends Error {
+  constructor(options?: { cause?: unknown }) {
+    super('Your user profile could not be loaded.', options);
+    this.name = 'UserProfileUnavailableError';
+  }
+}
+
 async function fetchUserProfile(): Promise<UserProfileUi> {
   if (isBrowserExtension() || isCanvasApp()) {
     return DEFAULT_PROFILE;
   }
-  const userProfile = await getUserProfile().catch(() => DEFAULT_PROFILE);
+  const userProfile = await getUserProfile().catch((error: unknown) => {
+    // 401/403 is the genuine signed-out path — the response interceptor is already sending the user
+    // to the login page, so keep handing out the logged out profile as before.
+    // Desktop is exempt from the throw below: its authoritative profile comes from the main process
+    // (see the desktop `Login` component, which overwrites this atom before the app renders) and it
+    // must still start with no connectivity.
+    if (isAuthenticationFailure(error) || isDesktop()) {
+      return DEFAULT_PROFILE;
+    }
+    throw new UserProfileUnavailableError({ cause: error });
+  });
   // Verify the server's signature once here so downstream atoms read trusted flags synchronously.
   // On any failure this returns code defaults (fail-safe), so we never trust a tampered payload.
   return await applyVerifiedFeatureFlags(userProfile);
@@ -237,7 +264,13 @@ export const AnnouncementState = atom((get) => get(appInfoSyncState).announcemen
 
 export const isBrowserExtensionState = atom<boolean>(isBrowserExtension());
 
-export const userProfileState = atom<Promise<UserProfileUi> | UserProfileUi>(fetchUserProfile());
+const userProfilePromise = fetchUserProfile();
+// React surfaces the rejection to the error boundary when a component first reads the atom, but the
+// fetch starts at module evaluation — mark it handled so a failed profile fetch is not also reported
+// as an unhandled rejection before anything has rendered.
+userProfilePromise.catch(() => undefined);
+
+export const userProfileState = atom<Promise<UserProfileUi> | UserProfileUi>(userProfilePromise);
 
 export const analyticsState = atom<'accepted' | 'rejected' | null>(null);
 

--- a/libs/shared/ui-core/src/app/ErrorBoundaryFallback.tsx
+++ b/libs/shared/ui-core/src/app/ErrorBoundaryFallback.tsx
@@ -3,6 +3,7 @@ import { APP_ROUTES } from '@jetstream/shared/ui-router';
 import { tracker } from '@jetstream/shared/ui-utils';
 import { ensureError } from '@jetstream/shared/utils';
 import { Icon } from '@jetstream/ui';
+import { UserProfileUnavailableError } from '@jetstream/ui/app-state';
 import { FunctionComponent, useEffect } from 'react';
 import { FallbackProps } from 'react-error-boundary';
 import { Link } from 'react-router';
@@ -28,6 +29,29 @@ export const ErrorBoundaryFallback: FunctionComponent<FallbackProps> = ({ error:
 
   function resetPage() {
     window.location.reload();
+  }
+
+  // The profile fetch happens once per page load and its rejected promise lives as long as the page,
+  // so re-rendering the tree cannot recover from this one - only a reload can. Say what happened
+  // instead of the generic copy below, since this is usually a passing network or server problem.
+  if (_error instanceof UserProfileUnavailableError) {
+    return (
+      <div className="slds-card slds-box">
+        <p>We were unable to load your account, so Jetstream could not finish starting up.</p>
+        <p className="slds-m-top_x-small">
+          This is usually caused by a temporary network or server problem. Reload the page to try again - if it keeps happening, email{' '}
+          <a href="mailto:support@getjetstream.app" target="_blank" rel="noreferrer">
+            support@getjetstream.app
+          </a>
+          .
+        </p>
+        <div className="slds-m-top_large">
+          <button className="slds-button slds-button_brand" onClick={resetPage}>
+            Reload Page
+          </button>
+        </div>
+      </div>
+    );
   }
 
   return (


### PR DESCRIPTION
If fetching the profile failed, the app wold be left in an inconsistent state

Now we show a full-page error so the user can reload to recover - this would happen because of a network issue

A signed out user still gets a 401/403 and is logged out