### PR TITLE
chore: add CI log distillation and Playwright report extraction utilities

### DIFF
--- a/.claude/commands/fix-ci.md
+++ b/.claude/commands/fix-ci.md
@@ -1,0 +1,135 @@
+---
+description: Diagnose and fix a failed CI run — Playwright E2E, unit tests, typecheck, lint or build
+argument-hint: '[PR number | run url | --run <id> | --branch <name>] (default: current branch)'
+---
+
+CI is red. Your job is to find out **why**, decide whether it should be fixed in the app, in the
+test, or not at all, and then fix it. Work through the steps below.
+
+Arguments: `$ARGUMENTS` (e.g. nothing, `1870`, a run/job URL pasted from the browser, `--run <id>`).
+
+## Step 1 — Download the evidence
+
+```
+pnpm ci:failures <args>
+```
+
+Pass `$ARGUMENTS` straight through — the script takes a PR number, a run/job URL, `--run <id>`,
+`--branch <name>`, or nothing (current branch, newest failing run). Add `--force` only if you need
+to re-download a bundle you already have.
+
+Let it download the full Playwright report by default: the screenshots, page snapshot and trace it
+carries are what make an E2E failure diagnosable. Only pass `--no-report` when the user asks for a
+quick look — it reads the small JSON summary instead, which has the errors but none of the evidence
+files.
+
+It writes `tmp/ci-failures/<pr-or-branch>-<run-number>/` containing a distilled excerpt per failed
+job, the full logs, and — when the run produced a Playwright report — one folder per failed test
+with the error, the page snapshot taken at failure, screenshots, console errors and failed requests.
+
+## Step 2 — Orient
+
+Read **`summary.md` only**. It is a few KB and already contains the failing assertion, the code
+frame, and where every other piece of evidence lives. Do not read the full `logs/*.log` files unless
+the excerpt turns out to be insufficient — they are hundreds of KB of runner noise.
+
+Then establish the blame radius, which is the single most useful triage input:
+
+```
+git diff main...HEAD --stat
+```
+
+Does this branch touch the code the failure is in — or anything it depends on? Also check
+`- Local:` in the summary: if HEAD is not the commit that failed, some of what you find may already
+be fixed locally.
+
+## Step 3 — Classify every failure before fixing anything
+
+Failures are listed per job. For each one, decide which of these it is:
+
+| Class           | Signals                                                                                                  | What to do                                                   |
+| --------------- | -------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
+| **Product bug** | The branch touched this area; the test asserts behavior that used to work                                | Fix the app code                                             |
+| **Test drift**  | The branch deliberately changed the UI/API the test asserts on                                           | Update the test to the new intended behavior                 |
+| **Flake**       | Failure is unrelated to the diff, timing/ordering-dependent, or passed on retry (`FLAKY` in the summary) | Find the race; only fix it if the root cause is clear        |
+| **Infra**       | `Detected: infra`, registry/action/runner errors, no repo code involved                                  | Do not touch code — report it and suggest re-running the job |
+| **Gate job**    | The summary says the job produced almost no output                                                       | Ignore it; it mirrors another job's failure                  |
+
+A shard failure with `maxFailures` reached means the suite **stopped early** — other tests never
+ran, so "only one test failed" is not the same as "only one test is broken."
+
+## Step 4 — Investigate, cheapest evidence first
+
+**Playwright.** Read the per-test folder in this order, stopping as soon as you can explain it:
+
+1. `error.txt` — the failing locator/assertion and the code frame.
+2. `page-snapshot.md` — the accessibility tree at the moment of failure. This answers the most
+   common question directly: was the element missing entirely, or present under a different
+   name/role? Search it for the text the locator was looking for.
+3. `screenshot-*.png` — read the image when the snapshot is ambiguous.
+4. `console-errors.txt` / `network-failures.txt` — present only when there were any. The summary's
+   `- Trace:` line reports the counts; **zero of both means the app was not erroring**, so the
+   problem is the locator or the UI state, not a broken request.
+5. `trace.zip` via `pnpm exec playwright show-trace <path>` — only if you still cannot explain it,
+   and say so rather than guessing.
+
+Then read the spec and the component/page under test and compare against the snapshot.
+
+**Everything else.** The excerpt already contains the compiler/linter/test error and file:line. Open
+those files, read the surrounding code, and confirm the cause before changing anything.
+
+## Step 5 — Fix
+
+Fix the **cause**, not the symptom. These are never acceptable:
+
+- Adding `waitForTimeout`/arbitrary sleeps to make a locator resolve
+- `test.skip`, `test.fixme`, raising `retries`, or loosening an assertion to make it pass
+- `@ts-ignore`, `any`, or disabling a lint rule instead of fixing what it caught
+- Weakening a locator (e.g. dropping `exact`) when the real problem is a duplicate element
+
+If the only way you can make it pass is one of those, stop and report that instead — an honest
+"this needs a human, here is why" is the correct outcome.
+
+Follow the repo conventions in `CLAUDE.md`, and after editing TypeScript run `pnpm format` and
+`pnpm organize-imports <files>`.
+
+## Step 6 — Verify with the narrowest check that proves it
+
+Match the check to the failure — never run the whole suite when one file will do:
+
+| Failure       | Verify with                                             |
+| ------------- | ------------------------------------------------------- |
+| typecheck     | `pnpm nx run <project>:typecheck`                       |
+| unit test     | `pnpm nx test <project>` (add `-- <file>` for one spec) |
+| lint / format | `pnpm lint` / `pnpm format:check`                       |
+| build         | `pnpm nx run <project>:build`                           |
+| Playwright    | See below                                               |
+
+E2E is expensive here: a local run needs the apps built, postgres migrated and seeded, and a live
+Salesforce org, and CI shards against a shared org. **Do not run the E2E suite to check a hunch.**
+Reason from the evidence and the code. If a run is genuinely warranted, use the exact repro command
+from `summary.md` for that one test — it targets a single spec with `-g` — and tell the user what
+it requires before running it.
+
+## Step 7 — Report
+
+Summarize, per failure:
+
+- **What failed** — test/job name and the one-line error
+- **Classification** — from the table in Step 3
+- **Root cause** — what actually went wrong, in one or two sentences
+- **Fix** — files changed and why, or why you deliberately did not change anything
+- **Verification** — the command you ran and its result. If you could not verify (E2E), say so
+  plainly rather than implying it passes
+- **Needs a human** — anything unresolved, flaky, or infrastructure-related
+
+Do not commit or push. Leave the bundle in `tmp/` (it is git-ignored) so the user can open the HTML
+report or trace themselves.
+
+## Working on several failures at once
+
+If the run has three or more failures that are clearly independent (different jobs, different
+subsystems), investigating them in parallel with one subagent each is worthwhile — give each agent
+the bundle path, its own failure's section of the summary, and Steps 3-6, then merge the results
+into a single report. For one or two failures, do it inline: the context you build reading the first
+one usually explains the second.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -17,6 +17,11 @@
       "Bash(pnpm nx run landing:build)",
       "Bash(pnpm build:ci)",
       "Bash(gh api:*)",
+      "Bash(gh run list:*)",
+      "Bash(gh run view:*)",
+      "Bash(gh run download:*)",
+      "Bash(gh pr view:*)",
+      "Bash(pnpm ci:failures:*)",
       "Bash(pnpm why *)",
       "Bash(pnpm config *)",
       "Bash(pnpm exec *)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -349,15 +349,6 @@ jobs:
           retention-days: 1
           if-no-files-found: ignore
 
-      - name: Upload failure traces
-        if: failure() && steps.guard.outputs.should_run == 'true'
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: test-results-${{ matrix.shardIndex }}
-          path: test-results
-          retention-days: 7
-          if-no-files-found: ignore
-
   # Stitches the 4 shard reports back into the single HTML report the old job produced.
   merge-e2e-reports:
     if: always() && !cancelled()
@@ -390,13 +381,19 @@ jobs:
 
       # The E2E job exits successfully without producing reports when the affected-guard skips it,
       # so an empty download here is expected rather than an error.
-      - name: Merge into HTML report
+      #
+      # Both reporters run off one merge: `html` for a human to open, `json` as a machine-readable
+      # summary of every result. Only the JSON name needs directing; `html` defaults to
+      # ./playwright-report, which is what the upload below expects.
+      - name: Merge into HTML report and JSON summary
+        env:
+          PLAYWRIGHT_JSON_OUTPUT_NAME: playwright-summary.json
         run: |
           if [ -z "$(ls -A all-blob-reports 2>/dev/null)" ]; then
             echo "::notice::No blob reports found — E2E was skipped by the affected guard"
             exit 0
           fi
-          pnpm exec playwright merge-reports --reporter html ./all-blob-reports
+          pnpm exec playwright merge-reports --reporter html,json ./all-blob-reports
 
       - name: Upload HTML report
         if: hashFiles('playwright-report/**') != ''
@@ -405,6 +402,17 @@ jobs:
           name: playwright-report
           path: playwright-report
           retention-days: 14
+
+      # A few hundred KB against the HTML report's ~45MB, so it is worth keeping around longer.
+      # `pnpm ci:failures --no-report` reads this to explain a failure without the large download,
+      # and it is the only source left once the HTML report expires.
+      - name: Upload JSON summary
+        if: hashFiles('playwright-summary.json') != ''
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: playwright-summary
+          path: playwright-summary.json
+          retention-days: 30
 
   # The check branch protection points at.
   #

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "release-notes:generate": "zx ./scripts/generate-release-notes.ts",
     "release-notes:context": "node ./scripts/release-notes-context.mjs",
     "new-release-note": "zx ./scripts/new-release-note.mjs",
+    "ci:failures": "node ./scripts/ci-failures.mjs",
     "nx": "nx",
     "start": "nx serve",
     "start:api": "nx serve api",

--- a/scripts/ci-failures.mjs
+++ b/scripts/ci-failures.mjs
@@ -1,0 +1,544 @@
+#!/usr/bin/env node
+
+/**
+ * Download everything needed to diagnose a failed GitHub Actions run and unpack it into a folder
+ * that is readable without a browser.
+ *
+ * This script does NOT call any AI — it only gathers evidence. Run it yourself when CI goes red,
+ * or let the Claude Code `/fix-ci` slash command run it and work from what it produces.
+ *
+ * For every failed job it writes the full cleaned log plus a distilled excerpt containing the part
+ * that explains the failure. When the run produced a Playwright HTML report it also unpacks that
+ * report's embedded data and writes one folder per failed test: the error, the page snapshot taken
+ * at failure, screenshots, browser console errors, failed HTTP requests, and the trace.
+ *
+ * Output lands in `tmp/ci-failures/<pr-or-branch>-<run-number>/`, starting with `summary.md`.
+ *
+ * Usage:
+ *   pnpm ci:failures                       # latest failing run on the current branch
+ *   pnpm ci:failures 1870                  # latest failing run for PR #1870
+ *   pnpm ci:failures --run 31495580131     # a specific run id
+ *   pnpm ci:failures <github url>          # PR url, run url, or job url (pasted from the browser)
+ *   pnpm ci:failures --branch feat/thing --open
+ *
+ * Options:
+ *   --run <id>        target a specific workflow run
+ *   --branch <name>   target a branch instead of the current one
+ *   --repo <o/r>      target a different repository (default: this checkout's remote)
+ *   --workflow <name> only consider runs of this workflow (e.g. "CI")
+ *   --latest          use the most recent run even if it passed (default: newest failing run)
+ *   --force           re-download over an existing bundle
+ *   --no-report       skip the ~45MB HTML report and read the small JSON summary instead:
+ *                     every failing test with its error, but no screenshots, page snapshot or trace
+ *   --no-artifacts    skip artifact downloads entirely (job logs only)
+ *   --no-traces       skip trace extraction (no console/network evidence)
+ *   --open            open the Playwright HTML report when done
+ *   --out <dir>       write the bundle somewhere other than tmp/ci-failures/
+ */
+
+import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { mkdir, rm, writeFile } from 'node:fs/promises';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import minimist from 'minimist';
+import { distillJobLog, reproCommandFor } from './lib/ci-log-distiller.mjs';
+import { extractFailuresFromJsonSummary, extractPlaywrightFailures, playwrightReproCommand } from './lib/playwright-report.mjs';
+
+const require = createRequire(import.meta.url);
+const JSZip = require('jszip');
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const OUTPUT_ROOT = path.join(ROOT, 'tmp', 'ci-failures');
+const PLAYWRIGHT_ARTIFACT = 'playwright-report';
+const PLAYWRIGHT_SUMMARY_ARTIFACT = 'playwright-summary';
+const RUNS_TO_SCAN = 15;
+const FAILED_CONCLUSIONS = new Set(['failure', 'timed_out', 'cancelled', 'startup_failure']);
+
+const options = parseArgs(process.argv.slice(2));
+const repo = options.repo ?? currentRepoSlug();
+
+const run = await resolveRun();
+const jobs = await fetchJobs(run.id);
+const failedJobs = jobs.filter(({ conclusion }) => FAILED_CONCLUSIONS.has(conclusion));
+
+if (!failedJobs.length) {
+  console.log(`\n${run.workflowName} #${run.runNumber} (${run.conclusion ?? run.status}) has no failed jobs — nothing to download.`);
+  console.log(`  ${run.htmlUrl}\n`);
+  process.exit(0);
+}
+
+const bundleDir = options.out ?? path.join(OUTPUT_ROOT, bundleName());
+await prepareBundleDir();
+
+console.log(`\n${run.workflowName} #${run.runNumber} — ${failedJobs.length} failed job(s) on ${run.headBranch}`);
+console.log(`  ${run.htmlUrl}`);
+
+const jobReports = await collectJobLogs();
+const playwright = options.artifacts ? await collectPlaywrightReport() : null;
+
+const summary = buildSummary(jobReports, playwright);
+await writeFile(path.join(bundleDir, 'summary.md'), summary.markdown);
+await writeFile(path.join(bundleDir, 'summary.json'), `${JSON.stringify(summary.json, null, 2)}\n`);
+
+printConsoleSummary(jobReports, playwright);
+
+if (options.open && playwright?.reportDir) {
+  execFileSync('pnpm', ['exec', 'playwright', 'show-report', playwright.reportDir], { cwd: ROOT, stdio: 'inherit' });
+}
+
+// ---------------------------------------------------------------------------
+// arguments and run resolution
+// ---------------------------------------------------------------------------
+
+function parseArgs(argv) {
+  const parsed = minimist(argv, {
+    boolean: ['artifacts', 'report', 'traces', 'open', 'force', 'latest', 'help'],
+    string: ['run', 'branch', 'repo', 'workflow', 'out'],
+    alias: { h: 'help', 'run-id': 'run' },
+    default: { artifacts: true, report: true, traces: true },
+  });
+
+  if (parsed.help) {
+    printHelpAndExit();
+  }
+
+  parsed.runId = parsed.run || undefined;
+  parsed.out = parsed.out ? path.resolve(parsed.out) : undefined;
+  parsed._.forEach((value) => applyPositional(parsed, String(value)));
+
+  return parsed;
+}
+
+/** A bare number is a PR; a URL can carry a run id, a PR number, or both. */
+function applyPositional(parsed, value) {
+  if (/^\d+$/.test(value)) {
+    parsed.prNumber = Number(value);
+    return;
+  }
+
+  const runMatch = value.match(/actions\/runs\/(\d+)/);
+  const prFromQuery = value.match(/[?&]pr=(\d+)/);
+  const pullMatch = value.match(/\/pull\/(\d+)/);
+
+  if (runMatch) {
+    parsed.runId = runMatch[1];
+  }
+  if (prFromQuery || pullMatch) {
+    parsed.prNumber = Number((prFromQuery ?? pullMatch)[1]);
+  }
+  if (!runMatch && !prFromQuery && !pullMatch) {
+    throw new Error(`Unrecognized argument: ${value} (expected a PR number, a GitHub URL, or a flag)`);
+  }
+}
+
+function printHelpAndExit() {
+  const source = readFileSync(fileURLToPath(import.meta.url), 'utf8');
+  const doc = source.slice(source.indexOf('/**'), source.indexOf('*/'));
+  console.log(doc.replace(/^\/\*\*\n/, '').replace(/^ \* ?/gm, ''));
+  process.exit(0);
+}
+
+function gh(args, { json = true, buffer = false } = {}) {
+  const result = execFileSync('gh', args, {
+    cwd: ROOT,
+    maxBuffer: 512 * 1024 * 1024,
+    encoding: buffer ? 'buffer' : 'utf8',
+  });
+  if (buffer) {
+    return result;
+  }
+  return json ? JSON.parse(result) : result.trim();
+}
+
+function currentRepoSlug() {
+  return gh(['repo', 'view', '--json', 'nameWithOwner', '--jq', '.nameWithOwner'], { json: false });
+}
+
+function currentBranch() {
+  return execFileSync('git', ['rev-parse', '--abbrev-ref', 'HEAD'], { cwd: ROOT, encoding: 'utf8' }).trim();
+}
+
+function normalizeRun(raw) {
+  return {
+    id: raw.id,
+    runNumber: raw.run_number,
+    attempt: raw.run_attempt,
+    workflowName: raw.name,
+    headBranch: raw.head_branch,
+    headSha: raw.head_sha,
+    status: raw.status,
+    conclusion: raw.conclusion,
+    createdAt: raw.created_at,
+    htmlUrl: raw.html_url,
+    displayTitle: raw.display_title,
+    prNumber: options.prNumber ?? raw.pull_requests?.[0]?.number ?? null,
+  };
+}
+
+async function resolveRun() {
+  if (options.runId) {
+    return normalizeRun(gh(['api', `repos/${repo}/actions/runs/${options.runId}`]));
+  }
+
+  // A PR is resolved by its head commit so that forks and renamed branches still work, and also by
+  // its branch so that a push made after CI failed does not hide the failure behind a fresh run.
+  const queries = [];
+  if (options.prNumber) {
+    const pr = gh(['pr', 'view', String(options.prNumber), '--repo', repo, '--json', 'headRefName,headRefOid']);
+    queries.push({ head_sha: pr.headRefOid }, { branch: pr.headRefName });
+  } else {
+    queries.push({ branch: options.branch ?? currentBranch() });
+  }
+
+  const byId = new Map();
+  for (const filter of queries) {
+    const query = new URLSearchParams({ per_page: String(RUNS_TO_SCAN), ...filter });
+    const { workflow_runs: runs = [] } = gh(['api', `repos/${repo}/actions/runs?${query}`]);
+    runs.forEach((raw) => byId.set(raw.id, raw));
+  }
+
+  const candidates = [...byId.values()]
+    .filter(({ name }) => !options.workflow || name === options.workflow)
+    .sort((left, right) => new Date(right.created_at) - new Date(left.created_at));
+
+  if (!candidates.length) {
+    throw new Error(`No workflow runs found for ${options.prNumber ? `PR #${options.prNumber}` : (options.branch ?? currentBranch())}`);
+  }
+
+  const failed = candidates.find(({ conclusion }) => FAILED_CONCLUSIONS.has(conclusion));
+  const selected = options.latest ? candidates[0] : (failed ?? candidates[0]);
+
+  if (selected.id !== candidates[0].id) {
+    console.log(
+      `Note: the newest run ${candidates[0].conclusion ?? candidates[0].status}; using the newest failing run instead (--latest overrides).`,
+    );
+  }
+  if (selected.status !== 'completed') {
+    console.log(`Note: this run is still ${selected.status} — jobs that have not finished cannot report a failure yet.`);
+  }
+
+  return normalizeRun(selected);
+}
+
+async function fetchJobs(runId) {
+  const { jobs = [] } = gh(['api', `repos/${repo}/actions/runs/${runId}/jobs?per_page=100`]);
+  return jobs.map((job) => ({
+    id: job.id,
+    name: job.name,
+    conclusion: job.conclusion,
+    htmlUrl: job.html_url,
+    failedSteps: (job.steps ?? []).filter(({ conclusion }) => FAILED_CONCLUSIONS.has(conclusion)).map(({ name }) => name),
+  }));
+}
+
+function bundleName() {
+  const label = run.prNumber ? `pr-${run.prNumber}` : (run.headBranch ?? 'unknown').replace(/[^\w.-]+/g, '-');
+  return `${label}-${run.runNumber}`;
+}
+
+async function prepareBundleDir() {
+  if (existsSync(bundleDir)) {
+    if (!options.force) {
+      console.log(`\nBundle already exists at ${relative(bundleDir)} — refreshing it (pass --force to start clean).`);
+    } else {
+      await rm(bundleDir, { recursive: true, force: true });
+    }
+  }
+  await mkdir(bundleDir, { recursive: true });
+}
+
+/** Repo-relative path when the target is inside the repo, absolute when `--out` points elsewhere. */
+function relative(target) {
+  const relativePath = path.relative(ROOT, target);
+  if (!relativePath) {
+    return '.';
+  }
+  return relativePath.startsWith('..') ? target : relativePath;
+}
+
+function slug(value) {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+function truncate(value = '', max) {
+  return value.length > max ? `${value.slice(0, max)}\n… truncated, see the linked file …` : value;
+}
+
+function firstLine(value = '') {
+  return value.split('\n')[0].trim() || '(no message)';
+}
+
+// ---------------------------------------------------------------------------
+// logs
+// ---------------------------------------------------------------------------
+
+/**
+ * The whole run's logs come down as one small zip (a few hundred KB), which is far cheaper than
+ * `gh run view --log` per job. Entries are named `<index>_<job name>.txt`.
+ */
+async function collectJobLogs() {
+  const logsDir = path.join(bundleDir, 'logs');
+  await mkdir(logsDir, { recursive: true });
+
+  let archive;
+  try {
+    archive = await JSZip.loadAsync(gh(['api', `repos/${repo}/actions/runs/${run.id}/logs`], { buffer: true }));
+  } catch (error) {
+    console.warn(`  ! Could not download run logs (${error.message.split('\n')[0]}) — they may have expired.`);
+    return failedJobs.map((job) => ({ job, unavailable: true }));
+  }
+
+  const entries = Object.keys(archive.files).filter((name) => /^\d+_.+\.txt$/.test(name));
+
+  return Promise.all(
+    failedJobs.map(async (job) => {
+      const entry =
+        entries.find((name) => name.replace(/^\d+_/, '').replace(/\.txt$/, '') === job.name) ??
+        entries.find((name) => slug(name.replace(/^\d+_/, '').replace(/\.txt$/, '')) === slug(job.name));
+
+      if (!entry) {
+        return { job, unavailable: true };
+      }
+
+      const distilled = distillJobLog(await archive.file(entry).async('string'));
+      const fileBase = slug(job.name);
+      await writeFile(path.join(logsDir, `${fileBase}.log`), distilled.cleanedLog);
+      await writeFile(path.join(logsDir, `${fileBase}.failure.txt`), `${distilled.excerpt}\n`);
+
+      return {
+        job,
+        framework: distilled.framework,
+        failingCommand: distilled.failingCommand,
+        failedNxTasks: distilled.failedNxTasks,
+        likelyGateJob: distilled.likelyGateJob,
+        excerpt: distilled.excerpt,
+        fullLog: path.posix.join('logs', `${fileBase}.log`),
+        failureLog: path.posix.join('logs', `${fileBase}.failure.txt`),
+        repro: reproCommandFor(distilled.framework, distilled.failedNxTasks),
+      };
+    }),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// playwright artifacts
+// ---------------------------------------------------------------------------
+
+function downloadArtifact(name, targetDir) {
+  execFileSync('gh', ['run', 'download', String(run.id), '--repo', repo, '--name', name, '--dir', targetDir], {
+    cwd: ROOT,
+    stdio: 'inherit',
+  });
+}
+
+/**
+ * Prefer the full HTML report, which carries the screenshots, page snapshots and traces. Fall back
+ * to the small JSON summary when the report is unwanted (`--no-report`) or gone: it still yields
+ * every failing test with its error and code frame, for a download measured in KB rather than tens
+ * of MB.
+ */
+async function collectPlaywrightReport() {
+  const { artifacts = [] } = gh(['api', `repos/${repo}/actions/runs/${run.id}/artifacts?per_page=100`]);
+  const byName = (wanted) => artifacts.find(({ name, expired }) => name === wanted && !expired);
+
+  const reportArtifact = byName(PLAYWRIGHT_ARTIFACT);
+  const summary = byName(PLAYWRIGHT_SUMMARY_ARTIFACT);
+
+  // `--no-report` avoids the large *download*; a report already sitting in the bundle is free, and
+  // discarding it would silently downgrade a bundle that already had screenshots and traces.
+  const reportDir = path.join(bundleDir, 'playwright', 'report');
+  const reportOnDisk = existsSync(path.join(reportDir, 'index.html'));
+  const useReport = reportOnDisk || (options.report && Boolean(reportArtifact));
+
+  if (!useReport && !summary) {
+    if (!options.report && reportArtifact) {
+      console.log(`  ! --no-report was passed and this run has no ${PLAYWRIGHT_SUMMARY_ARTIFACT} artifact — using job logs only.`);
+    } else if (artifacts.some(({ name, expired }) => name === PLAYWRIGHT_ARTIFACT && expired)) {
+      console.log('  ! The Playwright artifacts for this run have expired — using job logs only.');
+    }
+    return null;
+  }
+
+  const failuresDir = path.join(bundleDir, 'playwright', 'failures');
+  await mkdir(failuresDir, { recursive: true });
+
+  if (useReport) {
+    if (!reportOnDisk) {
+      console.log(`  · downloading ${PLAYWRIGHT_ARTIFACT} (${(reportArtifact.size_in_bytes / 1024 / 1024).toFixed(1)} MB)…`);
+      await mkdir(reportDir, { recursive: true });
+      downloadArtifact(PLAYWRIGHT_ARTIFACT, reportDir);
+    }
+    try {
+      return { ...(await extractPlaywrightFailures(reportDir, failuresDir, { includeTraces: options.traces })), reportDir };
+    } catch (error) {
+      console.warn(`  ! Could not read the Playwright report: ${error.message} — trying the JSON summary.`);
+    }
+  }
+
+  if (!summary) {
+    return { failures: [] };
+  }
+
+  const summaryDir = path.join(bundleDir, 'playwright');
+  const summaryPath = path.join(summaryDir, 'playwright-summary.json');
+  if (!existsSync(summaryPath)) {
+    downloadArtifact(PLAYWRIGHT_SUMMARY_ARTIFACT, summaryDir);
+  }
+
+  try {
+    return await extractFailuresFromJsonSummary(summaryPath, failuresDir);
+  } catch (error) {
+    console.warn(`  ! Could not read the Playwright JSON summary: ${error.message}`);
+    return { failures: [] };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// summary
+// ---------------------------------------------------------------------------
+
+/** Whether the working tree is actually on the commit that failed, which changes how to read all of this. */
+function localCommitState() {
+  try {
+    const head = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: ROOT, encoding: 'utf8' }).trim();
+    if (head === run.headSha) {
+      return 'HEAD is the commit that failed';
+    }
+    try {
+      execFileSync('git', ['merge-base', '--is-ancestor', run.headSha, 'HEAD'], { cwd: ROOT, stdio: 'ignore' });
+      return `HEAD (${head.slice(0, 8)}) is ahead of the failing commit (${run.headSha.slice(0, 8)}) — local fixes may already cover this`;
+    } catch {
+      return `HEAD (${head.slice(0, 8)}) does not contain the failing commit (${run.headSha.slice(0, 8)}) — check out the run's branch before reproducing`;
+    }
+  } catch {
+    return 'unknown (not a git checkout?)';
+  }
+}
+
+function buildSummary(jobReports, playwright) {
+  const lines = [];
+  const push = (...values) => lines.push(...values);
+
+  push(`# CI failure — ${run.workflowName} #${run.runNumber}`, '');
+  push(`- Run: ${run.htmlUrl} (attempt ${run.attempt}, ${run.conclusion ?? run.status})`);
+  if (run.prNumber) {
+    push(`- PR: #${run.prNumber} — ${run.displayTitle}`);
+  }
+  push(`- Branch: \`${run.headBranch}\` @ \`${run.headSha?.slice(0, 8)}\``);
+  push(`- Local: ${localCommitState()}`);
+  push(`- Failed jobs: ${failedJobs.map(({ name }) => name).join(', ')}`);
+  push('');
+
+  if (playwright?.stats) {
+    const { total, expected, unexpected, flaky, skipped } = playwright.stats;
+    push(`Playwright: ${unexpected} failed, ${flaky} flaky, ${expected} passed, ${skipped} skipped (of ${total})`, '');
+  }
+
+  const failures = playwright?.failures ?? [];
+
+  push('## Failed jobs', '');
+  for (const report of jobReports) {
+    const { job } = report;
+    push(`### ${job.name}`);
+    push(`- Step: ${job.failedSteps.join(', ') || '(unknown)'} · ${job.htmlUrl}`);
+    if (report.unavailable) {
+      push('- Log unavailable (expired or not in the run archive)', '');
+      continue;
+    }
+    push(`- Detected: ${report.framework}${report.failedNxTasks.length ? ` · failed Nx tasks: ${report.failedNxTasks.join(', ')}` : ''}`);
+    push(`- Ran: \`${report.failingCommand.split('\n')[0].slice(0, 160)}\``);
+    push(`- Distilled excerpt: \`${report.failureLog}\` · full log: \`${report.fullLog}\``);
+    if (report.likelyGateJob) {
+      push("- This job produced almost no output — it is a gate reporting another job's failure, not a failure of its own.");
+    }
+    if (report.repro) {
+      push(`- Repro: \`${report.repro}\``);
+    }
+    // When the structured Playwright section below covers the same failure, the log excerpt only
+    // needs to establish context — it otherwise repeats every error once per retry.
+    const excerptBudget = report.framework === 'playwright' && failures.length ? 1200 : 2500;
+    push('', '```', truncate(report.excerpt, excerptBudget), '```', '');
+  }
+
+  if (failures.length) {
+    push('## Failed Playwright tests', '');
+    if (playwright.textOnly) {
+      push(
+        'Read from the small `playwright-summary` artifact: error text and code frames only. For the',
+        'screenshots, the page snapshot and the trace, re-run without `--no-report` while the',
+        '`playwright-report` artifact still exists (it is kept for 14 days).',
+        '',
+      );
+    }
+    failures.forEach((failure, index) => {
+      push(`### ${index + 1}. ${failure.title}`);
+      push(
+        `- Outcome: ${failure.outcome === 'flaky' ? 'FLAKY (passed on retry)' : 'failed'} after ${failure.attempts} attempt(s), project ${failure.projectName}`,
+      );
+      push(
+        `- Spec: \`${failure.specFile}:${failure.specLine}\`${failure.throwSite ? ` · threw at \`${failure.throwSite.file}:${failure.throwSite.line}\`` : ''}`,
+      );
+      push(`- Error: ${firstLine(failure.errors[0]?.message)}`);
+      push(`- Evidence: \`playwright/failures/${failure.dir}/\` → ${failure.evidence.join(', ')}`);
+      if (failure.traceSignals) {
+        const { consoleErrors, networkFailures, requestCount } = failure.traceSignals;
+        push(
+          `- Trace: ${consoleErrors} console error(s), ${networkFailures} failed request(s) of ${requestCount} — ${consoleErrors + networkFailures === 0 ? 'the app was not erroring, so look at the locator/UI state' : 'see the files above'}`,
+        );
+      }
+      if (failure.tracePath) {
+        push(`- Trace viewer: \`pnpm exec playwright show-trace ${relative(failure.tracePath)}\``);
+      }
+      push('- Repro:', '', '```bash', playwrightReproCommand(failure), '```', '');
+    });
+  } else if (playwright?.reportDir) {
+    push('## Playwright', '', 'The report contained no failed tests — the job failed before or after the suite.', '');
+  }
+
+  if (playwright?.topLevelErrors?.length) {
+    push('## Playwright run-level notes', '', '```', playwright.topLevelErrors.join('\n\n'), '```', '');
+  }
+
+  push('## Files', '');
+  push(`- \`${relative(bundleDir)}/summary.json\` — the same data, machine readable`);
+  push(`- \`${relative(bundleDir)}/logs/*.failure.txt\` — distilled failure excerpt per job`);
+  push(`- \`${relative(bundleDir)}/logs/*.log\` — full cleaned job logs`);
+  if (playwright?.reportDir) {
+    push(`- \`${relative(playwright.reportDir)}\` — HTML report: \`pnpm exec playwright show-report ${relative(playwright.reportDir)}\``);
+    push('- `playwright/failures/<n>-<test>/page-snapshot.md` — accessibility snapshot of the page at the moment of failure');
+    push('- `playwright/failures/<n>-<test>/screenshot-*.png` — what the page looked like when it failed');
+  }
+  push('');
+
+  return {
+    markdown: lines.join('\n'),
+    json: {
+      repo,
+      run: { ...run, url: run.htmlUrl },
+      generatedAt: new Date().toISOString(),
+      jobs: jobReports.map(({ job, excerpt, ...rest }) => ({ name: job.name, failedSteps: job.failedSteps, url: job.htmlUrl, ...rest })),
+      playwright: playwright ? { stats: playwright.stats ?? null, expired: Boolean(playwright.expired), failures } : null,
+    },
+  };
+}
+
+function printConsoleSummary(jobReports, playwright) {
+  console.log('');
+  for (const report of jobReports) {
+    const detail = report.unavailable
+      ? 'log unavailable'
+      : `${report.framework}${report.failedNxTasks.length ? ` · ${report.failedNxTasks.join(', ')}` : ''}`;
+    console.log(`  ✗ ${report.job.name} — ${report.job.failedSteps.join(', ') || 'unknown step'} (${detail})`);
+  }
+  for (const failure of playwright?.failures ?? []) {
+    console.log(`  ✗ ${failure.title}`);
+    console.log(`      ${firstLine(failure.errors[0]?.message)}`);
+    console.log(`      ${relative(path.join(bundleDir, 'playwright', 'failures', failure.dir))}/`);
+  }
+  console.log(`\n  → ${relative(bundleDir)}/summary.md\n`);
+}

--- a/scripts/lib/ci-log-distiller.mjs
+++ b/scripts/lib/ci-log-distiller.mjs
@@ -1,0 +1,339 @@
+/**
+ * Turns a raw GitHub Actions job log into the ~1% of it that explains the failure.
+ *
+ * A single CI job log here is 200-400KB of runner boilerplate, pnpm install chatter, Nx task
+ * output and postgres service noise. The failure is usually 20-60 lines somewhere in the middle.
+ * `distillJobLog` finds the step that failed, keeps the regions around high-signal lines plus the
+ * tail of that step, and drops everything else.
+ *
+ * Nothing here is Playwright-specific — the same treatment works for typecheck, vitest, lint and
+ * build failures, which is the point.
+ */
+
+const BOM_AND_TIMESTAMP = /^\uFEFF?\d{4}-\d{2}-\d{2}T[\d:.]+Z ?/;
+// Matching a control character is the entire point here: CI output is full of color codes.
+// oxlint-disable-next-line no-control-regex
+const ANSI_ESCAPE = /\u001B\[[0-9;]*[A-Za-z]/g;
+const GROUP_PREFIX = '##[group]Run ';
+
+/** Remove terminal color codes so error text can be read, matched and diffed as plain text. */
+export function stripAnsi(value) {
+  return (value || '').replace(ANSI_ESCAPE, '');
+}
+
+/**
+ * Lines that never explain anything but show up next to real errors often enough to crowd them
+ * out of the excerpt. They stay in the full log, they just do not count as signal or context.
+ */
+const NOISE_PATTERNS = [
+  /^##\[debug\]/,
+  /^Download action repository/,
+  /Mail client not configured/,
+  /FATAL: {2}role "root" does not exist/,
+  /DeprecationWarning:/,
+  /^\(Use `node --trace-deprecation/,
+  /^ *(Progress|Received) \d+ of \d+/,
+  /^npm warn|WARN deprecated/,
+  /^Post job cleanup/,
+  // Playwright prints where it wrote each attachment on the runner. Those paths are gone with the
+  // runner; the bundle carries the attachments themselves.
+  /^ *attachment #\d+: /,
+  /^ *[─-]{20,}$/,
+  /^ *Error Context: /,
+  /^ *Usage:$/,
+  /playwright show-trace /,
+  /^ *dist\/\.playwright\//,
+];
+
+/** Lines that open a block of runner-injected key/value noise, closed by `##[endgroup]`. */
+const SUPPRESSED_BLOCK_START = /^ *(env|with):$/;
+
+/**
+ * When a step fails the job stops, so everything the runner prints afterwards — post-action
+ * cleanup, service container teardown, the postgres image's startup banner — lands inside that
+ * step's slice of the log. These markers are where the step's own output actually ends.
+ */
+const POST_STEP_MARKERS = [
+  /^Post job cleanup/,
+  /^Stop and remove container:/,
+  /^Print service container logs:/,
+  /^Cleaning up orphan processes/,
+  /^Pruning is unnecessary\./,
+  /^Temporarily overriding HOME=/,
+];
+
+/**
+ * Each entry keeps `before` lines above and `after` lines below a match. The windows differ a lot
+ * by tool: a Playwright failure block runs ~45 lines (call log, code frame, attachments), while a
+ * `tsc` diagnostic is done in three.
+ */
+const SIGNAL_PATTERNS = [
+  // Nx replays a failed task's whole output inside a collapsed group at the end of the run. For any
+  // Nx target — build, test, typecheck — this is where the actual error text lives.
+  { pattern: /^##\[group\]❌/, before: 0, after: 60 },
+  { pattern: /^##\[error\]/, before: 10, after: 4 },
+  { pattern: /^ *Type error: /, before: 6, after: 8 },
+  { pattern: /^ *(Failed to compile|Build failed|Compilation failed|Build error occurred)/, before: 2, after: 20 },
+  { pattern: /^ {0,4}\d+\) .+ › /, before: 1, after: 45 },
+  { pattern: /\berror TS\d+\b/, before: 1, after: 4 },
+  { pattern: /^ *(FAIL|✗|×|✘|❯) /, before: 0, after: 14 },
+  { pattern: /(AssertionError|TimeoutError|ReferenceError|SyntaxError|TypeError|Unhandled error)\b/, before: 3, after: 14 },
+  { pattern: /^ *Failed tasks:/, before: 3, after: 14 },
+  { pattern: /^ *(Test Files|Tests) +\d+ failed/, before: 8, after: 3 },
+  { pattern: /^ {0,4}\d+ (failed|flaky)$/, before: 3, after: 4 },
+  { pattern: /^ *(Error|error): /, before: 2, after: 10 },
+  { pattern: /Found \d+ (error|warning)/, before: 24, after: 2 },
+  { pattern: /^ *(✖|error) .*(oxlint|oxfmt)/, before: 2, after: 10 },
+  { pattern: /Cannot find (module|name)|is not assignable to|has no exported member/, before: 2, after: 6 },
+];
+
+/** Command substrings that identify what tool ran, used for framework detection and repro hints. */
+const FRAMEWORK_RULES = [
+  { framework: 'playwright', match: /playwright test|start-server-and-test/ },
+  { framework: 'vitest', match: /--target=test\b|\bvitest\b|pnpm test:?\b/ },
+  { framework: 'typescript', match: /typecheck|tsc\b|sync:check/ },
+  { framework: 'lint', match: /\blint\b|oxlint/ },
+  { framework: 'format', match: /format:check|oxfmt/ },
+  { framework: 'build', match: /\bbuild\b/ },
+  { framework: 'database', match: /db:migrate|db:seed|db:generate|prisma/ },
+];
+
+/** Strip the runner timestamp and ANSI codes from every line of a raw job log. */
+export function cleanLog(rawLog) {
+  return rawLog.split(/\r?\n/).map((line) => line.replace(BOM_AND_TIMESTAMP, '').replace(ANSI_ESCAPE, '').replace(/\r/g, '').trimEnd());
+}
+
+/**
+ * Split cleaned lines into the steps the workflow ran. GitHub opens every step with
+ * `##[group]Run <command>`, so the command — not the step's display name — is what identifies it.
+ */
+export function splitSteps(lines) {
+  const steps = [];
+  let current = { command: 'Set up job', startLine: 0, lines: [] };
+
+  lines.forEach((line, index) => {
+    if (line.startsWith(GROUP_PREFIX)) {
+      steps.push(current);
+      current = { command: line.slice(GROUP_PREFIX.length).trim(), startLine: index, lines: [] };
+    }
+    current.lines.push(line);
+  });
+  steps.push(current);
+
+  return steps;
+}
+
+function isNoise(line) {
+  return NOISE_PATTERNS.some((pattern) => pattern.test(line));
+}
+
+/**
+ * Indices of the `env:` / `with:` dumps the runner prints when it opens a step. They are long,
+ * identical in every job, and full of masked secret names that read like content but are not.
+ */
+function suppressedBlockIndices(lines) {
+  const suppressed = new Set();
+  let inBlock = false;
+
+  lines.forEach((line, index) => {
+    if (SUPPRESSED_BLOCK_START.test(line)) {
+      inBlock = true;
+    } else if (line.startsWith('##[endgroup]')) {
+      inBlock = false;
+    }
+    if (inBlock) {
+      suppressed.add(index);
+    }
+  });
+
+  return suppressed;
+}
+
+/** Drop the runner's post-job output that trails a failing step (see POST_STEP_MARKERS). */
+function trimPostStepOutput(lines) {
+  const lastError = lines.findLastIndex((line) => line.startsWith('##[error]'));
+  const searchFrom = lastError >= 0 ? lastError + 1 : 0;
+  const cutoff = lines.findIndex((line, index) => index >= searchFrom && POST_STEP_MARKERS.some((marker) => marker.test(line)));
+  return cutoff > 0 ? lines.slice(0, cutoff) : lines;
+}
+
+function detectFramework(command, lines) {
+  // A step that runs a marketplace action (`owner/repo@ref`) failed in the runner setup, not in
+  // this repo's tooling — decide that from the command before any keyword can match its output.
+  if (/^[\w.-]+\/[\w.-]+@\S+$/.test(command.trim())) {
+    return 'infra';
+  }
+  const haystack = `${command}\n${lines.slice(0, 400).join('\n')}`;
+  return FRAMEWORK_RULES.find(({ match }) => match.test(haystack))?.framework ?? 'unknown';
+}
+
+/**
+ * Nx prints the tasks it could not complete under a `Failed tasks:` heading. Those `project:target`
+ * pairs are the most precise "run this locally" instruction the log contains.
+ */
+function findFailedNxTasks(lines) {
+  const tasks = new Set();
+  lines.forEach((line, index) => {
+    if (!/^ *Failed tasks:/.test(line)) {
+      return;
+    }
+    for (let cursor = index + 1; cursor < Math.min(index + 30, lines.length); cursor++) {
+      const match = lines[cursor].match(/^ *- ([\w@/.-]+:[\w:.-]+)$/);
+      if (match) {
+        tasks.add(match[1]);
+      } else if (lines[cursor].trim() && !lines[cursor].startsWith(' ')) {
+        break;
+      }
+    }
+  });
+  return [...tasks];
+}
+
+/**
+ * How far after a matched line to keep. A wide window is what captures a replayed task log, but it
+ * must stop at the next group so a failed Nx task does not drag in the output of the ones that
+ * succeeded after it.
+ */
+function endOfContext(lines, matchIndex, after) {
+  const limit = Math.min(lines.length - 1, matchIndex + after);
+  for (let cursor = matchIndex + 1; cursor <= limit; cursor++) {
+    if (lines[cursor].startsWith('##[group]')) {
+      return cursor - 1;
+    }
+  }
+  return limit;
+}
+
+/** Merge overlapping/adjacent [start, end] ranges so the excerpt does not repeat context lines. */
+function mergeRanges(ranges) {
+  const sorted = [...ranges].sort((left, right) => left.start - right.start);
+  const merged = [];
+  for (const range of sorted) {
+    const previous = merged[merged.length - 1];
+    if (previous && range.start <= previous.end + 3) {
+      previous.end = Math.max(previous.end, range.end);
+    } else {
+      merged.push({ ...range });
+    }
+  }
+  return merged;
+}
+
+/**
+ * Pull the explanatory part out of one job log.
+ *
+ * @param {string} rawLog full job log as downloaded from the run's log archive
+ * @param {{ maxLines?: number, tailLines?: number }} [options]
+ */
+export function distillJobLog(rawLog, { maxLines = 450, tailLines = 60 } = {}) {
+  const lines = cleanLog(rawLog);
+  const steps = splitSteps(lines);
+
+  // The runner emits `##[error]` inside the failing step's own output, before the next group opens.
+  const failingStep =
+    [...steps].reverse().find((step) => step.lines.some((line) => line.startsWith('##[error]'))) ?? steps[steps.length - 1];
+
+  const stepLines = trimPostStepOutput(failingStep.lines);
+  const suppressed = suppressedBlockIndices(stepLines);
+  const skip = (index) => suppressed.has(index) || isNoise(stepLines[index]);
+  const contentLines = stepLines.filter((line, index) => line.trim() && !skip(index)).length;
+
+  const framework = detectFramework(
+    failingStep.command,
+    stepLines.filter((_, index) => !suppressed.has(index)),
+  );
+  const failedNxTasks = findFailedNxTasks(stepLines);
+
+  const ranges = [];
+  stepLines.forEach((line, index) => {
+    if (skip(index)) {
+      return;
+    }
+    for (const { pattern, before, after } of SIGNAL_PATTERNS) {
+      if (pattern.test(line)) {
+        ranges.push({ start: Math.max(0, index - before), end: endOfContext(stepLines, index, after) });
+        break;
+      }
+    }
+  });
+  // Falling back to the tail only helps when nothing matched. Once a signal has been found, the end
+  // of a step is usually the *successful* work Nx replayed after the failure, so keeping it hurts.
+  if (!ranges.length) {
+    ranges.push({ start: Math.max(0, stepLines.length - tailLines), end: stepLines.length - 1 });
+  }
+
+  const merged = mergeRanges(ranges);
+
+  const excerptLines = [];
+  let omittedLines = 0;
+  let previousEnd = -1;
+  let truncated = false;
+
+  for (const { start, end } of merged) {
+    if (excerptLines.length >= maxLines) {
+      truncated = true;
+      omittedLines += end - start + 1;
+      continue;
+    }
+    if (previousEnd >= 0 && start > previousEnd + 1) {
+      const gap = start - previousEnd - 1;
+      omittedLines += gap;
+      excerptLines.push(`… ${gap} lines omitted …`);
+    }
+    for (let cursor = start; cursor <= end; cursor++) {
+      if (skip(cursor)) {
+        omittedLines++;
+        continue;
+      }
+      excerptLines.push(stepLines[cursor]);
+    }
+    previousEnd = end;
+  }
+
+  if (truncated) {
+    excerptLines.push(`… excerpt truncated at ${maxLines} lines — read the full log for the rest …`);
+  }
+
+  return {
+    framework,
+    failingCommand: failingStep.command,
+    failedNxTasks,
+    excerpt: excerptLines
+      .join('\n')
+      .replace(/\n{3,}/g, '\n\n')
+      .trim(),
+    omittedLines,
+    cleanedLog: lines.join('\n'),
+    // A step that ran no recognizable tooling and produced almost no output did no work of its
+    // own: it is a gate job reporting that a job it depends on failed.
+    likelyGateJob: framework === 'unknown' && contentLines < 25,
+  };
+}
+
+/**
+ * A concrete local command that reproduces this class of failure, or null when the failure is a
+ * runner/infrastructure problem that cannot be reproduced locally.
+ */
+export function reproCommandFor(framework, failedNxTasks) {
+  if (failedNxTasks.length) {
+    return `pnpm nx run ${failedNxTasks[0]}${failedNxTasks.length > 1 ? `   # also failed: ${failedNxTasks.slice(1).join(', ')}` : ''}`;
+  }
+  switch (framework) {
+    case 'playwright':
+      return `pnpm start-server-and-test --expect 200 'pnpm start:e2e' http://localhost:3333 'pnpm playwright test <spec> --config apps/jetstream-e2e/playwright.config.ts'`;
+    case 'vitest':
+      return 'pnpm test:affected';
+    case 'typescript':
+      return 'pnpm typecheck:affected';
+    case 'lint':
+      return 'pnpm lint';
+    case 'format':
+      return 'pnpm format:check';
+    case 'build':
+      return 'pnpm build:affected';
+    case 'database':
+      return 'pnpm db:generate && pnpm db:migrate';
+    default:
+      return null;
+  }
+}

--- a/scripts/lib/playwright-report.mjs
+++ b/scripts/lib/playwright-report.mjs
@@ -1,0 +1,335 @@
+/**
+ * Reads a downloaded Playwright HTML report and turns the failures into plain files.
+ *
+ * The HTML report is built for a browser, not for reading: `index.html` is a ~1MB React bundle
+ * with the entire report zipped and base64'd into a `<template>` tag, and every attachment is a
+ * content-addressed blob under `data/`. Nothing in there can be grepped or opened directly.
+ *
+ * This module unpacks that template back into JSON, pulls out the tests that did not pass, and
+ * writes each one into its own folder with the error, the page snapshot taken at failure, the
+ * screenshots, and — dug out of the trace — the browser console errors and failed HTTP requests.
+ * Those last two usually answer "why did the locator never appear" faster than anything else.
+ */
+
+import { copyFile, mkdir, readFile, writeFile } from 'node:fs/promises';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import { stripAnsi } from './ci-log-distiller.mjs';
+
+const require = createRequire(import.meta.url);
+const JSZip = require('jszip');
+
+const EMBEDDED_REPORT = /<template id=["']playwrightReportBase64["']>data:application\/zip;base64,([\s\S]*?)<\/template>/;
+const MAX_CONSOLE_ENTRIES = 200;
+const MAX_NETWORK_ENTRIES = 200;
+const DEFAULT_SPEC_PREFIX = 'apps/jetstream-e2e/src';
+
+/** Filesystem-safe, still-readable folder name for a test title. */
+function slugify(value) {
+  return (
+    value
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '')
+      .slice(0, 60) || 'test'
+  );
+}
+
+/** Decode the report data that the HTML reporter embeds in `index.html`. */
+async function loadEmbeddedReport(reportDir) {
+  const html = await readFile(path.join(reportDir, 'index.html'), 'utf8');
+  const match = html.match(EMBEDDED_REPORT);
+  if (!match) {
+    throw new Error(`No embedded report found in ${reportDir}/index.html — the report format may have changed`);
+  }
+  const zip = await JSZip.loadAsync(Buffer.from(match[1], 'base64'));
+  const report = JSON.parse(await zip.file('report.json').async('string'));
+
+  const testFiles = [];
+  for (const name of Object.keys(zip.files)) {
+    if (name === 'report.json' || !name.endsWith('.json')) {
+      continue;
+    }
+    testFiles.push(JSON.parse(await zip.file(name).async('string')));
+  }
+
+  return { report, testFiles };
+}
+
+/**
+ * Console errors and failed requests from a trace zip. Best effort — the trace format is internal
+ * to Playwright, so a shape change here degrades the bundle instead of failing the run.
+ */
+async function readTraceSignals(traceZipPath) {
+  const consoleMessages = [];
+  const networkFailures = [];
+  let requestCount = 0;
+
+  try {
+    const zip = await JSZip.loadAsync(await readFile(traceZipPath));
+
+    for (const name of Object.keys(zip.files)) {
+      if (!name.endsWith('.trace') && !name.endsWith('.network')) {
+        continue;
+      }
+      const contents = await zip.file(name).async('string');
+      for (const line of contents.split('\n')) {
+        if (!line.trim()) {
+          continue;
+        }
+        let event;
+        try {
+          event = JSON.parse(line);
+        } catch {
+          continue;
+        }
+
+        // Console logs and page errors share one budget: a page that throws in a loop should not
+        // be able to fill the bundle with thousands of near-identical entries.
+        const withinConsoleBudget = consoleMessages.length < MAX_CONSOLE_ENTRIES;
+
+        if (event.type === 'console' && withinConsoleBudget) {
+          consoleMessages.push({ level: event.messageType || 'log', text: stripAnsi(event.text || '') });
+        } else if (event.type === 'event' && withinConsoleBudget && /error/i.test(event.method || '')) {
+          consoleMessages.push({ level: 'pageerror', text: JSON.stringify(event.params || {}).slice(0, 2000) });
+        } else if (event.type === 'resource-snapshot') {
+          requestCount += 1;
+          const { request, response } = event.snapshot || {};
+          const status = response?.status ?? 0;
+          if (request?.url && (status === 0 || status >= 400) && networkFailures.length < MAX_NETWORK_ENTRIES) {
+            networkFailures.push({ method: request.method, url: request.url, status, statusText: response?.statusText });
+          }
+        }
+      }
+    }
+  } catch {
+    return { consoleMessages: [], networkFailures: [], requestCount: 0, unreadable: true };
+  }
+
+  return { consoleMessages, networkFailures, requestCount, unreadable: false };
+}
+
+/** The `file.spec.ts:line:col` the error was thrown at, which is usually not the test's own line. */
+function findThrowSite(errorMessage) {
+  const match = stripAnsi(errorMessage).match(/at (?:.*[/\\])?([\w.-]+\.(?:spec|test)\.ts):(\d+):(\d+)/);
+  return match ? { file: match[1], line: Number(match[2]), column: Number(match[3]) } : null;
+}
+
+/**
+ * Spec paths are reported relative to Playwright's rootDir, which is an absolute path on the
+ * runner. Recover the repo-relative path so every reference in the bundle is clickable locally.
+ */
+function repoRelativeSpec(file, rootDir) {
+  const match = /(?:^|\/)((?:apps|libs)\/.*)$/.exec(rootDir ?? '');
+  return path.posix.join(match ? match[1] : DEFAULT_SPEC_PREFIX, file);
+}
+
+function collectFailures({ report, testFiles }) {
+  const failures = [];
+
+  for (const testFile of testFiles) {
+    for (const test of testFile.tests || []) {
+      if (test.outcome !== 'unexpected' && test.outcome !== 'flaky') {
+        continue;
+      }
+      const attempts = test.results || [];
+      const lastFailed = [...attempts].reverse().find(({ status }) => status !== 'passed') ?? attempts[attempts.length - 1];
+      const errors = (lastFailed?.errors || []).map((error) => ({
+        message: stripAnsi(error.message || ''),
+        codeframe: stripAnsi(error.codeframe || ''),
+      }));
+
+      failures.push({
+        title: [...(test.path || []), test.title].join(' › '),
+        projectName: test.projectName,
+        outcome: test.outcome,
+        specFile: repoRelativeSpec(test.location?.file || testFile.fileName),
+        specLine: test.location?.line,
+        attempts: attempts.length,
+        durationMs: test.duration,
+        throwSite: findThrowSite(errors[0]?.message || ''),
+        errors,
+        attachments: lastFailed?.attachments || [],
+        stdout: (lastFailed?.attachments || []).find(({ name }) => name === 'stdout')?.body,
+        stderr: (lastFailed?.attachments || []).find(({ name }) => name === 'stderr')?.body,
+      });
+    }
+  }
+
+  return { stats: report.stats, topLevelErrors: (report.errors || []).map(stripAnsi), failures };
+}
+
+/**
+ * The same failure records, read from the small `playwright-summary` JSON artifact instead of the
+ * HTML report. Everything textual survives; the attachments do not, because the JSON reporter only
+ * records where they were written on the runner.
+ */
+function collectFailuresFromJson(json) {
+  const failures = [];
+  const rootDir = json.config?.rootDir;
+
+  const walk = (suite, titlePath) => {
+    for (const spec of suite.specs || []) {
+      for (const test of spec.tests || []) {
+        if (test.status !== 'unexpected' && test.status !== 'flaky') {
+          continue;
+        }
+        const attempts = test.results || [];
+        const lastFailed = [...attempts].reverse().find(({ status }) => status !== 'passed') ?? attempts[attempts.length - 1];
+        const { error, errorLocation } = lastFailed ?? {};
+
+        failures.push({
+          title: [...titlePath, spec.title].join(' › '),
+          projectName: test.projectName,
+          outcome: test.status,
+          specFile: repoRelativeSpec(spec.file, rootDir),
+          specLine: spec.line,
+          attempts: attempts.length,
+          throwSite: errorLocation ? { file: path.basename(errorLocation.file), line: errorLocation.line } : null,
+          errors: [{ message: stripAnsi(error?.message || ''), codeframe: stripAnsi(error?.snippet || '') }],
+          attachments: [],
+        });
+      }
+    }
+    for (const child of suite.suites || []) {
+      walk(child, child.title ? [...titlePath, child.title] : titlePath);
+    }
+  };
+
+  // The outermost suite is the spec file itself, whose title would just repeat the path.
+  for (const fileSuite of json.suites || []) {
+    walk(fileSuite, []);
+  }
+
+  const { expected = 0, unexpected = 0, flaky = 0, skipped = 0 } = json.stats ?? {};
+
+  return {
+    stats: { total: expected + unexpected + flaky + skipped, expected, unexpected, flaky, skipped },
+    topLevelErrors: (json.errors || []).map(({ message }) => stripAnsi(message || '')),
+    failures,
+  };
+}
+
+/** Create a failed test's folder and write the one file every source can produce: the error. */
+async function startFailureFolder(bundleDir, failure, index) {
+  const folderName = `${index + 1}-${slugify(failure.title)}`;
+  const failureDir = path.join(bundleDir, folderName);
+  await mkdir(failureDir, { recursive: true });
+
+  const errorText = failure.errors
+    .map(({ message, codeframe }, errorIndex) => [`--- error ${errorIndex + 1} ---`, message, '', codeframe].join('\n'))
+    .join('\n\n');
+  await writeFile(path.join(failureDir, 'error.txt'), `${failure.title}\n${failure.specFile}:${failure.specLine}\n\n${errorText}\n`);
+
+  return { failureDir, folderName, evidence: ['error.txt'] };
+}
+
+/**
+ * Write one folder per failed test under `bundleDir`, and return the failures annotated with the
+ * evidence files that were produced.
+ *
+ * @param {string} reportDir  unzipped `playwright-report` artifact
+ * @param {string} bundleDir  where per-test folders are written
+ * @param {{ includeTraces?: boolean }} [options]
+ */
+export async function extractPlaywrightFailures(reportDir, bundleDir, { includeTraces = true } = {}) {
+  const { stats, topLevelErrors, failures } = collectFailures(await loadEmbeddedReport(reportDir));
+
+  for (const [index, failure] of failures.entries()) {
+    const { failureDir, folderName, evidence } = await startFailureFolder(bundleDir, failure, index);
+
+    let screenshotCount = 0;
+    for (const attachment of failure.attachments) {
+      if (!attachment.path) {
+        continue;
+      }
+      const source = path.join(reportDir, attachment.path);
+      if (attachment.name === 'screenshot') {
+        screenshotCount += 1;
+        const target = `screenshot-${screenshotCount}.png`;
+        await copyFile(source, path.join(failureDir, target));
+        evidence.push(target);
+      } else if (attachment.name === 'error-context') {
+        // Playwright's accessibility snapshot of the page at the moment of failure — the fastest
+        // way to tell "the element was never rendered" from "it rendered with a different name".
+        await copyFile(source, path.join(failureDir, 'page-snapshot.md'));
+        evidence.push('page-snapshot.md');
+      } else if (attachment.name === 'trace' && includeTraces) {
+        // The trace is tens of MB and already sits in the report folder — point at it there.
+        failure.tracePath = path.join(reportDir, attachment.path);
+
+        const { consoleMessages, networkFailures, requestCount, unreadable } = await readTraceSignals(source);
+        const interesting = consoleMessages.filter(({ level }) => level === 'error' || level === 'warning' || level === 'pageerror');
+        failure.traceSignals = unreadable
+          ? null
+          : { consoleErrors: interesting.length, networkFailures: networkFailures.length, requestCount };
+        if (interesting.length) {
+          await writeFile(
+            path.join(failureDir, 'console-errors.txt'),
+            interesting.map(({ level, text }) => `[${level}] ${text}`).join('\n'),
+          );
+          evidence.push('console-errors.txt');
+        }
+        if (networkFailures.length) {
+          await writeFile(
+            path.join(failureDir, 'network-failures.txt'),
+            networkFailures
+              .map(({ method, status, statusText, url }) => `${status} ${statusText || ''} ${method} ${url}`.trim())
+              .join('\n'),
+          );
+          evidence.push('network-failures.txt');
+        }
+      } else if (attachment.name === 'video') {
+        failure.videoPath = path.join(reportDir, attachment.path);
+      }
+    }
+
+    if (failure.stdout?.trim()) {
+      await writeFile(path.join(failureDir, 'stdout.txt'), stripAnsi(failure.stdout));
+      evidence.push('stdout.txt');
+    }
+    if (failure.stderr?.trim()) {
+      await writeFile(path.join(failureDir, 'stderr.txt'), stripAnsi(failure.stderr));
+      evidence.push('stderr.txt');
+    }
+
+    failure.dir = folderName;
+    failure.evidence = evidence;
+    delete failure.attachments;
+  }
+
+  return { stats, topLevelErrors, failures };
+}
+
+/**
+ * Same output shape as `extractPlaywrightFailures`, built from the `playwright-summary` artifact.
+ * Use when the HTML report is unwanted (too large) or gone (expired): the error and the code frame
+ * survive, the screenshots, page snapshot and trace do not.
+ *
+ * @param {string} jsonPath   downloaded `playwright-summary.json`
+ * @param {string} bundleDir  where per-test folders are written
+ */
+export async function extractFailuresFromJsonSummary(jsonPath, bundleDir) {
+  const { stats, topLevelErrors, failures } = collectFailuresFromJson(JSON.parse(await readFile(jsonPath, 'utf8')));
+
+  for (const [index, failure] of failures.entries()) {
+    const { folderName, evidence } = await startFailureFolder(bundleDir, failure, index);
+    failure.dir = folderName;
+    failure.evidence = evidence;
+    delete failure.attachments;
+  }
+
+  return { stats, topLevelErrors, failures, textOnly: true };
+}
+
+/**
+ * Repro command for a single failed test. `-g` matches against the full title path, which is what
+ * `failure.title` already is.
+ */
+export function playwrightReproCommand(failure) {
+  const grep = failure.title.replace(/["`$]/g, '.');
+  return [
+    `pnpm start-server-and-test --expect 200 'pnpm start:e2e' http://localhost:3333 \\`,
+    `  'pnpm playwright test ${failure.specFile} --config apps/jetstream-e2e/playwright.config.ts -g "${grep}"'`,
+  ].join('\n');
+}


### PR DESCRIPTION
- Implemented `ci-log-distiller.mjs` to distill GitHub Actions job logs, focusing on extracting relevant failure information while filtering out noise.
- Introduced `playwright-report.mjs` to parse Playwright HTML reports, extracting failed test details and associated artifacts into structured folders for easier analysis.