### PR TITLE
feat: retain form values on record type change and add utility for unavailable picklist values

### DIFF
--- a/libs/features/create-records/src/lib/CreateRecords.tsx
+++ b/libs/features/create-records/src/lib/CreateRecords.tsx
@@ -1,10 +1,10 @@
 import { css } from '@emotion/react';
-import { getPicklistValuesForRecordAndRecordType, UiRecordForm } from '@jetstream/record-form';
+import { getPicklistValuesForRecordAndRecordType, removeUnavailablePicklistValues, UiRecordForm } from '@jetstream/record-form';
 import { logger } from '@jetstream/shared/client-logger';
 import { ANALYTICS_KEYS } from '@jetstream/shared/constants';
 import { describeSObject, sobjectOperation } from '@jetstream/shared/data';
 import { APP_ROUTES } from '@jetstream/shared/ui-router';
-import { filterCreateSobjects, isErrorResponse, useNonInitialEffect, tracker } from '@jetstream/shared/ui-utils';
+import { filterCreateSobjects, isErrorResponse, tracker, useNonInitialEffect } from '@jetstream/shared/ui-utils';
 import { getErrorMessage } from '@jetstream/shared/utils';
 import { SplitWrapper as Split } from '@jetstream/splitjs';
 import {
@@ -43,7 +43,7 @@ export const CreateRecords = () => {
 
   const { defaultApiVersion } = useAtomValue(applicationCookieState);
   const selectedOrg = useAtomValue(selectedOrgState);
-  const [key, setKey] = useState(() => new Date().getTime());
+  const [formKey, setFormKey] = useState(0);
 
   const [loading, setLoading] = useState<boolean>(false);
   const [saving, setSaving] = useState<boolean>(false);
@@ -98,7 +98,7 @@ export const CreateRecords = () => {
   function handleClearForm() {
     setInitialRecord({});
     setModifiedRecord({});
-    setKey(new Date().getTime());
+    setFormKey((priorKey) => priorKey + 1);
     setFormErrors({ hasErrors: false, fieldErrors: {}, generalErrors: [] });
     setCreatedRecord(null);
   }
@@ -108,16 +108,43 @@ export const CreateRecords = () => {
   }
 
   async function handleRecordTypeChange(recordTypeId: string) {
+    const priorRecordTypeId = selectedRecordTypeId;
     setSelectedRecordTypeId(recordTypeId);
-    calculatePicklistValues({ recordTypeId, updateLoadingState: true });
-    setModifiedRecord({});
     setFormErrors({ hasErrors: false, fieldErrors: {}, generalErrors: [] });
+
+    const updatedPicklistValues = await calculatePicklistValues({ recordTypeId, updateLoadingState: true });
+    if (!isMounted.current) {
+      return;
+    }
+    // Picklist values could not be obtained, the form still has the prior record type's values so the prior selection is restored
+    if (!updatedPicklistValues) {
+      setSelectedRecordTypeId(priorRecordTypeId);
+      return;
+    }
+
+    // Everything the user already entered is retained, only picklist values that the new record type does not allow are removed
+    const { record, fieldsWithClearedValues } = removeUnavailablePicklistValues(
+      sobjectMetadata?.fields || [],
+      updatedPicklistValues,
+      modifiedRecord,
+    );
+    setModifiedRecord(record);
+    setFormKey((priorKey) => priorKey + 1);
+
+    if (fieldsWithClearedValues.length) {
+      fireToast({
+        type: 'info',
+        message: `Some values were removed because they are not available for the selected record type: ${fieldsWithClearedValues
+          .map(({ label }) => label)
+          .join(', ')}`,
+      });
+    }
   }
 
   async function calculatePicklistValues({
     recordTypeId,
     updateLoadingState = false,
-  }: { recordTypeId?: string; updateLoadingState?: boolean } = {}) {
+  }: { recordTypeId?: string; updateLoadingState?: boolean } = {}): Promise<PicklistFieldValues | undefined> {
     try {
       if (updateLoadingState) {
         setLoading(true);
@@ -135,6 +162,7 @@ export const CreateRecords = () => {
         apiVersion: defaultApiVersion,
       });
       setPicklistValues(picklistValues);
+      return picklistValues;
     } catch (ex) {
       if (isMounted.current) {
         logger.error('Error calculating record types', ex);
@@ -305,7 +333,12 @@ export const CreateRecords = () => {
                 {Array.isArray(recordTypes) && (
                   <div className="slds-p-horizontal_xx-small">
                     <ComboboxWithItems
-                      comboboxProps={{ label: 'Record Type', labelHelp: 'The Record Type controls which picklist values are available' }}
+                      comboboxProps={{
+                        label: 'Record Type',
+                        labelHelp: 'The Record Type controls which picklist values are available',
+                        // Prevents overlapping picklist value requests from applying out of order
+                        disabled: loading || saving,
+                      }}
                       items={recordTypes}
                       selectedItemId={selectedRecordTypeId}
                       onSelected={(item) => handleRecordTypeChange(item.id)}
@@ -314,14 +347,16 @@ export const CreateRecords = () => {
                   </div>
                 )}
                 <UiRecordForm
-                  key={`${key}-${selectedRecordTypeId || ''}`}
+                  key={formKey}
                   org={selectedOrg}
                   controlClassName="slds-p-bottom_x-small slds-p-horizontal_xx-small"
                   action="create"
                   sobjectFields={sobjectMetadata.fields || []}
                   picklistValues={picklistValues || {}}
                   record={initialRecord}
+                  initialModifiedRecord={modifiedRecord}
                   saveErrors={formErrors.fieldErrors}
+                  disabled={loading || saving}
                   onChange={handleRecordChange}
                 />
               </>

--- a/libs/shared/ui-record-form/src/index.ts
+++ b/libs/shared/ui-record-form/src/index.ts
@@ -3,6 +3,7 @@ export {
   convertMetadataToEditableFields,
   getPicklistValuesForRecordAndRecordType,
   mockPicklistValuesFromSobjectDescribe,
+  removeUnavailablePicklistValues,
 } from './lib/ui-record-form-utils';
 export * from './lib/UiRecordForm';
 export { UiRecordFormField } from './lib/UiRecordFormField';

--- a/libs/shared/ui-record-form/src/lib/UiRecordForm.tsx
+++ b/libs/shared/ui-record-form/src/lib/UiRecordForm.tsx
@@ -16,6 +16,11 @@ export interface UiRecordFormProps {
   sobjectFields: Field[];
   picklistValues: PicklistFieldValues;
   record: SalesforceRecord;
+  /**
+   * Values the user already entered, used to re-populate the form when it is re-mounted (e.g. the record type changed).
+   * This is only read when the component mounts, use the `key` prop to force a re-mount with updated values.
+   */
+  initialModifiedRecord?: SalesforceRecord;
   saveErrors?: Record<string, string | undefined>;
   disabled?: boolean;
   onChange: (record: SalesforceRecord) => void;
@@ -30,6 +35,7 @@ export const UiRecordForm: FunctionComponent<UiRecordFormProps> = ({
   sobjectFields,
   picklistValues,
   record,
+  initialModifiedRecord,
   saveErrors,
   disabled = false,
   onChange,
@@ -39,7 +45,7 @@ export const UiRecordForm: FunctionComponent<UiRecordFormProps> = ({
   const [showFieldTypes, setShowFieldTypes] = useState(false);
   const [limitToRequired, setLimitToRequired] = useState(false);
   const [limitToErrorFields, setLimitToErrorFields] = useState(false);
-  const [modifiedRecord, setModifiedRecord] = useState<SalesforceRecord>({});
+  const [modifiedRecord, setModifiedRecord] = useState<SalesforceRecord>(() => initialModifiedRecord || {});
   const [visibleFieldMetadataRows, setVisibleFieldMetadataRows] = useState<EditableFields[][]>();
   const [fieldMetadata, setFieldMetadata] = useState(() => {
     return convertMetadataToEditableFields(sobjectFields, picklistValues, action, record);

--- a/libs/shared/ui-record-form/src/lib/__tests__/ui-record-form-utils.spec.ts
+++ b/libs/shared/ui-record-form/src/lib/__tests__/ui-record-form-utils.spec.ts
@@ -1,0 +1,123 @@
+import { Field, FieldType, PicklistFieldValues } from '@jetstream/types';
+import { describe, expect, it } from 'vitest';
+import { convertMetadataToEditableFields, removeUnavailablePicklistValues } from '../ui-record-form-utils';
+
+function getField(name: string, type: FieldType): Field {
+  return { name, type, label: `${name} label` } as Field;
+}
+
+function getPicklistValues(fieldName: string, values: string[]): PicklistFieldValues {
+  return {
+    [fieldName]: {
+      eTag: '',
+      url: '',
+      controllerValues: {},
+      defaultValue: null,
+      values: values.map((value) => ({ attributes: null, label: value, value, validFor: null })),
+    },
+  };
+}
+
+describe('convertMetadataToEditableFields', () => {
+  it('should sort Id, Name and RecordTypeId to the top, followed by the remaining fields', () => {
+    const fields = [
+      getField('Amount__c', 'currency'),
+      getField('Name', 'string'),
+      getField('RecordTypeId', 'reference'),
+      getField('Description', 'textarea'),
+      getField('Id', 'id'),
+    ];
+
+    const editableFields = convertMetadataToEditableFields(fields, {}, 'edit', {});
+
+    expect(editableFields.map(({ name }) => name)).toEqual(['Id', 'Name', 'RecordTypeId', 'Amount__c', 'Description']);
+  });
+
+  it('should sort RecordTypeId to the top for objects without a Name field', () => {
+    const fields = [getField('Amount__c', 'currency'), getField('RecordTypeId', 'reference'), getField('Id', 'id')];
+
+    const editableFields = convertMetadataToEditableFields(fields, {}, 'edit', {});
+
+    expect(editableFields.map(({ name }) => name)).toEqual(['Id', 'RecordTypeId', 'Amount__c']);
+  });
+
+  it('should leave the sort order alone when there is no RecordTypeId field', () => {
+    const fields = [getField('Amount__c', 'currency'), getField('Name', 'string'), getField('Id', 'id')];
+
+    const editableFields = convertMetadataToEditableFields(fields, {}, 'edit', {});
+
+    expect(editableFields.map(({ name }) => name)).toEqual(['Id', 'Name', 'Amount__c']);
+  });
+});
+
+describe('removeUnavailablePicklistValues', () => {
+  const fields = [
+    getField('Name', 'string'),
+    getField('Description', 'textarea'),
+    getField('IsActive', 'boolean'),
+    getField('Status__c', 'picklist'),
+    getField('Categories__c', 'multipicklist'),
+  ];
+
+  it('should retain all non-picklist values', () => {
+    const { record, fieldsWithClearedValues } = removeUnavailablePicklistValues(fields, getPicklistValues('Status__c', ['New']), {
+      Name: 'Test Record',
+      Description: 'Some description',
+      IsActive: true,
+    });
+
+    expect(record).toEqual({ Name: 'Test Record', Description: 'Some description', IsActive: true });
+    expect(fieldsWithClearedValues).toEqual([]);
+  });
+
+  it('should retain picklist values that are still available', () => {
+    const { record, fieldsWithClearedValues } = removeUnavailablePicklistValues(
+      fields,
+      getPicklistValues('Status__c', ['New', 'Working']),
+      { Name: 'Test Record', Status__c: 'Working' },
+    );
+
+    expect(record).toEqual({ Name: 'Test Record', Status__c: 'Working' });
+    expect(fieldsWithClearedValues).toEqual([]);
+  });
+
+  it('should remove picklist values that are not available and keep everything else', () => {
+    const { record, fieldsWithClearedValues } = removeUnavailablePicklistValues(fields, getPicklistValues('Status__c', ['New']), {
+      Name: 'Test Record',
+      IsActive: false,
+      Status__c: 'Working',
+    });
+
+    expect(record).toEqual({ Name: 'Test Record', IsActive: false });
+    expect(fieldsWithClearedValues.map(({ name }) => name)).toEqual(['Status__c']);
+  });
+
+  it('should remove picklist values for fields that have no available values', () => {
+    const { record, fieldsWithClearedValues } = removeUnavailablePicklistValues(fields, {}, { Name: 'Test Record', Status__c: 'Working' });
+
+    expect(record).toEqual({ Name: 'Test Record' });
+    expect(fieldsWithClearedValues.map(({ name }) => name)).toEqual(['Status__c']);
+  });
+
+  it('should retain the available portion of a multi-select picklist', () => {
+    const { record, fieldsWithClearedValues } = removeUnavailablePicklistValues(
+      fields,
+      getPicklistValues('Categories__c', ['One', 'Three']),
+      { Categories__c: 'One;Two;Three' },
+    );
+
+    expect(record).toEqual({ Categories__c: 'One;Three' });
+    expect(fieldsWithClearedValues.map(({ name }) => name)).toEqual(['Categories__c']);
+  });
+
+  it('should not modify empty or undefined values', () => {
+    const { record, fieldsWithClearedValues } = removeUnavailablePicklistValues(fields, getPicklistValues('Status__c', ['New']), {
+      Name: '',
+      Status__c: '',
+      Categories__c: undefined,
+    });
+
+    expect(record).toEqual({ Name: '', Status__c: '', Categories__c: undefined });
+    expect(fieldsWithClearedValues).toEqual([]);
+  });
+});

--- a/libs/shared/ui-record-form/src/lib/ui-record-form-utils.ts
+++ b/libs/shared/ui-record-form/src/lib/ui-record-form-utils.ts
@@ -34,6 +34,9 @@ const TIME_FIELD_TYPES = new Set<FieldType>(['time']);
 const PICKLIST_FIELD_TYPES = new Set<FieldType>(['combobox', 'picklist', 'multipicklist']);
 const TEXTAREA_FIELD_TYPES = new Set<FieldType>(['textarea']);
 const NUMBER_TYPES = new Set<FieldType>(['int', 'double', 'currency', 'percent']);
+const MULTI_PICKLIST_SEPARATOR = ';';
+// Id and Name are already sorted to the top by sortQueryFields
+const FIELDS_SORTED_TO_TOP = new Set<string>(['Id', 'Name']);
 
 export const OWNER_AND_AUDIT_FIELDS = new Set<string>(['OwnerId', 'CreatedById', 'CreatedDate', 'LastModifiedById', 'LastModifiedDate']);
 
@@ -69,6 +72,21 @@ export function isPicklist(value: EditableFields): value is EditableFieldPicklis
   return value && value.type === 'picklist';
 }
 
+/**
+ * Sort the record type field just below Id and Name since it determines which values other fields allow,
+ * otherwise it sorts alphabetically and is easy to miss.
+ */
+function sortRecordFormFields(fields: Field[]): Field[] {
+  const sortedFields = sortQueryFields(fields);
+  const recordTypeFieldIndex = sortedFields.findIndex((field) => field.name === 'RecordTypeId');
+  if (recordTypeFieldIndex < 0) {
+    return sortedFields;
+  }
+  const [recordTypeField] = sortedFields.splice(recordTypeFieldIndex, 1);
+  sortedFields.splice(sortedFields.filter((field) => FIELDS_SORTED_TO_TOP.has(field.name)).length, 0, recordTypeField);
+  return sortedFields;
+}
+
 export function convertMetadataToEditableFields(
   fields: Field[],
   picklistValues: PicklistFieldValues,
@@ -76,7 +94,7 @@ export function convertMetadataToEditableFields(
   record: SalesforceRecord,
   isCustomMetadata = false,
 ): EditableFields[] {
-  return sortQueryFields(fields.filter((field) => !IGNORED_FIELD_TYPES.has(field.type))).map((field): EditableFields => {
+  return sortRecordFormFields(fields.filter((field) => !IGNORED_FIELD_TYPES.has(field.type))).map((field): EditableFields => {
     let readOnly = action === 'view';
     if (!readOnly && !isCustomMetadata) {
       readOnly = action === 'edit' ? !field.updateable : !field.createable;
@@ -162,6 +180,44 @@ export function convertMetadataToEditableFields(
     }
     return output as EditableFields;
   });
+}
+
+/**
+ * Remove any picklist selections that are not available for the provided picklist values, such as after the user changes the record type.
+ * Every other value the user entered is retained so that changing the record type does not throw away their work.
+ *
+ * Returns a cloned record along with the fields that had one or more values removed.
+ */
+export function removeUnavailablePicklistValues(
+  fields: Field[],
+  picklistValues: PicklistFieldValues,
+  record: SalesforceRecord,
+): { record: SalesforceRecord; fieldsWithClearedValues: Field[] } {
+  const picklistFieldsByName = new Map(fields.filter(({ type }) => PICKLIST_FIELD_TYPES.has(type)).map((field) => [field.name, field]));
+  const fieldsWithClearedValues: Field[] = [];
+
+  const updatedRecord = Object.keys(record).reduce<SalesforceRecord>((output, fieldName) => {
+    const value = record[fieldName];
+    const field = picklistFieldsByName.get(fieldName);
+    if (!field || !isString(value) || !value) {
+      output[fieldName] = value;
+      return output;
+    }
+
+    const availableValues = new Set(picklistValues[fieldName]?.values.map((picklistValue) => picklistValue.value) || []);
+    const currentValues = field.type === 'multipicklist' ? value.split(MULTI_PICKLIST_SEPARATOR) : [value];
+    const retainedValues = currentValues.filter((currentValue) => availableValues.has(currentValue));
+
+    if (retainedValues.length !== currentValues.length) {
+      fieldsWithClearedValues.push(field);
+    }
+    if (retainedValues.length) {
+      output[fieldName] = retainedValues.join(MULTI_PICKLIST_SEPARATOR);
+    }
+    return output;
+  }, {});
+
+  return { record: updatedRecord, fieldsWithClearedValues };
 }
 
 // UI API is not supported, artificially build picklist values


### PR DESCRIPTION
When creating or editing a record, changing the record type retains existing valid values

Picklist values which are not compatible continue to be cleared out, but other values retain their previously modified but unsaved value.

Moved the Record Type Id field to the top of the form since picklist values may change their available options based on this field