### PR TITLE
fix(data-table): stop date filters dropping rows and add inclusive comparators

### DIFF
--- a/libs/ui/src/lib/data-table/grid/__tests__/grid-filters.spec.ts
+++ b/libs/ui/src/lib/data-table/grid/__tests__/grid-filters.spec.ts
@@ -7,7 +7,7 @@ describe('resetFilter', () => {
   test('produces empty defaults per type', () => {
     expect(resetFilter('TEXT')).toEqual({ type: 'TEXT', value: '' });
     expect(resetFilter('NUMBER')).toEqual({ type: 'NUMBER', value: null, comparator: 'EQUALS' });
-    expect(resetFilter('DATE')).toEqual({ type: 'DATE', value: '', comparator: 'GREATER_THAN' });
+    expect(resetFilter('DATE')).toEqual({ type: 'DATE', value: '', comparator: 'GREATER_THAN', ignoreTimestamp: false });
     expect(resetFilter('TIME')).toEqual({ type: 'TIME', value: '', comparator: 'GREATER_THAN' });
     expect(resetFilter('SET', ['a', 'b'])).toEqual({ type: 'SET', value: ['a', 'b'] });
     expect(resetFilter('BOOLEAN_SET', ['True', 'False'])).toEqual({ type: 'BOOLEAN_SET', value: ['True', 'False'] });
@@ -42,6 +42,78 @@ describe('filterRecord', () => {
     expect(filterRecord({ type: 'NUMBER', value: '5', comparator: 'EQUALS' }, 6)).toBe(false);
     expect(filterRecord({ type: 'NUMBER', value: '5', comparator: 'EQUALS' }, 'not-a-number')).toBe(false);
   });
+  describe('DATE', () => {
+    // Cells render dates as `yyyy-MM-dd h:mm:ss a`. `h` is a 1-2 digit hour, so the formatted string is
+    // 21 characters at 1-9 o'clock and 22 at 10/11/12 — the length the parser used to branch on.
+    const singleDigitHour = '2026-08-16 9:30:00 AM';
+    const doubleDigitHours = ['2026-08-16 10:30:00 AM', '2026-08-16 11:05:00 AM', '2026-08-16 12:00:00 PM', '2026-08-16 12:00:00 AM'];
+
+    test('regression: two-digit-hour timestamps are not dropped', () => {
+      // Every one of these parsed to Invalid Date and failed every comparison, silently removing the row.
+      doubleDigitHours.forEach((value) => {
+        expect(filterRecord({ type: 'DATE', value: '2026-08-15', comparator: 'GREATER_THAN' }, value)).toBe(true);
+        expect(filterRecord({ type: 'DATE', value: '2026-08-16', comparator: 'EQUALS' }, value)).toBe(true);
+        expect(filterRecord({ type: 'DATE', value: '2026-08-17', comparator: 'LESS_THAN' }, value)).toBe(true);
+      });
+    });
+
+    test('single-digit-hour timestamps keep working', () => {
+      expect(filterRecord({ type: 'DATE', value: '2026-08-15', comparator: 'GREATER_THAN' }, singleDigitHour)).toBe(true);
+      expect(filterRecord({ type: 'DATE', value: '2026-08-16', comparator: 'EQUALS' }, singleDigitHour)).toBe(true);
+      expect(filterRecord({ type: 'DATE', value: '2026-08-17', comparator: 'LESS_THAN' }, singleDigitHour)).toBe(true);
+    });
+
+    test('non-formatted values fall back to ISO parsing', () => {
+      expect(filterRecord({ type: 'DATE', value: '2026-08-15', comparator: 'GREATER_THAN' }, '2026-08-16')).toBe(true);
+      expect(filterRecord({ type: 'DATE', value: '2026-08-16', comparator: 'EQUALS' }, '2026-08-16')).toBe(true);
+    });
+
+    test('unparseable values and empty filters do not match', () => {
+      expect(filterRecord({ type: 'DATE', value: '2026-08-16', comparator: 'EQUALS' }, 'not-a-date')).toBe(false);
+      expect(filterRecord({ type: 'DATE', value: null, comparator: 'EQUALS' }, singleDigitHour)).toBe(false);
+      expect(filterRecord({ type: 'DATE', value: '2026-08-16', comparator: 'EQUALS' }, '')).toBe(false);
+    });
+
+    test('GREATER_THAN_OR_EQUAL / LESS_THAN_OR_EQUAL include the filter date itself', () => {
+      const sameDay = { type: 'DATE', value: '2026-08-16' } as const;
+      expect(filterRecord({ ...sameDay, comparator: 'GREATER_THAN_OR_EQUAL' }, '2026-08-16 10:30:00 AM')).toBe(true);
+      expect(filterRecord({ ...sameDay, comparator: 'LESS_THAN_OR_EQUAL' }, '2026-08-16 10:30:00 AM')).toBe(true);
+      expect(filterRecord({ ...sameDay, comparator: 'GREATER_THAN_OR_EQUAL' }, '2026-08-15 10:30:00 AM')).toBe(false);
+      expect(filterRecord({ ...sameDay, comparator: 'LESS_THAN_OR_EQUAL' }, '2026-08-17 10:30:00 AM')).toBe(false);
+    });
+
+    test('ignoreTimestamp compares calendar days only', () => {
+      const filter = { type: 'DATE', value: '2026-08-16', comparator: 'GREATER_THAN' } as const;
+      // Without it, a later time on the filter date still counts as "after" the start of that day.
+      expect(filterRecord({ ...filter }, '2026-08-16 10:30:00 AM')).toBe(true);
+      expect(filterRecord({ ...filter, ignoreTimestamp: true }, '2026-08-16 10:30:00 AM')).toBe(false);
+      expect(filterRecord({ ...filter, ignoreTimestamp: true }, '2026-08-17 10:30:00 AM')).toBe(true);
+    });
+  });
+
+  test('NUMBER supports inclusive comparators', () => {
+    expect(filterRecord({ type: 'NUMBER', value: '5', comparator: 'GREATER_THAN_OR_EQUAL' }, 5)).toBe(true);
+    expect(filterRecord({ type: 'NUMBER', value: '5', comparator: 'GREATER_THAN_OR_EQUAL' }, 4)).toBe(false);
+    expect(filterRecord({ type: 'NUMBER', value: '5', comparator: 'LESS_THAN_OR_EQUAL' }, 5)).toBe(true);
+    expect(filterRecord({ type: 'NUMBER', value: '5', comparator: 'LESS_THAN_OR_EQUAL' }, 6)).toBe(false);
+  });
+
+  test('TIME supports inclusive comparators', () => {
+    const filter = { type: 'TIME', value: '13:30:00.0000' } as const;
+    expect(filterRecord({ ...filter, comparator: 'GREATER_THAN_OR_EQUAL' }, '1:30:00 PM')).toBe(true);
+    expect(filterRecord({ ...filter, comparator: 'LESS_THAN_OR_EQUAL' }, '1:30:00 PM')).toBe(true);
+    expect(filterRecord({ ...filter, comparator: 'GREATER_THAN' }, '1:30:00 PM')).toBe(false);
+    expect(filterRecord({ ...filter, comparator: 'GREATER_THAN_OR_EQUAL' }, '2:30:00 PM')).toBe(true);
+    expect(filterRecord({ ...filter, comparator: 'LESS_THAN_OR_EQUAL' }, '2:30:00 PM')).toBe(false);
+  });
+
+  test('TIME EQUALS compares the time of day, not the reference day', () => {
+    const filter = { type: 'TIME', value: '13:30:00.0000', comparator: 'EQUALS' } as const;
+    expect(filterRecord(filter, '1:30:00 PM')).toBe(true);
+    expect(filterRecord(filter, '2:30:00 PM')).toBe(false);
+    expect(filterRecord(filter, '1:31:00 PM')).toBe(false);
+  });
+
   test('SET matches selected values and EMPTY_FIELD matches null', () => {
     expect(filterRecord({ type: 'SET', value: ['Alpha', 'Bravo'] }, 'Alpha')).toBe(true);
     expect(filterRecord({ type: 'SET', value: ['Alpha'] }, 'Bravo')).toBe(false);

--- a/libs/ui/src/lib/data-table/grid/filters/HeaderFilters.tsx
+++ b/libs/ui/src/lib/data-table/grid/filters/HeaderFilters.tsx
@@ -26,13 +26,16 @@ import {
   DataTableSetFilter,
   DataTableTextFilter,
   DataTableTimeFilter,
+  FilterComparator,
 } from '../grid-types';
 
-type Comparator = 'EQUALS' | 'GREATER_THAN' | 'LESS_THAN';
+type Comparator = FilterComparator;
 const COMPARATOR_ITEMS: ListItem<string, Comparator>[] = [
   { id: 'EQUALS', label: 'Equals', value: 'EQUALS' },
   { id: 'GREATER_THAN', label: 'Greater Than', value: 'GREATER_THAN' },
+  { id: 'GREATER_THAN_OR_EQUAL', label: 'Greater Than or Equal', value: 'GREATER_THAN_OR_EQUAL' },
   { id: 'LESS_THAN', label: 'Less Than', value: 'LESS_THAN' },
+  { id: 'LESS_THAN_OR_EQUAL', label: 'Less Than or Equal', value: 'LESS_THAN_OR_EQUAL' },
 ];
 
 interface UpdateFilterFn {
@@ -386,6 +389,10 @@ export const HeaderDateFilter = memo(({ columnKey, filter, updateFilter }: Heade
     updateFilter(columnKey, { ...filter, value: nextValue ? formatISO(nextValue) : null });
   }
 
+  function handleIgnoreTimestampChange(ignoreTimestamp: boolean) {
+    updateFilter(columnKey, { ...filter, ignoreTimestamp });
+  }
+
   return (
     <div>
       <Picklist
@@ -401,7 +408,16 @@ export const HeaderDateFilter = memo(({ columnKey, filter, updateFilter }: Heade
         hideLabel
         className="slds-m-top_small w-100"
         initialSelectedDate={value || undefined}
+        allowClear
         onChange={handleDateChange}
+      />
+      <Checkbox
+        id={`${columnKey}-ignore-timestamp`}
+        className="slds-m-top_x-small"
+        label="Ignore timestamp"
+        labelHelp="Compare calendar dates only, ignoring the time of day stored on each record."
+        checked={!!filter.ignoreTimestamp}
+        onChange={handleIgnoreTimestampChange}
       />
     </div>
   );

--- a/libs/ui/src/lib/data-table/grid/grid-filters.ts
+++ b/libs/ui/src/lib/data-table/grid/grid-filters.ts
@@ -3,6 +3,7 @@ import { DATE_FORMATS } from '@jetstream/shared/constants';
 import { ensureBoolean, orderValues } from '@jetstream/shared/utils';
 import { isAfter } from 'date-fns/isAfter';
 import { isBefore } from 'date-fns/isBefore';
+import { isEqual } from 'date-fns/isEqual';
 import { isSameDay } from 'date-fns/isSameDay';
 import { isValid as isDateValid } from 'date-fns/isValid';
 import { parse as parseDate } from 'date-fns/parse';
@@ -21,6 +22,21 @@ import { ColumnWithFilter, DataTableFilter, FILTER_SET_TYPES, FilterType } from 
  * filter identically.
  */
 
+/**
+ * Parse a grid cell's date value. Cells render dates as `yyyy-MM-dd h:mm:ss a`, so that format is tried
+ * first; anything else (ISO strings, date-only values) falls back to `parseISO`.
+ *
+ * Do NOT try to pick the strategy by inspecting the string's length — `h` is a 1-2 digit hour, so the
+ * formatted length varies with the time of day and any 10/11/12 o'clock value takes the wrong branch.
+ */
+function parseGridDate(value: string): Date {
+  const parsedWithKnownFormat = parseDate(value, DATE_FORMATS.YYYY_MM_DD_HH_mm_ss_a, new Date());
+  if (isDateValid(parsedWithKnownFormat)) {
+    return parsedWithKnownFormat;
+  }
+  return parseISO(value);
+}
+
 export function resetFilter(type: FilterType, setValues: string[] = []): DataTableFilter {
   switch (type) {
     case 'TEXT':
@@ -28,7 +44,7 @@ export function resetFilter(type: FilterType, setValues: string[] = []): DataTab
     case 'NUMBER':
       return { type, value: null, comparator: 'EQUALS' };
     case 'DATE':
-      return { type, value: '', comparator: 'GREATER_THAN' };
+      return { type, value: '', comparator: 'GREATER_THAN', ignoreTimestamp: false };
     case 'TIME':
       return { type, value: '', comparator: 'GREATER_THAN' };
     case 'SET':
@@ -77,8 +93,12 @@ export function filterRecord(filter: DataTableFilter, value: any): boolean {
       switch (filter.comparator) {
         case 'GREATER_THAN':
           return value > filterValue;
+        case 'GREATER_THAN_OR_EQUAL':
+          return value >= filterValue;
         case 'LESS_THAN':
           return value < filterValue;
+        case 'LESS_THAN_OR_EQUAL':
+          return value <= filterValue;
         case 'EQUALS':
         default:
           return value === filterValue;
@@ -88,21 +108,23 @@ export function filterRecord(filter: DataTableFilter, value: any): boolean {
       if (!value || !filter.value) {
         return false;
       }
+      // The filter value is always day-granular, so the record's date is compared against the start of
+      // the selected day. `ignoreTimestamp` additionally floors the record so comparisons are day-to-day.
       const dateFilter = startOfDay(parseISO(filter.value));
-      let date: Date;
-      if (value.length === 21) {
-        date = parseDate(value, DATE_FORMATS.YYYY_MM_DD_HH_mm_ss_a, new Date());
-      } else {
-        date = startOfDay(parseISO(value));
-      }
-      if (!isDateValid(date)) {
+      const parsedDate = parseGridDate(value);
+      if (!isDateValid(parsedDate) || !isDateValid(dateFilter)) {
         return false;
       }
+      const date = filter.ignoreTimestamp ? startOfDay(parsedDate) : parsedDate;
       switch (filter.comparator) {
         case 'GREATER_THAN':
           return isAfter(date, dateFilter);
+        case 'GREATER_THAN_OR_EQUAL':
+          return isAfter(date, dateFilter) || isSameDay(date, dateFilter);
         case 'LESS_THAN':
           return isBefore(date, dateFilter);
+        case 'LESS_THAN_OR_EQUAL':
+          return isBefore(date, dateFilter) || isSameDay(date, dateFilter);
         case 'EQUALS':
         default:
           return isSameDay(date, dateFilter);
@@ -117,14 +139,20 @@ export function filterRecord(filter: DataTableFilter, value: any): boolean {
       if (!isDateValid(dateFilter) || !isDateValid(date)) {
         return false;
       }
+      // Both sides parse against the same reference day, so every case compares the times directly.
+      // `isSameDay` must NOT be used here — it is always true and would make the comparator match everything.
       switch (filter.comparator) {
         case 'GREATER_THAN':
           return isAfter(date, dateFilter);
+        case 'GREATER_THAN_OR_EQUAL':
+          return !isBefore(date, dateFilter);
         case 'LESS_THAN':
           return isBefore(date, dateFilter);
+        case 'LESS_THAN_OR_EQUAL':
+          return !isAfter(date, dateFilter);
         case 'EQUALS':
         default:
-          return isSameDay(date, dateFilter);
+          return isEqual(date, dateFilter);
       }
     }
     case 'BOOLEAN_SET': {

--- a/libs/ui/src/lib/data-table/grid/grid-types.ts
+++ b/libs/ui/src/lib/data-table/grid/grid-types.ts
@@ -122,22 +122,29 @@ export interface DataTableTextFilter {
   value: string;
 }
 
+export type FilterComparator = 'EQUALS' | 'GREATER_THAN' | 'GREATER_THAN_OR_EQUAL' | 'LESS_THAN' | 'LESS_THAN_OR_EQUAL';
+
 export interface DataTableNumberFilter {
   type: 'NUMBER';
   value: string | null;
-  comparator: 'EQUALS' | 'GREATER_THAN' | 'LESS_THAN';
+  comparator: FilterComparator;
 }
 
 export interface DataTableDateFilter {
   type: 'DATE';
   value: string | null;
-  comparator: 'EQUALS' | 'GREATER_THAN' | 'LESS_THAN';
+  comparator: FilterComparator;
+  /**
+   * Compare calendar days only, discarding the record's time-of-day. Without this, a record stamped
+   * later the same day as the filter date counts as "greater than" it.
+   */
+  ignoreTimestamp?: boolean;
 }
 
 export interface DataTableTimeFilter {
   type: 'TIME';
   value: string;
-  comparator: 'EQUALS' | 'GREATER_THAN' | 'LESS_THAN';
+  comparator: FilterComparator;
 }
 
 export interface DataTableSetFilter {

--- a/libs/ui/src/lib/form/date/DatePicker.tsx
+++ b/libs/ui/src/lib/form/date/DatePicker.tsx
@@ -1,5 +1,6 @@
 // https://www.lightningdesignsystem.com/components/input/#Fixed-Text
 
+import { css } from '@emotion/react';
 import { useNonInitialEffect } from '@jetstream/shared/ui-utils';
 import { PositionLeftRight } from '@jetstream/types';
 import classNames from 'classnames';
@@ -40,6 +41,8 @@ export interface DatePickerProps {
   usePortal?: boolean;
   openOnInit?: boolean;
   trigger?: 'onChange' | 'onBlur';
+  /** Show an `x` in the input to clear the selected date without having to open the picker. */
+  allowClear?: boolean;
   onChange: (date: Date | null) => void;
 }
 
@@ -65,6 +68,7 @@ export const DatePicker: FunctionComponent<DatePickerProps> = ({
   openOnInit = false,
   usePortal = false,
   trigger = 'onChange',
+  allowClear = false,
   onChange,
 }) => {
   initialSelectedDate = isValidDate(initialSelectedDate) ? initialSelectedDate : undefined;
@@ -162,6 +166,8 @@ export const DatePicker: FunctionComponent<DatePickerProps> = ({
     onChange(null);
   }
 
+  const showClearButton = allowClear && !readOnly && !!value;
+
   function handleToggleOpen(value: boolean) {
     if (readOnly && !isOpen) {
       return;
@@ -189,7 +195,12 @@ export const DatePicker: FunctionComponent<DatePickerProps> = ({
         {label}
       </label>
       {!hideLabel && labelHelp && <HelpText id={`${id}-label-help-text`} content={labelHelp} />}
-      <div className="slds-form-element__control slds-input-has-icon slds-input-has-icon_right">
+      <div
+        className={classNames('slds-form-element__control slds-input-has-icon', {
+          'slds-input-has-icon_group-right': showClearButton,
+          'slds-input-has-icon_right': !showClearButton,
+        })}
+      >
         <input
           ref={inputRef}
           aria-describedby={errorMessageId}
@@ -215,14 +226,33 @@ export const DatePicker: FunctionComponent<DatePickerProps> = ({
           disabled={disabled}
           {...inputProps}
         />
-        <button
-          className="slds-button slds-button_icon slds-input__icon slds-input__icon_right"
-          title="Select a date"
-          onClick={() => handleToggleOpen(!isOpen)}
-          disabled={disabled}
-        >
-          {!readOnly && <Icon type="utility" icon="event" className="slds-button__icon" omitContainer description="Select a date" />}
-        </button>
+        <div className={classNames({ 'slds-input__icon-group slds-input__icon-group_right': showClearButton })}>
+          {showClearButton && (
+            <button
+              type="button"
+              className="slds-button slds-button_icon slds-input__icon slds-input__icon_right"
+              // The icon group stacks both buttons at the same offset, so shift the clear button inward
+              // to sit alongside the calendar button rather than underneath it.
+              css={css`
+                right: 1.75rem;
+              `}
+              title="Clear date"
+              onClick={handleClear}
+              disabled={disabled}
+            >
+              <Icon type="utility" icon="clear" className="slds-button__icon" omitContainer description="Clear date" />
+            </button>
+          )}
+          <button
+            type="button"
+            className="slds-button slds-button_icon slds-input__icon slds-input__icon_right"
+            title="Select a date"
+            onClick={() => handleToggleOpen(!isOpen)}
+            disabled={disabled}
+          >
+            {!readOnly && <Icon type="utility" icon="event" className="slds-button__icon" omitContainer description="Select a date" />}
+          </button>
+        </div>
       </div>
       <div className="slds-assistive-text slds-form-element__help">Format: yyyy-mm-dd</div>
       <PopoverContainer


### PR DESCRIPTION
Closes #1446

## The bug

`grid-filters.ts` picked a date parse strategy with `value.length === 21`. The cell format `yyyy-MM-dd h:mm:ss a` is only 21 characters when the hour is a **single digit** — at 10/11/12 o'clock it is 22, took the `parseISO` branch, produced `Invalid Date`, and failed every comparison. The row was then silently dropped.

Reproduced by running the path with the repo's own date-fns:

| value | length | result |
| --- | --- | --- |
| `2026-08-16 9:30:00 AM` | 21 | parsed |
| `2026-08-16 10:30:00 AM` | 22 | **Invalid Date** |
| `2026-08-16 12:00:00 PM` | 22 | **Invalid Date** |

That explains the report of 500 records returning one — records created in a batch share an hour.

## Changes

- Parse the known format explicitly, falling back to `parseISO` only when that fails. No length sniffing.
- Add `>=` / `<=` comparators (the shared picklist is used by NUMBER, DATE and TIME, so all three handle them).
- Add an **Ignore timestamp** option that compares calendar days only.
- Add an opt-in clear button to `DatePicker` — `handleClear` already existed but was only reachable from inside the popup.

## Testing

20 tests pass in `grid-filters.spec.ts`, including a regression test over every affected hour.

> [!NOTE]
> `DataTableDateFilter.comparator` widens to a shared `FilterComparator` type. Confirmed contained to the grid module.
