### PR TITLE
fix(formula-evaluator): stop Format producing formulas that fail to deploy

### DIFF
--- a/libs/features/formula-evaluator/src/FormulaEvaluator.tsx
+++ b/libs/features/formula-evaluator/src/FormulaEvaluator.tsx
@@ -48,6 +48,7 @@ import { useAtom, useAtomValue } from 'jotai';
 import type { editor } from 'monaco-editor';
 import { FunctionComponent, useCallback, useEffect, useRef, useState } from 'react';
 import { FormulaEvaluatorDeployModal } from './deploy/FormulaEvaluatorDeployModal';
+import { formatSalesforceFormula } from './formula-formatter';
 
 export function filterSobjectFn(sobject: DescribeGlobalSObjectResult): boolean {
   return (
@@ -207,21 +208,7 @@ export const FormulaEvaluator: FunctionComponent<FormulaEvaluatorProps> = () => 
       if (!editorRef.current || !value) {
         return;
       }
-      const prettier = await import('prettier/standalone');
-      const prettierPluginBabel = await import('prettier/plugins/babel');
-      const prettierPluginEstree = await import('prettier/plugins/estree');
-      editorRef.current.setValue(
-        await prettier.format(value, {
-          parser: 'babel',
-          plugins: [prettierPluginBabel, prettierPluginEstree as any],
-          bracketSpacing: false,
-          semi: false,
-          singleQuote: true,
-          trailingComma: 'none',
-          useTabs: false,
-          tabWidth: 2,
-        }),
-      );
+      editorRef.current.setValue(await formatSalesforceFormula(value));
     } catch (ex) {
       logger.warn('failed to format', ex);
     }

--- a/libs/features/formula-evaluator/src/__tests__/formula-formatter.spec.ts
+++ b/libs/features/formula-evaluator/src/__tests__/formula-formatter.spec.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from 'vitest';
+import { formatSalesforceFormula } from '../formula-formatter';
+
+describe('formatSalesforceFormula', () => {
+  test('preserves double quotes on string literals', async () => {
+    // Single quotes are a syntax error in a Salesforce formula — rewriting them made "Format" produce
+    // formulas that failed to deploy.
+    const result = await formatSalesforceFormula('IF(Amount > 100, "High", "Low")');
+    expect(result.trim()).toBe('IF(Amount > 100, "High", "Low")');
+    expect(result).not.toContain("'");
+  });
+
+  test('preserves empty string literals', async () => {
+    const result = await formatSalesforceFormula('IF(ISBLANK(Description), "", LEFT(Description, 10))');
+    expect(result.trim()).toBe('IF(ISBLANK(Description), "", LEFT(Description, 10))');
+  });
+
+  test('does not emit a leading semicolon for concatenation formulas', async () => {
+    const result = await formatSalesforceFormula('Name & " - " & TEXT(CloseDate)');
+    expect(result.trim()).toBe('Name & " - " & TEXT(CloseDate)');
+  });
+
+  test('does not emit a leading semicolon for parenthesized formulas', async () => {
+    const result = await formatSalesforceFormula('(Amount + Tax__c) * 2');
+    expect(result.trim()).toBe('(Amount + Tax__c) * 2');
+  });
+
+  test('indents nested function calls without altering quotes', async () => {
+    const formula =
+      'IF(AND(ISPICKVAL(StageName,"Closed Won"), Amount > 10000), "Big Win: " & Name, IF(ISBLANK(Description), "None", LEFT(Description, 50)))';
+    const result = await formatSalesforceFormula(formula);
+    expect(result).not.toContain("'");
+    expect(result).not.toMatch(/^\s*;/);
+    expect(result).toContain('\n');
+    expect(result).toContain('"Closed Won"');
+  });
+
+  test('rejects formula syntax that is not valid JavaScript so the caller can leave it alone', async () => {
+    await expect(formatSalesforceFormula('Amount <> 0')).rejects.toThrow();
+  });
+});

--- a/libs/features/formula-evaluator/src/formula-formatter.ts
+++ b/libs/features/formula-evaluator/src/formula-formatter.ts
@@ -1,0 +1,43 @@
+/**
+ * Pretty-printing for Salesforce formulas.
+ *
+ * There is no formula parser available in the browser, so prettier's JavaScript (babel) parser is used
+ * as a stand-in — formula syntax overlaps enough with JS expressions for indentation and line breaking
+ * to come out right. The trade-off is that prettier applies JavaScript conventions that are invalid in
+ * a formula, so the options below and the post-processing exist purely to undo them:
+ *
+ * - `singleQuote` MUST stay false. Salesforce string literals require double quotes, so rewriting
+ *   `"..."` to `'...'` turns a working formula into one that fails to deploy.
+ * - `semi: false` makes prettier prepend an ASI-guard `;` when the expression could otherwise continue
+ *   a preceding line (any top-level `&` concatenation hits this). That leading `;` is stripped below.
+ *
+ * Formulas using syntax that is not valid JavaScript (`<>`, for example) fail to parse; the caller
+ * treats that as "leave the formula alone".
+ */
+export async function formatSalesforceFormula(formula: string): Promise<string> {
+  const prettier = await import('prettier/standalone');
+  const prettierPluginBabel = await import('prettier/plugins/babel');
+  const prettierPluginEstree = await import('prettier/plugins/estree');
+
+  const formatted = await prettier.format(formula, {
+    parser: 'babel',
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    plugins: [prettierPluginBabel, prettierPluginEstree as any],
+    bracketSpacing: false,
+    semi: false,
+    singleQuote: false,
+    trailingComma: 'none',
+    useTabs: false,
+    tabWidth: 2,
+  });
+
+  return stripLeadingSemicolon(formatted);
+}
+
+/**
+ * Remove the ASI-guard semicolon prettier adds ahead of the expression. It is only ever emitted once,
+ * at the very start of the output, and is a syntax error in a Salesforce formula.
+ */
+function stripLeadingSemicolon(formatted: string): string {
+  return formatted.replace(/^(\s*);/, '$1');
+}


### PR DESCRIPTION
Closes #227

## The bug

Formulas are pretty-printed through prettier's **JavaScript** parser, and two JS conventions were leaking into the output:

1. `singleQuote: true` rewrote `"..."` → `'...'`. Salesforce string literals require double quotes, so **Format could silently turn a working formula into one that fails to deploy.** This is more serious than the reported symptom.
2. `semi: false` makes prettier prepend an ASI-guard `;` — the stray leading semicolon originally reported here.

Both verified against the repo's prettier:

| input | before | after |
| --- | --- | --- |
| `IF(Amount > 100, "High", "Low")` | `IF(Amount > 100, 'High', 'Low')` | unchanged |
| `Name & " - " & TEXT(CloseDate)` | `;Name & " - " & TEXT(CloseDate)` | unchanged |
| `(Amount + Tax__c) * 2` | `;(Amount + Tax__c) * 2` | unchanged |

So the two problems share a root cause: JS formatting conventions applied to a language that is not JavaScript.

## Changes

Extracted the formatter into a pure `formatSalesforceFormula`, pinned `singleQuote: false`, and stripped the leading semicolon. The docblock explains why each option is load-bearing rather than stylistic.

## Testing

6 new tests in `formula-formatter.spec.ts`.

> [!NOTE]
> Formulas using syntax that is not valid JS (e.g. `<>`) still fail to parse and leave the formula untouched. Pre-existing, out of scope here.
