### PR TITLE
fix(extension): restore View/Edit Record for objects with long API names

### DIFF
--- a/apps/jetstream-web-extension/src/utils/__tests__/web-extension.utils.spec.ts
+++ b/apps/jetstream-web-extension/src/utils/__tests__/web-extension.utils.spec.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test, vi } from 'vitest';
+import { getRecordPageObject, getRecordPageRecordId } from '../web-extension.utils';
+
+// The module imports the polyfill at load time, which refuses to initialize outside an extension.
+// Nothing under test touches the `browser` API, so a stub is enough to get the module loaded.
+vi.mock('webextension-polyfill', () => ({ default: { runtime: { sendMessage: vi.fn() } } }));
+
+describe('getRecordPageRecordId', () => {
+  test('reads the id positionally for objects with long API names', () => {
+    // Regression: an id-shaped search matched the first 18 characters of the object name instead.
+    expect(getRecordPageRecordId('/lightning/r/OpportunityLineItem/00k5j000000AbCdAAK/view')).toBe('00k5j000000AbCdAAK');
+    expect(getRecordPageRecordId('/lightning/r/ServiceAppointment/08p5j000000AbCdAAK/view')).toBe('08p5j000000AbCdAAK');
+    expect(getRecordPageRecordId('/lightning/r/OpportunityContactRole/00K5j000000AbCdEAK/view')).toBe('00K5j000000AbCdEAK');
+  });
+
+  test('reads the id for short object names', () => {
+    expect(getRecordPageRecordId('/lightning/r/Account/0015j00000AbCdEAAV/view')).toBe('0015j00000AbCdEAAV');
+    expect(getRecordPageRecordId('/lightning/r/Opportunity/0065j00000AbCdEAAV/edit')).toBe('0065j00000AbCdEAAV');
+  });
+
+  test('reads classic short URLs without the leading slash', () => {
+    expect(getRecordPageRecordId('/001D000000IqhSL')).toBe('001D000000IqhSL');
+    expect(getRecordPageRecordId('/001D000000IqhSLIAZ')).toBe('001D000000IqhSLIAZ');
+  });
+
+  test('rejects ids that fail the checksum instead of returning them', () => {
+    // The validation guard used to return the value on both branches, so bad ids were used anyway.
+    // `0015j00000AbCdE` checksums to `AAV`, so an `AAA` suffix is not a real id.
+    expect(getRecordPageRecordId('/lightning/r/Account/0015j00000AbCdEAAA/view')).toBeUndefined();
+  });
+
+  test('returns nothing for non-record pages', () => {
+    expect(getRecordPageRecordId('')).toBeUndefined();
+    expect(getRecordPageRecordId('/lightning/o/Account/list')).toBeUndefined();
+    expect(getRecordPageRecordId('/lightning/r/Account/0015j00000AbCdEAAV/related')).toBeUndefined();
+  });
+});
+
+describe('getRecordPageObject', () => {
+  test('returns the object name from record and object pages', () => {
+    expect(getRecordPageObject('/lightning/r/OpportunityLineItem/00k5j000000AbCdAAK/view')).toBe('OpportunityLineItem');
+    expect(getRecordPageObject('/lightning/r/Account/0015j00000AbCdEAAV/view')).toBe('Account');
+    expect(getRecordPageObject('/lightning/o/Account/list')).toBe('Account');
+  });
+
+  test('returns nothing when the path is not a Salesforce object or record page', () => {
+    expect(getRecordPageObject('')).toBeUndefined();
+    expect(getRecordPageObject('/lightning/setup/SetupOneHome/home')).toBeUndefined();
+  });
+});

--- a/apps/jetstream-web-extension/src/utils/web-extension.utils.ts
+++ b/apps/jetstream-web-extension/src/utils/web-extension.utils.ts
@@ -15,7 +15,16 @@ type ResponseForRequest<R> = R extends { message: infer M }
   : never;
 
 const OBJECT_PAGE_REGEX = /\/lightning\/o\/[a-z0-9_]+\//i;
-const RECORD_PAGE_REGEX = /\/lightning\/r\/[a-z0-9_]+\/[a-z0-9]{18}\/(view|edit)$/i;
+
+/**
+ * Lightning record pages are `/lightning/r/<objectName>/<recordId>/<action>`. Both the object name and
+ * the record id are captured positionally — searching the path for an id-shaped substring instead would
+ * match the *object name* for anything with an API name of 18+ characters (OpportunityLineItem,
+ * ServiceAppointment, OpportunityContactRole, …).
+ */
+const RECORD_PAGE_REGEX = /\/lightning\/r\/(?<objectName>[a-z0-9_]+)\/(?<recordId>[a-z0-9]{18}|[a-z0-9]{15})\/(?:view|edit)$/i;
+/** Classic-style short URL, e.g. `/001D000000IqhSL`. */
+const CLASSIC_RECORD_PAGE_REGEX = /^\/(?<recordId>[a-z0-9]{18}|[a-z0-9]{15})$/i;
 
 function handleResponse<T>(response: MessageResponse<ResponseForRequest<T>>) {
   logger.log('RESPONSE', response);
@@ -47,8 +56,9 @@ export async function sendMessage<T extends MessageRequest>(message: T): Promise
   }
 }
 
-const is15or18Digits = /[a-z0-9]{15}|[a-z0-9]{18}/i;
-const is18Digits = /[a-z0-9]{18}/i;
+// Anchored so a longer string that merely contains an id-shaped run is rejected.
+const is15or18Digits = /^(?:[a-z0-9]{18}|[a-z0-9]{15})$/i;
+const is18Digits = /^[a-z0-9]{18}$/i;
 
 function isValidSalesforceRecordId(recordId?: string, allow15Char = true): boolean {
   const regex = allow15Char ? is15or18Digits : is18Digits;
@@ -77,15 +87,10 @@ export function getRecordPageRecordId(pathName: string) {
   if (!pathName) {
     return;
   }
-  let recordId: string | undefined;
-  if (RECORD_PAGE_REGEX.test(pathName)) {
-    // extract the record id by matching [a-zA-Z0-9]{18}
-    recordId = pathName.match(/[a-zA-Z0-9]{18}/i)?.[0];
-  } else if (/^\/[a-zA-Z0-9]{15}$/.test(pathName)) {
-    recordId = pathName.match(/\/[a-z0-9]{15}$/i)?.[0];
-  }
-  if (isValidSalesforceRecordId(recordId)) {
-    return recordId;
+  const match = RECORD_PAGE_REGEX.exec(pathName) ?? CLASSIC_RECORD_PAGE_REGEX.exec(pathName);
+  const recordId = match?.groups?.recordId;
+  if (!isValidSalesforceRecordId(recordId)) {
+    return;
   }
   return recordId;
 }
@@ -100,9 +105,5 @@ export function getRecordPageObject(pathName: string) {
       return objectName;
     }
   }
-  if (RECORD_PAGE_REGEX.test(pathName)) {
-    const objectName = pathName.replace('/lightning/r/', '').split('/')[0];
-    return objectName;
-  }
-  return;
+  return RECORD_PAGE_REGEX.exec(pathName)?.groups?.objectName;
 }


### PR DESCRIPTION
Closes #1240

## The bug

The record id was extracted with an **unanchored** `pathName.match(/[a-zA-Z0-9]{18}/i)`. `OpportunityLineItem` is 19 characters, so on `/lightning/r/OpportunityLineItem/<id>/view` the regex matched the first 18 characters of the *object name*:

| path | returned |
| --- | --- |
| `/lightning/r/OpportunityLineItem/00k…/view` | `OpportunityLineIte` |
| `/lightning/r/ServiceAppointment/08p…/view` | `ServiceAppointment` |
| `/001D000000IqhSL` | `/001D000000IqhSL` ← leading slash |

Two compounding problems:

- The validation guard below it was **dead code** — both branches returned the id, so the bad value was used anyway.
- The classic short-URL branch returned the id with its leading slash attached (not previously reported).

Affects any object with an API name of 18+ characters, in both the button UI and the keyboard shortcut.

## Changes

Read the object name and record id **positionally** from `/lightning/r/<object>/<id>/<action>`, accept 15- and 18-character ids, anchor the validator's regexes, and make the guard actually reject.

Verified the existing checksum validator is correct on real ids before enabling it — otherwise turning on the guard would have broken View/Edit for everyone.

## Testing

7 new tests in `web-extension.utils.spec.ts`. Callers already handle `undefined`, so an unparseable id now hides the buttons instead of producing a broken link.
