### PR TITLE
fix(create-object): stop doubling the namespace prefix in namespaced orgs

### DIFF
--- a/libs/features/create-object-and-fields/src/create-new-object/__tests__/create-object-utils.spec.ts
+++ b/libs/features/create-object-and-fields/src/create-new-object/__tests__/create-object-utils.spec.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from 'vitest';
+import { CreateFieldParams } from '../create-object-types';
+import { getObjectAndTabPermissionRecords } from '../create-object-utils';
+
+function buildParams(overrides: Partial<CreateFieldParams> = {}): CreateFieldParams {
+  return {
+    apiName: 'myns__ObjName__c',
+    createTab: true,
+    tabMotif: 'Custom20: Airplane',
+    payload: {} as CreateFieldParams['payload'],
+    objectPermissions: {
+      scope: 'ALL',
+      permissions: {
+        allowCreate: true,
+        allowDelete: false,
+        allowEdit: true,
+        allowRead: true,
+        modifyAllRecords: false,
+        viewAllRecords: false,
+        viewAllFields: false,
+      },
+    },
+    permissionSets: ['0PS000000000001'],
+    profiles: ['00e000000000001'],
+    ...overrides,
+  };
+}
+
+describe('getObjectAndTabPermissionRecords', () => {
+  test('uses the api name as given, without re-applying the org namespace', () => {
+    // Regression: the namespace was applied here as well as where the form value is read, producing
+    // `myns__myns__ObjName__c` and failing the permissions step of an otherwise successful deploy.
+    const { objectPermissions, tabPermissions } = getObjectAndTabPermissionRecords(buildParams());
+
+    expect(objectPermissions).toHaveLength(2);
+    objectPermissions.forEach((record) => expect(record.SobjectType).toBe('myns__ObjName__c'));
+
+    expect(tabPermissions).toHaveLength(2);
+    tabPermissions.forEach((record) => expect(record.Name).toBe('myns__ObjName__c'));
+  });
+
+  test('builds one record per profile and permission set for each parent id', () => {
+    const { objectPermissions, tabPermissions } = getObjectAndTabPermissionRecords(
+      buildParams({ profiles: ['00e1', '00e2'], permissionSets: ['0PS1'] }),
+    );
+
+    expect(objectPermissions.map((record) => record.ParentId)).toEqual(['00e1', '00e2', '0PS1']);
+    expect(tabPermissions.map((record) => record.ParentId)).toEqual(['00e1', '00e2', '0PS1']);
+  });
+
+  test('omits tab permissions when no tab is created', () => {
+    const { objectPermissions, tabPermissions } = getObjectAndTabPermissionRecords(buildParams({ createTab: false }));
+
+    expect(objectPermissions).toHaveLength(2);
+    expect(tabPermissions).toHaveLength(0);
+  });
+
+  test('leaves a non-namespaced api name untouched', () => {
+    const { objectPermissions } = getObjectAndTabPermissionRecords(buildParams({ apiName: 'ObjName__c' }));
+
+    objectPermissions.forEach((record) => expect(record.SobjectType).toBe('ObjName__c'));
+  });
+});

--- a/libs/features/create-object-and-fields/src/create-new-object/create-object-utils.ts
+++ b/libs/features/create-object-and-fields/src/create-new-object/create-object-utils.ts
@@ -1,6 +1,6 @@
 import { queryAll, sobjectOperation } from '@jetstream/shared/data';
 import { REGEX, splitArrayToMaxSize } from '@jetstream/shared/utils';
-import { Maybe, ObjectPermissionRecordInsert, RecordResult, SalesforceOrgUi, TabPermissionRecordInsert } from '@jetstream/types';
+import { ObjectPermissionRecordInsert, RecordResult, SalesforceOrgUi, TabPermissionRecordInsert } from '@jetstream/types';
 import { composeQuery, getField } from '@jetstreamapp/soql-parser-js';
 import JSZip from 'jszip';
 import partition from 'lodash/partition';
@@ -72,11 +72,14 @@ export function generateApiNameFromLabel(value: string) {
   return apiNameLabel ? `${apiNameLabel}__c` : '';
 }
 
-export function getObjectAndTabPermissionRecords(
-  { apiName: apiNameWithoutNamespace, createTab, profiles, permissionSets, objectPermissions }: CreateFieldParams,
-  orgNamespacePrefix?: Maybe<string>,
-) {
-  const apiName = orgNamespacePrefix ? `${orgNamespacePrefix}__${apiNameWithoutNamespace}` : apiNameWithoutNamespace;
+/**
+ * `apiName` already carries the org's namespace prefix — it is applied once, where the form value is
+ * read (`CreateNewObjectModal`), and the same qualified name is what the metadata package and the
+ * post-deploy links use. Do not prefix it again here: doing so produced `myns__myns__ObjName__c` on
+ * `ObjectPermissions.SobjectType` and `PermissionSetTabSetting.Name`, so the object and tab deployed
+ * fine and only the permissions step failed.
+ */
+export function getObjectAndTabPermissionRecords({ apiName, createTab, profiles, permissionSets, objectPermissions }: CreateFieldParams) {
   const _objectPermissions: ObjectPermissionRecordInsert[] = [];
   const tabPermissions: TabPermissionRecordInsert[] = [];
 

--- a/libs/features/create-object-and-fields/src/create-new-object/useCreateObject.ts
+++ b/libs/features/create-object-and-fields/src/create-new-object/useCreateObject.ts
@@ -58,11 +58,10 @@ export default function useCreateObject({ apiVersion, serverUrl, selectedOrg }: 
     async (data: CreateFieldParams) => {
       try {
         const { apiName } = data;
-        const { orgNamespacePrefix } = selectedOrg;
         logger.info('[deployMetadata]', data);
         setStatus('LOADING_METADATA');
         setPermissionRecordResults(null);
-        const permissionRecords = getObjectAndTabPermissionRecords(data, orgNamespacePrefix);
+        const permissionRecords = getObjectAndTabPermissionRecords(data);
         const file = await getMetadataPackage(apiVersion, data);
 
         try {


### PR DESCRIPTION
Closes #1673

## The bug

The org namespace was applied **twice**:

- `CreateNewObjectModal.tsx` builds a namespaced `apiName` from the form value
- `getObjectAndTabPermissionRecords` in `create-object-utils.ts` prefixes it again

Result: `myns__myns__ObjName__c` on `ObjectPermissions.SobjectType` and `PermissionSetTabSetting.Name` — exactly the errors in the issue. Both prefix sites came from the same commit (`ee2386699`).

The metadata package uses `apiName` once, which is why the object and tab deploy fine and only the permissions step fails.

## Changes

Removed the **util's** prefix, not the modal's, and dropped the now-unused `orgNamespacePrefix` parameter.

> [!NOTE]
> The triage notes suggested the util was the better home for namespacing. The code says otherwise: the modal's qualified `apiName` is also consumed by `getMetadataPackage`, the post-deploy Object Manager link, and `savePermissionRecords` (which queries `ObjectPermissions` by that name). Moving ownership into the util would have meant re-applying the prefix in three more places. `getObjectAndTabPermissionRecords` has exactly one caller, so narrowing its contract is safe.

## Testing

4 new tests in `create-object-utils.spec.ts`.
