### PR TITLE
fix(automation-control): include duplicate rules in the exported package

### DIFF
--- a/libs/features/automation-control/src/AutomationControlEditor.tsx
+++ b/libs/features/automation-control/src/AutomationControlEditor.tsx
@@ -32,6 +32,8 @@ import AutomationControlEditorTable from './AutomationControlEditorTable';
 import AutomationControlLastRefreshedPopover from './AutomationControlLastRefreshedPopover';
 import {
   getAutomationDeployType,
+  getDuplicateRuleFileName,
+  getDuplicateRuleFullName,
   isDuplicateRecord,
   isTableRow,
   isTableRowChild,
@@ -150,8 +152,8 @@ export const AutomationControlEditor = () => {
             fullName = record.Name;
             fileName = `triggers/${record.Name}.trigger`;
           } else if (isDuplicateRecord(item.type, record)) {
-            fullName = record.DeveloperName;
-            fileName = `objects/${record.SobjectType}.duplicateRule`;
+            fullName = getDuplicateRuleFullName(record);
+            fileName = getDuplicateRuleFileName(record);
           } else if (isValidationRecord(item.type, record)) {
             fullName = record.FullName;
             fileName = `objects/${record.EntityDefinition.QualifiedApiName}.object`;

--- a/libs/features/automation-control/src/__tests__/automation-control-data-utils.spec.ts
+++ b/libs/features/automation-control/src/__tests__/automation-control-data-utils.spec.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from 'vitest';
+import { getDuplicateRuleFileName, getDuplicateRuleFullName } from '../automation-control-data-utils';
+import { DuplicateRuleRecord } from '../automation-control-types';
+
+const record = { SobjectType: 'Account', DeveloperName: 'Standard_Account_Duplicate_Rule' } as DuplicateRuleRecord;
+
+describe('duplicate rule metadata naming', () => {
+  test('qualifies the fullName with the object it belongs to', () => {
+    // An unqualified developer name matches nothing, so the retrieve returns package.xml and no metadata.
+    expect(getDuplicateRuleFullName(record)).toBe('Account.Standard_Account_Duplicate_Rule');
+  });
+
+  test('builds the duplicateRules file path from the qualified name', () => {
+    expect(getDuplicateRuleFileName(record)).toBe('duplicateRules/Account.Standard_Account_Duplicate_Rule.duplicateRule');
+  });
+});

--- a/libs/features/automation-control/src/automation-control-data-utils.tsx
+++ b/libs/features/automation-control/src/automation-control-data-utils.tsx
@@ -88,6 +88,19 @@ export function isValidationRecord(type: AutomationMetadataType, _record: any): 
   return type === 'ValidationRule';
 }
 
+/**
+ * The Metadata API identifies a duplicate rule by `SobjectType.DeveloperName`, not by its developer
+ * name alone — an unqualified member matches nothing and the retrieve comes back with only a
+ * package.xml. Both the deploy and export paths build their manifests from these.
+ */
+export function getDuplicateRuleFullName(record: DuplicateRuleRecord): string {
+  return `${record.SobjectType}.${record.DeveloperName}`;
+}
+
+export function getDuplicateRuleFileName(record: DuplicateRuleRecord): string {
+  return `duplicateRules/${getDuplicateRuleFullName(record)}.duplicateRule`;
+}
+
 export function isWorkflowRuleRecord(type: AutomationMetadataType, _record: any): _record is ToolingWorkflowRuleRecord {
   return type === 'WorkflowRule';
 }
@@ -576,13 +589,12 @@ async function initiateDuplicateRulesMetadataRequest(selectedOrg: SalesforceOrgU
     .filter((item) => !item.deploy.metadataRetrieve)
     .map(({ deploy: item, metadata }): ListMetadataResult => {
       const record = metadata.record as DuplicateRuleRecord;
-      const fullName = `${record.SobjectType}.${record.DeveloperName}`;
       return {
         createdById: null,
         createdByName: null,
         createdDate: null,
-        fileName: `duplicateRules/${fullName}.duplicateRule`,
-        fullName,
+        fileName: getDuplicateRuleFileName(record),
+        fullName: getDuplicateRuleFullName(record),
         id: item.id,
         lastModifiedById: null,
         lastModifiedByName: null,
@@ -604,8 +616,8 @@ async function prepareMetadataForDuplicateRules(
   for (const duplicateRule of duplicateRules) {
     const record = duplicateRule.metadata.record as DuplicateRuleRecord;
     const deploymentItem = { ...itemsByKey[duplicateRule.metadata.key].deploy };
-    const fullName = `${record.SobjectType}.${record.DeveloperName}`;
-    const fileName = `duplicateRules/${fullName}.duplicateRule`;
+    const fullName = getDuplicateRuleFullName(record);
+    const fileName = getDuplicateRuleFileName(record);
     if (!salesforcePackage.files[fileName]) {
       deploymentItem.retrieveError = [{ message: 'There was an error getting metadata from Salesforce', errorCode: 'MISSING_FILE' }];
       output.push({ key: duplicateRule.metadata.key, deploymentItem });


### PR DESCRIPTION
Closes #1134

## The bug

The export manifest used `fullName = record.DeveloperName` and pointed the file at `objects/<SobjectType>.duplicateRule`. The Metadata API identifies a duplicate rule as **`SobjectType.DeveloperName`** under `duplicateRules/`, so the unqualified member matched nothing in Salesforce and the retrieve came back with a `package.xml` and no metadata — the screenshots in the issue.

The **deploy** path in this same feature already built both names correctly; only the export path did not.

## Changes

Extracted the deploy path's naming into `getDuplicateRuleFullName` / `getDuplicateRuleFileName` and used it from all three sites, so the two paths cannot drift again.

## Testing

2 new tests in `automation-control-data-utils.spec.ts`.
