### PR TITLE
fix: five backlog triage fixes (#1750, #161, #528, #513, #1010)

### DIFF
--- a/libs/features/load-records/src/LoadRecords.tsx
+++ b/libs/features/load-records/src/LoadRecords.tsx
@@ -302,6 +302,11 @@ export const LoadRecords = () => {
         if (!isNextStepDisabled) {
           isNextStepDisabled = Object.values(fieldMapping).some((field) => field.mappedToLookup && !field.targetLookupField);
         }
+        // Any mapping error shown on a row (duplicate target field, record Id in an upsert) has to block
+        // the step — it is already surfaced in the UI and gates Save Mapping.
+        if (!isNextStepDisabled) {
+          isNextStepDisabled = Object.values(fieldMapping).some((field) => !!field.fieldErrorMsg);
+        }
         // Ensure required fields are mapped for custom metadata objects
         if (!isNextStepDisabled && isCustomMetadataObject) {
           isNextStepDisabled =

--- a/libs/features/load-records/src/steps/PerformLoad.tsx
+++ b/libs/features/load-records/src/steps/PerformLoad.tsx
@@ -1,5 +1,5 @@
 import { ANALYTICS_KEYS, DATE_FORMATS, TITLES } from '@jetstream/shared/constants';
-import { formatNumber, useNonInitialEffect } from '@jetstream/shared/ui-utils';
+import { formatNumber, useIntegerInput, useNonInitialEffect } from '@jetstream/shared/ui-utils';
 import { pluralizeIfMultiple } from '@jetstream/shared/utils';
 import {
   ApiMode,
@@ -88,6 +88,8 @@ export const LoadRecordsPerformLoad: FunctionComponent<LoadRecordsPerformLoadPro
   /** Only show date hint if the user has a mapped date/datetime field */
   const hasDateFieldMapped = useAtomValue(fromLoadRecordsState.selectHasDateFieldMapped);
 
+  const batchSizeInput = useIntegerInput(batchSize, setBatchSize);
+
   const batchSizeError = useAtomValue(fromLoadRecordsState.selectBatchSizeError);
   const batchApiLimitWarning = useAtomValue(fromLoadRecordsState.selectBatchApiLimitWarning);
   const batchApiLimitError = useAtomValue(fromLoadRecordsState.selectBatchApiLimitError);
@@ -165,15 +167,6 @@ export const LoadRecordsPerformLoad: FunctionComponent<LoadRecordsPerformLoadPro
     onIsLoading(false);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [trialRun, trialRunSize, inputFileData]);
-
-  function handleBatchSize(event: ChangeEvent<HTMLInputElement>) {
-    const value = Number.parseInt(event.target.value);
-    if (Number.isInteger(value)) {
-      setBatchSize(value);
-    } else if (!event.target.value) {
-      setBatchSize(null);
-    }
-  }
 
   function handletrialRunSize(event: ChangeEvent<HTMLInputElement>) {
     const value = Number.parseInt(event.target.value);
@@ -474,10 +467,11 @@ export const LoadRecordsPerformLoad: FunctionComponent<LoadRecordsPerformLoadPro
             id="batch-size"
             className="slds-input"
             placeholder="Set batch size"
-            value={batchSize || ''}
+            value={batchSizeInput.inputValue}
             aria-describedby={'batch-size-error'}
             disabled={loading || hasZipAttachment}
-            onChange={handleBatchSize}
+            onChange={batchSizeInput.handleChange}
+            onBlur={batchSizeInput.handleBlur}
           />
         </Input>
 

--- a/libs/features/query/src/QueryResults/BulkUpdateFromQuery/BulkUpdateFromQueryModal.tsx
+++ b/libs/features/query/src/QueryResults/BulkUpdateFromQuery/BulkUpdateFromQueryModal.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react';
 import { clearCacheForOrg } from '@jetstream/shared/data';
-import { convertDateToLocale, filterLoadSobjects, formatNumber, tracker } from '@jetstream/shared/ui-utils';
+import { convertDateToLocale, filterLoadSobjects, formatNumber, tracker, useIntegerInput } from '@jetstream/shared/ui-utils';
 import { getErrorMessage, getRecordIdFromAttributes, pluralizeFromNumber } from '@jetstream/shared/utils';
 import { ListItem, Maybe, SalesforceOrgUi, SalesforceRecord } from '@jetstream/types';
 import {
@@ -32,7 +32,7 @@ import { composeQuery, Query } from '@jetstreamapp/soql-parser-js';
 import { useAtom } from 'jotai';
 import { atomWithReset, useAtomCallback, useResetAtom } from 'jotai/utils';
 import isNumber from 'lodash/isNumber';
-import { ChangeEvent, FunctionComponent, useCallback, useEffect, useRef, useState } from 'react';
+import { FunctionComponent, useCallback, useEffect, useRef, useState } from 'react';
 import { buildProposedChanges, ProposedChangesResult } from './bulk-update-preview.utils';
 import BulkUpdateFromQueryRecordSelection from './BulkUpdateFromQueryRecordSelection';
 import BulkUpdateProposedChangesPreview from './BulkUpdateProposedChangesPreview';
@@ -100,6 +100,7 @@ export const BulkUpdateFromQueryModal: FunctionComponent<BulkUpdateFromQueryModa
   );
   const [batchSize, setBatchSize] = useState<Maybe<number>>(10000);
   const [batchSizeError, setBatchSizeError] = useState<string | null>(null);
+  const batchSizeInput = useIntegerInput(batchSize, setBatchSize);
   const [serialMode, setSerialMode] = useState(false);
   const [deployResults, setDeployResults] = useAtom(deployResultsState);
   const [didDeploy, setDidDeploy] = useState(false);
@@ -337,15 +338,6 @@ export const BulkUpdateFromQueryModal: FunctionComponent<BulkUpdateFromQueryModa
     onModalClose(didDeploy);
   };
 
-  function handleBatchSize(event: ChangeEvent<HTMLInputElement>) {
-    const value = Number.parseInt(event.target.value);
-    if (Number.isInteger(value)) {
-      setBatchSize(value);
-    } else if (!event.target.value) {
-      setBatchSize(null);
-    }
-  }
-
   const handleRefreshMetadata = async () => {
     setRefreshLoading(true);
     await clearCacheForOrg(selectedOrg);
@@ -538,10 +530,11 @@ export const BulkUpdateFromQueryModal: FunctionComponent<BulkUpdateFromQueryModa
                 id="batch-size"
                 className="slds-input"
                 placeholder="Set batch size"
-                value={batchSize || ''}
+                value={batchSizeInput.inputValue}
                 aria-describedby={batchSizeError ? 'batch-size-error' : undefined}
                 disabled={loading || deployInProgress}
-                onChange={handleBatchSize}
+                onChange={batchSizeInput.handleChange}
+                onBlur={batchSizeInput.handleBlur}
               />
             </Input>
           </Section>

--- a/libs/features/update-records/src/deployment/MassUpdateRecordsDeployment.tsx
+++ b/libs/features/update-records/src/deployment/MassUpdateRecordsDeployment.tsx
@@ -1,4 +1,4 @@
-import { useGoBackShortcut, usePrimaryActionShortcut } from '@jetstream/shared/ui-utils';
+import { useGoBackShortcut, useIntegerInput, usePrimaryActionShortcut } from '@jetstream/shared/ui-utils';
 import { BulkJobBatchInfo, Maybe } from '@jetstream/types';
 import {
   AutoFullHeightContainer,
@@ -20,7 +20,7 @@ import { selectedOrgState } from '@jetstream/ui/app-state';
 import { useAtomValue, useSetAtom } from 'jotai';
 import { useAtomCallback } from 'jotai/utils';
 import isNumber from 'lodash/isNumber';
-import { ChangeEvent, useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { Link, useNavigate } from 'react-router';
 import * as fromMassUpdateState from '../mass-update-records.state';
 
@@ -52,6 +52,7 @@ export const MassUpdateRecordsDeployment = () => {
   const [loading, setLoading] = useState(false);
   const [batchSize, setBatchSize] = useState<Maybe<number>>(10000);
   const [batchSizeError, setBatchSizeError] = useState<string | null>(null);
+  const batchSizeInput = useIntegerInput(batchSize, setBatchSize);
   const [serialMode, setSerialMode] = useState(false);
   const setDeploymentState = useSetAtom(fromMassUpdateState.rowsMapState);
 
@@ -92,15 +93,6 @@ export const MassUpdateRecordsDeployment = () => {
       setBatchSizeError(null);
     }
   }, [batchSize, batchSizeError]);
-
-  function handleBatchSize(event: ChangeEvent<HTMLInputElement>) {
-    const value = Number.parseInt(event.target.value);
-    if (Number.isInteger(value)) {
-      setBatchSize(value);
-    } else if (!event.target.value) {
-      setBatchSize(null);
-    }
-  }
 
   return (
     <Page testId="mass-update-records-deployment-page">
@@ -173,10 +165,11 @@ export const MassUpdateRecordsDeployment = () => {
               id="batch-size"
               className="slds-input"
               placeholder="Set batch size"
-              value={batchSize || ''}
-              aria-describedby={batchSizeError || undefined}
+              value={batchSizeInput.inputValue}
+              aria-describedby={batchSizeError ? 'batch-size-error' : undefined}
               disabled={loading}
-              onChange={handleBatchSize}
+              onChange={batchSizeInput.handleChange}
+              onBlur={batchSizeInput.handleBlur}
             />
           </Input>
         </Section>

--- a/libs/features/update-records/src/selection/MassUpdateRecordsApplyToAllRow.tsx
+++ b/libs/features/update-records/src/selection/MassUpdateRecordsApplyToAllRow.tsx
@@ -6,11 +6,10 @@ import {
   MetadataRow,
   TransformationCriteria,
   TransformationOption,
-  startsWithWhereRgx,
+  isValidWhereClause,
   transformationCriteriaListItems,
   transformationOptionListItems,
 } from '@jetstream/ui-core';
-import { isQueryValid } from '@jetstreamapp/soql-parser-js';
 import { FunctionComponent, useEffect, useState } from 'react';
 
 export interface MassUpdateRecordsApplyToAllRowProps {
@@ -38,10 +37,7 @@ export const MassUpdateRecordsApplyToAllRow: FunctionComponent<MassUpdateRecords
   const [whereClauseIsValid, setWhereClauseIsValid] = useState(true);
 
   useEffect(() => {
-    if (transformationCriteria === 'custom' && debouncedWhereClause) {
-      const whereClause = debouncedWhereClause.replace(startsWithWhereRgx, '');
-      setWhereClauseIsValid(isQueryValid(`WHERE ${whereClause}`, { allowPartialQuery: true }));
-    }
+    setWhereClauseIsValid(transformationCriteria !== 'custom' || !debouncedWhereClause || isValidWhereClause(debouncedWhereClause));
   }, [transformationCriteria, debouncedWhereClause]);
 
   useEffect(() => {

--- a/libs/shared/ui-core/src/mass-update-records/MassUpdateRecordsObjectRowCriteria.tsx
+++ b/libs/shared/ui-core/src/mass-update-records/MassUpdateRecordsObjectRowCriteria.tsx
@@ -2,10 +2,9 @@ import { css } from '@emotion/react';
 import { useDebounce } from '@jetstream/shared/ui-utils';
 import { ListItem } from '@jetstream/types';
 import { ComboboxWithItems, ControlledTextarea, Grid, Textarea } from '@jetstream/ui';
-import { isQueryValid } from '@jetstreamapp/soql-parser-js';
 import { FunctionComponent, useEffect, useState } from 'react';
 import { TransformationCriteria, TransformationOptions } from './mass-update-records.types';
-import { startsWithWhereRgx, transformationCriteriaListItems } from './mass-update-records.utils';
+import { isValidWhereClause, transformationCriteriaListItems } from './mass-update-records.utils';
 
 export interface MassUpdateRecordsObjectRowCriteriaProps {
   sobject: string;
@@ -26,10 +25,9 @@ export const MassUpdateRecordsObjectRowCriteria: FunctionComponent<MassUpdateRec
   const [whereClauseIsValid, setWhereClauseIsValid] = useState(true);
 
   useEffect(() => {
-    if (debouncedWhereClause) {
-      const whereClause = debouncedWhereClause.replace(startsWithWhereRgx, '');
-      setWhereClauseIsValid(isQueryValid(`WHERE ${whereClause}`, { allowPartialQuery: true }));
-    }
+    // An empty clause is incomplete rather than invalid — `isRequired` covers it, and leaving the
+    // previous result in place would keep an error on screen after the field is cleared.
+    setWhereClauseIsValid(!debouncedWhereClause || isValidWhereClause(debouncedWhereClause));
   }, [debouncedWhereClause]);
 
   function handleUpdateToApply(criteria: TransformationCriteria) {

--- a/libs/shared/ui-core/src/mass-update-records/__tests__/mass-update-records.utils.spec.ts
+++ b/libs/shared/ui-core/src/mass-update-records/__tests__/mass-update-records.utils.spec.ts
@@ -7,7 +7,9 @@ import {
   fetchRecordsWithRequiredFields,
   getFieldsToQuery,
   isValidRow,
+  isValidWhereClause,
   MAX_ID_QUERY_LENGTH,
+  normalizeWhereClause,
   prepareRecords,
 } from '../mass-update-records.utils';
 
@@ -105,6 +107,41 @@ describe('mass-update-records.utils#isValidRow', () => {
         ],
       } as any),
     ).toBe(false);
+  });
+});
+
+describe('mass-update-records.utils#normalizeWhereClause', () => {
+  test('strips a leading WHERE keyword regardless of case or spacing', () => {
+    expect(normalizeWhereClause('WHERE Foo = 1')).toBe('Foo = 1');
+    expect(normalizeWhereClause('  where   Foo = 1  ')).toBe('Foo = 1');
+    expect(normalizeWhereClause('WHERE(Foo = 1)')).toBe('(Foo = 1)');
+  });
+
+  test('leaves a clause without the keyword untouched', () => {
+    expect(normalizeWhereClause('Foo = 1')).toBe('Foo = 1');
+    // Only the keyword is stripped -- a field that merely starts with those letters must survive.
+    expect(normalizeWhereClause('Wherehouse__c = 1')).toBe('Wherehouse__c = 1');
+  });
+
+  test('handles empty input', () => {
+    expect(normalizeWhereClause(null)).toBe('');
+    expect(normalizeWhereClause('')).toBe('');
+  });
+});
+
+describe('mass-update-records.utils#isValidWhereClause', () => {
+  test('accepts a clause that includes the WHERE keyword', () => {
+    // Regression: the input stripped WHERE before validating but the consumers did not, so this
+    // silently blocked the row with no error surfaced.
+    expect(isValidWhereClause('WHERE Foo = 1')).toBe(true);
+    expect(isValidWhereClause('Foo = 1')).toBe(true);
+  });
+
+  test('rejects empty and malformed clauses', () => {
+    expect(isValidWhereClause('')).toBe(false);
+    expect(isValidWhereClause(null)).toBe(false);
+    expect(isValidWhereClause('WHERE')).toBe(false);
+    expect(isValidWhereClause('Foo =')).toBe(false);
   });
 });
 

--- a/libs/shared/ui-core/src/mass-update-records/mass-update-records.utils.tsx
+++ b/libs/shared/ui-core/src/mass-update-records/mass-update-records.utils.tsx
@@ -50,7 +50,22 @@ function buildChunkedIdInQueries(baseSoql: string, ids: string[]): string[] {
   return queries;
 }
 
-export const startsWithWhereRgx = /^( )*WHERE( )*/i;
+export const startsWithWhereRgx = /^\s*WHERE\b\s*/i;
+
+/**
+ * Users routinely paste a clause that still has its leading `WHERE` keyword. Every consumer normalizes
+ * through here so validation and query composition agree: previously only the input component stripped
+ * the keyword, so `WHERE Foo = 1` looked valid while `isValidRow` and the compose helpers rejected it —
+ * blocking the row with no message shown.
+ */
+export function normalizeWhereClause(whereClause: Maybe<string>): string {
+  return (whereClause || '').replace(startsWithWhereRgx, '').trim();
+}
+
+export function isValidWhereClause(whereClause: Maybe<string>): boolean {
+  const normalizedWhereClause = normalizeWhereClause(whereClause);
+  return !!normalizedWhereClause && isQueryValid(`WHERE ${normalizedWhereClause}`, { allowPartialQuery: true });
+}
 
 export const DEFAULT_FIELD_CONFIGURATION: MetadataRowConfiguration = {
   selectedField: null,
@@ -107,10 +122,8 @@ export function isValidRow(row: Maybe<MetadataRow>) {
     if (transformationOptions.option === 'staticValue' && !transformationOptions.staticValue) {
       return false;
     }
-    if (transformationOptions.criteria === 'custom') {
-      if (!transformationOptions.whereClause || !isQueryValid(`WHERE ${transformationOptions.whereClause}`, { allowPartialQuery: true })) {
-        return false;
-      }
+    if (transformationOptions.criteria === 'custom' && !isValidWhereClause(transformationOptions.whereClause)) {
+      return false;
     }
     return true;
   });
@@ -176,13 +189,8 @@ export function composeSoqlQueryOptionalCustomWhereClause(row: MetadataRow, fiel
         return `(${selectedField} = NULL)`;
       } else if (transformationOptions.criteria === 'onlyIfNotBlank' && selectedField) {
         return `(${selectedField} != NULL)`;
-      } else if (
-        includeCustom &&
-        transformationOptions.criteria === 'custom' &&
-        transformationOptions.whereClause &&
-        isQueryValid(`WHERE ${transformationOptions.whereClause}`, { allowPartialQuery: true })
-      ) {
-        return `(${transformationOptions.whereClause})`;
+      } else if (includeCustom && transformationOptions.criteria === 'custom' && isValidWhereClause(transformationOptions.whereClause)) {
+        return `(${normalizeWhereClause(transformationOptions.whereClause)})`;
       }
       return null;
     })
@@ -209,12 +217,9 @@ export function composeSoqlQueryCustomWhereClause(row: MetadataRow, fields: stri
 
   const whereClauses = row.configuration
     .filter(
-      ({ transformationOptions }) =>
-        transformationOptions.criteria === 'custom' &&
-        transformationOptions.whereClause &&
-        isQueryValid(`WHERE ${transformationOptions.whereClause}`, { allowPartialQuery: true }),
+      ({ transformationOptions }) => transformationOptions.criteria === 'custom' && isValidWhereClause(transformationOptions.whereClause),
     )
-    .map(({ transformationOptions }) => `(${transformationOptions.whereClause})`)
+    .map(({ transformationOptions }) => `(${normalizeWhereClause(transformationOptions.whereClause)})`)
     .join(' OR ');
 
   if (!whereClauses) {

--- a/libs/shared/ui-utils/src/index.ts
+++ b/libs/shared/ui-utils/src/index.ts
@@ -13,6 +13,7 @@ export * from './lib/hooks/useGlobalEventHandler';
 export * from './lib/hooks/useGoogleApi';
 export * from './lib/hooks/useHover';
 export * from './lib/hooks/useInjectScript';
+export * from './lib/hooks/useIntegerInput';
 export * from './lib/hooks/useInterval';
 export * from './lib/hooks/useKeyboardShortcuts';
 export * from './lib/hooks/useLocationState';

--- a/libs/shared/ui-utils/src/lib/__tests__/useIntegerInput.spec.ts
+++ b/libs/shared/ui-utils/src/lib/__tests__/useIntegerInput.spec.ts
@@ -1,0 +1,60 @@
+import { act, renderHook } from '@testing-library/react';
+import { ChangeEvent } from 'react';
+import { describe, expect, test, vi } from 'vitest';
+import { useIntegerInput } from '../hooks/useIntegerInput';
+
+function changeEvent(value: string) {
+  return { target: { value } } as ChangeEvent<HTMLInputElement>;
+}
+
+describe('useIntegerInput', () => {
+  test('deleting the leading digit keeps the remaining characters visible', () => {
+    // Regression: `value={batchSize || ''}` turned "0000" into 0, which is falsy, which blanked the field.
+    const onChange = vi.fn();
+    const { result } = renderHook(() => useIntegerInput(10000, onChange));
+
+    expect(result.current.inputValue).toBe('10000');
+
+    act(() => result.current.handleChange(changeEvent('0000')));
+
+    expect(result.current.inputValue).toBe('0000');
+    expect(onChange).toHaveBeenCalledWith(0);
+  });
+
+  test('reports null when the field does not hold a number', () => {
+    const onChange = vi.fn();
+    const { result } = renderHook(() => useIntegerInput(10000, onChange));
+
+    act(() => result.current.handleChange(changeEvent('')));
+
+    expect(result.current.inputValue).toBe('');
+    expect(onChange).toHaveBeenCalledWith(null);
+  });
+
+  test('normalizes the displayed value on blur', () => {
+    const { result } = renderHook(() => useIntegerInput(10000, vi.fn()));
+
+    act(() => result.current.handleChange(changeEvent('0000')));
+    act(() => result.current.handleBlur());
+
+    expect(result.current.inputValue).toBe('0');
+  });
+
+  test('adopts values changed outside the input', () => {
+    const { result, rerender } = renderHook(({ value }) => useIntegerInput(value, vi.fn()), { initialProps: { value: 10000 } });
+
+    rerender({ value: 200 });
+
+    expect(result.current.inputValue).toBe('200');
+  });
+
+  test('does not overwrite in-progress typing when the committed value already matches', () => {
+    const { result, rerender } = renderHook(({ value }) => useIntegerInput(value, vi.fn()), { initialProps: { value: 10000 } });
+
+    act(() => result.current.handleChange(changeEvent('0000')));
+    // The parent commits the parsed value back; the raw text must survive so the user can keep typing.
+    rerender({ value: 0 });
+
+    expect(result.current.inputValue).toBe('0000');
+  });
+});

--- a/libs/shared/ui-utils/src/lib/hooks/useIntegerInput.ts
+++ b/libs/shared/ui-utils/src/lib/hooks/useIntegerInput.ts
@@ -1,0 +1,44 @@
+import { Maybe } from '@jetstream/types';
+import { ChangeEvent, useEffect, useState } from 'react';
+
+function parseIntegerInput(value: string): number | null {
+  const parsed = Number.parseInt(value, 10);
+  return Number.isInteger(parsed) ? parsed : null;
+}
+
+/**
+ * Backs a numeric text input with the raw string the user typed rather than the parsed number.
+ *
+ * Rendering `value={someNumber || ''}` looks harmless but makes the field erase itself mid-edit:
+ * deleting the leading digit of `10000` leaves `"0000"`, which parses to `0`, which is falsy, which
+ * renders as an empty input. Keeping the string means partial input survives until the user is done.
+ *
+ * @param value The committed numeric value. Changes made outside the input (a recalculated default,
+ *   for example) are adopted without disturbing in-progress typing.
+ * @param onChange Receives the parsed value, or null when the field does not hold a number.
+ */
+export function useIntegerInput(value: Maybe<number>, onChange: (value: number | null) => void) {
+  const [inputValue, setInputValue] = useState(() => (value == null ? '' : String(value)));
+
+  useEffect(() => {
+    setInputValue((current) => {
+      if (parseIntegerInput(current) === (value ?? null)) {
+        return current;
+      }
+      return value == null ? '' : String(value);
+    });
+  }, [value]);
+
+  function handleChange(event: ChangeEvent<HTMLInputElement>) {
+    setInputValue(event.target.value);
+    onChange(parseIntegerInput(event.target.value));
+  }
+
+  /** Collapse whatever was typed to its canonical form once editing finishes (`"0000"` → `"0"`). */
+  function handleBlur() {
+    const parsed = parseIntegerInput(inputValue);
+    setInputValue(parsed == null ? '' : String(parsed));
+  }
+
+  return { inputValue, handleChange, handleBlur };
+}

--- a/libs/ui/src/lib/data-table/grid/grid-column-utils.tsx
+++ b/libs/ui/src/lib/data-table/grid/grid-column-utils.tsx
@@ -122,17 +122,22 @@ export function getColumnDefinitions(
   results.parsedQuery?.fields
     ?.filter((field) => isFieldSubquery(field))
     .forEach((parentField: FieldSubquery) => {
-      output.subqueryColumns[parentField.subquery.relationshipName.toLowerCase()] = getFlattenedFields(parentField.subquery || {}).map(
-        (field) =>
-          getQueryResultColumn({
-            field,
-            subqueryRelationshipName: parentField.subquery.relationshipName,
-            queryColumnsByPath,
-            isSubquery: false,
-            allowEdit: false,
-            fieldMetadata: fieldMetadataSubquery?.[parentField.subquery.relationshipName.toLowerCase()],
-          }),
+      const subqueryColumns = getFlattenedFields(parentField.subquery || {}).map((field) =>
+        getQueryResultColumn({
+          field,
+          subqueryRelationshipName: parentField.subquery.relationshipName,
+          queryColumnsByPath,
+          isSubquery: false,
+          allowEdit: false,
+          fieldMetadata: fieldMetadataSubquery?.[parentField.subquery.relationshipName.toLowerCase()],
+        }),
       );
+      // The subquery modal enables row selection, and a checkbox cell only renders for a column keyed
+      // SELECT_COLUMN_KEY — without this the selection UI has nowhere to draw.
+      if (subqueryColumns.length > 0) {
+        subqueryColumns.unshift({ ...SelectColumn, key: SELECT_COLUMN_KEY, resizable: false });
+      }
+      output.subqueryColumns[parentField.subquery.relationshipName.toLowerCase()] = subqueryColumns;
     });
 
   return output;

--- a/libs/ui/src/lib/sobject-field-list/WhereIsThisFieldUsed.tsx
+++ b/libs/ui/src/lib/sobject-field-list/WhereIsThisFieldUsed.tsx
@@ -49,7 +49,11 @@ export const QueryWhereIsThisUsed = ({ org, sobject, field }: QueryWhereIsThisUs
     }
   }, [items]);
 
-  function handleOpen() {
+  function handleOpen(event: React.MouseEvent<HTMLButtonElement>) {
+    // This control sits inside the field list's ListItemCheckbox — without this the click bubbles up
+    // and toggles the field's selection.
+    event.preventDefault();
+    event.stopPropagation();
     setIsOpen(true);
   }
 
@@ -66,88 +70,98 @@ export const QueryWhereIsThisUsed = ({ org, sobject, field }: QueryWhereIsThisUs
     copyRecordsToClipboard(exportData, 'excel', ['Reference Type', 'Reference Label', 'Namespace']);
   }
 
+  // The modals render through a portal, but React events still travel the component tree, so clicks
+  // inside them would otherwise reach the surrounding ListItemCheckbox and toggle the field.
+  function stopModalEventPropagation(event: React.SyntheticEvent) {
+    event.stopPropagation();
+  }
+
   return (
     <Fragment>
       {exportModalOpen && (
-        <FileDownloadModal
-          org={org}
-          modalHeader="Download Field Dependencies"
-          googleIntegrationEnabled={hasGoogleDriveAccess}
-          googleShowUpgradeToPro={googleShowUpgradeToPro}
-          google_apiKey={google_apiKey}
-          google_appId={google_appId}
-          google_clientId={google_clientId}
-          data={exportData}
-          header={['Reference Type', 'Reference Label', 'Namespace']}
-          fileNameParts={['dependencies', `${sobject}.${field}`]}
-          onModalClose={() => setExportModalOpen(false)}
-          source="where_is_this_used"
-          // This one is too much trouble to pass down amplitude dependency
-          // eslint-disable-next-line @typescript-eslint/no-empty-function
-          trackEvent={() => {}}
-        />
+        <div onClick={stopModalEventPropagation} onKeyDown={stopModalEventPropagation}>
+          <FileDownloadModal
+            org={org}
+            modalHeader="Download Field Dependencies"
+            googleIntegrationEnabled={hasGoogleDriveAccess}
+            googleShowUpgradeToPro={googleShowUpgradeToPro}
+            google_apiKey={google_apiKey}
+            google_appId={google_appId}
+            google_clientId={google_clientId}
+            data={exportData}
+            header={['Reference Type', 'Reference Label', 'Namespace']}
+            fileNameParts={['dependencies', `${sobject}.${field}`]}
+            onModalClose={() => setExportModalOpen(false)}
+            source="where_is_this_used"
+            // This one is too much trouble to pass down amplitude dependency
+            // eslint-disable-next-line @typescript-eslint/no-empty-function
+            trackEvent={() => {}}
+          />
+        </div>
       )}
       {isFieldEligible && (
         <Fragment>
           {isOpen && (
-            <Modal
-              closeOnEsc
-              closeOnBackdropClick
-              onClose={handleClose}
-              header="Where is this field used?"
-              tagline={`${sobject}: ${field}`}
-              footer={
-                <div>
-                  <button
-                    className="slds-button slds-button_neutral"
-                    onClick={handleCopyToClipboard}
-                    disabled={!hasLoaded || loading || !items?.length}
-                  >
-                    Copy to Clipboard
-                  </button>
-                  <button
-                    className="slds-button slds-button_neutral"
-                    onClick={handleDownload}
-                    disabled={!hasLoaded || loading || !items?.length}
-                  >
-                    Download
-                  </button>
-                  <button className="slds-button slds-button_brand" onClick={handleClose}>
-                    Close
-                  </button>
-                </div>
-              }
-            >
-              <div
-                className="slds-is-relative"
-                css={css`
-                  min-height: 100px;
-                `}
+            <div onClick={stopModalEventPropagation} onKeyDown={stopModalEventPropagation}>
+              <Modal
+                closeOnEsc
+                closeOnBackdropClick
+                onClose={handleClose}
+                header="Where is this field used?"
+                tagline={`${sobject}: ${field}`}
+                footer={
+                  <div>
+                    <button
+                      className="slds-button slds-button_neutral"
+                      onClick={handleCopyToClipboard}
+                      disabled={!hasLoaded || loading || !items?.length}
+                    >
+                      Copy to Clipboard
+                    </button>
+                    <button
+                      className="slds-button slds-button_neutral"
+                      onClick={handleDownload}
+                      disabled={!hasLoaded || loading || !items?.length}
+                    >
+                      Download
+                    </button>
+                    <button className="slds-button slds-button_brand" onClick={handleClose}>
+                      Close
+                    </button>
+                  </div>
+                }
               >
-                {loading && <Spinner />}
-                {hasError && <ScopedNotification theme="error">{errorMessage}</ScopedNotification>}
-                {hasLoaded && !loading && !hasError && (
-                  <Fragment>
-                    <p className="slds-text-color_weak slds-align_absolute-center">
-                      Up to the first 2,000 dependencies are shown and Reports are not included.
-                    </p>
-                    <p className="slds-text-color_weak slds-align_absolute-center">
-                      Dependencies may not be shown for standard objects, this is a Salesforce limitation.
-                    </p>
-                  </Fragment>
-                )}
-                {hasLoaded && !loading && !items?.length && !hasError && <EmptyState headline="No dependencies were found"></EmptyState>}
-                <ReadonlyList
-                  items={items || []}
-                  getContent={(item: ListItem<string, MetadataDependency>) => ({
-                    key: item.id,
-                    id: item.id,
-                    heading: item.label,
-                    subheading: item.secondaryLabel,
-                  })}
-                />
-              </div>
-            </Modal>
+                <div
+                  className="slds-is-relative"
+                  css={css`
+                    min-height: 100px;
+                  `}
+                >
+                  {loading && <Spinner />}
+                  {hasError && <ScopedNotification theme="error">{errorMessage}</ScopedNotification>}
+                  {hasLoaded && !loading && !hasError && (
+                    <Fragment>
+                      <p className="slds-text-color_weak slds-align_absolute-center">
+                        Up to the first 2,000 dependencies are shown and Reports are not included.
+                      </p>
+                      <p className="slds-text-color_weak slds-align_absolute-center">
+                        Dependencies may not be shown for standard objects, this is a Salesforce limitation.
+                      </p>
+                    </Fragment>
+                  )}
+                  {hasLoaded && !loading && !items?.length && !hasError && <EmptyState headline="No dependencies were found"></EmptyState>}
+                  <ReadonlyList
+                    items={items || []}
+                    getContent={(item: ListItem<string, MetadataDependency>) => ({
+                      key: item.id,
+                      id: item.id,
+                      heading: item.label,
+                      subheading: item.secondaryLabel,
+                    })}
+                  />
+                </div>
+              </Modal>
+            </div>
           )}
           <div className="slds-hint-parent">
             <button className="slds-button slds-button_icon" title="Where is this field used?" onClick={handleOpen}>


### PR DESCRIPTION
Five small, independently-located fixes from the 2026-08-16 backlog triage. One commit per issue, no shared files between them, so any single commit can be dropped without touching the others.

| Commit | Issue | Root cause |
| --- | --- | --- |
| `fix(query)` | #1750 | Field-usage trigger missing `stopPropagation`, so opening it toggled the field |
| `fix(data-table)` | #161 | `SelectColumn` unshifted onto parent columns only; subquery modal enabled selection with no column to render into |
| `fix(load)` | #528 | `nextStepDisabled` never consulted `fieldErrorMsg` |
| `fix(load)` | #513 | `value={batchSize \|\| ''}` + `parseInt` erased the field mid-edit |
| `fix(update-records)` | #1010 | Only the input stripped a leading `WHERE`; validators and compose helpers did not |

## Notes worth a reviewer's attention

**#513** — the same buggy input existed in three features (load records, mass update deployment, bulk update from query), so the raw-string handling went into a shared `useIntegerInput` hook rather than being fixed three times. It also has to adopt values set *outside* the input, because the load records default is recalculated when the API mode changes. This commit also corrects a pre-existing a11y bug on the same input, flagged in review: `aria-describedby` pointed at the error *message text* instead of the error element's id.

**#1010** — `WHERE Foo = 1` now works end to end instead of merely erroring. The regex also gained a word boundary, so a field named `Wherehouse__c` is no longer mangled.

**#161** — likely to conflict with `feat/query/multiple-subquery`, which restructures `getColumnDefinitions`.

## Testing

Full suite green: 177 files / 2248 tests. New coverage for `useIntegerInput` (5) and `normalizeWhereClause` / `isValidWhereClause` (7).

---

> [!NOTE]
> **#1470 (polymorphic lookup) was removed from this PR** and moved to its own branch.
>
> Copilot's review caught a real bug in it: because a drill-in item's id *is* its SOQL path, two targets of the same relationship produce colliding ids (`Owner.Name` under both `Owner::User` and `Owner::Group`). The flatten/unflatten round-trip in the caching step collapses them, so a field common to both targets silently disappears from one list:
>
> ```
> User target  -> [ Owner.Name, Owner.Email ]
> Group target -> [ Owner.Type ]              <- Owner.Name gone
> ```
>
> Reproduced against the real helpers. It affects both drill-in consumers. Since #1470 is a feature rather than a regression, it is being fixed and verified separately instead of holding up these five.
