### PR TITLE
fix: back off bulk load status polling and surface when it stops

### DIFF
--- a/libs/features/load-records/src/components/load-results/LoadRecordsBulkApiResults.tsx
+++ b/libs/features/load-records/src/components/load-results/LoadRecordsBulkApiResults.tsx
@@ -51,7 +51,13 @@ import {
 import { applicationCookieState, googleDriveAccessState, selectSkipFrontdoorAuth } from '@jetstream/ui/app-state';
 import { useAtomValue } from 'jotai';
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { LoadTypeDisplayNames, loadBulkApiData, prepareData } from '../../utils/load-records-process';
+import {
+  BULK_JOB_POLL_MAX_CHECKS,
+  LoadTypeDisplayNames,
+  getBulkJobPollInterval,
+  loadBulkApiData,
+  prepareData,
+} from '../../utils/load-records-process';
 import { extractRetryRecords, registerRetryRecord } from './retry-record-map';
 
 type Status = 'Preparing Data' | 'Uploading Data' | 'Processing Data' | 'Aborting' | 'Finished' | 'Error';
@@ -72,8 +78,6 @@ const STATUSES: {
   ERROR: 'Error',
 };
 
-const CHECK_INTERVAL = 3000;
-const MAX_INTERVAL_CHECK_COUNT = 200; // 3000*200/60=10 minutes
 const ABORTABLE_STATUSES = new Set<Status>([STATUSES.PREPARING, STATUSES.UPLOADING, STATUSES.PROCESSING, STATUSES.ABORTING]);
 const FETCH_FAILED_RECORDS_CONCURRENCY = 5;
 
@@ -257,6 +261,8 @@ export const LoadRecordsBulkApiResults = ({
   // Salesforce changes order of batches, so we want to ensure order is retained based on the input file
   const [batchIdByIndex, setBatchIdByIndex] = useState<Record<string, number>>();
   const [intervalCount, setIntervalCount] = useState<number>(0);
+  // Polling gives up after BULK_JOB_POLL_MAX_CHECKS so a runaway job doesn't poll forever; the user can resume it
+  const [pollingTimedOut, setPollingTimedOut] = useState(false);
   const [downloadModalData, setDownloadModalData] = useState<DownloadModalData>({
     open: false,
     data: [],
@@ -305,6 +311,46 @@ export const LoadRecordsBulkApiResults = ({
   }, [batchSummary]);
 
   /**
+   * Fetch the latest job status from Salesforce and store it, which re-triggers the polling effect.
+   * Salesforce returns batches in an arbitrary order, so they are re-ordered to match the input file.
+   * If the request fails, jobInfo is re-set with a fresh reference so polling carries on regardless.
+   */
+  async function pollJobStatus() {
+    if (!isMounted.current || !batchIdByIndex || !jobInfo?.id) {
+      return;
+    }
+    try {
+      const jobInfoWithBatches = await bulkApiGetJob(selectedOrg, jobInfo.id);
+      if (!isMounted.current) {
+        return;
+      }
+      const batches: BulkJobBatchInfo[] = [];
+      // re-order (if needed) while keeping the array dense
+      jobInfoWithBatches.batches.forEach((batch) => {
+        batches[batchIdByIndex[batch.id]] = batch;
+      });
+      jobInfoWithBatches.batches = batches.filter(Boolean);
+      setJobInfo(jobInfoWithBatches);
+    } catch (ex) {
+      logger.warn('Error polling bulk API job status', ex);
+      if (!isMounted.current) {
+        return;
+      }
+      // Set a new jobInfo reference to re-trigger the polling effect
+      setJobInfo((currentJobInfo) => (currentJobInfo ? { ...currentJobInfo } : currentJobInfo));
+    }
+    setIntervalCount((currentIntervalCount) => currentIntervalCount + 1);
+  }
+
+  /** Polling gave up on a long-running job - check it right away and start a fresh polling window */
+  function handleResumePolling() {
+    trackEvent(ANALYTICS_KEYS.load_PollingResumed, { loadType });
+    setPollingTimedOut(false);
+    setIntervalCount(0);
+    pollJobStatus();
+  }
+
+  /**
    * When jobInfo is modified, check to see if everything is done
    * If not done and status is processing, then continue polling
    */
@@ -343,34 +389,20 @@ export const LoadRecordsBulkApiResults = ({
             onFinishRef.current({ success: numSuccess, failure: numFailure, failedRecords });
           }
         })();
-      } else if ((status === STATUSES.PROCESSING || status === STATUSES.ABORTING) && intervalCount < MAX_INTERVAL_CHECK_COUNT) {
-        pollingTimerRef.current = setTimeout(async () => {
-          pollingTimerRef.current = null;
-          if (!isMounted.current || !batchIdByIndex || !jobInfo.id) {
-            return;
+      } else if (status === STATUSES.PROCESSING || status === STATUSES.ABORTING) {
+        if (intervalCount >= BULK_JOB_POLL_MAX_CHECKS) {
+          // Stop polling and hand control to the user - the job keeps running in Salesforce regardless.
+          // Guarded so a status change (e.g. abort) after timing out doesn't re-fire the event.
+          if (!pollingTimedOut) {
+            setPollingTimedOut(true);
+            trackEvent(ANALYTICS_KEYS.load_PollingTimedOut, { loadType, checkCount: intervalCount });
           }
-          try {
-            const jobInfoWithBatches = await bulkApiGetJob(selectedOrg, jobInfo.id);
-            if (!isMounted.current) {
-              return;
-            }
-            const batches: BulkJobBatchInfo[] = [];
-            // re-order (if needed) while keeping the array dense
-            jobInfoWithBatches.batches.forEach((batch) => {
-              batches[batchIdByIndex[batch.id]] = batch;
-            });
-            jobInfoWithBatches.batches = batches.filter(Boolean);
-            setJobInfo(jobInfoWithBatches);
-          } catch (ex) {
-            logger.warn('Error polling bulk API job status', ex);
-            if (!isMounted.current) {
-              return;
-            }
-            // Set a new jobInfo reference to re-trigger the polling effect
-            setJobInfo((currentJobInfo) => (currentJobInfo ? { ...currentJobInfo } : currentJobInfo));
-          }
-          setIntervalCount((currentIntervalCount) => currentIntervalCount + 1);
-        }, CHECK_INTERVAL);
+        } else {
+          pollingTimerRef.current = setTimeout(() => {
+            pollingTimerRef.current = null;
+            pollJobStatus();
+          }, getBulkJobPollInterval(intervalCount));
+        }
       }
     }
     return () => {
@@ -918,6 +950,20 @@ export const LoadRecordsBulkApiResults = ({
       {autoSplitBatchCount > 0 && (
         <ScopedNotification theme="info" className="slds-m-vertical_x-small" allowClose>
           Some of your batches were larger than Salesforce allows, so they were automatically split into smaller batches.
+        </ScopedNotification>
+      )}
+      {pollingTimedOut && (
+        <ScopedNotification theme="warning" className="slds-m-vertical_x-small">
+          <Grid verticalAlign="center" align="spread" wrap>
+            <span className="slds-m-right_small">
+              Jetstream stopped checking the status of this job because it has been running for a long time. The job continues in Salesforce
+              regardless - resume checking to pick up the latest status.
+            </span>
+            <button className="slds-button slds-button_neutral" onClick={handleResumePolling}>
+              <Icon type="utility" icon="refresh" className="slds-button__icon slds-button__icon_left" omitContainer />
+              Resume checking status
+            </button>
+          </Grid>
         </ScopedNotification>
       )}
       {/* Data is being processed */}

--- a/libs/features/load-records/src/utils/__tests__/load-records-process.spec.ts
+++ b/libs/features/load-records/src/utils/__tests__/load-records-process.spec.ts
@@ -1,14 +1,49 @@
 import {
+  BULK_JOB_POLL_INITIAL_INTERVAL_MS,
+  BULK_JOB_POLL_INTERVAL_STEP_MS,
+  BULK_JOB_POLL_MAX_CHECKS,
+  BULK_JOB_POLL_MAX_INTERVAL_MS,
   BatchCsv,
   MAX_BATCH_CSV_CHARS,
   MAX_CONSECUTIVE_FAILURES,
   generateSizeCappedBatchCsvs,
+  getBulkJobPollInterval,
   isFatalBulkApiError,
 } from '../load-records-process';
 
 describe('MAX_CONSECUTIVE_FAILURES', () => {
   it('should equal 5', () => {
     expect(MAX_CONSECUTIVE_FAILURES).toBe(5);
+  });
+});
+
+describe('getBulkJobPollInterval', () => {
+  it('starts at the initial interval', () => {
+    expect(getBulkJobPollInterval(0)).toBe(BULK_JOB_POLL_INITIAL_INTERVAL_MS);
+  });
+
+  it('grows by one step per check', () => {
+    expect(getBulkJobPollInterval(1)).toBe(BULK_JOB_POLL_INITIAL_INTERVAL_MS + BULK_JOB_POLL_INTERVAL_STEP_MS);
+    expect(getBulkJobPollInterval(10)).toBe(BULK_JOB_POLL_INITIAL_INTERVAL_MS + 10 * BULK_JOB_POLL_INTERVAL_STEP_MS);
+  });
+
+  it('never exceeds the max interval', () => {
+    expect(getBulkJobPollInterval(BULK_JOB_POLL_MAX_CHECKS)).toBe(BULK_JOB_POLL_MAX_INTERVAL_MS);
+    expect(getBulkJobPollInterval(Number.MAX_SAFE_INTEGER)).toBe(BULK_JOB_POLL_MAX_INTERVAL_MS);
+  });
+
+  it('never gets faster as checks accumulate', () => {
+    for (let checkCount = 1; checkCount < BULK_JOB_POLL_MAX_CHECKS; checkCount++) {
+      expect(getBulkJobPollInterval(checkCount)).toBeGreaterThanOrEqual(getBulkJobPollInterval(checkCount - 1));
+    }
+  });
+
+  it('keeps polling for well over the previous fixed 10 minute runway before giving up', () => {
+    const totalPollingMs = Array.from({ length: BULK_JOB_POLL_MAX_CHECKS }, (_, checkCount) => getBulkJobPollInterval(checkCount)).reduce(
+      (total, interval) => total + interval,
+      0,
+    );
+    expect(totalPollingMs).toBeGreaterThan(30 * 60 * 1000);
   });
 });
 

--- a/libs/features/load-records/src/utils/load-records-process.ts
+++ b/libs/features/load-records/src/utils/load-records-process.ts
@@ -74,6 +74,19 @@ export const MAX_CONSECUTIVE_FAILURES = 5;
 // even at modest batch sizes. Kept below the hard limit for encoding/newline headroom.
 export const MAX_BATCH_CSV_CHARS = 9_500_000;
 
+// Bulk API job status polling. Polling starts fast so small jobs feel responsive and slows down a
+// little on every check so long-running jobs get a much longer runway before we stop polling and
+// hand control back to the user (~38 minutes at these values, vs 10 minutes at a fixed 3s interval).
+export const BULK_JOB_POLL_INITIAL_INTERVAL_MS = 3_000;
+export const BULK_JOB_POLL_INTERVAL_STEP_MS = 100;
+export const BULK_JOB_POLL_MAX_INTERVAL_MS = 15_000;
+export const BULK_JOB_POLL_MAX_CHECKS = 200;
+
+/** Delay before the next job status check, growing linearly with the number of checks already made */
+export function getBulkJobPollInterval(checkCount: number): number {
+  return Math.min(BULK_JOB_POLL_INITIAL_INTERVAL_MS + checkCount * BULK_JOB_POLL_INTERVAL_STEP_MS, BULK_JOB_POLL_MAX_INTERVAL_MS);
+}
+
 export function isFatalBulkApiError(error: unknown): boolean {
   const message = getErrorMessage(error);
   return FATAL_BULK_ERROR_PATTERNS.some((pattern) => pattern.test(message));

--- a/libs/shared/constants/src/lib/shared-constants.ts
+++ b/libs/shared/constants/src/lib/shared-constants.ts
@@ -275,6 +275,8 @@ export const ANALYTICS_KEYS = {
   load_Submitted: 'load_Submitted',
   load_ViewRecords: 'load_ViewRecords',
   load_DownloadRecords: 'load_DownloadRecords',
+  load_PollingTimedOut: 'load_PollingTimedOut',
+  load_PollingResumed: 'load_PollingResumed',
   /** LOAD MULTI OBJECT */
   load_multi_obj_TemplateDownloaded: 'load_multi_obj_TemplateDownloaded',
   load_multi_obj_FileProcessed: 'load_multi_obj_FileProcessed',


### PR DESCRIPTION
Bulk API status polling stopped silently after 200 checks at a fixed 3s interval — exactly 10 minutes — with no message to the user, and the results download only appears once the job reports finished. A long job therefore looked stuck at whatever percentage it had reached, which is the consistent 40-50% stall reported in #1147 (and #1448).

Polling backs off within the same 200-check cap
- The interval starts at 3s and grows 100ms per check up to 15s, so short jobs stay responsive while long jobs get ~38 minutes of polling instead of 10 (getBulkJobPollInterval in load-records-process.ts)
- Covered by unit tests for the start value, growth, cap, monotonicity and the minimum runway

Hitting the cap is now visible and recoverable
- A warning banner explains that Jetstream stopped checking and that the job continues in Salesforce regardless, with a "Resume checking status" button that checks immediately and starts a fresh polling window
- Works in both the processing and aborting states; the poll body was extracted into pollJobStatus so the timer and the resume button share it
- load_PollingTimedOut / load_PollingResumed analytics events record how often the cap is actually reached

Closes #1147
Closes #1448