### PR TITLE
feat(update-records): choose which object to use for a polymorphic lookup

### DIFF
--- a/libs/features/update-records/src/selection/useMassUpdateFieldItems.ts
+++ b/libs/features/update-records/src/selection/useMassUpdateFieldItems.ts
@@ -2,23 +2,26 @@ import { logger } from '@jetstream/shared/client-logger';
 import { ANALYTICS_KEYS } from '@jetstream/shared/constants';
 import { describeSObject, query } from '@jetstream/shared/data';
 import {
-  getFlattenedListItemsById,
   getListItemsFromFieldWithRelatedItems,
+  getPolymorphicTargetListItems,
+  isPolymorphicReference,
+  isPolymorphicTargetItem,
+  PolymorphicTargetMeta,
+  setChildItemsForParent,
   sortQueryFields,
-  unFlattenedListItemsById,
-  useNonInitialEffect,
   tracker,
+  useNonInitialEffect,
 } from '@jetstream/shared/ui-utils';
 import { getErrorMessage } from '@jetstream/shared/utils';
 import { DescribeSObjectResult, Field, ListItem, Maybe, SalesforceOrgUi } from '@jetstream/types';
 import {
   DEFAULT_FIELD_CONFIGURATION,
+  getValidationSoqlQuery,
+  isValidRow,
   MetadataRow,
   TransformationCriteria,
   TransformationOption,
   TransformationOptions,
-  getValidationSoqlQuery,
-  isValidRow,
   useAmplitude,
 } from '@jetstream/ui-core';
 import { useAtom, useAtomValue } from 'jotai';
@@ -250,9 +253,7 @@ function reducer(state: State, action: Action): State {
       }
 
       // Add child items to the parent
-      let allItems = getFlattenedListItemsById(existingRow.valueFields);
-      allItems = { ...allItems, [parentId]: { ...allItems[parentId], childItems: childFields } };
-      const valueFields = unFlattenedListItemsById(allItems);
+      const valueFields = setChildItemsForParent(existingRow.valueFields, parentId, childFields);
 
       rowsMap.set(sobject, {
         ...existingRow,
@@ -420,13 +421,24 @@ export function useMassUpdateFieldItems(org: SalesforceOrgUi, selectedSObjects: 
 
   const onLoadChildFields = useCallback(
     async (sobject: string, item: ListItem): Promise<ListItem[]> => {
-      const field = item.meta as Field;
-      if (!Array.isArray(field.referenceTo) || field.referenceTo.length <= 0) {
-        return [];
+      let childFields: ListItem[];
+      if (isPolymorphicTargetItem(item)) {
+        const { relationshipPath, sobject: relatedSobject } = item.meta as PolymorphicTargetMeta;
+        const { data } = await describeSObject(org, relatedSobject);
+        childFields = getListItemsFromFieldWithRelatedItems(sortQueryFields(data.fields), item.id, relationshipPath);
+      } else {
+        const field = item.meta as Field;
+        if (!Array.isArray(field.referenceTo) || field.referenceTo.length <= 0) {
+          return [];
+        }
+        // Let the user pick which object to read from rather than silently traversing the first one.
+        if (isPolymorphicReference(field)) {
+          childFields = getPolymorphicTargetListItems(field, item.id);
+        } else {
+          const { data } = await describeSObject(org, field.referenceTo[0]);
+          childFields = getListItemsFromFieldWithRelatedItems(sortQueryFields(data.fields), item.id);
+        }
       }
-      const { data } = await describeSObject(org, field.referenceTo?.[0] || '');
-      const allFieldMetadata = sortQueryFields(data.fields);
-      const childFields = getListItemsFromFieldWithRelatedItems(allFieldMetadata, item.id);
 
       dispatch({ type: 'CHILD_FIELDS_LOADED', payload: { sobject, parentId: item.id, childFields } });
       return childFields;

--- a/libs/shared/ui-utils/src/lib/__tests__/polymorphic-drill-in.spec.ts
+++ b/libs/shared/ui-utils/src/lib/__tests__/polymorphic-drill-in.spec.ts
@@ -1,0 +1,154 @@
+import { Field, ListItem } from '@jetstream/types';
+import { describe, expect, test } from 'vitest';
+import {
+  getFlattenedListItemsById,
+  getListItemsFromFieldWithRelatedItems,
+  getPolymorphicTargetListItems,
+  isPolymorphicReference,
+  isPolymorphicTargetItem,
+  setChildItemsForParent,
+} from '../shared-ui-utils';
+
+const ownerField = {
+  name: 'OwnerId',
+  label: 'Owner Id',
+  relationshipName: 'Owner',
+  referenceTo: ['User', 'Group'],
+} as Field;
+
+const accountField = {
+  name: 'AccountId',
+  label: 'Account Id',
+  relationshipName: 'Account',
+  referenceTo: ['Account'],
+} as Field;
+
+describe('isPolymorphicReference', () => {
+  test('only true when more than one object can be referenced', () => {
+    expect(isPolymorphicReference(ownerField)).toBe(true);
+    expect(isPolymorphicReference(accountField)).toBe(false);
+    expect(isPolymorphicReference({ name: 'Name' } as Field)).toBe(false);
+  });
+});
+
+describe('getPolymorphicTargetListItems', () => {
+  test('offers every referenced object as a drill-in level under the relationship', () => {
+    const items = getPolymorphicTargetListItems(ownerField, 'Owner');
+
+    expect(items.map((item) => item.label)).toEqual(['Group', 'User']);
+    items.forEach((item) => {
+      expect(item.isDrillInItem).toBe(true);
+      expect(item.parentId).toBe('Owner');
+      expect(isPolymorphicTargetItem(item as ListItem)).toBe(true);
+    });
+  });
+
+  test('carries the relationship path so the loaded fields keep a valid SOQL path', () => {
+    const [group] = getPolymorphicTargetListItems(ownerField, 'Case.Owner');
+
+    expect(group.meta).toEqual({ _polymorphicTarget: true, relationshipPath: 'Case.Owner', sobject: 'Group' });
+  });
+});
+
+describe('getListItemsFromFieldWithRelatedItems', () => {
+  const fields = [{ name: 'Name', label: 'Name' } as Field, ownerField];
+
+  test('builds ids from the relationship path, not from the drill-in parent', () => {
+    // Under a polymorphic target the tree parent is a synthetic id, but the SOQL path must not include it.
+    const items = getListItemsFromFieldWithRelatedItems(fields, 'Owner::User', 'Owner');
+
+    const nameField = items.find((item) => item.label === 'Name');
+    expect(nameField?.id).toBe('Owner.Name');
+    expect(nameField?.parentId).toBe('Owner::User');
+  });
+
+  test('path defaults to the parent id for an ordinary lookup', () => {
+    const items = getListItemsFromFieldWithRelatedItems(fields, 'Account');
+
+    const nameField = items.find((item) => item.label === 'Name');
+    expect(nameField?.id).toBe('Account.Name');
+    expect(nameField?.parentId).toBe('Account');
+  });
+
+  test('labels a polymorphic relationship by its object count rather than an arbitrary object', () => {
+    const [relationship] = getListItemsFromFieldWithRelatedItems([ownerField]);
+    expect(relationship.secondaryLabel).toBe('2 related objects');
+
+    const [singleRelationship] = getListItemsFromFieldWithRelatedItems([accountField]);
+    expect(singleRelationship.secondaryLabel).toBe('Account');
+  });
+});
+
+describe('setChildItemsForParent', () => {
+  const userFields = [{ name: 'Name', label: 'Name' } as Field, { name: 'Email', label: 'Email' } as Field];
+  const groupFields = [{ name: 'Name', label: 'Name' } as Field, { name: 'Type', label: 'Type' } as Field];
+
+  /** Drill into the relationship, then into both of its target objects, as a user would. */
+  function buildTreeWithBothTargetsLoaded(cacheChildren: (items: ListItem[], parentId: string, children: ListItem[]) => ListItem[]) {
+    let fields = getListItemsFromFieldWithRelatedItems([ownerField, { name: 'Id', label: 'Id' } as Field]);
+    fields = cacheChildren(fields, 'Owner', getPolymorphicTargetListItems(ownerField, 'Owner') as ListItem[]);
+    fields = cacheChildren(fields, 'Owner::User', getListItemsFromFieldWithRelatedItems(userFields, 'Owner::User', 'Owner'));
+    fields = cacheChildren(fields, 'Owner::Group', getListItemsFromFieldWithRelatedItems(groupFields, 'Owner::Group', 'Owner'));
+    return fields;
+  }
+
+  function childIdsByTarget(fields: ListItem[]) {
+    const owner = fields.find((item) => item.id === 'Owner');
+    const forTarget = (targetId: string) =>
+      owner?.childItems
+        ?.find((item) => item.id === targetId)
+        ?.childItems?.map((item) => item.id)
+        .sort();
+    return { user: forTarget('Owner::User'), group: forTarget('Owner::Group') };
+  }
+
+  test('keeps fields that two polymorphic targets share', () => {
+    // Both targets expose `Name`, which resolves to the same SOQL path (`Owner.Name`) under either one.
+    const fields = buildTreeWithBothTargetsLoaded(setChildItemsForParent);
+
+    expect(childIdsByTarget(fields)).toEqual({
+      user: ['Owner.Email', 'Owner.Name'],
+      group: ['Owner.Name', 'Owner.Type'],
+    });
+  });
+
+  test('both targets stay resolvable through the drill-in combobox lookup', () => {
+    // ComboboxWithDrillInItems keeps `getFlattenedListItemsById(items)` and reads
+    // `allItemsById[activeItemId].childItems`. activeItemId is only ever a drill-in item's id, and those
+    // are unique, so the shared leaf path under two parents never has to survive the id-keyed map.
+    const fields = buildTreeWithBothTargetsLoaded(setChildItemsForParent);
+    const allItemsById = getFlattenedListItemsById(fields);
+
+    expect(allItemsById['Owner::User'].childItems?.map((item) => item.id).sort()).toEqual(['Owner.Email', 'Owner.Name']);
+    expect(allItemsById['Owner::Group'].childItems?.map((item) => item.id).sort()).toEqual(['Owner.Name', 'Owner.Type']);
+  });
+
+  test('leaves unrelated branches untouched', () => {
+    const fields = getListItemsFromFieldWithRelatedItems([ownerField, accountField]);
+    const updated = setChildItemsForParent(fields, 'Account', [{ id: 'Account.Name', label: 'Name', value: 'Account.Name' }]);
+
+    expect(updated.find((item) => item.id === 'Account')?.childItems?.map((item) => item.id)).toEqual(['Account.Name']);
+    expect(updated.find((item) => item.id === 'Owner')?.childItems).toBeUndefined();
+  });
+
+  test('keeps references stable for everything outside the updated branch', () => {
+    const fields = buildTreeWithBothTargetsLoaded(setChildItemsForParent);
+    const ownerBefore = fields.find((item) => item.id === 'Owner');
+    const idFieldBefore = fields.find((item) => item.id === 'Id');
+    const userTargetBefore = ownerBefore?.childItems?.find((item) => item.id === 'Owner::User');
+
+    const updated = setChildItemsForParent(fields, 'Owner::Group', [{ id: 'Owner.Name', label: 'Name', value: 'Owner.Name' }]);
+    const ownerAfter = updated.find((item) => item.id === 'Owner');
+
+    // Siblings and untouched targets are reused; only the path down to the updated parent is rebuilt.
+    expect(updated.find((item) => item.id === 'Id')).toBe(idFieldBefore);
+    expect(ownerAfter?.childItems?.find((item) => item.id === 'Owner::User')).toBe(userTargetBefore);
+    expect(ownerAfter).not.toBe(ownerBefore);
+  });
+
+  test('returns the original array when the parent is not present', () => {
+    const fields = getListItemsFromFieldWithRelatedItems([ownerField, accountField]);
+
+    expect(setChildItemsForParent(fields, 'NotARelationship', [])).toBe(fields);
+  });
+});

--- a/libs/shared/ui-utils/src/lib/shared-ui-utils.ts
+++ b/libs/shared/ui-utils/src/lib/shared-ui-utils.ts
@@ -19,6 +19,7 @@ import {
   getErrorMessage,
   getExcelSafeSheetName,
   orderObjectsBy,
+  orderValues,
 } from '@jetstream/shared/utils';
 import type {
   AddOrgHandlerFn,
@@ -1915,6 +1916,32 @@ export function getFlattenedListItemsById(items: ListItem[], output: Record<stri
 }
 
 /**
+ * Attach freshly loaded children to one item in a drill-in tree.
+ *
+ * Walks to the item instead of round-tripping the whole tree through
+ * `getFlattenedListItemsById` → `unFlattenedListItemsById`. That round trip keys every item by `id`,
+ * which is lossy once a polymorphic relationship is involved: each target object hangs its own copy of
+ * a shared field off the same SOQL path (`Owner.Name` under both `Owner::User` and `Owner::Group`), so
+ * the map collapses the two and the rebuild re-nests the survivor under a single parent — silently
+ * dropping that field from the other target's list.
+ */
+export function setChildItemsForParent(items: ListItem[], parentId: string, childItems: ListItem[]): ListItem[] {
+  const updatedItems = items.map((item) => {
+    if (item.id === parentId) {
+      return { ...item, childItems };
+    }
+    if (!item.childItems?.length) {
+      return item;
+    }
+    const updatedChildItems = setChildItemsForParent(item.childItems, parentId, childItems);
+    return updatedChildItems === item.childItems ? item : { ...item, childItems: updatedChildItems };
+  });
+  // Only the branch containing `parentId` is rebuilt — everything else keeps its existing reference,
+  // and an id that matches nothing returns the original array untouched.
+  return updatedItems.some((item, index) => item !== items[index]) ? updatedItems : items;
+}
+
+/**
  * Given an object of all items by id, use the parentId field to create a tree structure
  * the parentId is blank for all the top level items and is "." delimited for all parentId's
  */
@@ -1940,8 +1967,16 @@ export function unFlattenedListItemsById(items: Record<string, ListItem>): ListI
   return output;
 }
 
-export function getListItemsFromFieldWithRelatedItems(fields: Field[], parentId = ''): ListItem[] {
-  const parentPath = parentId ? `${parentId}.` : '';
+/**
+ * Build drill-in list items for a set of fields.
+ *
+ * @param parentId Id of the item these fields hang off of, used to nest them in the drill-in tree.
+ * @param pathPrefix SOQL relationship path the generated ids are built from. Defaults to `parentId`,
+ *   which is the same thing for an ordinary lookup. They differ only under a polymorphic relationship,
+ *   where the tree has an extra level for choosing the target object but the SOQL path must not.
+ */
+export function getListItemsFromFieldWithRelatedItems(fields: Field[], parentId = '', pathPrefix = parentId): ListItem[] {
+  const parentPath = pathPrefix ? `${pathPrefix}.` : '';
   const allowChildren = parentPath.split('.').length <= 5;
   const relatedFields: ListItem[] = fields
     .filter((field) => allowChildren && Array.isArray(field.referenceTo) && field.referenceTo.length > 0 && field.relationshipName)
@@ -1950,7 +1985,7 @@ export function getListItemsFromFieldWithRelatedItems(fields: Field[], parentId 
       value: `${parentPath}${field.relationshipName}`,
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       label: field.relationshipName!,
-      secondaryLabel: field.referenceTo?.[0],
+      secondaryLabel: isPolymorphicReference(field) ? `${field.referenceTo?.length} related objects` : field.referenceTo?.[0],
       secondaryLabelOnNewLine: true,
       isDrillInItem: true,
       parentId,
@@ -1969,6 +2004,45 @@ export function getListItemsFromFieldWithRelatedItems(fields: Field[], parentId 
 
   return [...relatedFields, ...coreFields];
 }
+
+/** A lookup that can point at more than one object (`Owner`, `What`, `Who`, …). */
+export function isPolymorphicReference(field: Field): boolean {
+  return Array.isArray(field.referenceTo) && field.referenceTo.length > 1;
+}
+
+export interface PolymorphicTargetMeta {
+  _polymorphicTarget: true;
+  /** SOQL relationship path the chosen object hangs off of, e.g. `Owner` or `Account.Owner`. */
+  relationshipPath: string;
+  sobject: string;
+}
+
+export function isPolymorphicTargetItem(item: ListItem): boolean {
+  return !!(item.meta as Maybe<PolymorphicTargetMeta>)?._polymorphicTarget;
+}
+
+/**
+ * Drill-in items letting the user choose which object of a polymorphic lookup to read a field from.
+ * Previously the first entry in `referenceTo` was traversed silently, so the field list shown belonged
+ * to an arbitrary one of the possible objects.
+ *
+ * These ids are deliberately NOT SOQL paths — they only position the extra level in the drill-in tree.
+ * The fields loaded underneath still use `relationshipPath`, so the selected value stays a valid path.
+ */
+export function getPolymorphicTargetListItems(field: Field, relationshipPath: string): ListItem<string, PolymorphicTargetMeta>[] {
+  return orderValues(field.referenceTo || []).map((sobject) => ({
+    id: `${relationshipPath}${POLYMORPHIC_TARGET_ID_SEPARATOR}${sobject}`,
+    value: `${relationshipPath}${POLYMORPHIC_TARGET_ID_SEPARATOR}${sobject}`,
+    label: sobject,
+    secondaryLabel: `Fields from ${sobject}`,
+    secondaryLabelOnNewLine: true,
+    isDrillInItem: true,
+    parentId: relationshipPath,
+    meta: { _polymorphicTarget: true, relationshipPath, sobject },
+  }));
+}
+
+const POLYMORPHIC_TARGET_ID_SEPARATOR = '::';
 
 /**
  * If there is a change in UI that would make an element take a render ror more

--- a/libs/ui/src/lib/form/combobox/useFieldListItemsWithDrillIn.tsx
+++ b/libs/ui/src/lib/form/combobox/useFieldListItemsWithDrillIn.tsx
@@ -1,9 +1,12 @@
 import { describeSObject } from '@jetstream/shared/data';
 import {
-  getFlattenedListItemsById,
   getListItemsFromFieldWithRelatedItems,
+  getPolymorphicTargetListItems,
+  isPolymorphicReference,
+  isPolymorphicTargetItem,
+  PolymorphicTargetMeta,
+  setChildItemsForParent,
   sortQueryFields,
-  unFlattenedListItemsById,
 } from '@jetstream/shared/ui-utils';
 import { DescribeSObjectResult, Field, ListItem, SalesforceOrgUi } from '@jetstream/types';
 import { useCallback, useState } from 'react';
@@ -35,20 +38,26 @@ export function useFieldListItemsWithDrillIn(selectedOrg: SalesforceOrgUi) {
       if (!selectedOrg?.uniqueId) {
         throw new Error('Org is required');
       }
-      const field = item.meta as Field;
-      if (!Array.isArray(field.referenceTo) || field.referenceTo.length <= 0) {
-        return [];
+      let childFields: ListItem[];
+      if (isPolymorphicTargetItem(item)) {
+        const { relationshipPath, sobject } = item.meta as PolymorphicTargetMeta;
+        const { data } = await describeSObject(selectedOrg, sobject);
+        childFields = getListItemsFromFieldWithRelatedItems(sortQueryFields(data.fields), item.id, relationshipPath);
+      } else {
+        const field = item.meta as Field;
+        if (!Array.isArray(field.referenceTo) || field.referenceTo.length <= 0) {
+          return [];
+        }
+        // Let the user pick which object to read from rather than silently traversing the first one.
+        if (isPolymorphicReference(field)) {
+          childFields = getPolymorphicTargetListItems(field, item.id);
+        } else {
+          const { data } = await describeSObject(selectedOrg, field.referenceTo[0]);
+          childFields = getListItemsFromFieldWithRelatedItems(sortQueryFields(data.fields), item.id);
+        }
       }
-      const { data } = await describeSObject(selectedOrg, field.referenceTo?.[0] || '');
-      const allFieldMetadata = sortQueryFields(data.fields);
-      const childFields = getListItemsFromFieldWithRelatedItems(allFieldMetadata, item.id);
 
-      setFields((prevValues) => {
-        let allItems = getFlattenedListItemsById(prevValues);
-        allItems = { ...allItems, [item.id]: { ...allItems[item.id], childItems: childFields } };
-        const newItems = unFlattenedListItemsById(allItems);
-        return newItems;
-      });
+      setFields((prevValues) => setChildItemsForParent(prevValues, item.id, childFields));
       return childFields;
     },
     [selectedOrg],


### PR DESCRIPTION
Closes #1470

Split out of #1958 so the five straightforward fixes there could land on their own. This is the feature half, with the drill-in bug Copilot caught on that PR fixed.

## The problem

Drilling into a lookup described `field.referenceTo[0]`, so for a polymorphic relationship the field list belonged to an arbitrary one of the possible objects — the "random one being chosen for me" in the issue. Both drill-in loaders did it: mass update and bulk update from query.

## Changes

A polymorphic relationship now expands to a level listing every referenced object; picking one loads that object's fields.

The extra level exists **only** in the drill-in tree. Generated ids still use the relationship path, so the selected value stays a valid SOQL field path and the persisted `alternateField` round-trips unchanged:

```
Owner                     (relationship, id "Owner")
├─ User                   (target,       id "Owner::User")
│  ├─ Name                (field,        id "Owner.Name")   <- SOQL path
│  └─ Email               (field,        id "Owner.Email")
└─ Group                  (target,       id "Owner::Group")
   ├─ Name                (field,        id "Owner.Name")
   └─ Type                (field,        id "Owner.Type")
```

`getListItemsFromFieldWithRelatedItems` gained an optional third argument so the tree parent (`Owner::User`) and the path prefix (`Owner`) can differ. It defaults to the parent id, so every existing call site is unchanged.

## The bug from #1958

Two targets of the same relationship hang their copy of a shared field off the **same** path, so `Owner.Name` exists under both `Owner::User` and `Owner::Group`. The caching step round-tripped the whole tree through `getFlattenedListItemsById` → `unFlattenedListItemsById`, and that map is keyed by `id` — so the two collapsed into one and the rebuild re-nested the survivor under a single parent:

```
User target  -> [ Owner.Name, Owner.Email ]
Group target -> [ Owner.Type ]              <- Owner.Name silently gone
```

Fixed by caching through a new `setChildItemsForParent`, which walks to the parent and updates it immutably instead of rebuilding the tree from an id-keyed map. Ids stay SOQL paths, no component contract changes, and both loaders use it.

> [!NOTE]
> I did not take the suggested id/value split (unique ids, SOQL path in `value`). `selectedItemId` is the persisted SOQL path and `ComboboxWithDrillInItems` derives `activeItemId` from it via `selectedItemId.split('.').slice(0, -1)`, so unique ids would break a saved selection on reopen. Leaf-id collisions in the combobox's own `allItemsById` are harmless because `activeItemId` is only ever a drill-in item's id, and those are unique — there is a test pinning that.

## Testing

9 tests in `polymorphic-drill-in.spec.ts`, three of which cover the collision directly. Full suite green: 177 files / 2247 tests; all 66 projects typecheck.

> [!WARNING]
> The pure list-building and caching logic is unit-tested, but the **interactive** drill-in has not been exercised against a live org with a real polymorphic lookup. Worth a manual pass on `Owner` (two targets) before merge.
