### PR TITLE
fix(download): retain the selected file format for server-side downloads

### DIFF
--- a/libs/ui/src/lib/file-download-modal/FileDownloadModal.tsx
+++ b/libs/ui/src/lib/file-download-modal/FileDownloadModal.tsx
@@ -241,9 +241,9 @@ export const FileDownloadModal: FunctionComponent<FileDownloadModalProps> = ({
 
         saveFile(fileData, fileNameWithExt, mimeType);
         onModalClose();
-        saveFileFormatToStorage(fileFormat, LS_KEY);
       }
-      trackEvent(ANALYTICS_KEYS.file_download, { source, fileFormat, component: 'FileFauxDownloadModal' });
+      saveFileFormatToStorage(fileFormat, LS_KEY);
+      trackEvent(ANALYTICS_KEYS.file_download, { source, fileFormat, component: 'FileDownloadModal' });
     } catch (ex) {
       logger.error('[FILE DOWNLOAD][ERROR]', ex);
       onError && onError(ensureError(ex));

--- a/libs/ui/src/lib/file-download-modal/RecordDownloadModal.tsx
+++ b/libs/ui/src/lib/file-download-modal/RecordDownloadModal.tsx
@@ -518,6 +518,10 @@ export const RecordDownloadModal: FunctionComponent<RecordDownloadModalProps> = 
           onDownload(fileFormat, whichFields, (includeSubquery && hasSubqueryFields) || includeSubqueriesInTemplate);
         }
         handleModalClose();
+      }
+      // The load template is only offered to callers that provide `loadTemplateOption`, so persisting it would
+      // discard a usable preference in favor of one that cannot be restored anywhere else
+      if (!isLoadTemplate) {
         saveFileFormatToStorage(fileFormat, LS_KEY);
       }
       trackEvent(ANALYTICS_KEYS.file_download, { source, fileFormat, component: 'RecordDownloadModal' });

--- a/libs/ui/src/lib/file-download-modal/__tests__/RecordDownloadModal.spec.tsx
+++ b/libs/ui/src/lib/file-download-modal/__tests__/RecordDownloadModal.spec.tsx
@@ -1,0 +1,108 @@
+import { SalesforceOrgUi } from '@jetstream/types';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { RecordDownloadModal, RecordDownloadModalProps } from '../RecordDownloadModal';
+
+vi.mock('@jetstream/shared/data', () => ({
+  describeSObject: vi.fn().mockResolvedValue({ data: { childRelationships: [] } }),
+}));
+
+const saveFile = vi.hoisted(() => vi.fn());
+vi.mock('@jetstream/shared/ui-utils', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@jetstream/shared/ui-utils')>()),
+  saveFile,
+}));
+
+const LS_KEY = 'RECENT_FILE_FORMAT_RecordDownloadModal';
+
+const org = { uniqueId: 'org-1', username: 'test@example.com' } as SalesforceOrgUi;
+const records = [
+  { Id: '001', Name: 'Record 1' },
+  { Id: '002', Name: 'Record 2' },
+];
+
+function setup(props: Partial<RecordDownloadModalProps> = {}) {
+  const onDownload = vi.fn();
+  const onDownloadFromServer = vi.fn();
+  render(
+    <MemoryRouter>
+      <RecordDownloadModal
+        org={org}
+        googleIntegrationEnabled={false}
+        googleShowUpgradeToPro={false}
+        google_apiKey=""
+        google_appId=""
+        google_clientId=""
+        downloadModalOpen
+        fields={['Id', 'Name']}
+        records={records}
+        source="test"
+        trackEvent={vi.fn()}
+        onModalClose={vi.fn()}
+        onDownload={onDownload}
+        onDownloadFromServer={onDownloadFromServer}
+        {...props}
+      />
+    </MemoryRouter>,
+  );
+  return { onDownload, onDownloadFromServer };
+}
+
+describe('RecordDownloadModal file format persistence', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.clearAllMocks();
+  });
+
+  test('restores the previously used format when the modal opens', () => {
+    localStorage.setItem(LS_KEY, 'json');
+    setup();
+    expect(screen.getByLabelText<HTMLInputElement>('JSON').checked).toBe(true);
+  });
+
+  test('saves the format after a browser download', async () => {
+    localStorage.setItem(LS_KEY, 'json');
+    setup();
+
+    await userEvent.click(screen.getByLabelText('CSV'));
+    await userEvent.click(screen.getByRole('button', { name: 'Download' }));
+
+    expect(saveFile).toHaveBeenCalled();
+    expect(localStorage.getItem(LS_KEY)).toBe('csv');
+  });
+
+  /**
+   * The regression this covers: downloads that run on the server closed the modal without persisting the
+   * format, so reopening reverted to whatever the last browser download had saved.
+   */
+  test('saves the format after a server download', async () => {
+    localStorage.setItem(LS_KEY, 'json');
+    // more records exist than are loaded, which makes the server-side scope the default
+    const { onDownloadFromServer } = setup({ totalRecordCount: 5000 });
+
+    expect(screen.getByLabelText<HTMLInputElement>(/^All records/).checked).toBe(true);
+
+    await userEvent.click(screen.getByLabelText('CSV'));
+    await userEvent.click(screen.getByRole('button', { name: 'Download' }));
+
+    expect(onDownloadFromServer).toHaveBeenCalledWith(expect.objectContaining({ fileFormat: 'csv' }));
+    expect(localStorage.getItem(LS_KEY)).toBe('csv');
+  });
+
+  /**
+   * The load template is only offered when the caller passes `loadTemplateOption`, so persisting it would leave
+   * every other caller falling back to the first allowed format instead of the user's real preference.
+   */
+  test('leaves the stored format alone after a load template download', async () => {
+    localStorage.setItem(LS_KEY, 'csv');
+    setup({ loadTemplateOption: { sobject: 'Account' } });
+
+    await userEvent.click(screen.getByLabelText('Load template (Excel)'));
+    await userEvent.click(screen.getByRole('button', { name: 'Download' }));
+
+    expect(saveFile).toHaveBeenCalled();
+    expect(localStorage.getItem(LS_KEY)).toBe('csv');
+  });
+});


### PR DESCRIPTION
The chosen download format is saved to local storage so the next download starts where the last one left off, but saveFileFormatToStorage was only called on the branch that builds the file in the browser. Downloads handed off to run in the background — Google Drive, and any "All records" download where more records exist than are loaded — closed the modal without saving.

Closing the modal re-reads the stored value, so the format snapped straight back on the next open. Any result set large enough to default to the server-side scope could therefore never have its format changed: picking CSV downloaded a CSV, then reverted to whatever the last in-browser download had saved.

Save on every successful download path
- RecordDownloadModal and FileDownloadModal now save after the branch rather than inside it, matching FileFauxDownloadModal which already did
- Covered by tests for the browser path, the server path, and the format restored when the modal opens

Do not persist the load template format
- The load template is only offered when the caller passes loadTemplateOption and is absent from allowedTypes, so getInitialDownloadFileFormat rejects it on read and falls back to the first allowed format
- Saving it discarded a working preference and replaced it with one that can never be restored, which became reachable once the radio was enabled in #1950

Also corrects FileDownloadModal's file_download analytics event, which reported component: 'FileFauxDownloadModal' and made the two components indistinguishable.