### PR TITLE
feat(query): surface and load subquery records Salesforce truncated

### DIFF
--- a/libs/features/query/src/QueryResults/QueryResults.tsx
+++ b/libs/features/query/src/QueryResults/QueryResults.tsx
@@ -434,20 +434,24 @@ export const QueryResults = React.memo(() => {
     }
   }
 
+  /**
+   * `results.queryResults.records` is the complete record set, not just the page that was fetched - the table
+   * merges pages by record identity (a parent whose child records were truncated can be returned again), so
+   * appending here would duplicate any record that came back more than once.
+   */
   function handleLoadMore(results: IQueryResults<any>) {
     if (isMounted.current) {
+      const existingRecordCount = records?.length || 0;
       const sobjectName = results.parsedQuery?.sObject || results.columns?.entityName;
+      const allRecords = results.queryResults.records;
       setNextRecordsUrl(results.queryResults.nextRecordsUrl);
       sobjectName && saveQueryHistory(soql, sobjectName, isTooling);
-      if (records) {
-        const newRecords = records.concat(results.queryResults.records);
-        setRecordCount(getTotalRecordCount(results.queryResults, newRecords));
-        setTotalRecordCount(getTotalRecordCount(results.queryResults, newRecords));
-        setRecords(newRecords);
-      }
+      setRecordCount(getTotalRecordCount(results.queryResults, allRecords));
+      setTotalRecordCount(getTotalRecordCount(results.queryResults, allRecords));
+      setRecords(allRecords);
       trackEvent(ANALYTICS_KEYS.query_LoadMore, {
-        existingRecordCount: records?.length || 0,
-        nextSetCount: results.queryResults.records.length,
+        existingRecordCount,
+        nextSetCount: allRecords.length - existingRecordCount,
         totalSize: results.queryResults.totalSize,
         isTooling,
       });

--- a/libs/features/query/src/QueryResults/QueryResultsCopyToClipboard.tsx
+++ b/libs/features/query/src/QueryResults/QueryResultsCopyToClipboard.tsx
@@ -1,12 +1,8 @@
 import { ANALYTICS_KEYS } from '@jetstream/shared/constants';
-import { copyRecordsToClipboard } from '@jetstream/shared/ui-utils';
-import { CopyAsDataType, Maybe, SalesforceRecord } from '@jetstream/types';
-import { ButtonGroupContainer, DropDown, Icon, Modal, Radio, RadioGroup, Tooltip } from '@jetstream/ui';
+import { Maybe, SalesforceRecord } from '@jetstream/types';
+import { CopyRecordsToClipboardButton } from '@jetstream/ui';
 import { useAmplitude } from '@jetstream/ui-core';
-import classNames from 'classnames';
-import { Fragment, FunctionComponent, useEffect, useState } from 'react';
-
-type WhichRecords = 'all' | 'filtered' | 'selected';
+import { FunctionComponent } from 'react';
 
 export interface QueryResultsCopyToClipboardProps {
   className?: string;
@@ -28,148 +24,17 @@ export const QueryResultsCopyToClipboard: FunctionComponent<QueryResultsCopyToCl
   isTooling,
 }) => {
   const { trackEvent } = useAmplitude();
-  const [isModalOpen, setIsModalOpen] = useState(false);
-  const [format, setFormat] = useState<CopyAsDataType>('excel');
-  const [whichRecords, setWhichRecords] = useState<WhichRecords>('all');
-  const [hasFilteredRows, setHasFilteredRows] = useState<boolean>(false);
-  const [hasPartialSelectedRows, setHasPartialSelectedRows] = useState<boolean>(false);
-
-  useEffect(() => {
-    if (filteredRows && records) {
-      setHasFilteredRows(filteredRows.length > 0 && filteredRows.length < records.length);
-    }
-  }, [filteredRows, records]);
-
-  useEffect(() => {
-    if (selectedRows && records) {
-      setHasPartialSelectedRows(selectedRows.length > 0 && selectedRows.length < records.length);
-    }
-  }, [selectedRows, records]);
-
-  useEffect(() => {
-    setWhichRecords('all');
-  }, [records, filteredRows, selectedRows]);
-
-  function handleCopyToClipboard(format: CopyAsDataType = 'excel') {
-    if (
-      (records && hasFilteredRows && filteredRows.length < records.length) ||
-      (records && hasPartialSelectedRows && selectedRows.length < records.length)
-    ) {
-      setFormat(format);
-      setIsModalOpen(true);
-      return;
-    }
-    copyRecordsToClipboard(records, format, fields);
-    trackEvent(ANALYTICS_KEYS.query_CopyToClipboard, { isTooling, whichRecords, format });
-  }
-
-  function handleModalConfirmation(doCopy = false) {
-    setIsModalOpen(false);
-
-    if (!doCopy) {
-      setFormat('excel');
-      setWhichRecords('all');
-      return;
-    }
-
-    let recordsToCopy = records;
-
-    if (whichRecords === 'filtered') {
-      recordsToCopy = filteredRows;
-    } else if (whichRecords === 'selected') {
-      recordsToCopy = selectedRows;
-    }
-
-    copyRecordsToClipboard(recordsToCopy, format, fields);
-    trackEvent(ANALYTICS_KEYS.query_CopyToClipboard, { isTooling, whichRecords, format });
-
-    setFormat('excel');
-    setWhichRecords('all');
-  }
 
   return (
-    <Fragment>
-      <ButtonGroupContainer>
-        <Tooltip
-          openDelay={1000}
-          content="This will copy in a format compatible with a spreadsheet program, such as Excel or Google Sheets. Use the dropdown for additional options."
-        >
-          <button
-            className={classNames('slds-button slds-button_neutral slds-button_first', className)}
-            onClick={() => handleCopyToClipboard()}
-            disabled={!hasRecords}
-          >
-            <Icon type="utility" icon="copy_to_clipboard" className="slds-button__icon slds-button__icon_left" omitContainer />
-            <span>Copy to Clipboard</span>
-          </button>
-        </Tooltip>
-        <DropDown
-          className="slds-button_last"
-          dropDownClassName="slds-dropdown_actions"
-          position="right"
-          disabled={!hasRecords}
-          items={[
-            { id: 'csv', value: 'Copy as CSV' },
-            { id: 'json', value: 'Copy as JSON' },
-          ]}
-          onSelected={(item) => handleCopyToClipboard(item as CopyAsDataType)}
-        />
-      </ButtonGroupContainer>
-      {isModalOpen && (
-        <Modal
-          header="Which records would you like to copy?"
-          footer={
-            <Fragment>
-              <button className="slds-button slds-button_neutral" onClick={() => handleModalConfirmation(false)}>
-                Cancel
-              </button>
-              <button className="slds-button slds-button_brand" onClick={() => handleModalConfirmation(true)}>
-                Copy
-              </button>
-            </Fragment>
-          }
-          closeOnBackdropClick
-          closeOnEsc
-          onClose={() => handleModalConfirmation(false)}
-        >
-          <div>
-            <RadioGroup>
-              <Radio
-                idPrefix="all"
-                id="radio-all"
-                name="which-records"
-                label={`All Records (${records?.length || 0})`}
-                value="all"
-                checked={whichRecords === 'all'}
-                onChange={(_value) => setWhichRecords('all')}
-              />
-              {hasFilteredRows && (
-                <Radio
-                  idPrefix="filtered"
-                  id="radio-filtered"
-                  name="which-records"
-                  label={`Filtered Records (${filteredRows.length})`}
-                  value="filtered"
-                  checked={whichRecords === 'filtered'}
-                  onChange={(_value) => setWhichRecords('filtered')}
-                />
-              )}
-              {hasPartialSelectedRows && (
-                <Radio
-                  idPrefix="selected"
-                  id="radio-selected"
-                  name="which-records"
-                  label={`Selected Records (${selectedRows.length})`}
-                  value="selected"
-                  checked={whichRecords === 'selected'}
-                  onChange={(_value) => setWhichRecords('selected')}
-                />
-              )}
-            </RadioGroup>
-          </div>
-        </Modal>
-      )}
-    </Fragment>
+    <CopyRecordsToClipboardButton
+      className={className}
+      disabled={!hasRecords}
+      fields={fields}
+      records={records}
+      filteredRecords={filteredRows}
+      selectedRecords={selectedRows}
+      onCopy={({ format, whichRecords }) => trackEvent(ANALYTICS_KEYS.query_CopyToClipboard, { isTooling, whichRecords, format })}
+    />
   );
 };
 

--- a/libs/shared/data/src/lib/__tests__/client-data-subquery.spec.ts
+++ b/libs/shared/data/src/lib/__tests__/client-data-subquery.spec.ts
@@ -1,0 +1,130 @@
+import type { SalesforceOrgUi } from '@jetstream/types';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockedHandleRequest } = vi.hoisted(() => ({ mockedHandleRequest: vi.fn() }));
+
+vi.mock('../client-data-data-helper', () => ({
+  handleRequest: mockedHandleRequest,
+  handleExternalRequest: vi.fn(),
+  transformListMetadataResponse: vi.fn(),
+}));
+
+import { queryRemainingSubqueryRecords, queryRemainingSubqueryResults } from '../client-data';
+
+const ORG = { uniqueId: 'org-1' } as unknown as SalesforceOrgUi;
+
+/* eslint-disable @typescript-eslint/no-explicit-any -- record trees are dynamically shaped, so assertions index into `any` */
+type AnyRecord = Record<string, any>;
+
+function record(id: string, type: string, extra: Record<string, unknown> = {}): AnyRecord {
+  return { Id: id, attributes: { type, url: `/services/data/v65.0/sobjects/${type}/${id}` }, ...extra };
+}
+
+function subquery(records: AnyRecord[], nextRecordsUrl?: string, totalSize = records.length) {
+  return { done: !nextRecordsUrl, totalSize, records, ...(nextRecordsUrl ? { nextRecordsUrl } : {}) };
+}
+
+/** `queryMore` unwraps `{ data }` off the shared request helper, so responses are shaped the way the API returns them. */
+function respondWith(pagesByUrl: Record<string, { records: AnyRecord[]; nextRecordsUrl?: string; totalSize?: number }>) {
+  mockedHandleRequest.mockImplementation((request: { params?: { nextRecordsUrl?: string } }) => {
+    const url = request.params?.nextRecordsUrl ?? '';
+    const page = pagesByUrl[url];
+    if (!page) {
+      throw new Error(`Unexpected query locator: ${url}`);
+    }
+    return Promise.resolve({
+      data: { queryResults: subquery(page.records, page.nextRecordsUrl, page.totalSize ?? page.records.length) },
+    });
+  });
+}
+
+describe('queryRemainingSubqueryResults', () => {
+  beforeEach(() => {
+    mockedHandleRequest.mockReset();
+  });
+
+  it('follows the locator until every child record is loaded', async () => {
+    respondWith({
+      '/next/contacts/1': { records: [record('003B', 'Contact')], nextRecordsUrl: '/next/contacts/2', totalSize: 3 },
+      '/next/contacts/2': { records: [record('003C', 'Contact')], totalSize: 3 },
+    });
+
+    const results = await queryRemainingSubqueryResults(ORG, subquery([record('003A', 'Contact')], '/next/contacts/1', 3));
+
+    expect(results.records.map(({ Id }: any) => Id)).toEqual(['003A', '003B', '003C']);
+    expect(results.done).toBe(true);
+    expect(mockedHandleRequest).toHaveBeenCalledTimes(2);
+  });
+
+  it('reports progress as child records arrive', async () => {
+    respondWith({
+      '/next/1': { records: [record('003B', 'Contact')], nextRecordsUrl: '/next/2' },
+      '/next/2': { records: [record('003C', 'Contact')] },
+    });
+    const onProgress = vi.fn();
+
+    await queryRemainingSubqueryResults(ORG, subquery([record('003A', 'Contact')], '/next/1'), false, onProgress);
+
+    // queryRemaining follows the whole locator chain before returning, so this reports once per subquery completed
+    expect(onProgress).toHaveBeenCalledWith(2);
+  });
+
+  it('completes subqueries nested inside the child records', async () => {
+    const contactWithTruncatedCases = record('003A', 'Contact', {
+      Cases: subquery([record('500A', 'Case')], '/next/cases', 2),
+    });
+    respondWith({ '/next/cases': { records: [record('500B', 'Case')], totalSize: 2 } });
+
+    const results = await queryRemainingSubqueryResults(ORG, subquery([contactWithTruncatedCases]));
+
+    expect(results.records[0].Cases.records.map(({ Id }: any) => Id)).toEqual(['500A', '500B']);
+    expect(results.records[0].Cases.done).toBe(true);
+  });
+
+  it('completes a subquery three levels deep', async () => {
+    const caseWithTruncatedComments = record('500A', 'Case', {
+      CaseComments: subquery([record('00aA', 'CaseComment')], '/next/comments', 2),
+    });
+    const contact = record('003A', 'Contact', { Cases: subquery([caseWithTruncatedComments]) });
+    respondWith({ '/next/comments': { records: [record('00aB', 'CaseComment')], totalSize: 2 } });
+
+    const results = await queryRemainingSubqueryResults(ORG, subquery([contact]));
+
+    expect(results.records[0].Cases.records[0].CaseComments.records.map(({ Id }: any) => Id)).toEqual(['00aA', '00aB']);
+  });
+
+  it('makes no requests when nothing was truncated', async () => {
+    const results = await queryRemainingSubqueryResults(ORG, subquery([record('003A', 'Contact')]));
+
+    expect(mockedHandleRequest).not.toHaveBeenCalled();
+    expect(results.records).toHaveLength(1);
+  });
+});
+
+describe('queryRemainingSubqueryRecords', () => {
+  beforeEach(() => {
+    mockedHandleRequest.mockReset();
+  });
+
+  it('returns the same array when no record is missing anything', async () => {
+    const records = [record('001A', 'Account', { Contacts: subquery([record('003A', 'Contact')]) })];
+
+    await expect(queryRemainingSubqueryRecords(ORG, records)).resolves.toBe(records);
+    expect(mockedHandleRequest).not.toHaveBeenCalled();
+  });
+
+  it('completes truncated subqueries across every record without touching the originals', async () => {
+    const records = [
+      record('001A', 'Account', { Contacts: subquery([record('003A', 'Contact')], '/next/a', 2) }),
+      record('001B', 'Account', { Contacts: subquery([record('003C', 'Contact')]) }),
+    ];
+    respondWith({ '/next/a': { records: [record('003B', 'Contact')], totalSize: 2 } });
+
+    const completed = await queryRemainingSubqueryRecords(ORG, records);
+
+    expect(completed[0].Contacts.records.map(({ Id }: any) => Id)).toEqual(['003A', '003B']);
+    expect(completed[1]).toBe(records[1]);
+    // The caller's copy is left alone - the table swaps in the returned records instead
+    expect(records[0].Contacts.records).toHaveLength(1);
+  });
+});

--- a/libs/shared/data/src/lib/client-data.ts
+++ b/libs/shared/data/src/lib/client-data.ts
@@ -22,7 +22,13 @@ import type {
 } from '@jetstream/auth/types';
 import { logger } from '@jetstream/shared/client-logger';
 import { HTTP, MIME_TYPES } from '@jetstream/shared/constants';
-import { splitArrayToMaxSize } from '@jetstream/shared/utils';
+import {
+  hasIncompleteSubqueries,
+  isIncompleteSubqueryResult,
+  isSubqueryResult,
+  mergeSubqueryResults,
+  splitArrayToMaxSize,
+} from '@jetstream/shared/utils';
 import {
   AnonymousApexResponse,
   ApexCompletionResponse,
@@ -63,6 +69,7 @@ import {
   OrgGroup,
   PullResponse,
   PullResponseSchema,
+  QueryResult,
   QueryResults,
   RecordResult,
   RetrieveResult,
@@ -889,6 +896,92 @@ export async function queryRemaining<T = any>(
   }
   results.queryResults.done = true;
   return results;
+}
+
+/**
+ * Fetch every child record Salesforce truncated from the subqueries on these records and return records carrying
+ * the complete child sets. Subqueries can be nested, so this walks the whole tree - a truncated subquery several
+ * levels down is completed just like a top level one. Records with nothing missing are returned untouched.
+ *
+ * Each subquery is completed through its own query locator, so the result is exact regardless of how the parent
+ * query itself was paged. Records with nothing truncated cost nothing - they are never requested.
+ */
+export async function queryRemainingSubqueryRecords<T = any>(
+  org: SalesforceOrgUi,
+  records: T[],
+  isTooling = false,
+  onProgress?: (fetchedChildRecordCount: number) => void,
+): Promise<T[]> {
+  if (!records.some(hasIncompleteSubqueries)) {
+    return records;
+  }
+  const progress = { fetched: 0 };
+  const output: T[] = [];
+  for (const record of records) {
+    output.push(await completeSubqueryRecords(org, record, isTooling, progress, onProgress));
+  }
+  return output;
+}
+
+/**
+ * Same as `queryRemainingSubqueryRecords` for a single subquery result: fetches whatever Salesforce truncated from
+ * it, then does the same for every subquery nested within its child records.
+ */
+export async function queryRemainingSubqueryResults<T = any>(
+  org: SalesforceOrgUi,
+  queryResults: QueryResult<T>,
+  isTooling = false,
+  onProgress?: (fetchedChildRecordCount: number) => void,
+): Promise<QueryResult<T>> {
+  return completeSubqueryResults(org, queryResults, isTooling, { fetched: 0 }, onProgress);
+}
+
+async function completeSubqueryResults<T = any>(
+  org: SalesforceOrgUi,
+  queryResults: QueryResult<T>,
+  isTooling: boolean,
+  progress: { fetched: number },
+  onProgress?: (fetchedChildRecordCount: number) => void,
+): Promise<QueryResult<T>> {
+  if (!isIncompleteSubqueryResult(queryResults)) {
+    return queryResults;
+  }
+  let output = queryResults;
+  if (!output.done && output.nextRecordsUrl) {
+    const results = await queryRemaining<T>(org, output.nextRecordsUrl, isTooling);
+    progress.fetched += results.queryResults.records.length;
+    onProgress?.(progress.fetched);
+    output = mergeSubqueryResults(output, results.queryResults);
+  }
+  if (!output.records.some(hasIncompleteSubqueries)) {
+    return output;
+  }
+  const records: T[] = [];
+  for (const record of output.records) {
+    records.push(await completeSubqueryRecords(org, record, isTooling, progress, onProgress));
+  }
+  return { ...output, records };
+}
+
+async function completeSubqueryRecords<T = any>(
+  org: SalesforceOrgUi,
+  record: T,
+  isTooling: boolean,
+  progress: { fetched: number },
+  onProgress?: (fetchedChildRecordCount: number) => void,
+): Promise<T> {
+  if (!hasIncompleteSubqueries(record)) {
+    return record;
+  }
+  let output: any = record;
+  // Every subquery on the record, whether it was truncated itself or only has truncated subqueries beneath it
+  for (const [relationshipName, value] of Object.entries(output)) {
+    if (!isSubqueryResult(value)) {
+      continue;
+    }
+    output = { ...output, [relationshipName]: await completeSubqueryResults(org, value, isTooling, progress, onProgress) };
+  }
+  return output;
 }
 
 /**

--- a/libs/shared/utils/src/index.ts
+++ b/libs/shared/utils/src/index.ts
@@ -8,4 +8,5 @@ export * from './lib/salesforce-org-expiration';
 export * from './lib/sobject-api-name-utils';
 export * from './lib/sso-certificate-expiration';
 export * from './lib/subquery-path-utils';
+export * from './lib/subquery-record-utils';
 export * from './lib/utils';

--- a/libs/shared/utils/src/lib/__tests__/subquery-record-utils.spec.ts
+++ b/libs/shared/utils/src/lib/__tests__/subquery-record-utils.spec.ts
@@ -1,0 +1,187 @@
+import { describe, expect, test } from 'vitest';
+import {
+  getQueryRecordKey,
+  hasIncompleteSubqueries,
+  isIncompleteSubqueryResult,
+  isSubqueryResult,
+  mergeQueryRecordPages,
+  mergeSubqueryResults,
+} from '../subquery-record-utils';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function makeRecord(id: string, type = 'Account', extra: Record<string, unknown> = {}): Record<string, any> {
+  return { Id: id, attributes: { type, url: `/services/data/v65.0/sobjects/${type}/${id}` }, ...extra };
+}
+
+function makeSubquery(
+  records: unknown[],
+  { done = true, nextRecordsUrl = undefined as string | undefined, totalSize = records.length } = {},
+) {
+  return { done, totalSize, records, ...(nextRecordsUrl ? { nextRecordsUrl } : {}) };
+}
+
+describe('isSubqueryResult', () => {
+  test.each([
+    ['a subquery result', makeSubquery([]), true],
+    ['a plain string', 'Acme', false],
+    ['null', null, false],
+    ['an address compound field', { city: 'Portland', state: 'OR' }, false],
+    ['an object with records but no done flag', { records: [] }, false],
+  ])('%s', (_label, value, expected) => {
+    expect(isSubqueryResult(value)).toBe(expected);
+  });
+});
+
+describe('getQueryRecordKey', () => {
+  test('prefers the record url', () => {
+    expect(getQueryRecordKey(makeRecord('001A'))).toBe('/services/data/v65.0/sobjects/Account/001A');
+  });
+
+  test('falls back to the id', () => {
+    expect(getQueryRecordKey({ Id: '001A' })).toBe('001A');
+  });
+
+  test('returns null when there is nothing to key on', () => {
+    expect(getQueryRecordKey({ Name: 'Acme' })).toBeNull();
+    expect(getQueryRecordKey(null)).toBeNull();
+  });
+});
+
+describe('isIncompleteSubqueryResult', () => {
+  test('is false when the result set is fully loaded', () => {
+    expect(isIncompleteSubqueryResult(makeSubquery([makeRecord('003A', 'Contact')]))).toBe(false);
+  });
+
+  test('is true when the result set has its own records left to fetch', () => {
+    expect(isIncompleteSubqueryResult(makeSubquery([], { done: false, nextRecordsUrl: '/next/contacts' }))).toBe(true);
+  });
+
+  test('is true when a subquery nested within its records was truncated', () => {
+    const contactWithTruncatedCases = makeRecord('003A', 'Contact', {
+      Cases: makeSubquery([], { done: false, nextRecordsUrl: '/next/cases' }),
+    });
+
+    expect(isIncompleteSubqueryResult(makeSubquery([contactWithTruncatedCases]))).toBe(true);
+  });
+
+  test('is false when there is no result set', () => {
+    expect(isIncompleteSubqueryResult(null)).toBe(false);
+    expect(isIncompleteSubqueryResult(undefined)).toBe(false);
+  });
+});
+
+describe('hasIncompleteSubqueries', () => {
+  test('is false when everything came back', () => {
+    expect(hasIncompleteSubqueries(makeRecord('001A', 'Account', { Contacts: makeSubquery([makeRecord('003A', 'Contact')]) }))).toBe(false);
+  });
+
+  test('is true when the record itself has a truncated subquery', () => {
+    const record = makeRecord('001A', 'Account', { Contacts: makeSubquery([], { done: false, nextRecordsUrl: '/next' }) });
+    expect(hasIncompleteSubqueries(record)).toBe(true);
+  });
+
+  test('is true when a subquery nested several levels down was truncated', () => {
+    const contactWithTruncatedCases = makeRecord('003A', 'Contact', {
+      Cases: makeSubquery([], { done: false, nextRecordsUrl: '/next/cases' }),
+    });
+    const record = makeRecord('001A', 'Account', { Contacts: makeSubquery([contactWithTruncatedCases]) });
+
+    expect(hasIncompleteSubqueries(record)).toBe(true);
+  });
+
+  test('is false for records without subqueries at all', () => {
+    expect(hasIncompleteSubqueries(makeRecord('001A'))).toBe(false);
+    expect(hasIncompleteSubqueries(null)).toBe(false);
+  });
+});
+
+describe('mergeSubqueryResults', () => {
+  test('appends the page and takes its paging state', () => {
+    const existing = makeSubquery([makeRecord('003A', 'Contact')], { done: false, nextRecordsUrl: '/next/1', totalSize: 3 });
+    const page = makeSubquery([makeRecord('003B', 'Contact'), makeRecord('003C', 'Contact')], { done: true, totalSize: 3 });
+
+    const merged = mergeSubqueryResults(existing, page);
+
+    expect(merged.records.map(({ Id }) => Id)).toEqual(['003A', '003B', '003C']);
+    expect(merged.done).toBe(true);
+    expect(merged.nextRecordsUrl).toBeUndefined();
+    expect(merged.totalSize).toBe(3);
+  });
+
+  test('skips records already loaded so an overlapping page cannot duplicate rows', () => {
+    const existing = makeSubquery([makeRecord('003A', 'Contact'), makeRecord('003B', 'Contact')], { done: false, nextRecordsUrl: '/next' });
+    const page = makeSubquery([makeRecord('003B', 'Contact'), makeRecord('003C', 'Contact')]);
+
+    expect(mergeSubqueryResults(existing, page).records.map(({ Id }) => Id)).toEqual(['003A', '003B', '003C']);
+  });
+
+  test('keeps records that have no id to compare on', () => {
+    const existing = makeSubquery([{ Amount: 1 }], { done: false, nextRecordsUrl: '/next' });
+    const page = makeSubquery([{ Amount: 2 }]);
+
+    expect(mergeSubqueryResults(existing, page).records).toHaveLength(2);
+  });
+
+  test('folds a repeated child record into the loaded copy rather than dropping its nested subquery records', () => {
+    const existing = makeSubquery(
+      [
+        makeRecord('003A', 'Contact', {
+          Cases: makeSubquery([makeRecord('500A', 'Case')], { done: false, nextRecordsUrl: '/next/cases' }),
+        }),
+      ],
+      { done: false, nextRecordsUrl: '/next/contacts' },
+    );
+    // The same contact comes back on the next page carrying its next batch of cases
+    const page = makeSubquery([makeRecord('003A', 'Contact', { Cases: makeSubquery([makeRecord('500B', 'Case')]) })]);
+
+    const merged = mergeSubqueryResults(existing, page);
+
+    expect(merged.records).toHaveLength(1);
+    expect(merged.records[0].Cases.records.map(({ Id }: { Id: string }) => Id)).toEqual(['500A', '500B']);
+    expect(merged.records[0].Cases.done).toBe(true);
+  });
+});
+
+describe('mergeQueryRecordPages', () => {
+  test('appends records that have not been seen', () => {
+    const merged = mergeQueryRecordPages([makeRecord('001A')], [makeRecord('001B'), makeRecord('001C')]);
+
+    expect(merged.map(({ Id }) => Id)).toEqual(['001A', '001B', '001C']);
+  });
+
+  test('folds a repeated parent into the loaded copy instead of adding a second row', () => {
+    const loaded = [
+      makeRecord('001A', 'Account', {
+        Contacts: makeSubquery([makeRecord('003A', 'Contact')], { done: false, nextRecordsUrl: '/next/1', totalSize: 3 }),
+      }),
+    ];
+    // Child rows count toward the batch size, so the same account comes back carrying its next batch of contacts
+    const nextPage = [
+      makeRecord('001A', 'Account', {
+        Contacts: makeSubquery([makeRecord('003B', 'Contact'), makeRecord('003C', 'Contact')], { done: true, totalSize: 3 }),
+      }),
+    ];
+
+    const merged = mergeQueryRecordPages(loaded, nextPage);
+
+    expect(merged).toHaveLength(1);
+    expect(merged[0].Contacts.records.map(({ Id }: { Id: string }) => Id)).toEqual(['003A', '003B', '003C']);
+    expect(merged[0].Contacts.done).toBe(true);
+  });
+
+  test('does not mutate the records it was given', () => {
+    const loaded = [makeRecord('001A', 'Account', { Contacts: makeSubquery([makeRecord('003A', 'Contact')], { done: false }) })];
+    const nextPage = [makeRecord('001A', 'Account', { Contacts: makeSubquery([makeRecord('003B', 'Contact')]) })];
+
+    mergeQueryRecordPages(loaded, nextPage);
+
+    expect(loaded[0].Contacts.records.map(({ Id }: { Id: string }) => Id)).toEqual(['003A']);
+    expect(loaded).toHaveLength(1);
+  });
+
+  test('appends records with no usable key rather than dropping them', () => {
+    const merged = mergeQueryRecordPages([{ Total: 1 }], [{ Total: 2 }]);
+
+    expect(merged).toHaveLength(2);
+  });
+});

--- a/libs/shared/utils/src/lib/subquery-record-utils.ts
+++ b/libs/shared/utils/src/lib/subquery-record-utils.ts
@@ -1,0 +1,116 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { Maybe, QueryResult } from '@jetstream/types';
+
+/**
+ * Salesforce counts subquery child rows toward a query's batch size, so a query can come back with only part of
+ * a parent's child records. When that happens the child result set is marked `done: false` and carries its own
+ * `nextRecordsUrl`, and the top level result is marked `done: false` as well - even when every parent record was
+ * returned. These helpers identify what is missing and fold newly fetched pages back into the loaded records.
+ */
+
+/**
+ * Salesforce nests a parent-to-child subquery's result set on the parent record, keyed by relationship name.
+ * The shape matches a top level query result, including its own paging state.
+ */
+export function isSubqueryResult(value: unknown): value is QueryResult<any> {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+  const { records, done } = value as QueryResult<any>;
+  return Array.isArray(records) && typeof done === 'boolean';
+}
+
+/** Identity used to recognize the same record across pages, or null for records without a usable id. */
+export function getQueryRecordKey(record: any): string | null {
+  const url = record?.attributes?.url;
+  if (typeof url === 'string' && url) {
+    return url;
+  }
+  const id = record?.Id ?? record?.id;
+  return typeof id === 'string' && id ? id : null;
+}
+
+/**
+ * True when this result set is missing records - either its own paging is unfinished, or a subquery nested
+ * somewhere within its records was truncated. Truncation at any depth counts: a subquery several levels down
+ * being short is just as invisible from a table as this one being short, and both make an export incomplete.
+ */
+export function isIncompleteSubqueryResult(queryResults: Maybe<QueryResult<any>>): boolean {
+  if (!queryResults) {
+    return false;
+  }
+  return (!queryResults.done && !!queryResults.nextRecordsUrl) || queryResults.records.some(hasIncompleteSubqueries);
+}
+
+/** True when this record - or any child record nested within its subqueries - is missing child records. */
+export function hasIncompleteSubqueries(record: any): boolean {
+  if (!record || typeof record !== 'object') {
+    return false;
+  }
+  return Object.values(record).some((value) => isSubqueryResult(value) && isIncompleteSubqueryResult(value));
+}
+
+/**
+ * Append a newly fetched page of child records onto a subquery result. Paging state is taken from the page,
+ * which is the newer of the two. The records themselves are merged by identity, so an overlapping page cannot
+ * duplicate rows, and a child record repeated to carry more of its own children keeps both batches.
+ */
+export function mergeSubqueryResults(existing: QueryResult<any>, page: QueryResult<any>): QueryResult<any> {
+  return {
+    ...page,
+    records: mergeQueryRecordPages(existing.records, page.records),
+    totalSize: Math.max(existing.totalSize ?? 0, page.totalSize ?? 0),
+  };
+}
+
+/**
+ * Fold a record that appeared again in a later page into the copy already loaded, appending whatever child
+ * records its subqueries carry. Every other field is identical between the two, so the loaded copy wins.
+ */
+function mergeRecordSubqueries(existing: any, incoming: any): any {
+  const subqueryEntries = Object.entries(incoming).filter(([, value]) => isSubqueryResult(value));
+  if (!subqueryEntries.length) {
+    return existing;
+  }
+  const merged = { ...existing };
+  subqueryEntries.forEach(([relationshipName, value]) => {
+    const existingValue = existing[relationshipName];
+    merged[relationshipName] = isSubqueryResult(existingValue)
+      ? mergeSubqueryResults(existingValue, value as QueryResult<any>)
+      : (value as QueryResult<any>);
+  });
+  return merged;
+}
+
+/**
+ * Merge a page of records into the records already loaded. Used at every depth - the top level result set and any
+ * subquery nested within it page the same way.
+ *
+ * A record whose child records were truncated can be returned again by a later page, carrying its next batch of
+ * children. Merging by record identity keeps that record from being added a second time and folds the extra
+ * children into the copy already loaded.
+ */
+export function mergeQueryRecordPages(existingRecords: any[], incomingRecords: any[]): any[] {
+  const indexByKey = new Map<string, number>();
+  existingRecords.forEach((record, index) => {
+    const key = getQueryRecordKey(record);
+    if (key && !indexByKey.has(key)) {
+      indexByKey.set(key, index);
+    }
+  });
+
+  const merged = existingRecords.slice();
+  incomingRecords.forEach((record) => {
+    const key = getQueryRecordKey(record);
+    const existingIndex = key ? indexByKey.get(key) : undefined;
+    if (existingIndex === undefined) {
+      if (key) {
+        indexByKey.set(key, merged.length);
+      }
+      merged.push(record);
+      return;
+    }
+    merged[existingIndex] = mergeRecordSubqueries(merged[existingIndex], record);
+  });
+  return merged;
+}

--- a/libs/ui/src/index.ts
+++ b/libs/ui/src/index.ts
@@ -126,6 +126,7 @@ export * from './lib/list/ReadonlyList';
 export * from './lib/modal/ConfirmationModalPromise';
 export * from './lib/modal/Modal';
 export * from './lib/modal/PortalContext';
+export * from './lib/modal/WhichRecordsToCopyModalPromise';
 export * from './lib/modal/XlsxSheetSelectionModalPromise';
 export * from './lib/nav/Navbar';
 export * from './lib/nav/NavbarAppLauncher';

--- a/libs/ui/src/lib/data-table/SalesforceRecordDataTable.tsx
+++ b/libs/ui/src/lib/data-table/SalesforceRecordDataTable.tsx
@@ -2,15 +2,18 @@
 import { css } from '@emotion/react';
 import { logger } from '@jetstream/shared/client-logger';
 import { ANALYTICS_KEYS } from '@jetstream/shared/constants';
-import { queryRemaining } from '@jetstream/shared/data';
+import { queryRemaining, queryRemainingSubqueryRecords } from '@jetstream/shared/data';
 import { formatNumber, hasCtrlOrMeta, isEnterKey, tracker, useGlobalEventHandler } from '@jetstream/shared/ui-utils';
 import {
   flattenRecord,
   getErrorMessage,
   getIdFromRecordUrl,
   groupByFlat,
+  hasIncompleteSubqueries,
   isInvalidQueryLocatorError,
+  mergeQueryRecordPages,
   nullifyEmptyStrings,
+  pluralizeFromNumber,
 } from '@jetstream/shared/utils';
 import {
   CloneEditView,
@@ -18,6 +21,7 @@ import {
   ErrorResult,
   Field,
   Maybe,
+  QueryResult,
   QueryResults,
   SalesforceOrgUi,
   SobjectCollectionResponse,
@@ -32,6 +36,7 @@ import { ConfirmationModalPromise } from '../modal/ConfirmationModalPromise';
 import { PopoverErrorButton } from '../popover/PopoverErrorButton';
 import { fireToast } from '../toast/AppToast';
 import Spinner from '../widgets/Spinner';
+import Tooltip from '../widgets/Tooltip';
 import { DataTableSubqueryContext } from './data-table-context';
 import { applyPasteCellsToRows, revertCellsInRows } from './data-table-paste-utils';
 import {
@@ -52,6 +57,7 @@ import {
 } from './data-table-utils';
 import { DataTable } from './DataTable';
 import { FieldMetadataModal } from './FieldMetadataModal';
+import { replaceSubqueryOnRecord } from './grid/grid-row-utils';
 import { RowsChangeData } from './grid/rdg-compat';
 import { getRowErrorMessages, mapSaveErrorsToRow, summarizeRowErrors, validateRow } from './grid/validate-cell-value';
 import { DownloadConfig, MAX_SAVE_BATCH_SIZE, PreviewChangesModal } from './PreviewChangesModal';
@@ -203,6 +209,8 @@ export const SalesforceRecordDataTable = memo<SalesforceRecordDataTableProps>(
 
     const [totalRecordCountText, setTotalRecordCountText] = useState<string>();
     const [isLoadingMore, setIsLoadingMore] = useState(false);
+    // Completing truncated subqueries can take far longer than fetching the parent records, so it reports its own progress
+    const [loadedChildRecordCount, setLoadedChildRecordCount] = useState(0);
     const [loadMoreErrorMessage, setLoadMoreErrorMessage] = useState<string | null>(null);
     const [hasMoreRecords, setHasMoreRecords] = useState(false);
     const [nextRecordsUrl, setNextRecordsUrl] = useState<Maybe<string>>(null);
@@ -374,36 +382,69 @@ export const SalesforceRecordDataTable = memo<SalesforceRecordDataTableProps>(
       redoStackRef.current = [];
     }, [columns, handleRowAction, records]);
 
+    /**
+     * Replacing the records rebuilds every row, which drops in-progress edits - so anything that does it has to
+     * offer the user a way out first. Resolves true when there is nothing to lose.
+     */
+    async function confirmDiscardUnsavedChanges(): Promise<boolean> {
+      if (!dirtyRows?.length) {
+        return true;
+      }
+      return ConfirmationModalPromise({ content: 'If you load these records your unsaved changes will not be saved.' });
+    }
+
+    /**
+     * Load everything Salesforce held back: the remaining parent records, and the child records truncated from
+     * subqueries at any depth.
+     *
+     * Child rows count toward a query's batch size, so a query can be reported as incomplete purely because a
+     * parent's related records did not fit - in which case there are no parent records left to fetch at all, only
+     * child records. Both halves are handled here because either one alone leaves an export short of records.
+     */
     async function loadRemaining() {
       try {
-        if (
-          dirtyRows?.length &&
-          !(await ConfirmationModalPromise({
-            content: 'If you load all records your unsaved changes will not be saved.',
-          }))
-        ) {
-          return;
-        }
-
-        if (!nextRecordsUrl) {
+        if (!(await confirmDiscardUnsavedChanges())) {
           return;
         }
         setIsLoadingMore(true);
         setLoadMoreErrorMessage(null);
-        const results = await queryRemaining(org, nextRecordsUrl, isTooling);
+        setLoadedChildRecordCount(0);
+
+        let allRecords = records || [];
+        let latestQueryResults = queryResults?.queryResults;
+
+        if (nextRecordsUrl) {
+          const results = await queryRemaining(org, nextRecordsUrl, isTooling);
+          if (!isMounted.current) {
+            return;
+          }
+          latestQueryResults = results.queryResults;
+          allRecords = mergeQueryRecordPages(allRecords, results.queryResults.records);
+          setNextRecordsUrl(results.queryResults.nextRecordsUrl);
+        }
+
+        allRecords = await queryRemainingSubqueryRecords(org, allRecords, isTooling, (fetched) => {
+          if (isMounted.current) {
+            setLoadedChildRecordCount(fetched);
+          }
+        });
         if (!isMounted.current) {
           return;
         }
-        setNextRecordsUrl(results.queryResults.nextRecordsUrl);
-        if (results.queryResults.done) {
-          setHasMoreRecords(false);
-        }
-        const newRecords = (records || []).concat(results.queryResults.records);
-        setRecords(newRecords);
-        setTotalRecordCountText(getTotalCountText({ ...results.queryResults, records: newRecords }));
+
+        setHasMoreRecords(false);
+        setRecords(allRecords);
+        setTotalRecordCountText(
+          getTotalCountText({ totalSize: latestQueryResults?.totalSize ?? allRecords.length, done: true, records: allRecords }),
+        );
         setIsLoadingMore(false);
-        if (onLoadMoreRecords) {
-          onLoadMoreRecords(results);
+        // Hand back the complete record set rather than just the new page - the parent pages were merged by record
+        // identity here, so appending them again upstream would double up any record that came back more than once.
+        if (onLoadMoreRecords && queryResults) {
+          onLoadMoreRecords({
+            ...queryResults,
+            queryResults: { ...queryResults.queryResults, done: true, nextRecordsUrl: undefined, records: allRecords },
+          });
         }
       } catch (ex) {
         if (!isMounted.current) {
@@ -420,6 +461,38 @@ export const SalesforceRecordDataTable = memo<SalesforceRecordDataTableProps>(
         }
       }
     }
+
+    // Read instead of the render's copy of `records`: the subquery modal can publish several loads in a row from
+    // different levels, and each has to fold into the result of the one before it.
+    const recordsRef = useRef(records);
+    recordsRef.current = records;
+
+    /**
+     * A subquery cell finished loading the child records Salesforce had truncated. The completed set has to land
+     * back on the record here *and* be handed to the host - the host's copy is what feeds the page level downloads
+     * and copy-to-clipboard, so stopping at local state would leave the very exports this exists to fix incomplete.
+     */
+    const handleSubqueryRecordsLoaded = useCallback(
+      (parentRowKey: string, relationshipName: string, subqueryResults: QueryResult<any>) => {
+        const allRecords = replaceSubqueryOnRecord(recordsRef.current || [], parentRowKey, relationshipName, subqueryResults);
+        recordsRef.current = allRecords;
+        setRecords(allRecords);
+        // Paging state is passed through as it stands rather than reported as complete - only child records were
+        // fetched here, and any parent records still unloaded have to stay loadable.
+        if (onLoadMoreRecords && queryResults) {
+          onLoadMoreRecords({
+            ...queryResults,
+            queryResults: {
+              ...queryResults.queryResults,
+              done: !nextRecordsUrl,
+              nextRecordsUrl: nextRecordsUrl ?? undefined,
+              records: allRecords,
+            },
+          });
+        }
+      },
+      [nextRecordsUrl, onLoadMoreRecords, queryResults],
+    );
 
     const handleSortedAndFilteredRowsChange = useCallback(
       (rows: readonly RowSalesforceRecordWithKey[]) => {
@@ -714,6 +787,10 @@ export const SalesforceRecordDataTable = memo<SalesforceRecordDataTableProps>(
 
     const hasBlockingErrors = useMemo(() => dirtyRows.some((row) => rowHasBlockingErrors(row, fieldMetadata)), [dirtyRows, fieldMetadata]);
 
+    // Salesforce reports the query as incomplete when child records were truncated, but the records are what say
+    // what is actually missing - this also covers a complete set of parents whose related records were cut short.
+    const hasRecordsToLoad = useMemo(() => hasMoreRecords || !!records?.some(hasIncompleteSubqueries), [hasMoreRecords, records]);
+
     return records ? (
       <Fragment>
         <Grid className="slds-p-around_xx-small" align="spread">
@@ -721,16 +798,26 @@ export const SalesforceRecordDataTable = memo<SalesforceRecordDataTableProps>(
             <div className="slds-p-around_x-small">
               Showing {formatNumber(visibleRecordCount)} of {totalRecordCountText} records
             </div>
-            {hasMoreRecords && (
+            {hasRecordsToLoad && (
               <div>
-                <button
-                  className="slds-button slds-button_brand slds-m-left_x-small slds-is-relative"
-                  onClick={loadRemaining}
-                  disabled={isLoadingMore}
+                <Tooltip
+                  openDelay={1000}
+                  content="Fetch every record Salesforce left out, including related records missing from subqueries."
                 >
-                  Load All Records
-                  {isLoadingMore && <Spinner size="small" />}
-                </button>
+                  <button
+                    className="slds-button slds-button_brand slds-m-left_x-small slds-is-relative"
+                    onClick={loadRemaining}
+                    disabled={isLoadingMore}
+                  >
+                    Load All Records
+                    {isLoadingMore && <Spinner size="small" />}
+                  </button>
+                </Tooltip>
+                {isLoadingMore && !!loadedChildRecordCount && (
+                  <span className="slds-m-left_x-small slds-text-body_small">
+                    Loaded {formatNumber(loadedChildRecordCount)} related {pluralizeFromNumber('record', loadedChildRecordCount)}
+                  </span>
+                )}
                 {loadMoreErrorMessage && <PopoverErrorButton errors={loadMoreErrorMessage} />}
               </div>
             )}
@@ -822,6 +909,8 @@ export const SalesforceRecordDataTable = memo<SalesforceRecordDataTableProps>(
               isTooling,
               columnDefinitions: subqueryColumnsMap,
               onSubqueryFieldReorder: handleSubqueryFieldsChanged,
+              onSubqueryRecordsLoaded: handleSubqueryRecordsLoaded,
+              confirmReplaceRecords: confirmDiscardUnsavedChanges,
               hasGoogleDriveAccess,
               googleShowUpgradeToPro,
               google_apiKey,

--- a/libs/ui/src/lib/data-table/grid/__tests__/SubqueryRenderer.spec.tsx
+++ b/libs/ui/src/lib/data-table/grid/__tests__/SubqueryRenderer.spec.tsx
@@ -1,7 +1,16 @@
+/* eslint-disable import/first -- vi.mock calls must be evaluated before the modules they intercept are imported */
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+const { mockedQueryRemainingSubqueryResults } = vi.hoisted(() => ({ mockedQueryRemainingSubqueryResults: vi.fn() }));
+
+vi.mock('@jetstream/shared/data', async () => {
+  const actual = await vi.importActual<typeof import('@jetstream/shared/data')>('@jetstream/shared/data');
+  return { ...actual, queryRemainingSubqueryResults: mockedQueryRemainingSubqueryResults };
+});
+
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { describe, expect, test, vi } from 'vitest';
 import { GridSubqueryContext } from '../grid-context';
 import { ColumnWithFilter, SubqueryContext, SubqueryLevel } from '../grid-types';
 import { SubqueryRenderer } from '../renderers/SubqueryRenderer';
@@ -10,15 +19,16 @@ function makeColumns(keys: string[]): ColumnWithFilter<any>[] {
   return keys.map((key) => ({ key, name: key })) as ColumnWithFilter<any>[];
 }
 
-function makeQueryResult(count: number) {
-  return {
-    done: true,
-    totalSize: count,
-    records: Array.from({ length: count }, (_, index) => ({
-      Id: `00${index}`,
-      attributes: { type: 'Case', url: `/services/data/v66.0/sobjects/Case/00${index}` },
-    })),
-  };
+function makeRecords(count: number, type = 'Case', extra: (index: number) => Record<string, unknown> = () => ({})) {
+  return Array.from({ length: count }, (_, index) => ({
+    Id: `00${index}`,
+    attributes: { type, url: `/services/data/v66.0/sobjects/${type}/00${index}` },
+    ...extra(index),
+  }));
+}
+
+function makeQueryResult(count: number, { done = true, nextRecordsUrl = undefined as string | undefined, totalSize = count } = {}) {
+  return { done, totalSize, records: makeRecords(count), ...(nextRecordsUrl ? { nextRecordsUrl } : {}) };
 }
 
 function renderCell({ columnKey, row, context }: { columnKey: string; row: any; context: Partial<SubqueryContext> }) {
@@ -42,7 +52,13 @@ function renderCell({ columnKey, row, context }: { columnKey: string; row: any; 
   );
 }
 
+const WARNING_NAME = /Some related records were not loaded/;
+
 describe('SubqueryRenderer', () => {
+  beforeEach(() => {
+    mockedQueryRemainingSubqueryResults.mockReset();
+  });
+
   test('renders nothing when the subquery returned no records', () => {
     renderCell({ columnKey: 'Cases', row: { Cases: { done: true, totalSize: 0, records: [] } }, context: {} });
 
@@ -114,5 +130,115 @@ describe('SubqueryRenderer', () => {
     });
 
     expect(screen.getByRole('button', { name: /1 Records/ })).toBeTruthy();
+  });
+
+  describe('truncated child records', () => {
+    test('shows no warning when Salesforce returned every child record', () => {
+      renderCell({
+        columnKey: 'Cases',
+        row: { _key: '001A', Cases: makeQueryResult(2) },
+        context: { columnDefinitions: { cases: makeColumns(['Id']) } },
+      });
+
+      expect(screen.queryByRole('button', { name: WARNING_NAME })).toBeNull();
+    });
+
+    test('warns with the loaded and total counts when the subquery itself was truncated', async () => {
+      renderCell({
+        columnKey: 'Cases',
+        row: { _key: '001A', Cases: makeQueryResult(2, { done: false, nextRecordsUrl: '/next', totalSize: 2317 }) },
+        context: { columnDefinitions: { cases: makeColumns(['Id']) }, onSubqueryRecordsLoaded: vi.fn() },
+      });
+
+      await userEvent.click(screen.getByRole('button', { name: WARNING_NAME }));
+
+      expect(screen.getByText(/Salesforce returned 2 of 2,317 Cases records/)).toBeTruthy();
+    });
+
+    test('warns when only a subquery nested inside the child records was truncated', () => {
+      const casesWithTruncatedComments = {
+        done: true,
+        totalSize: 1,
+        records: makeRecords(1, 'Case', () => ({
+          CaseComments: { done: false, totalSize: 500, records: [], nextRecordsUrl: '/next/comments' },
+        })),
+      };
+      renderCell({
+        columnKey: 'Cases',
+        row: { _key: '001A', Cases: casesWithTruncatedComments },
+        context: { columnDefinitions: { cases: makeColumns(['Id']) } },
+      });
+
+      expect(screen.getByRole('button', { name: WARNING_NAME })).toBeTruthy();
+    });
+
+    test('loads the remaining records and hands them back to the record that owns them', async () => {
+      const onSubqueryRecordsLoaded = vi.fn();
+      const completed = makeQueryResult(3);
+      mockedQueryRemainingSubqueryResults.mockResolvedValue(completed);
+
+      renderCell({
+        columnKey: 'Cases',
+        row: { _key: '001A', Cases: makeQueryResult(1, { done: false, nextRecordsUrl: '/next', totalSize: 3 }) },
+        context: { columnDefinitions: { cases: makeColumns(['Id']) }, onSubqueryRecordsLoaded },
+      });
+
+      await userEvent.click(screen.getByRole('button', { name: WARNING_NAME }));
+      await userEvent.click(screen.getByRole('button', { name: 'Load remaining records' }));
+
+      await waitFor(() => expect(onSubqueryRecordsLoaded).toHaveBeenCalledWith('001A', 'Cases', completed));
+      // The popover closes itself once the records are handed off
+      await waitFor(() => expect(screen.queryByRole('button', { name: 'Load remaining records' })).toBeNull());
+    });
+
+    test('does not load anything when the owner refuses to replace its records', async () => {
+      const onSubqueryRecordsLoaded = vi.fn();
+      renderCell({
+        columnKey: 'Cases',
+        row: { _key: '001A', Cases: makeQueryResult(1, { done: false, nextRecordsUrl: '/next', totalSize: 3 }) },
+        context: {
+          columnDefinitions: { cases: makeColumns(['Id']) },
+          onSubqueryRecordsLoaded,
+          confirmReplaceRecords: () => Promise.resolve(false),
+        },
+      });
+
+      await userEvent.click(screen.getByRole('button', { name: WARNING_NAME }));
+      await userEvent.click(screen.getByRole('button', { name: 'Load remaining records' }));
+
+      await waitFor(() => expect(screen.queryByRole('button', { name: 'Load remaining records' })).toBeNull());
+      expect(mockedQueryRemainingSubqueryResults).not.toHaveBeenCalled();
+      expect(onSubqueryRecordsLoaded).not.toHaveBeenCalled();
+    });
+
+    test("the modal's own load action asks before replacing records too", async () => {
+      const onSubqueryRecordsLoaded = vi.fn();
+      const confirmReplaceRecords = vi.fn().mockResolvedValue(false);
+
+      renderCell({
+        columnKey: 'Cases',
+        row: { _key: '001A', Cases: makeQueryResult(1, { done: false, nextRecordsUrl: '/next', totalSize: 3 }) },
+        context: { columnDefinitions: { cases: makeColumns(['Id']) }, onSubqueryRecordsLoaded, confirmReplaceRecords },
+      });
+
+      await userEvent.click(screen.getByRole('button', { name: /1 Records/ }));
+      await userEvent.click(await screen.findByRole('button', { name: 'Load Remaining' }));
+
+      await waitFor(() => expect(confirmReplaceRecords).toHaveBeenCalled());
+      expect(mockedQueryRemainingSubqueryResults).not.toHaveBeenCalled();
+      expect(onSubqueryRecordsLoaded).not.toHaveBeenCalled();
+    });
+
+    test('omits the load action when there is nowhere to put the records', async () => {
+      renderCell({
+        columnKey: 'Cases',
+        row: { _key: '001A', Cases: makeQueryResult(1, { done: false, nextRecordsUrl: '/next', totalSize: 3 }) },
+        context: { columnDefinitions: { cases: makeColumns(['Id']) } },
+      });
+
+      await userEvent.click(screen.getByRole('button', { name: WARNING_NAME }));
+
+      expect(screen.queryByRole('button', { name: 'Load remaining records' })).toBeNull();
+    });
   });
 });

--- a/libs/ui/src/lib/data-table/grid/grid-row-utils.ts
+++ b/libs/ui/src/lib/data-table/grid/grid-row-utils.ts
@@ -2,6 +2,7 @@
 import { logger } from '@jetstream/shared/client-logger';
 import { RECORD_PREFIX_MAP } from '@jetstream/shared/constants';
 import { getIdFromRecordUrl } from '@jetstream/shared/utils';
+import { QueryResult } from '@jetstream/types';
 import isNil from 'lodash/isNil';
 import isObject from 'lodash/isObject';
 import isString from 'lodash/isString';
@@ -68,6 +69,21 @@ export function getRowId(data: any): string {
     return data && typeof data === 'object' ? getOrGenerateId(data) : uniqueId('row-id');
   }
   return nodeId;
+}
+
+/**
+ * Fold a completed subquery result back onto the record that owns it.
+ *
+ * Records only ever become complete by being written back through here - the table's own record set, and each
+ * level of the subquery modal's drill-down stack, all replace a subquery the same way.
+ */
+export function replaceSubqueryOnRecord(
+  records: any[],
+  parentRowKey: string,
+  relationshipName: string,
+  queryResults: QueryResult<any>,
+): any[] {
+  return records.map((record) => (getRowId(record) === parentRowKey ? { ...record, [relationshipName]: queryResults } : record));
 }
 
 /**

--- a/libs/ui/src/lib/data-table/grid/grid-types.ts
+++ b/libs/ui/src/lib/data-table/grid/grid-types.ts
@@ -354,6 +354,17 @@ export interface SubqueryContext<TRow extends object = any> {
   /** Keyed by lowercased relationship path, so a nested subquery resolves independently of a same-named one elsewhere */
   columnDefinitions?: Record<string, ColumnWithFilter<TRow, unknown>[]>;
   onSubqueryFieldReorder?: (relationshipPath: string, fields: string[], columnOrder: number[]) => void;
+  /**
+   * Replaces a subquery result on the record that owns it, once the child records Salesforce truncated have been
+   * fetched. The owner of the records has to hold the completed set - otherwise it would only ever exist inside
+   * the modal, and everything else reading those records (downloads above all) would stay incomplete.
+   */
+  onSubqueryRecordsLoaded?: (parentRowKey: string, relationshipName: string, queryResults: QueryResult<TRow>) => void;
+  /**
+   * Asked before records are replaced so an owner holding unsaved inline edits can warn first; loading proceeds
+   * when it resolves true. Treated as allowed when not provided.
+   */
+  confirmReplaceRecords?: () => Promise<boolean>;
   hasGoogleDriveAccess: boolean;
   googleShowUpgradeToPro: boolean;
   google_apiKey: string;

--- a/libs/ui/src/lib/data-table/grid/renderers/SubqueryRenderer.tsx
+++ b/libs/ui/src/lib/data-table/grid/renderers/SubqueryRenderer.tsx
@@ -1,42 +1,45 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { queryMore } from '@jetstream/shared/data';
-import { appActionObservable, copyRecordsToClipboard, formatNumber } from '@jetstream/shared/ui-utils';
-import { flattenRecord, getSubqueryPath } from '@jetstream/shared/utils';
+import { logger } from '@jetstream/shared/client-logger';
+import { queryRemainingSubqueryResults } from '@jetstream/shared/data';
+import { appActionObservable, formatNumber } from '@jetstream/shared/ui-utils';
+import { flattenRecord, getSubqueryPath, isIncompleteSubqueryResult, pluralizeFromNumber } from '@jetstream/shared/utils';
 import { CloneEditView, ContextMenuItem, QueryResult } from '@jetstream/types';
+import { RowSelectionState } from '@tanstack/react-table';
 import { Dispatch, ReactNode, SetStateAction, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import RecordDownloadModal from '../../../file-download-modal/RecordDownloadModal';
 import Grid from '../../../grid/Grid';
 import AutoFullHeightContainer from '../../../layout/AutoFullHeightContainer';
 import Modal from '../../../modal/Modal';
+import { Popover, PopoverRef } from '../../../popover/Popover';
 import { Breadcrumbs } from '../../../widgets/Breadcrumbs';
+import { CopyRecordsToClipboardButton } from '../../../widgets/CopyRecordsToClipboardButton';
 import Icon from '../../../widgets/Icon';
 import Spinner from '../../../widgets/Spinner';
+import Tooltip from '../../../widgets/Tooltip';
 import { DataTableV2 } from '../DataTableV2';
 import { copySalesforceRecordTableDataToClipboard } from '../grid-clipboard';
 import { NON_DATA_COLUMN_KEYS, TABLE_CONTEXT_MENU_ITEMS } from '../grid-constants';
 import { GridSubqueryContext } from '../grid-context';
-import { getRowId, getSubqueryModalTagline } from '../grid-row-utils';
+import { getRowId, getSubqueryModalTagline, replaceSubqueryOnRecord } from '../grid-row-utils';
 import { ContextAction, ContextMenuActionData, DataTableCellProps, RowWithKey, SubqueryContext, SubqueryLevel } from '../grid-types';
 
 /**
- * Subquery cell — shows "N Records".
+ * Subquery cell — shows "N Records", plus a warning when Salesforce truncated the child records.
  *
- * At the top level it opens a modal with a nested data table (load-more + export). Salesforce allows subqueries to be
- * nested, so when this renders inside that modal it instead drills the modal down a level, which keeps navigation in a
- * single modal with a breadcrumb trail rather than stacking a modal per level.
+ * At the top level it opens a modal with a nested data table (load-remaining + export). Salesforce allows subqueries to
+ * be nested, so when this renders inside that modal it instead drills the modal down a level, which keeps navigation in
+ * a single modal with a breadcrumb trail rather than stacking a modal per level.
  */
 export const SubqueryRenderer = ({ column, row }: DataTableCellProps<RowWithKey>): ReactNode => {
   const [isActive, setIsActive] = useState(false);
-  // The drill-down stack lives here rather than in the modal so that records appended by "Load More"
-  // survive closing and reopening it. Opening returns to the top of the stack, keeping those records.
   const [levels, setLevels] = useState<SubqueryLevel[]>([]);
-  const queryResults: QueryResult<any> = row[column.key] || {};
-  const { records } = queryResults;
-  // "Load More" appends onto the preserved stack rather than the row, so the label reads from the stack once it
-  // exists - otherwise it keeps reporting the count the query originally returned after the user has loaded more.
-  const recordCount = levels[0]?.queryResults.records.length ?? records?.length;
+  const queryResults: QueryResult<any> | undefined = row[column.key];
+  const records = queryResults?.records;
+  // Memoized because the check walks every child record, and the grid re-renders these cells on any scroll or
+  // selection change.
+  const isIncomplete = useMemo(() => isIncompleteSubqueryResult(queryResults), [queryResults]);
 
-  if (!Array.isArray(records) || records.length === 0) {
+  if (!queryResults || !Array.isArray(records) || records.length === 0) {
     return <div />;
   }
 
@@ -58,31 +61,155 @@ export const SubqueryRenderer = ({ column, row }: DataTableCellProps<RowWithKey>
             props.nestedRender.onDrillDown(level);
             return;
           }
-          // Drop back to the top of the stack, but keep whatever it has already loaded
-          setLevels((prev) => (prev.length ? prev.slice(0, 1) : [level]));
+          // The modal works against its own copy of the stack, rebuilt each time from the record - loading more
+          // records writes them back through `onSubqueryRecordsLoaded`, so the record is always the newer copy.
+          setLevels([level]);
           setIsActive(true);
         }
 
         return (
-          <div>
+          <Grid verticalAlign="center">
             {isActive && !props.nestedRender && levels.length > 0 && (
               <SubqueryModal levels={levels} setLevels={setLevels} onClose={() => setIsActive(false)} {...props} />
             )}
             <button className="slds-button" tabIndex={-1} onClick={handleClick}>
               <Icon type="utility" icon="search" className="slds-button__icon slds-button__icon_left" omitContainer />
-              {`${recordCount} Records`}
+              {`${formatNumber(records.length)} Records`}
             </button>
-          </div>
+            {isIncomplete && (
+              <IncompleteSubqueryPopover
+                org={props.org}
+                isTooling={props.isTooling}
+                onSubqueryRecordsLoaded={props.onSubqueryRecordsLoaded}
+                confirmReplaceRecords={props.confirmReplaceRecords}
+                relationshipName={column.key}
+                queryResults={queryResults}
+                rowKey={row._key}
+              />
+            )}
+          </Grid>
         );
       }}
     </GridSubqueryContext.Consumer>
   );
 };
 
+interface IncompleteSubqueryPopoverProps extends Pick<
+  SubqueryContext,
+  'org' | 'isTooling' | 'onSubqueryRecordsLoaded' | 'confirmReplaceRecords'
+> {
+  relationshipName: string;
+  queryResults: QueryResult<any>;
+  rowKey: string;
+}
+
+/**
+ * Salesforce counts child rows toward the query's batch size, so a parent with many related records comes back with
+ * only some of them. Nothing else in the table shows that the count in the cell is short of the real total, which is
+ * how an export silently ends up missing records - hence the warning, and the offer to fetch the rest.
+ */
+function IncompleteSubqueryPopover({
+  relationshipName,
+  queryResults,
+  rowKey,
+  org,
+  isTooling,
+  onSubqueryRecordsLoaded,
+  confirmReplaceRecords,
+}: IncompleteSubqueryPopoverProps) {
+  const [isLoading, setIsLoading] = useState(false);
+  const popoverRef = useRef<PopoverRef>(null);
+  const { records, done, totalSize, nextRecordsUrl } = queryResults;
+  const isTruncatedItself = !done && !!nextRecordsUrl;
+
+  async function handleLoadRemaining() {
+    if (isLoading || !onSubqueryRecordsLoaded) {
+      return;
+    }
+    // Asked before fetching: applying the records is what discards unsaved inline edits, and asking afterwards
+    // would mean throwing away a load the user just waited for.
+    if (confirmReplaceRecords && !(await confirmReplaceRecords())) {
+      popoverRef.current?.close();
+      return;
+    }
+    setIsLoading(true);
+    try {
+      onSubqueryRecordsLoaded(rowKey, relationshipName, await queryRemainingSubqueryResults(org, queryResults, isTooling));
+      popoverRef.current?.close();
+    } catch (ex) {
+      // Query errors surface via the shared data layer; leave the popover open so the action can be retried
+      logger.warn('[SUBQUERY] Unable to load remaining subquery records', ex);
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  return (
+    <Popover
+      ref={popoverRef}
+      placement="bottom"
+      header={
+        <header className="slds-popover__header">
+          <h2 className="slds-text-heading_small">Related records not fully loaded</h2>
+        </header>
+      }
+      content={
+        <div className="slds-is-relative">
+          {isLoading && <Spinner size="small" />}
+          {isTruncatedItself ? (
+            <p>
+              Salesforce returned {formatNumber(records.length)} of {formatNumber(totalSize)} {relationshipName} records.
+            </p>
+          ) : (
+            <p>Salesforce did not return all of the records related to these {relationshipName} records.</p>
+          )}
+          <p className="slds-m-top_x-small">Exports and the record count in this cell only cover the records already loaded.</p>
+          {onSubqueryRecordsLoaded && (
+            <button className="slds-button slds-button_brand slds-m-top_x-small" disabled={isLoading} onClick={handleLoadRemaining}>
+              Load remaining records
+            </button>
+          )}
+        </div>
+      }
+      buttonProps={{
+        className: 'slds-button slds-button_icon',
+        title: 'Some related records were not loaded',
+        'aria-label': 'Some related records were not loaded',
+        tabIndex: -1,
+      }}
+    >
+      <Icon
+        type="utility"
+        icon="warning"
+        className="slds-icon slds-icon_x-small slds-icon-text-warning"
+        containerClassname="slds-icon_container slds-icon-utility-warning"
+      />
+    </Popover>
+  );
+}
+
 interface SubqueryModalProps extends SubqueryContext {
   levels: SubqueryLevel[];
   setLevels: Dispatch<SetStateAction<SubqueryLevel[]>>;
   onClose: () => void;
+}
+
+/**
+ * Write a level's updated records back through the stack.
+ *
+ * Every level's records physically live inside its parent's records, so records loaded at any depth only become
+ * part of the record that owns the whole tree by being folded back up one level at a time.
+ */
+function applyQueryResultsToLevels(levels: SubqueryLevel[], levelIndex: number, queryResults: QueryResult<any>): SubqueryLevel[] {
+  const updated = levels.slice();
+  updated[levelIndex] = { ...levels[levelIndex], queryResults };
+  for (let index = levelIndex; index > 0; index--) {
+    const child = updated[index];
+    const parent = updated[index - 1];
+    const records = replaceSubqueryOnRecord(parent.queryResults.records, getRowId(child.parentRecord), child.columnKey, child.queryResults);
+    updated[index - 1] = { ...parent, queryResults: { ...parent.queryResults, records } };
+  }
+  return updated;
 }
 
 /**
@@ -103,12 +230,17 @@ function SubqueryModal({
   google_clientId,
   columnDefinitions,
   onSubqueryFieldReorder,
+  onSubqueryRecordsLoaded,
+  confirmReplaceRecords,
   onClose,
 }: SubqueryModalProps) {
   const isMounted = useRef(true);
   const [downloadModalIsActive, setDownloadModalIsActive] = useState(false);
   const [isLoadingMore, setIsLoadingMore] = useState(false);
-  // Guards against re-entry while a queryMore is in flight (the loading state hasn't re-rendered yet).
+  const [loadedRecordCount, setLoadedRecordCount] = useState(0);
+  const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
+  const [filteredRows, setFilteredRows] = useState<readonly RowWithKey[]>([]);
+  // Guards against re-entry while a load is in flight (the loading state hasn't re-rendered yet).
   const isLoadingMoreRef = useRef(false);
 
   useEffect(() => {
@@ -119,7 +251,9 @@ function SubqueryModal({
   }, []);
 
   const currentLevel = levels[levels.length - 1];
-  const { records, done, totalSize, nextRecordsUrl } = currentLevel.queryResults;
+  const { records, totalSize } = currentLevel.queryResults;
+  // "Load Remaining" covers this level's own paging plus anything truncated in the subqueries nested within it
+  const isLevelIncomplete = useMemo(() => isIncompleteSubqueryResult(currentLevel.queryResults), [currentLevel.queryResults]);
   // Memoized so the empty fallback keeps a stable identity - the rows/fields memo below feeds an effect
   // that calls setFields, which would re-render endlessly on a new array every render.
   const columns = useMemo(
@@ -145,9 +279,42 @@ function SubqueryModal({
     }
   }
 
-  async function loadMore() {
+  /**
+   * Apply records loaded at `levelIndex` to the stack and hand the rebuilt root back to the record that owns it.
+   *
+   * The owner is notified even when the user has navigated away from that level in the meantime - the records were
+   * fetched either way, and dropping them would leave the table claiming they are still missing.
+   */
+  function publishLevelResults(levelIndex: number, level: SubqueryLevel, queryResults: QueryResult<any>) {
+    const [rootLevel] = applyQueryResultsToLevels(levels, levelIndex, queryResults);
+    onSubqueryRecordsLoaded?.(rootLevel.parentRecord._key, rootLevel.columnKey, rootLevel.queryResults);
+    if (isMounted.current) {
+      // Functional update against the stack's latest value. Levels are only ever appended or truncated, never
+      // swapped in place, so an identity mismatch means the level the records belong to is no longer open.
+      setLevels((prev) => (prev[levelIndex] === level ? applyQueryResultsToLevels(prev, levelIndex, queryResults) : prev));
+    }
+  }
+
+  /** A subquery nested inside the level on screen finished loading whatever Salesforce had truncated from it. */
+  const handleNestedSubqueryRecordsLoaded = (parentRowKey: string, relationshipName: string, queryResults: QueryResult<any>) => {
+    const levelIndex = levels.length - 1;
+    const level = levels[levelIndex];
+    const records = replaceSubqueryOnRecord(level.queryResults.records, parentRowKey, relationshipName, queryResults);
+    publishLevelResults(levelIndex, level, { ...level.queryResults, records });
+  };
+
+  /**
+   * Fetch everything Salesforce left out of this level, including any subqueries nested within its records - paging
+   * a locator one batch at a time only made the user click the same button over and over.
+   */
+  async function loadRemaining() {
     // Guard before the try so the finally only runs for calls that actually start a load.
-    if (!nextRecordsUrl || isLoadingMoreRef.current) {
+    if (!isLevelIncomplete || isLoadingMoreRef.current) {
+      return;
+    }
+    // These records are folded back into the record the table owns, which rebuilds its rows and drops any
+    // in-progress inline edits - so ask first, before the fetch, exactly as the cell warning popover does.
+    if (confirmReplaceRecords && !(await confirmReplaceRecords())) {
       return;
     }
     // Pin the level the request belongs to. The table and breadcrumbs stay interactive while loading, so by the
@@ -156,30 +323,17 @@ function SubqueryModal({
     const targetIndex = levels.length - 1;
     isLoadingMoreRef.current = true;
     setIsLoadingMore(true);
+    setLoadedRecordCount(0);
     try {
-      const results = await queryMore(org, nextRecordsUrl, isTooling);
-      if (isMounted.current) {
-        // Functional update so the append merges onto that level's latest records. Levels are only ever
-        // appended or truncated, never swapped in place, so an identity mismatch means the level is gone.
-        setLevels((prev) => {
-          if (prev[targetIndex] !== targetLevel) {
-            return prev;
-          }
-          return prev.map((level, index) =>
-            index === targetIndex
-              ? {
-                  ...level,
-                  queryResults: {
-                    ...results.queryResults,
-                    records: [...level.queryResults.records, ...results.queryResults.records],
-                  },
-                }
-              : level,
-          );
-        });
-      }
-    } catch {
+      const queryResults = await queryRemainingSubqueryResults(org, targetLevel.queryResults, isTooling, (fetched) => {
+        if (isMounted.current) {
+          setLoadedRecordCount(fetched);
+        }
+      });
+      publishLevelResults(targetIndex, targetLevel, queryResults);
+    } catch (ex) {
       // Query errors surface via the shared data layer; just stop the spinner here.
+      logger.warn('[SUBQUERY] Unable to load remaining subquery records', ex);
     } finally {
       isLoadingMoreRef.current = false;
       if (isMounted.current) {
@@ -204,6 +358,15 @@ function SubqueryModal({
   useEffect(() => {
     setFields(initialFields);
   }, [initialFields]);
+
+  // Each level has its own records, so a selection made before drilling down or navigating back is meaningless
+  // once a different level is on top. Loading more records keeps both values, preserving the selection there.
+  useEffect(() => {
+    setRowSelection({});
+  }, [currentLevel.relationshipPath, levels.length]);
+
+  const selectedRecords = useMemo(() => rows.filter(({ _key }) => rowSelection[_key]).map(({ _record }) => _record), [rows, rowSelection]);
+  const filteredRecords = useMemo(() => filteredRows.map(({ _record }) => _record), [filteredRows]);
 
   /**
    * Relationship paths nested beneath the level being viewed, relative to it and cased to match the record keys,
@@ -231,6 +394,10 @@ function SubqueryModal({
     [fields],
   );
 
+  const handleSortedAndFilteredRowsChange = useCallback((rows: readonly RowWithKey[]) => {
+    setFilteredRows(rows);
+  }, []);
+
   const handleColumnReorder = useCallback(
     (reordered: string[], columnOrder: number[]) => {
       setFields(reordered);
@@ -251,6 +418,9 @@ function SubqueryModal({
     google_clientId,
     columnDefinitions,
     onSubqueryFieldReorder,
+    onSubqueryRecordsLoaded: handleNestedSubqueryRecordsLoaded,
+    // Records loaded here are folded back into the record the table owns, so the same warning about unsaved edits applies
+    confirmReplaceRecords,
     nestedRender: { relationshipPath: currentLevel.relationshipPath, onDrillDown: handleDrillDown },
   };
 
@@ -289,27 +459,35 @@ function SubqueryModal({
                 <span className="slds-m-right_small">
                   Showing {formatNumber(records.length)} of {formatNumber(totalSize)} records
                 </span>
-                {!done && (
-                  <button className="slds-button slds-button_neutral" disabled={isLoadingMore} onClick={() => loadMore()}>
-                    Load More
-                  </button>
+                {isLevelIncomplete && (
+                  <Tooltip openDelay={1000} content="Fetch every related record Salesforce left out, including nested subqueries.">
+                    <button className="slds-button slds-button_neutral" disabled={isLoadingMore} onClick={() => loadRemaining()}>
+                      Load Remaining
+                    </button>
+                  </Tooltip>
                 )}
-                {isLoadingMore && <Spinner />}
+                {isLoadingMore && (
+                  <>
+                    <Spinner size="small" />
+                    <span className="slds-m-left_small slds-text-body_small">
+                      Loaded {formatNumber(loadedRecordCount)} related {pluralizeFromNumber('record', loadedRecordCount)}
+                    </span>
+                  </>
+                )}
               </Grid>
-              <div>
-                <button
-                  className="slds-button slds-button_neutral"
-                  onClick={() => copyRecordsToClipboard(records, 'excel', fields)}
-                  title="Copy the queried records to the clipboard."
-                >
-                  <Icon type="utility" icon="copy_to_clipboard" className="slds-button__icon slds-button__icon_left" omitContainer />
-                  Copy to Clipboard
-                </button>
+              <Grid verticalAlign="end">
+                <CopyRecordsToClipboardButton
+                  containerClassName="slds-m-right_xx-small"
+                  fields={fields}
+                  records={records}
+                  filteredRecords={filteredRecords}
+                  selectedRecords={selectedRecords}
+                />
                 <button className="slds-button slds-button_brand" onClick={() => setDownloadModalIsActive(true)}>
                   <Icon type="utility" icon="download" className="slds-button__icon slds-button__icon_left" omitContainer />
                   Download Records
                 </button>
-              </div>
+              </Grid>
             </Grid>
           }
         >
@@ -325,9 +503,12 @@ function SubqueryModal({
                   getRowKey={getRowId}
                   rowHeight={28.5}
                   enableRowSelection
+                  rowSelection={rowSelection}
+                  onRowSelectionChange={setRowSelection}
                   contextMenuItems={TABLE_CONTEXT_MENU_ITEMS}
                   contextMenuAction={handleContextMenuAction}
                   onReorderColumns={handleColumnReorder}
+                  onSortedAndFilteredRowsChange={handleSortedAndFilteredRowsChange}
                   context={{
                     org,
                     onRecordAction: (action: CloneEditView, recordId: string, objectName: string) => {
@@ -356,6 +537,8 @@ function SubqueryModal({
           fields={fields}
           subqueryFields={subqueryFields}
           records={records}
+          filteredRecords={filteredRecords}
+          selectedRecords={selectedRecords}
           onModalClose={handleCloseModal}
           source="data_table_subquery"
           // eslint-disable-next-line @typescript-eslint/no-empty-function

--- a/libs/ui/src/lib/modal/WhichRecordsToCopyModalPromise.tsx
+++ b/libs/ui/src/lib/modal/WhichRecordsToCopyModalPromise.tsx
@@ -1,0 +1,99 @@
+import { formatNumber } from '@jetstream/shared/ui-utils';
+import { Maybe, SalesforceRecord } from '@jetstream/types';
+import { Fragment, FunctionComponent, useState } from 'react';
+import { create, InstanceProps } from 'react-modal-promise';
+import { hasSelectableSubset } from '../file-download-modal/download-modal-utils';
+import Radio from '../form/radio/Radio';
+import RadioGroup from '../form/radio/RadioGroup';
+import Modal from './Modal';
+
+export type WhichRecordsToCopy = 'all' | 'filtered' | 'selected';
+
+export interface WhichRecordsToCopyModalProps extends InstanceProps<Maybe<WhichRecordsToCopy>, never> {
+  isOpen: boolean;
+  records: SalesforceRecord[];
+  filteredRecords?: Maybe<SalesforceRecord[]>;
+  selectedRecords?: Maybe<SalesforceRecord[]>;
+  onResolve: (whichRecords?: Maybe<WhichRecordsToCopy>) => void;
+}
+
+const WhichRecordsToCopyModal: FunctionComponent<WhichRecordsToCopyModalProps> = ({
+  isOpen,
+  records,
+  filteredRecords,
+  selectedRecords,
+  onResolve,
+}) => {
+  const [whichRecords, setWhichRecords] = useState<WhichRecordsToCopy>('all');
+  const hasFilteredRecords = hasSelectableSubset(filteredRecords, records);
+  const hasSelectedRecords = hasSelectableSubset(selectedRecords, records);
+
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <Modal
+      header="Which records would you like to copy?"
+      footer={
+        <Fragment>
+          <button className="slds-button slds-button_neutral" onClick={() => onResolve()}>
+            Cancel
+          </button>
+          <button className="slds-button slds-button_brand" onClick={() => onResolve(whichRecords)}>
+            Copy
+          </button>
+        </Fragment>
+      }
+      closeOnBackdropClick
+      closeOnEsc
+      onClose={() => onResolve()}
+    >
+      <div>
+        <RadioGroup>
+          <Radio
+            idPrefix="all"
+            id="radio-all"
+            name="which-records"
+            label={`All Records (${formatNumber(records.length)})`}
+            value="all"
+            checked={whichRecords === 'all'}
+            onChange={() => setWhichRecords('all')}
+          />
+          {hasFilteredRecords && (
+            <Radio
+              idPrefix="filtered"
+              id="radio-filtered"
+              name="which-records"
+              label={`Filtered Records (${formatNumber(filteredRecords?.length || 0)})`}
+              value="filtered"
+              checked={whichRecords === 'filtered'}
+              onChange={() => setWhichRecords('filtered')}
+            />
+          )}
+          {hasSelectedRecords && (
+            <Radio
+              idPrefix="selected"
+              id="radio-selected"
+              name="which-records"
+              label={`Selected Records (${formatNumber(selectedRecords?.length || 0)})`}
+              value="selected"
+              checked={whichRecords === 'selected'}
+              onChange={() => setWhichRecords('selected')}
+            />
+          )}
+        </RadioGroup>
+      </div>
+    </Modal>
+  );
+};
+
+/**
+ * Asks which subset of records to copy, resolving to the choice or `undefined` if canceled.
+ *
+ * Rendered through react-modal-promise (i.e. in the app-root modal tree) rather than inline, so that it also
+ * works when the copy button lives inside another modal - a nested modal dismisses its parent on any click.
+ */
+export const WhichRecordsToCopyModalPromise = create<WhichRecordsToCopyModalProps, Maybe<WhichRecordsToCopy>, never>(
+  WhichRecordsToCopyModal,
+);

--- a/libs/ui/src/lib/widgets/CopyRecordsToClipboardButton.tsx
+++ b/libs/ui/src/lib/widgets/CopyRecordsToClipboardButton.tsx
@@ -2,26 +2,59 @@ import { copyRecordsToClipboard } from '@jetstream/shared/ui-utils';
 import { CopyAsDataType, Maybe, SalesforceRecord } from '@jetstream/types';
 import classNames from 'classnames';
 import { FunctionComponent } from 'react';
+import { hasSelectableSubset } from '../file-download-modal/download-modal-utils';
 import ButtonGroupContainer from '../form/button/ButtonGroupContainer';
 import DropDown from '../form/dropdown/DropDown';
+import { WhichRecordsToCopy, WhichRecordsToCopyModalPromise } from '../modal/WhichRecordsToCopyModalPromise';
 import Icon from './Icon';
 import Tooltip from './Tooltip';
 
 export interface CopyRecordsToClipboardButtonProps {
   className?: string;
   containerClassName?: string;
+  disabled?: boolean;
   fields: Maybe<string[]>;
   records: Maybe<SalesforceRecord[]>;
+  /** Records left after the table's filters, when the caller tracks them - offered as a choice when it is a subset of `records` */
+  filteredRecords?: Maybe<SalesforceRecord[]>;
+  /** Records the user checked in the table - offered as a choice when it is a subset of `records` */
+  selectedRecords?: Maybe<SalesforceRecord[]>;
+  onCopy?: (options: { format: CopyAsDataType; whichRecords: WhichRecordsToCopy }) => void;
 }
 
 export const CopyRecordsToClipboardButton: FunctionComponent<CopyRecordsToClipboardButtonProps> = ({
   className,
   containerClassName,
+  disabled,
   fields,
   records,
+  filteredRecords,
+  selectedRecords,
+  onCopy,
 }) => {
-  function handleCopyToClipboard(format: CopyAsDataType = 'excel') {
-    copyRecordsToClipboard(records, format, fields);
+  const isDisabled = disabled || !records?.length;
+  // Copying everything is only ambiguous once the user has narrowed the table down to a subset
+  const hasSubsetToChooseFrom = hasSelectableSubset(filteredRecords, records || []) || hasSelectableSubset(selectedRecords, records || []);
+
+  async function handleCopyToClipboard(format: CopyAsDataType = 'excel') {
+    let whichRecords: WhichRecordsToCopy = 'all';
+    if (hasSubsetToChooseFrom) {
+      const choice = await WhichRecordsToCopyModalPromise({ records: records || [], filteredRecords, selectedRecords });
+      if (!choice) {
+        return;
+      }
+      whichRecords = choice;
+    }
+
+    let recordsToCopy = records;
+    if (whichRecords === 'filtered') {
+      recordsToCopy = filteredRecords;
+    } else if (whichRecords === 'selected') {
+      recordsToCopy = selectedRecords;
+    }
+
+    copyRecordsToClipboard(recordsToCopy, format, fields);
+    onCopy?.({ format, whichRecords });
   }
 
   return (
@@ -33,7 +66,7 @@ export const CopyRecordsToClipboardButton: FunctionComponent<CopyRecordsToClipbo
         <button
           className={classNames('slds-button slds-button_neutral slds-button_first', className)}
           onClick={() => handleCopyToClipboard()}
-          disabled={!records?.length}
+          disabled={isDisabled}
         >
           <Icon type="utility" icon="copy_to_clipboard" className="slds-button__icon slds-button__icon_left" omitContainer />
           <span>Copy to Clipboard</span>
@@ -43,7 +76,7 @@ export const CopyRecordsToClipboardButton: FunctionComponent<CopyRecordsToClipbo
         className="slds-button_last"
         dropDownClassName="slds-dropdown_actions"
         position="right"
-        disabled={!records?.length}
+        disabled={isDisabled}
         items={[
           { id: 'csv', value: 'Copy as CSV' },
           { id: 'json', value: 'Copy as JSON' },

--- a/libs/ui/src/lib/widgets/__tests__/CopyRecordsToClipboardButton.spec.tsx
+++ b/libs/ui/src/lib/widgets/__tests__/CopyRecordsToClipboardButton.spec.tsx
@@ -1,0 +1,79 @@
+/* eslint-disable import/first -- vi.mock calls must be evaluated before the modules they intercept are imported */
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+vi.mock('@jetstream/shared/ui-utils', async () => {
+  const actual = await vi.importActual<typeof import('@jetstream/shared/ui-utils')>('@jetstream/shared/ui-utils');
+  return { ...actual, copyRecordsToClipboard: vi.fn() };
+});
+
+import { copyRecordsToClipboard } from '@jetstream/shared/ui-utils';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ModalContainer from 'react-modal-promise';
+import { CopyRecordsToClipboardButton, CopyRecordsToClipboardButtonProps } from '../CopyRecordsToClipboardButton';
+
+const mockCopyRecordsToClipboard = vi.mocked(copyRecordsToClipboard);
+
+const RECORDS = [{ Id: '001' }, { Id: '002' }, { Id: '003' }];
+const FIELDS = ['Id'];
+
+function renderButton(props: Partial<CopyRecordsToClipboardButtonProps> = {}) {
+  return render(
+    <>
+      <ModalContainer />
+      <CopyRecordsToClipboardButton fields={FIELDS} records={RECORDS} {...props} />
+    </>,
+  );
+}
+
+describe('CopyRecordsToClipboardButton', () => {
+  beforeEach(() => {
+    mockCopyRecordsToClipboard.mockClear();
+  });
+
+  test('copies every record without prompting when there is no subset to choose from', async () => {
+    renderButton({ filteredRecords: RECORDS, selectedRecords: [] });
+
+    await userEvent.click(screen.getByRole('button', { name: /Copy to Clipboard/ }));
+
+    expect(screen.queryByRole('dialog')).toBeNull();
+    expect(mockCopyRecordsToClipboard).toHaveBeenCalledWith(RECORDS, 'excel', FIELDS);
+  });
+
+  test('copies as the format picked from the dropdown', async () => {
+    renderButton();
+
+    await userEvent.click(screen.getByRole('button', { name: 'action' }));
+    await userEvent.click(screen.getByRole('menuitem', { name: 'Copy as CSV' }));
+
+    expect(mockCopyRecordsToClipboard).toHaveBeenCalledWith(RECORDS, 'csv', FIELDS);
+  });
+
+  test('prompts for which records to copy once some are selected and copies only those', async () => {
+    const onCopy = vi.fn();
+    const selectedRecords = [RECORDS[1]];
+    renderButton({ selectedRecords, onCopy });
+
+    await userEvent.click(screen.getByRole('button', { name: /Copy to Clipboard/ }));
+    await userEvent.click(await screen.findByLabelText('Selected Records (1)'));
+    await userEvent.click(screen.getByRole('button', { name: 'Copy' }));
+
+    expect(mockCopyRecordsToClipboard).toHaveBeenCalledWith(selectedRecords, 'excel', FIELDS);
+    expect(onCopy).toHaveBeenCalledWith({ format: 'excel', whichRecords: 'selected' });
+  });
+
+  test('copies nothing when the prompt is canceled', async () => {
+    renderButton({ selectedRecords: [RECORDS[0]] });
+
+    await userEvent.click(screen.getByRole('button', { name: /Copy to Clipboard/ }));
+    await userEvent.click(await screen.findByRole('button', { name: 'Cancel' }));
+
+    expect(mockCopyRecordsToClipboard).not.toHaveBeenCalled();
+  });
+
+  test('is disabled without records', () => {
+    renderButton({ records: [] });
+
+    expect(screen.getByRole('button', { name: /Copy to Clipboard/ })).toHaveProperty('disabled', true);
+  });
+});


### PR DESCRIPTION
Salesforce counts subquery child rows toward a query's batch size, so an account with 2,317 contacts comes back carrying only the first 499 of them. Nothing in the UI said so: the cell read "499 Records", the modal offered "Load More" one batch at a time, and downloads silently shipped the short set.

Truncated related records
- Warn in the subquery cell whenever child records are missing, at any nesting depth, with a popover reporting loaded-of-total and an action to fetch the rest
- Replace the modal's "Load More" with "Load Remaining", which follows the locator to the end and then completes subqueries nested inside what it loaded
- "Load All Records" completes truncated subqueries at every depth as well as fetching the remaining parent records, and is offered whenever the records report missing children rather than only when Salesforce flags the query
- Records loaded anywhere are folded back into the record the table owns, so they reach exports instead of living only inside the modal

Merge parent pages by record identity A parent whose children were truncated leaves the whole result `done: false` and can be returned again by a later page carrying its next batch of children. Concatenating pages added that parent to the table a second time, so pages are now merged by record identity and a repeat parent has its children folded into the copy already loaded. `onLoadMoreRecords` hands back the complete merged set for the same reason - the query page kept a second copy and appended to it.

Subquery modal selection
- Row checkboxes were rendered but wired to nothing; selection now feeds the download modal's "Selected records" option and the copy action
- Copy to Clipboard matches the main query results page: a button group with Copy as CSV / JSON, and a prompt for which records when a subset is selected or filtered. QueryResultsCopyToClipboard shares that component, and the prompt moved to react-modal-promise so it also works from inside the modal

Replacing records rebuilds every row and drops in-progress inline edits, so the confirmation that guarded "Load All Records" is now shared through the subquery context and asked before fetching rather than after a load the user waited for.