### PR TITLE
feat: surface SSO on the login form and remember successful logins

### DIFF
--- a/apps/api/src/app/controllers/__tests__/auth.controller.spec.ts
+++ b/apps/api/src/app/controllers/__tests__/auth.controller.spec.ts
@@ -91,6 +91,7 @@ const authServerMocks = vi.hoisted(() => {
       rememberDevice: { name: 'rememberDevice', options: {} },
       redirectUrl: { name: 'redirectUrl', options: {} },
       teamInviteState: { name: 'teamInviteState', options: {} },
+      lastLoginMethod: { name: 'lastLoginMethod', options: {} },
     })),
     getLoginConfiguration: vi.fn(),
     getTeamLoginConfigWithSso: vi.fn(),
@@ -237,6 +238,7 @@ describe('auth.controller - placeholder session email suppression', () => {
       rememberDevice: { name: 'rememberDevice', options: {} },
       redirectUrl: { name: 'redirectUrl', options: {} },
       teamInviteState: { name: 'teamInviteState', options: {} },
+      lastLoginMethod: { name: 'lastLoginMethod', options: {} },
     } as never);
     authServerMocks.getProviders.mockReturnValue({
       credentials: { type: 'credentials', provider: 'credentials' },
@@ -554,6 +556,11 @@ describe('auth.controller - placeholder session email suppression', () => {
  * when the `returnUrl` cookie is missing (the desktop login interstitial only sets `redirectUrl`),
  * and (3) `normalizeRedirectCandidate` collapses the `/app/app` path that the frontend sometimes
  * emits, so post-login navigation lands on a real route.
+ *
+ * They also pin down the `lastLoginMethod` cookie, the API half of a cross-app contract with
+ * `getLastUsedLoginMethod` in the landing app. Only the callbacks know that SSO actually succeeded,
+ * so a change to the cookie name or payload shape here breaks the login form's returning-user view
+ * with nothing else to catch it.
  */
 describe('auth.controller - SSO callback redirect resolution', () => {
   const TEAM_ID = '550e8400-e29b-41d4-a716-446655440000';
@@ -571,6 +578,7 @@ describe('auth.controller - SSO callback redirect resolution', () => {
       rememberDevice: { name: 'rememberDevice', options: {} },
       redirectUrl: { name: 'redirectUrl', options: {} },
       teamInviteState: { name: 'teamInviteState', options: {} },
+      lastLoginMethod: { name: 'lastLoginMethod', options: {} },
     } as never);
     authServerMocks.ensureAuthError.mockImplementation((error: unknown) => error);
     authServerMocks.validateRedirectUrl.mockImplementation((url: string) => url || 'https://client.test');
@@ -653,6 +661,56 @@ describe('auth.controller - SSO callback redirect resolution', () => {
     );
     expect(responseHandlerMocks.redirect).toHaveBeenCalledWith(res, 'https://client.test/app/query');
   });
+
+  it('SAML callback: records the successful SSO login so the login form can offer it again', async () => {
+    const req = makeReq({
+      headers: { cookie: '' },
+      params: { teamId: TEAM_ID },
+      body: { SAMLResponse: 'fake-saml-response', RelayState: 'https://client.test/app' },
+    });
+    const res = makeRes();
+    const next = vi.fn();
+
+    const handler = routeDefinition.handleSamlCallback.controllerFn();
+    await handler(req as never, res as never, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.locals.cookies).toEqual(
+      expect.objectContaining({
+        lastLoginMethod: {
+          name: 'lastLoginMethod',
+          value: JSON.stringify({ method: 'sso', email: 'sso@example.com' }),
+          options: {},
+        },
+      }),
+    );
+  });
+
+  it('OIDC callback: records the successful SSO login so the login form can offer it again', async () => {
+    const req = makeReq({
+      headers: { cookie: 'state=state-val; pkceCodeVerifier=pkce-val; nonce=nonce-val' },
+      params: { teamId: TEAM_ID },
+      query: { code: 'auth-code', state: 'state-val' },
+      body: {},
+    });
+    (req as MockRequest & { originalUrl: string }).originalUrl = '/api/auth/sso/oidc/callback?code=auth-code&state=state-val';
+    const res = makeRes();
+    const next = vi.fn();
+
+    const handler = routeDefinition.handleOidcCallback.controllerFn();
+    await handler(req as never, res as never, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.locals.cookies).toEqual(
+      expect.objectContaining({
+        lastLoginMethod: {
+          name: 'lastLoginMethod',
+          value: JSON.stringify({ method: 'sso', email: 'sso@example.com' }),
+          options: {},
+        },
+      }),
+    );
+  });
 });
 
 /**
@@ -695,6 +753,7 @@ describe('auth.controller - 2fa-otp single-use replay enforcement', () => {
       rememberDevice: { name: 'rememberDevice', options: {} },
       redirectUrl: { name: 'redirectUrl', options: {} },
       teamInviteState: { name: 'teamInviteState', options: {} },
+      lastLoginMethod: { name: 'lastLoginMethod', options: {} },
     } as never);
     authServerMocks.ensureAuthError.mockImplementation((error: unknown) => error);
     authServerMocks.validateRedirectUrl.mockImplementation((url: string) => url || 'https://client.test');

--- a/apps/api/src/app/controllers/auth.controller.ts
+++ b/apps/api/src/app/controllers/auth.controller.ts
@@ -52,6 +52,7 @@ import {
   verifyTotpCodeOnceOrThrow,
 } from '@jetstream/auth/server';
 import {
+  CookieOptions,
   OauthProviderType,
   OauthProviderTypeSchema,
   Provider,
@@ -1319,9 +1320,22 @@ const startSso = createRoute(routeDefinition.startSso.validators, async ({ body,
   }
 });
 
+/**
+ * Records that SSO is the method that actually worked on this device, which the login form uses to
+ * offer the same login again on the next visit. Only called once the identity provider has
+ * authenticated the user - the login page cannot set this itself, because it navigates away before
+ * knowing whether the login succeeded.
+ *
+ * The value shape is a contract with `getLastUsedLoginMethod` in the landing app.
+ */
+function setLastLoginMethodCookie(setCookie: (name: string, value: string, options: CookieOptions) => void, email: string) {
+  const { lastLoginMethod } = getCookieConfig(ENV.USE_SECURE_COOKIES);
+  setCookie(lastLoginMethod.name, JSON.stringify({ method: 'sso', email }), lastLoginMethod.options);
+}
+
 const handleSamlCallback = createRoute(
   routeDefinition.handleSamlCallback.validators,
-  async ({ params, body, clearCookie }, req, res, next) => {
+  async ({ params, body, setCookie, clearCookie }, req, res, next) => {
     try {
       const { teamId } = params;
       const { SAMLResponse } = body;
@@ -1353,6 +1367,8 @@ const handleSamlCallback = createRoute(
         teamId,
         success: true,
       });
+
+      setLastLoginMethodCookie(setCookie, user.email);
 
       const { returnUrl: returnUrlCookie, redirectUrl: redirectUrlCookie } = getCookieConfig(ENV.USE_SECURE_COOKIES);
       const cookies = req.headers.cookie ? parseCookie(req.headers.cookie) : {};
@@ -1477,104 +1493,109 @@ const initiateOidcLogin = createRoute(routeDefinition.initiateOidcLogin.validato
   }
 });
 
-const handleOidcCallback = createRoute(routeDefinition.handleOidcCallback.validators, async ({ params, clearCookie }, req, res, next) => {
-  try {
-    const { teamId } = params;
+const handleOidcCallback = createRoute(
+  routeDefinition.handleOidcCallback.validators,
+  async ({ params, setCookie, clearCookie }, req, res, next) => {
+    try {
+      const { teamId } = params;
 
-    const cookieConfig = getCookieConfig(ENV.USE_SECURE_COOKIES);
-    const cookies = req.headers.cookie ? parseCookie(req.headers.cookie) : {};
+      const cookieConfig = getCookieConfig(ENV.USE_SECURE_COOKIES);
+      const cookies = req.headers.cookie ? parseCookie(req.headers.cookie) : {};
 
-    const state = cookies[cookieConfig.state.name];
-    const codeVerifier = cookies[cookieConfig.pkceCodeVerifier.name];
-    const nonce = cookies[cookieConfig.nonce.name];
-    // Fall back to the `redirectUrl` cookie when `returnUrl` is absent — this is what the desktop
-    // login middleware (desktop-app.controller.ts) and other pre-login interstitials set, and what
-    // the credentials/OAuth callbacks already honor. Without this, desktop SSO users land on /app
-    // instead of /desktop-app/auth and have to log in a second time.
-    const returnUrlCandidate = normalizeRedirectCandidate(cookies[cookieConfig.returnUrl.name] || cookies[cookieConfig.redirectUrl.name]);
-    if (cookies[cookieConfig.redirectUrl.name]) {
-      clearCookie(cookieConfig.redirectUrl.name, cookieConfig.redirectUrl.options);
-    }
-    const returnUrl = validateRedirectUrl(
-      returnUrlCandidate,
-      [ENV.JETSTREAM_CLIENT_URL, ENV.JETSTREAM_SERVER_URL],
-      ENV.JETSTREAM_CLIENT_URL,
-    );
-
-    // Clear cookies
-    clearOauthCookies(res);
-
-    if (!state || !codeVerifier || !nonce) {
-      throw new InvalidSession('Missing or invalid OIDC state');
-    }
-
-    const team = await getTeamLoginConfigWithSso(teamId);
-
-    if (!team?.loginConfig.oidcConfiguration) {
-      throw new InvalidProvider('OIDC not configured for this team');
-    }
-
-    const config = team.loginConfig.oidcConfiguration;
-
-    // Build current URL from request
-    const currentUrl = new URL(`${ENV.JETSTREAM_SERVER_URL}${req.originalUrl}`);
-
-    // Validate callback and exchange code for tokens
-    const { claims, idTokenResult } = await oidcService.validateOidcCallback(config, teamId, currentUrl, state, codeVerifier, nonce);
-
-    // Extract user info from claims
-    const attributeMapping = config.attributeMapping as any;
-    const userInfo = await oidcService.extractUserInfo(config, claims, idTokenResult.access_token, attributeMapping);
-
-    // Handle SSO login (create/update user, add to team, create session)
-    const user = await handleSsoLogin('oidc', teamId, userInfo, req as any);
-
-    // Log success
-    createUserActivityFromReq(req, res, {
-      action: 'SSO_LOGIN',
-      method: 'OIDC',
-      userId: user.id,
-      email: user.email,
-      teamId,
-      success: true,
-    });
-
-    // Send verification email and redirect to verify page if verification is pending (e.g. MFA)
-    if (Array.isArray(req.session.pendingVerification) && req.session.pendingVerification.length > 0) {
-      const initialVerification = req.session.pendingVerification[0];
-      if (initialVerification.type === 'email') {
-        await sendEmailVerification(user.email, initialVerification.token, EMAIL_VERIFICATION_TOKEN_DURATION_HOURS);
-      } else if (initialVerification.type === '2fa-email') {
-        await sendVerificationCode(user.email, initialVerification.token, TOKEN_DURATION_MINUTES);
+      const state = cookies[cookieConfig.state.name];
+      const codeVerifier = cookies[cookieConfig.pkceCodeVerifier.name];
+      const nonce = cookies[cookieConfig.nonce.name];
+      // Fall back to the `redirectUrl` cookie when `returnUrl` is absent — this is what the desktop
+      // login middleware (desktop-app.controller.ts) and other pre-login interstitials set, and what
+      // the credentials/OAuth callbacks already honor. Without this, desktop SSO users land on /app
+      // instead of /desktop-app/auth and have to log in a second time.
+      const returnUrlCandidate = normalizeRedirectCandidate(cookies[cookieConfig.returnUrl.name] || cookies[cookieConfig.redirectUrl.name]);
+      if (cookies[cookieConfig.redirectUrl.name]) {
+        clearCookie(cookieConfig.redirectUrl.name, cookieConfig.redirectUrl.options);
       }
-      setCsrfCookie(res);
-      redirect(res, '/auth/verify');
-    } else if (req.session.pendingMfaEnrollment) {
-      redirect(res, '/auth/mfa-enroll');
-    } else if (req.session.pendingTosAcceptance) {
-      setCsrfCookie(res);
-      redirect(res, '/auth/accept-terms');
-    } else {
-      if (req.session.sendNewUserEmailAfterVerify) {
-        req.session.sendNewUserEmailAfterVerify = undefined;
-        await sendWelcomeEmail(user.email);
-      }
-      redirect(res, returnUrl);
-    }
-  } catch (ex) {
-    getLogger().error(getErrorMessageAndStackObj(ex), '[AUTH][OIDC_CALLBACK] Error processing OIDC callback');
-    createUserActivityFromReqWithError(req, res, ex, {
-      action: 'SSO_LOGIN',
-      method: 'OIDC',
-      teamId: params.teamId,
-      success: false,
-    });
+      const returnUrl = validateRedirectUrl(
+        returnUrlCandidate,
+        [ENV.JETSTREAM_CLIENT_URL, ENV.JETSTREAM_SERVER_URL],
+        ENV.JETSTREAM_CLIENT_URL,
+      );
 
-    req.session.destroy(() => {
-      next(ensureAuthError(ex));
-    });
-  }
-});
+      // Clear cookies
+      clearOauthCookies(res);
+
+      if (!state || !codeVerifier || !nonce) {
+        throw new InvalidSession('Missing or invalid OIDC state');
+      }
+
+      const team = await getTeamLoginConfigWithSso(teamId);
+
+      if (!team?.loginConfig.oidcConfiguration) {
+        throw new InvalidProvider('OIDC not configured for this team');
+      }
+
+      const config = team.loginConfig.oidcConfiguration;
+
+      // Build current URL from request
+      const currentUrl = new URL(`${ENV.JETSTREAM_SERVER_URL}${req.originalUrl}`);
+
+      // Validate callback and exchange code for tokens
+      const { claims, idTokenResult } = await oidcService.validateOidcCallback(config, teamId, currentUrl, state, codeVerifier, nonce);
+
+      // Extract user info from claims
+      const attributeMapping = config.attributeMapping as any;
+      const userInfo = await oidcService.extractUserInfo(config, claims, idTokenResult.access_token, attributeMapping);
+
+      // Handle SSO login (create/update user, add to team, create session)
+      const user = await handleSsoLogin('oidc', teamId, userInfo, req as any);
+
+      // Log success
+      createUserActivityFromReq(req, res, {
+        action: 'SSO_LOGIN',
+        method: 'OIDC',
+        userId: user.id,
+        email: user.email,
+        teamId,
+        success: true,
+      });
+
+      setLastLoginMethodCookie(setCookie, user.email);
+
+      // Send verification email and redirect to verify page if verification is pending (e.g. MFA)
+      if (Array.isArray(req.session.pendingVerification) && req.session.pendingVerification.length > 0) {
+        const initialVerification = req.session.pendingVerification[0];
+        if (initialVerification.type === 'email') {
+          await sendEmailVerification(user.email, initialVerification.token, EMAIL_VERIFICATION_TOKEN_DURATION_HOURS);
+        } else if (initialVerification.type === '2fa-email') {
+          await sendVerificationCode(user.email, initialVerification.token, TOKEN_DURATION_MINUTES);
+        }
+        setCsrfCookie(res);
+        redirect(res, '/auth/verify');
+      } else if (req.session.pendingMfaEnrollment) {
+        redirect(res, '/auth/mfa-enroll');
+      } else if (req.session.pendingTosAcceptance) {
+        setCsrfCookie(res);
+        redirect(res, '/auth/accept-terms');
+      } else {
+        if (req.session.sendNewUserEmailAfterVerify) {
+          req.session.sendNewUserEmailAfterVerify = undefined;
+          await sendWelcomeEmail(user.email);
+        }
+        redirect(res, returnUrl);
+      }
+    } catch (ex) {
+      getLogger().error(getErrorMessageAndStackObj(ex), '[AUTH][OIDC_CALLBACK] Error processing OIDC callback');
+      createUserActivityFromReqWithError(req, res, ex, {
+        action: 'SSO_LOGIN',
+        method: 'OIDC',
+        teamId: params.teamId,
+        success: false,
+      });
+
+      req.session.destroy(() => {
+        next(ensureAuthError(ex));
+      });
+    }
+  },
+);
 
 const acceptTerms = createRoute(routeDefinition.acceptTerms.validators, async ({ body, clearCookie }, req, res, next) => {
   try {

--- a/apps/jetstream-e2e/src/setup/global.setup.ts
+++ b/apps/jetstream-e2e/src/setup/global.setup.ts
@@ -32,7 +32,7 @@ setup('login and ensure org exists', async ({ page, request }) => {
   await page.getByRole('link', { name: 'Log in' }).click();
   await page.getByLabel('Email Address').click();
   await page.getByLabel('Email Address').fill(user.email);
-  await page.getByRole('button', { name: 'Continue' }).click();
+  await page.getByRole('button', { name: 'Continue', exact: true }).click();
   await page.getByLabel('Password').click();
   await page.getByLabel('Password').fill(ENV.EXAMPLE_USER_PASSWORD as string);
   await page.getByRole('button', { name: 'Sign in', exact: true }).click();

--- a/apps/jetstream-e2e/src/tests/authentication/rate-limit/auth-rate-limit-ui.spec.ts
+++ b/apps/jetstream-e2e/src/tests/authentication/rate-limit/auth-rate-limit-ui.spec.ts
@@ -57,9 +57,9 @@ test.describe('Auth rate limit UI behavior', () => {
       await authPage.goToLogin(false);
 
       await authPage.emailInput.fill(`user@${fixture.domain}`);
-      await page.getByRole('button', { name: 'Continue' }).click();
+      await authPage.continueButton.click();
 
-      // checkSso returns null when the response is not ok (including 429), so the UI
+      // discoverSso returns false when the response is not ok (including 429), so the UI
       // silently falls back to the regular password login form without showing an error.
       await expect(authPage.passwordInput).toBeVisible();
       await expect(page.getByText('Single Sign-On is available')).toBeHidden();

--- a/apps/landing/AGENTS.md
+++ b/apps/landing/AGENTS.md
@@ -1,0 +1,9 @@
+<!-- BEGIN:nextjs-agent-rules -->
+
+# This is NOT the Next.js you know
+
+This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` (resolved from this file's directory; in monorepos the `next` package may not be visible from the repo root) before writing any code. Heed deprecation notices.
+
+This block is written and re-added by `next dev` — verify at `node_modules/next/dist/server/lib/generate-agent-files.js`. Removing it from a diff only re-creates the uncommitted change; committing it with your work keeps the tree clean.
+
+<!-- END:nextjs-agent-rules -->

--- a/apps/landing/CLAUDE.md
+++ b/apps/landing/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/apps/landing/components/Alert.tsx
+++ b/apps/landing/components/Alert.tsx
@@ -25,6 +25,17 @@ const errorClassMap = {
   },
 };
 
+/**
+ * Failures interrupt whatever the screen reader is saying, everything else waits for a pause.
+ * `alert` is an assertive live region, so using it for a success or info banner talks over the user.
+ */
+const roleByType: Record<keyof typeof errorClassMap, 'alert' | 'status'> = {
+  error: 'alert',
+  warning: 'alert',
+  success: 'status',
+  info: 'status',
+};
+
 interface AlertProps {
   message: string;
   type?: keyof typeof errorClassMap;
@@ -43,7 +54,7 @@ export default function Alert({ message, type = 'error', dismissable }: AlertPro
   }
 
   return (
-    <div className={classNames('rounded-md p-4', errorClassMap[type].container)}>
+    <div role={roleByType[type]} className={classNames('rounded-md p-4', errorClassMap[type].container)}>
       <div className="flex">
         <div className="shrink-0">
           <XCircleIcon aria-hidden="true" className={classNames('h-5 w-5', errorClassMap[type].icon)} />

--- a/apps/landing/components/auth/ContinueWithSsoButton.tsx
+++ b/apps/landing/components/auth/ContinueWithSsoButton.tsx
@@ -1,0 +1,34 @@
+import { LockClosedIcon } from '@heroicons/react/20/solid';
+import classNames from 'classnames';
+import { LastUsedBadge } from './LastUsedBadge';
+
+interface ContinueWithSsoButtonProps {
+  isLastUsed: boolean;
+  onClick: () => void;
+}
+
+/**
+ * Grouped with the social login buttons so SSO is discoverable before an email address is entered.
+ * The email address is collected afterwards since the identity provider is resolved from its domain.
+ */
+export function ContinueWithSsoButton({ isLastUsed, onClick }: ContinueWithSsoButtonProps) {
+  return (
+    <div className="mt-4 flex flex-col">
+      <button
+        type="button"
+        onClick={onClick}
+        data-testid="continue-with-sso-button"
+        className={classNames(
+          'flex w-full items-center justify-center gap-3 rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-xs ring-1 ring-inset ring-gray-300 hover:bg-gray-50 focus-visible:ring-transparent',
+          {
+            'outline-2 outline-offset-2': isLastUsed,
+          },
+        )}
+      >
+        <LockClosedIcon aria-hidden="true" className="h-5 w-5 text-gray-500" />
+        <span className="text-sm font-semibold leading-6">Continue with SSO</span>
+      </button>
+      {isLastUsed && <LastUsedBadge className="mt-1 justify-center" />}
+    </div>
+  );
+}

--- a/apps/landing/components/auth/LastUsedBadge.tsx
+++ b/apps/landing/components/auth/LastUsedBadge.tsx
@@ -1,0 +1,14 @@
+import classNames from 'classnames';
+
+export function LastUsedBadge({ className }: { className?: string }) {
+  return (
+    <span
+      className={classNames(
+        'inline-flex items-center bg-blue-100 px-2 py-1 text-xs font-medium text-blue-700 dark:bg-blue-400/10 dark:text-blue-400',
+        className,
+      )}
+    >
+      Last Used
+    </span>
+  );
+}

--- a/apps/landing/components/auth/LastUsedSsoLogin.tsx
+++ b/apps/landing/components/auth/LastUsedSsoLogin.tsx
@@ -1,0 +1,65 @@
+import { ArrowRightIcon, LockClosedIcon } from '@heroicons/react/20/solid';
+import { Maybe } from '@jetstream/types';
+import Alert from '../Alert';
+import { LastUsedBadge } from './LastUsedBadge';
+
+interface LastUsedSsoLoginProps {
+  email: string;
+  isStartingSso: boolean;
+  error?: Maybe<string>;
+  onLogin: () => void;
+  onUseAnotherMethod: () => void;
+}
+
+/**
+ * Shown instead of the full login form when the last successful login on this device was SSO.
+ * Every other login method is one click away, but is kept out of the way until asked for.
+ */
+export function LastUsedSsoLogin({ email, isStartingSso, error, onLogin, onUseAnotherMethod }: LastUsedSsoLoginProps) {
+  return (
+    <div className="mt-10 sm:mx-auto sm:w-full sm:max-w-sm">
+      {error && (
+        <div className="mb-6">
+          <Alert type="error" message={error} />
+        </div>
+      )}
+
+      <button
+        type="button"
+        onClick={onLogin}
+        disabled={isStartingSso}
+        autoFocus
+        data-testid="sso-last-used-login-button"
+        className="flex w-full items-center justify-between gap-3 rounded-md bg-white px-4 py-3 text-left shadow-xs ring-1 ring-inset ring-gray-300 hover:bg-gray-50 disabled:cursor-not-allowed disabled:bg-gray-50"
+      >
+        <span className="flex min-w-0 items-center gap-3">
+          <LockClosedIcon aria-hidden="true" className="h-5 w-5 shrink-0 text-gray-500" />
+          <span className="sr-only">Sign in with single sign-on as</span>
+          <span className="truncate text-sm font-semibold leading-6 text-gray-900">{email}</span>
+        </span>
+        <LastUsedBadge className="shrink-0" />
+      </button>
+
+      {isStartingSso && <p className="mt-2 text-sm text-gray-500">Redirecting to your identity provider…</p>}
+
+      <div className="relative mt-6">
+        <div aria-hidden="true" className="absolute inset-0 flex items-center">
+          <div className="w-full border-t border-gray-200" />
+        </div>
+        <div className="relative flex justify-center text-sm font-medium leading-6">
+          <span className="bg-white px-6 text-gray-500">or</span>
+        </div>
+      </div>
+
+      <button
+        type="button"
+        onClick={onUseAnotherMethod}
+        data-testid="use-another-login-method-button"
+        className="mt-6 flex w-full items-center justify-center gap-2 rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-xs ring-1 ring-inset ring-gray-300 hover:bg-gray-50"
+      >
+        Log in with another method
+        <ArrowRightIcon aria-hidden="true" className="h-4 w-4" />
+      </button>
+    </div>
+  );
+}

--- a/apps/landing/components/auth/LoginOrSignUp.tsx
+++ b/apps/landing/components/auth/LoginOrSignUp.tsx
@@ -4,31 +4,29 @@ import { containsUserInfo } from '@jetstream/shared/utils';
 import { PASSWORD_MIN_LENGTH, PasswordSchema } from '@jetstream/types';
 import type { TurnstileInstance } from '@marsidev/react-turnstile';
 import classNames from 'classnames';
-import Link from 'next/link';
 import { useSearchParams } from 'next/navigation';
 import { useRouter } from 'next/router';
-import { Fragment, useEffect, useRef, useState } from 'react';
+import { Fragment, ReactNode, useEffect, useRef, useState } from 'react';
 import { FieldErrors, useForm } from 'react-hook-form';
 import { z } from 'zod';
+import { useSsoLogin } from '../../hooks/sso.hooks';
 import { ENVIRONMENT, ROUTES } from '../../utils/environment';
 import { getLastUsedLoginMethod, setLastUsedLoginMethod } from '../../utils/utils';
+import Alert from '../Alert';
 import { ErrorQueryParamErrorBanner } from '../ErrorQueryParamErrorBanner';
 import { Checkbox } from '../form/Checkbox';
 import { Input } from '../form/Input';
 import { Captcha, isCaptchaRequired } from './Captcha';
+import { ContinueWithSsoButton } from './ContinueWithSsoButton';
 import { ForgotPasswordLink } from './ForgotPasswordLink';
+import { LastUsedSsoLogin } from './LastUsedSsoLogin';
+import { LoginOrSignUpHeader } from './LoginOrSignUpHeader';
 import { LoginOrSignUpOAuthButton } from './LoginOrSignUpOAuthButton';
 import { PasswordStrengthIndicator } from './PasswordStrengthIndicator';
 import { RegisterOrSignUpLink } from './RegisterOrSignUpLink';
 import { ShowPasswordButton } from './ShowPasswordButton';
-
-const SsoDiscoveryResponseSchema = z.object({
-  data: z.object({
-    available: z.boolean(),
-  }),
-});
-
-type SsoDiscoveryResponse = z.infer<typeof SsoDiscoveryResponseSchema>;
+import { SsoAvailableBanner } from './SsoAvailableBanner';
+import { SsoEmailStep } from './SsoEmailStep';
 
 const LoginSchema = z.object({
   action: z.literal('login'),
@@ -84,6 +82,41 @@ const FormSchema = z.discriminatedUnion('action', [LoginSchema, RegisterSchema])
 type RegisterForm = z.infer<typeof RegisterSchema>;
 type Form = z.infer<typeof FormSchema>;
 
+/**
+ * `lastUsedSso` mirrors the returning SSO user experience - the only login method offered is the
+ * one that worked last time. `ssoEmail` collects just an email address to resolve the identity
+ * provider from, without the credential fields getting in the way.
+ */
+type LoginFormView = 'lastUsedSso' | 'default' | 'ssoEmail';
+
+/**
+ * Whether the email address has been checked for an SSO configuration. Only meaningful on the
+ * `default` view - the other two views never run discovery.
+ */
+type SsoDiscoveryState = 'unchecked' | 'unavailable' | 'available';
+
+/** Shared by the credentials form and the SSO email step so the field behaves the same in both */
+const EMAIL_INPUT_PROPS = {
+  type: 'email',
+  required: true,
+  autoComplete: 'email',
+  spellCheck: 'false',
+  autoCapitalize: 'off',
+} as const;
+
+/** Chrome shared by every view so switching views cannot change the page framing */
+function LoginFormShell({ action, children }: { action: 'login' | 'register'; children: ReactNode }) {
+  return (
+    <Fragment>
+      <ErrorQueryParamErrorBanner />
+      <div className="flex min-h-full flex-1 flex-col justify-center px-6 py-12 lg:px-8">
+        <LoginOrSignUpHeader action={action} />
+        {children}
+      </div>
+    </Fragment>
+  );
+}
+
 interface LoginOrSignUpProps {
   action: 'login' | 'register';
   providers: Providers;
@@ -95,16 +128,22 @@ export function LoginOrSignUp({ action, providers, csrfToken, currentTosVersion 
   const router = useRouter();
   const [showPasswordActive, setShowPasswordActive] = useState(false);
   const [{ lastUsedLogin, rememberedEmail }] = useState(getLastUsedLoginMethod);
-  const [ssoInfo, setSsoInfo] = useState<SsoDiscoveryResponse['data'] | null>(null);
-  const [hasCheckedSso, setHasCheckedSso] = useState(false);
-  const [checkingSso, setCheckingSso] = useState(false);
-  const [discoveryError, setDiscoveryError] = useState<string | null>(null);
+  const [ssoDiscovery, setSsoDiscovery] = useState<SsoDiscoveryState>('unchecked');
 
   const captchaRef = useRef<TurnstileInstance>(null);
+  const isCheckingSsoRef = useRef(false);
   const searchParams = useSearchParams();
 
-  const emailHint = searchParams?.get('email') || (action === 'login' ? rememberedEmail : null);
+  const emailAddressHint = searchParams?.get('email');
+  const emailHint = emailAddressHint || (action === 'login' ? rememberedEmail : null);
   const returnUrl = searchParams?.get('returnUrl');
+
+  const { discoverSso, startSsoLogin, isCheckingSso, isStartingSso, ssoError, clearSsoError } = useSsoLogin({ csrfToken, returnUrl });
+
+  // A login link for a specific email address takes priority over the remembered SSO login
+  const [view, setView] = useState<LoginFormView>(() =>
+    action === 'login' && lastUsedLogin === 'sso' && rememberedEmail && !emailAddressHint ? 'lastUsedSso' : 'default',
+  );
 
   const {
     register,
@@ -112,6 +151,7 @@ export function LoginOrSignUp({ action, providers, csrfToken, currentTosVersion 
     watch,
     resetField,
     trigger,
+    getValues,
     formState: { errors, isSubmitting },
   } = useForm({
     resolver: zodResolver(FormSchema),
@@ -134,12 +174,11 @@ export function LoginOrSignUp({ action, providers, csrfToken, currentTosVersion 
 
   useEffect(() => {
     // Reset state when email changes
-    setSsoInfo(null);
-    setHasCheckedSso(false);
-    setDiscoveryError(null);
+    setSsoDiscovery('unchecked');
+    clearSsoError();
     resetField('password');
     resetField('confirmPassword');
-  }, [watchEmail, resetField]);
+  }, [watchEmail, resetField, clearSsoError]);
 
   const onSubmit = async (payload: Form) => {
     try {
@@ -219,332 +258,299 @@ export function LoginOrSignUp({ action, providers, csrfToken, currentTosVersion 
     }
   };
 
-  const checkSso = async (email: string): Promise<SsoDiscoveryResponse['data'] | null> => {
-    if (!email || !email.includes('@')) {
-      return null;
+  const handleContinue = async () => {
+    // Both the Continue button and Enter on the email input land here, and validation is awaited
+    // before discovery flips `isCheckingSso`, so a ref rather than that state is what keeps a second
+    // press from firing a duplicate request against the rate limited discovery endpoint. Concurrent
+    // calls would also let the first one to finish hide the "Checking for SSO" indicator early.
+    if (isCheckingSsoRef.current) {
+      return;
     }
+    isCheckingSsoRef.current = true;
 
     try {
-      const response = await fetch(ROUTES.AUTH.api_sso_discover, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
-        body: JSON.stringify({ email, csrfToken }),
-      });
-
-      if (!response.ok) {
-        return null;
+      const emailValid = await trigger('email');
+      if (!emailValid) {
+        return;
       }
 
-      const { data } = await response.json().then((data) => SsoDiscoveryResponseSchema.parse(data));
+      const checkedEmail = watchEmail;
+      const isAvailable = await discoverSso(checkedEmail);
 
-      return response.ok && data.available ? data : null;
-    } catch (error) {
-      console.error('Error discovering SSO', error);
-      return null;
+      // The email input stays editable while discovery is in flight, and changing it resets discovery.
+      // Applying a result for an address the user has already moved on from would report SSO
+      // availability for an address that was never checked.
+      if (getValues('email') !== checkedEmail) {
+        return;
+      }
+
+      setSsoDiscovery(isAvailable ? 'available' : 'unavailable');
+    } finally {
+      isCheckingSsoRef.current = false;
     }
   };
 
-  const handleContinue = async () => {
+  /** SSO was explicitly requested, so the domain is resolved by starting the login rather than discovering first */
+  const handleSsoEmailContinue = async () => {
     const emailValid = await trigger('email');
     if (!emailValid) {
       return;
     }
 
-    setCheckingSso(true);
-    setDiscoveryError(null);
-    const data = await checkSso(watchEmail);
-    setSsoInfo(data);
-    setHasCheckedSso(true);
-    setCheckingSso(false);
-    if (!data) {
-      setDiscoveryError(null);
-    }
+    await startSsoLogin(watchEmail);
   };
 
-  const handleSsoLogin = async () => {
-    if (!ssoInfo?.available) {
-      return;
-    }
-
-    const url = new URL(ROUTES.AUTH.api_sso_start, window.location.origin);
-    if (returnUrl) {
-      url.searchParams.set('returnUrl', returnUrl);
-    }
-
-    const response = await fetch(url.toString(), {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
-      body: JSON.stringify({ csrfToken, email: watchEmail }),
-    });
-
-    if (!response.ok) {
-      // TODO: show error to user
-      return;
-    }
-
-    const {
-      data: { redirectUrl },
-    } = (await response.json()) as { data: { redirectUrl: string } };
-
-    setLastUsedLoginMethod({
-      lastUsedLogin: 'sso',
-      rememberedEmail: watchEmail,
-      ssoAvailable: ssoInfo?.available,
-    });
-    window.location.href = redirectUrl;
+  // The button that was clicked is gone once the view changes, so focus lands on the email address -
+  // the one input every view has. Each view renders its own tree, so the freshly mounted input's
+  // `autoFocus` is what moves focus; focusing from here would target the input that is unmounting.
+  const handleShowSsoEmailView = () => {
+    clearSsoError();
+    setView('ssoEmail');
   };
 
-  return (
-    <Fragment>
-      <ErrorQueryParamErrorBanner />
-      <div className="flex min-h-full flex-1 flex-col justify-center px-6 py-12 lg:px-8">
+  const handleShowDefaultView = () => {
+    clearSsoError();
+    setView('default');
+  };
+
+  if (view === 'lastUsedSso' && rememberedEmail) {
+    return (
+      <LoginFormShell action={action}>
+        <LastUsedSsoLogin
+          email={rememberedEmail}
+          isStartingSso={isStartingSso}
+          error={ssoError}
+          onLogin={() => startSsoLogin(rememberedEmail)}
+          onUseAnotherMethod={handleShowDefaultView}
+        />
         <div className="sm:mx-auto sm:w-full sm:max-w-sm">
-          <Link href={ROUTES.HOME}>
-            <img
-              alt="Jetstream"
-              src="https://res.cloudinary.com/getjetstream/image/upload/v1634516624/public/jetstream-logo.svg"
-              className="mx-auto h-10 w-auto"
-            />
-          </Link>
-          <h2 className="mt-10 text-center text-2xl font-bold leading-9 tracking-tight text-gray-900">
-            {action === 'login' ? 'Sign in' : 'Sign up'}
-          </h2>
+          <RegisterOrSignUpLink action={action} emailHint={rememberedEmail} />
         </div>
+      </LoginFormShell>
+    );
+  }
 
-        <div className="mt-10 sm:mx-auto sm:w-full sm:max-w-sm">
-          <div className="grid grid-cols-2 gap-4">
-            <LoginOrSignUpOAuthButton
-              action={action}
-              provider={providers?.google}
-              csrfToken={csrfToken}
-              returnUrl={returnUrl}
-              lastUsedLogin={lastUsedLogin}
-              setLastUsed={setLastUsedLoginMethod}
-            />
-
-            <LoginOrSignUpOAuthButton
-              action={action}
-              provider={providers?.salesforce}
-              csrfToken={csrfToken}
-              returnUrl={returnUrl}
-              lastUsedLogin={lastUsedLogin}
-              setLastUsed={setLastUsedLoginMethod}
-            />
-          </div>
-
-          {action === 'register' && (
-            <p className="text-xs text-center text-gray-500">
-              By signing in with Google or Salesforce, you agree to our{' '}
-              <a href={ROUTES.TERMS_OF_SERVICE} target="_blank" rel="noreferrer" className="text-blue-600 hover:text-blue-500 underline">
-                Terms of Service
-              </a>
-              ,{' '}
-              <a href={ROUTES.PRIVACY} target="_blank" rel="noreferrer" className="text-blue-600 hover:text-blue-500 underline">
-                Privacy Policy
-              </a>
-              , and{' '}
-              <a href={ROUTES.DPA} target="_blank" rel="noreferrer" className="text-blue-600 hover:text-blue-500 underline">
-                Data Processing Agreement
-              </a>
-              .
-            </p>
-          )}
-
-          <div>
-            <div className="relative mt-10">
-              <div aria-hidden="true" className="absolute inset-0 flex items-center">
-                <div className="w-full border-t border-gray-200" />
-              </div>
-              <div className="relative flex justify-center text-sm font-medium leading-6">
-                <span className="bg-white px-6 text-gray-900">or continue with</span>
-              </div>
-            </div>
-          </div>
-
-          <form
-            action={providers?.credentials.callbackUrl}
-            onSubmit={handleSubmit(onSubmit)}
-            method="POST"
-            noValidate
-            className="space-y-6"
-          >
-            <input type="hidden" {...register('csrfToken')} />
-            <input type="hidden" {...register('action')} />
-            {action === 'register' && <input type="hidden" {...register('tosVersion')} />}
-
+  if (view === 'ssoEmail') {
+    return (
+      <LoginFormShell action={action}>
+        <SsoEmailStep
+          isStartingSso={isStartingSso}
+          error={ssoError}
+          onContinue={handleSsoEmailContinue}
+          onBack={handleShowDefaultView}
+          emailInput={
             <Input
               label="Email Address"
               error={errors?.email?.message}
               inputProps={{
-                type: 'email',
+                ...EMAIL_INPUT_PROPS,
                 autoFocus: true,
-                required: true,
-                autoComplete: 'email',
-                spellCheck: 'false',
-                autoCapitalize: 'off',
                 ...register('email'),
-                onKeyDown: (e) => {
-                  if (e.key === 'Enter' && !ssoInfo && !hasCheckedSso) {
-                    e.preventDefault();
-                    handleContinue();
+                onKeyDown: (event) => {
+                  if (event.key !== 'Enter') {
+                    return;
                   }
+                  event.preventDefault();
+                  handleSsoEmailContinue();
                 },
               }}
             />
-            {checkingSso && <p className="text-sm text-gray-500">Checking for SSO…</p>}
-            {discoveryError && <p className="text-sm text-red-600">{discoveryError}</p>}
+          }
+        />
+        <div className="sm:mx-auto sm:w-full sm:max-w-sm">
+          <RegisterOrSignUpLink action={action} emailHint={emailHint} />
+        </div>
+      </LoginFormShell>
+    );
+  }
 
-            {ssoInfo?.available && (
-              <div className="rounded-md bg-blue-50 p-4">
-                <div className="flex">
-                  <div className="shrink-0">
-                    <svg className="h-5 w-5 text-blue-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-                      <path
-                        fillRule="evenodd"
-                        d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z"
-                        clipRule="evenodd"
-                      />
-                    </svg>
-                  </div>
-                  {/* TODO: add a "last used" indicator on SSO */}
-                  <div className="ml-3 flex-1 md:flex md:justify-between">
-                    <p className="text-sm text-blue-700">Single Sign-On is available</p>
-                    <p className="mt-3 text-sm md:ml-6 md:mt-0">
-                      <button
-                        type="button"
-                        onClick={handleSsoLogin}
-                        className="whitespace-nowrap font-medium text-blue-700 hover:text-blue-600"
-                        autoFocus={true}
-                      >
-                        Log in with SSO <span aria-hidden="true">&rarr;</span>
-                      </button>
-                    </p>
-                  </div>
-                </div>
-              </div>
-            )}
+  return (
+    <LoginFormShell action={action}>
+      <div className="mt-10 sm:mx-auto sm:w-full sm:max-w-sm">
+        <div className="grid grid-cols-2 gap-4">
+          <LoginOrSignUpOAuthButton
+            action={action}
+            provider={providers?.google}
+            csrfToken={csrfToken}
+            returnUrl={returnUrl}
+            lastUsedLogin={lastUsedLogin}
+            setLastUsed={setLastUsedLoginMethod}
+          />
 
-            {!hasCheckedSso && (
+          <LoginOrSignUpOAuthButton
+            action={action}
+            provider={providers?.salesforce}
+            csrfToken={csrfToken}
+            returnUrl={returnUrl}
+            lastUsedLogin={lastUsedLogin}
+            setLastUsed={setLastUsedLoginMethod}
+          />
+        </div>
+
+        <ContinueWithSsoButton isLastUsed={action === 'login' && lastUsedLogin === 'sso'} onClick={handleShowSsoEmailView} />
+
+        <div>
+          <div className="relative mt-10">
+            <div aria-hidden="true" className="absolute inset-0 flex items-center">
+              <div className="w-full border-t border-gray-200" />
+            </div>
+            <div className="relative flex justify-center text-sm font-medium leading-6">
+              <span className="bg-white px-6 text-gray-900">or continue with</span>
+            </div>
+          </div>
+        </div>
+
+        <form action={providers?.credentials.callbackUrl} onSubmit={handleSubmit(onSubmit)} method="POST" noValidate className="space-y-6">
+          <input type="hidden" {...register('csrfToken')} />
+          <input type="hidden" {...register('action')} />
+          {action === 'register' && <input type="hidden" {...register('tosVersion')} />}
+
+          <Input
+            label="Email Address"
+            error={errors?.email?.message}
+            inputProps={{
+              ...EMAIL_INPUT_PROPS,
+              autoFocus: true,
+              ...register('email'),
+              onKeyDown: (event) => {
+                // Once discovery has run the form can submit normally
+                if (event.key !== 'Enter' || ssoDiscovery !== 'unchecked') {
+                  return;
+                }
+                event.preventDefault();
+                handleContinue();
+              },
+            }}
+          />
+          {isCheckingSso && <p className="text-sm text-gray-500">Checking for SSO…</p>}
+          {ssoError && <Alert type="error" message={ssoError} />}
+
+          {ssoDiscovery === 'available' && <SsoAvailableBanner isStartingSso={isStartingSso} onLogin={() => startSsoLogin(watchEmail)} />}
+
+          {ssoDiscovery === 'unchecked' && (
+            <Fragment>
               <button
                 type="button"
                 onClick={handleContinue}
                 className="mt-4 flex w-full justify-center rounded-md bg-blue-600 px-3 py-2 text-sm font-semibold leading-6 text-white shadow-xs hover:bg-blue-700 disabled:bg-gray-300 disabled:cursor-not-allowed focus-visible:outline-solid focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600"
-                disabled={checkingSso}
+                disabled={isCheckingSso}
               >
                 Continue
               </button>
+
+              <RegisterOrSignUpLink action={action} emailHint={emailHint} />
+            </Fragment>
+          )}
+
+          {/* We want the components to render in the DOM to allow for password auto-fill */}
+          <span className={classNames('space-y-6', { invisible: ssoDiscovery === 'unchecked' })}>
+            {action === 'register' && (
+              <Input
+                label="Full Name"
+                error={(errors as FieldErrors<RegisterForm>)?.name?.message}
+                inputProps={{
+                  type: 'text',
+                  required: true,
+                  spellCheck: 'false',
+                  autoComplete: 'name',
+                  ...register('name'),
+                }}
+              />
             )}
 
-            {!hasCheckedSso && <RegisterOrSignUpLink action={action} emailHint={emailHint} />}
-
-            {/* We want the components to render in the DOM to allow for password auto-fill */}
-            <span className={classNames('space-y-6', { invisible: !hasCheckedSso })}>
-              {action === 'register' && (
-                <Input
-                  label="Full Name"
-                  error={(errors as FieldErrors<RegisterForm>)?.name?.message}
-                  inputProps={{
-                    type: 'text',
-                    required: true,
-                    spellCheck: 'false',
-                    autoComplete: 'name',
-                    ...register('name'),
-                  }}
-                />
+            <Input
+              label="Password"
+              error={errors?.password?.message}
+              inputProps={{
+                type: showPasswordActive ? 'text' : 'password',
+                required: true,
+                autoComplete: action === 'login' ? 'current-password' : 'new-password',
+                spellCheck: 'false',
+                minLength: action === 'register' ? PASSWORD_MIN_LENGTH : 8,
+                maxLength: 255,
+                // Only once discovery has ruled SSO out, so it does not take focus from the email
+                // address while the credential fields are still hidden
+                autoFocus: ssoDiscovery === 'unavailable',
+                ...register('password'),
+              }}
+            >
+              {action !== 'register' && (
+                <div className="flex items-center justify-between">
+                  <Checkbox inputProps={{ ...register('rememberMe') }}>Remember Me</Checkbox>
+                  <ShowPasswordButton isActive={showPasswordActive} onClick={() => setShowPasswordActive(!showPasswordActive)} />
+                </div>
               )}
+            </Input>
 
+            {action === 'register' && (
               <Input
-                label="Password"
-                error={errors?.password?.message}
+                label="Confirm Password"
+                error={(errors as FieldErrors<RegisterForm>)?.confirmPassword?.message}
                 inputProps={{
                   type: showPasswordActive ? 'text' : 'password',
                   required: true,
-                  autoComplete: action === 'login' ? 'current-password' : 'new-password',
-                  spellCheck: 'false',
-                  minLength: action === 'register' ? PASSWORD_MIN_LENGTH : 8,
+                  autoComplete: 'new-password',
+                  minLength: PASSWORD_MIN_LENGTH,
                   maxLength: 255,
-                  autoFocus: !ssoInfo?.available,
-                  ...register('password'),
+                  ...register('confirmPassword'),
                 }}
               >
-                {action !== 'register' && (
-                  <div className="flex items-center justify-between">
-                    <Checkbox inputProps={{ ...register('rememberMe') }}>Remember Me</Checkbox>
-                    <ShowPasswordButton isActive={showPasswordActive} onClick={() => setShowPasswordActive(!showPasswordActive)} />
-                  </div>
-                )}
-              </Input>
-
-              {action === 'register' && (
-                <Input
-                  label="Confirm Password"
-                  error={(errors as FieldErrors<RegisterForm>)?.confirmPassword?.message}
-                  inputProps={{
-                    type: showPasswordActive ? 'text' : 'password',
-                    required: true,
-                    autoComplete: 'new-password',
-                    minLength: PASSWORD_MIN_LENGTH,
-                    maxLength: 255,
-                    ...register('confirmPassword'),
-                  }}
-                >
-                  <div className="flex items-center justify-between">
-                    <Checkbox inputProps={{ ...register('rememberMe') }}>Remember Me</Checkbox>
-                    <ShowPasswordButton isActive={showPasswordActive} onClick={() => setShowPasswordActive(!showPasswordActive)} />
-                  </div>
-                </Input>
-              )}
-
-              {action === 'register' && watchPassword && (
-                <PasswordStrengthIndicator password={watchPassword} confirmPassword={watchConfirmPassword} email={watchEmail} />
-              )}
-
-              {action === 'register' && (
-                <div className="space-y-1">
-                  <Checkbox inputProps={{ ...register('tosAccepted') }}>
-                    I agree to the{' '}
-                    <a
-                      href={ROUTES.TERMS_OF_SERVICE}
-                      target="_blank"
-                      rel="noreferrer"
-                      className="text-blue-600 hover:text-blue-500 underline"
-                    >
-                      Terms of Service
-                    </a>
-                    ,{' '}
-                    <a href={ROUTES.PRIVACY} target="_blank" rel="noreferrer" className="text-blue-600 hover:text-blue-500 underline">
-                      Privacy Policy
-                    </a>
-                    , and{' '}
-                    <a href={ROUTES.DPA} target="_blank" rel="noreferrer" className="text-blue-600 hover:text-blue-500 underline">
-                      Data Processing Agreement
-                    </a>
-                  </Checkbox>
-                  {(errors as FieldErrors<RegisterForm>)?.tosAccepted && (
-                    <p className="text-sm text-red-600">{(errors as FieldErrors<RegisterForm>).tosAccepted?.message}</p>
-                  )}
+                <div className="flex items-center justify-between">
+                  <Checkbox inputProps={{ ...register('rememberMe') }}>Remember Me</Checkbox>
+                  <ShowPasswordButton isActive={showPasswordActive} onClick={() => setShowPasswordActive(!showPasswordActive)} />
                 </div>
-              )}
+              </Input>
+            )}
 
-              <div className="flex items-center justify-end">
-                <ForgotPasswordLink />
+            {action === 'register' && watchPassword && (
+              <PasswordStrengthIndicator password={watchPassword} confirmPassword={watchConfirmPassword} email={watchEmail} />
+            )}
+
+            {action === 'register' && (
+              <div className="space-y-1">
+                <Checkbox inputProps={{ ...register('tosAccepted') }}>
+                  I agree to the{' '}
+                  <a
+                    href={ROUTES.TERMS_OF_SERVICE}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="text-blue-600 hover:text-blue-500 underline"
+                  >
+                    Terms of Service
+                  </a>
+                  ,{' '}
+                  <a href={ROUTES.PRIVACY} target="_blank" rel="noreferrer" className="text-blue-600 hover:text-blue-500 underline">
+                    Privacy Policy
+                  </a>
+                  , and{' '}
+                  <a href={ROUTES.DPA} target="_blank" rel="noreferrer" className="text-blue-600 hover:text-blue-500 underline">
+                    Data Processing Agreement
+                  </a>
+                </Checkbox>
+                {(errors as FieldErrors<RegisterForm>)?.tosAccepted && (
+                  <p className="text-sm text-red-600">{(errors as FieldErrors<RegisterForm>).tosAccepted?.message}</p>
+                )}
               </div>
+            )}
 
-              <Captcha ref={captchaRef} action={action} />
+            <div className="flex items-center justify-end">
+              <ForgotPasswordLink />
+            </div>
 
-              <button
-                type="submit"
-                className="flex w-full justify-center rounded-md bg-blue-600 px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-xs hover:bg-blue-700 disabled:bg-gray-300 disabled:cursor-not-allowed focus-visible:outline-solid focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600"
-                disabled={!hasCheckedSso || isSubmitting}
-              >
-                {action === 'login' ? 'Sign in' : 'Sign up'}
-              </button>
-            </span>
-          </form>
+            <Captcha ref={captchaRef} action={action} />
 
-          {hasCheckedSso && <RegisterOrSignUpLink action={action} emailHint={emailHint} />}
-        </div>
+            <button
+              type="submit"
+              className="flex w-full justify-center rounded-md bg-blue-600 px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-xs hover:bg-blue-700 disabled:bg-gray-300 disabled:cursor-not-allowed focus-visible:outline-solid focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600"
+              disabled={ssoDiscovery === 'unchecked' || isSubmitting}
+            >
+              {action === 'login' ? 'Sign in' : 'Sign up'}
+            </button>
+          </span>
+        </form>
+
+        {ssoDiscovery !== 'unchecked' && <RegisterOrSignUpLink action={action} emailHint={emailHint} />}
       </div>
-    </Fragment>
+    </LoginFormShell>
   );
 }

--- a/apps/landing/components/auth/LoginOrSignUpHeader.tsx
+++ b/apps/landing/components/auth/LoginOrSignUpHeader.tsx
@@ -1,0 +1,19 @@
+import Link from 'next/link';
+import { ROUTES } from '../../utils/environment';
+
+export function LoginOrSignUpHeader({ action }: { action: 'login' | 'register' }) {
+  return (
+    <div className="sm:mx-auto sm:w-full sm:max-w-sm">
+      <Link href={ROUTES.HOME}>
+        <img
+          alt="Jetstream"
+          src="https://res.cloudinary.com/getjetstream/image/upload/v1634516624/public/jetstream-logo.svg"
+          className="mx-auto h-10 w-auto"
+        />
+      </Link>
+      <h2 className="mt-10 text-center text-2xl font-bold leading-9 tracking-tight text-gray-900">
+        {action === 'login' ? 'Sign in' : 'Sign up'}
+      </h2>
+    </div>
+  );
+}

--- a/apps/landing/components/auth/LoginOrSignUpOAuthButton.tsx
+++ b/apps/landing/components/auth/LoginOrSignUpOAuthButton.tsx
@@ -1,15 +1,17 @@
-import type { Provider, Providers } from '@jetstream/auth/types';
+import type { Provider } from '@jetstream/auth/types';
 import { Maybe } from '@jetstream/types';
 import classNames from 'classnames';
 import { useMemo } from 'react';
+import type { LastUsedLoginMethod } from '../../utils/utils';
+import { LastUsedBadge } from './LastUsedBadge';
 
 interface LoginOrSignUpOAuthButtonProps {
   action: 'login' | 'register';
   provider: Provider;
   csrfToken: string;
   returnUrl?: Maybe<string>;
-  lastUsedLogin: keyof Providers | null;
-  setLastUsed: (data: { lastUsedLogin?: keyof Providers | null; rememberedEmail?: string | null }) => void;
+  lastUsedLogin: LastUsedLoginMethod | null;
+  setLastUsed: (data: { lastUsedLogin?: LastUsedLoginMethod | null; rememberedEmail?: string | null }) => void;
 }
 
 export function LoginOrSignUpOAuthButton({
@@ -69,11 +71,7 @@ export function LoginOrSignUpOAuthButton({
           <img src={logo} alt={`Sign in with ${label} Logo`} className="h-5 w-5" />
           <span className="text-sm font-semibold leading-6">{label}</span>
         </button>
-        {action === 'login' && lastUsedLogin === provider.provider && (
-          <span className="mt-1 justify-center inline-flex items-center bg-blue-100 px-2 py-1 text-xs font-medium text-blue-700 dark:bg-blue-400/10 dark:text-blue-400">
-            Last Used
-          </span>
-        )}
+        {action === 'login' && lastUsedLogin === provider.provider && <LastUsedBadge className="mt-1 justify-center" />}
       </div>
     </form>
   );

--- a/apps/landing/components/auth/SsoAvailableBanner.tsx
+++ b/apps/landing/components/auth/SsoAvailableBanner.tsx
@@ -1,0 +1,34 @@
+import { InformationCircleIcon } from '@heroicons/react/20/solid';
+
+interface SsoAvailableBannerProps {
+  isStartingSso: boolean;
+  onLogin: () => void;
+}
+
+/** Shown when SSO was discovered from the email address the user typed in */
+export function SsoAvailableBanner({ isStartingSso, onLogin }: SsoAvailableBannerProps) {
+  return (
+    <div className="rounded-md bg-blue-50 p-4">
+      <div className="flex">
+        <div className="shrink-0">
+          <InformationCircleIcon aria-hidden="true" className="h-5 w-5 text-blue-400" />
+        </div>
+        <div className="ml-3 flex-1 md:flex md:justify-between">
+          <p className="text-sm text-blue-700">Single Sign-On is available</p>
+          <p className="mt-3 text-sm md:ml-6 md:mt-0">
+            <button
+              type="button"
+              onClick={onLogin}
+              disabled={isStartingSso}
+              autoFocus
+              data-testid="sso-available-login-button"
+              className="whitespace-nowrap font-medium text-blue-700 hover:text-blue-600 disabled:text-blue-400"
+            >
+              Log in with SSO <span aria-hidden="true">&rarr;</span>
+            </button>
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/landing/components/auth/SsoEmailStep.tsx
+++ b/apps/landing/components/auth/SsoEmailStep.tsx
@@ -1,0 +1,58 @@
+import { LockClosedIcon } from '@heroicons/react/20/solid';
+import { Maybe } from '@jetstream/types';
+import { ReactNode } from 'react';
+import Alert from '../Alert';
+
+interface SsoEmailStepProps {
+  /**
+   * The email field, rendered by the parent so it stays bound to the same form instance as the
+   * credentials view - switching between the two views keeps whatever the user already typed.
+   */
+  emailInput: ReactNode;
+  isStartingSso: boolean;
+  error?: Maybe<string>;
+  onContinue: () => void;
+  onBack: () => void;
+}
+
+/**
+ * Collects just an email address to resolve the identity provider from. Deliberately rendered
+ * instead of the credentials form rather than inside it, so there is no password field, captcha, or
+ * submit path present on a screen that only ever redirects to an identity provider.
+ */
+export function SsoEmailStep({ emailInput, isStartingSso, error, onContinue, onBack }: SsoEmailStepProps) {
+  return (
+    <div className="mt-10 sm:mx-auto sm:w-full sm:max-w-sm">
+      <p className="mb-6 text-sm text-gray-600">
+        Enter your email address and you will be redirected to your identity provider to sign in.
+      </p>
+
+      <div className="space-y-6">
+        {emailInput}
+
+        {error && <Alert type="error" message={error} />}
+
+        <button
+          type="button"
+          onClick={onContinue}
+          data-testid="sso-email-continue-button"
+          className="mt-4 flex w-full items-center justify-center gap-2 rounded-md bg-blue-600 px-3 py-2 text-sm font-semibold leading-6 text-white shadow-xs hover:bg-blue-700 disabled:bg-gray-300 disabled:cursor-not-allowed focus-visible:outline-solid focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600"
+          disabled={isStartingSso}
+        >
+          <LockClosedIcon aria-hidden="true" className="h-5 w-5" />
+          Continue with SSO
+        </button>
+
+        <button
+          type="button"
+          onClick={onBack}
+          data-testid="back-to-all-login-options-button"
+          className="flex w-full items-center justify-center gap-1 text-sm font-semibold leading-6 text-blue-600 hover:text-blue-700"
+        >
+          <span aria-hidden="true">&larr;</span>
+          Back to all sign in options
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/landing/hooks/sso.hooks.ts
+++ b/apps/landing/hooks/sso.hooks.ts
@@ -1,0 +1,147 @@
+import { Maybe } from '@jetstream/types';
+import { useCallback, useRef, useState } from 'react';
+import { z } from 'zod';
+import { ROUTES } from '../utils/environment';
+
+const SsoDiscoveryResponseSchema = z.object({
+  data: z.object({ available: z.boolean() }),
+});
+
+const SsoStartResponseSchema = z.object({
+  data: z.object({ redirectUrl: z.string().min(1) }),
+});
+
+const SsoErrorResponseSchema = z.object({
+  errorType: z.string().optional(),
+  data: z.object({ errorType: z.string().optional() }).optional(),
+});
+
+/** Error types the API returns when the email domain has no usable SSO configuration */
+const SSO_UNAVAILABLE_ERROR_TYPES = new Set(['InvalidProvider', 'ProviderNotAllowed']);
+
+const SSO_UNAVAILABLE_MESSAGE =
+  'Single sign-on is not available for this email address. Contact your administrator or sign in with another method.';
+const SSO_RATE_LIMITED_MESSAGE = 'Too many attempts. Wait a few minutes and try again.';
+const SSO_UNKNOWN_ERROR_MESSAGE = 'Something went wrong starting single sign-on. Try again or sign in with another method.';
+
+const JSON_HEADERS = { 'Content-Type': 'application/json', Accept: 'application/json' };
+
+async function getStartErrorMessage(response: Response): Promise<string> {
+  if (response.status === 429) {
+    return SSO_RATE_LIMITED_MESSAGE;
+  }
+
+  const errorType = await response
+    .json()
+    .then((body) => {
+      const parsed = SsoErrorResponseSchema.safeParse(body);
+      return parsed.success ? parsed.data.errorType || parsed.data.data?.errorType : undefined;
+    })
+    .catch(() => undefined);
+
+  return errorType && SSO_UNAVAILABLE_ERROR_TYPES.has(errorType) ? SSO_UNAVAILABLE_MESSAGE : SSO_UNKNOWN_ERROR_MESSAGE;
+}
+
+interface UseSsoLoginOptions {
+  csrfToken: string;
+  returnUrl?: Maybe<string>;
+}
+
+/**
+ * SSO discovery and login for the login/sign-up form. Discovery is best-effort so that an
+ * unavailable or rate limited endpoint falls back to the other login options, but starting
+ * a login the user explicitly asked for always reports a failure back to them.
+ */
+export function useSsoLogin({ csrfToken, returnUrl }: UseSsoLoginOptions) {
+  const [isCheckingSso, setIsCheckingSso] = useState(false);
+  const [isStartingSso, setIsStartingSso] = useState(false);
+  const [ssoError, setSsoError] = useState<string | null>(null);
+  const isStartingSsoRef = useRef(false);
+
+  const clearSsoError = useCallback(() => setSsoError(null), []);
+
+  const discoverSso = useCallback(
+    async (email: string): Promise<boolean> => {
+      if (!email || !email.includes('@')) {
+        return false;
+      }
+
+      setIsCheckingSso(true);
+      setSsoError(null);
+      try {
+        const response = await fetch(ROUTES.AUTH.api_sso_discover, {
+          method: 'POST',
+          headers: JSON_HEADERS,
+          body: JSON.stringify({ email, csrfToken }),
+        });
+
+        if (!response.ok) {
+          return false;
+        }
+
+        const { data } = SsoDiscoveryResponseSchema.parse(await response.json());
+        return data.available;
+      } catch (ex) {
+        console.error('Error discovering SSO', ex);
+        return false;
+      } finally {
+        setIsCheckingSso(false);
+      }
+    },
+    [csrfToken],
+  );
+
+  /** Redirects to the identity provider, otherwise sets `ssoError` and resolves false */
+  const startSsoLogin = useCallback(
+    async (email: string): Promise<boolean> => {
+      // Guards against a second start overwriting the single-valued PKCE/state/nonce cookies the
+      // first one just set, which fails OIDC state validation after a full round trip to the
+      // provider. A ref rather than `isStartingSso` because callers can re-enter within a render.
+      if (isStartingSsoRef.current) {
+        return false;
+      }
+      isStartingSsoRef.current = true;
+
+      setIsStartingSso(true);
+      setSsoError(null);
+      try {
+        const url = new URL(ROUTES.AUTH.api_sso_start, window.location.origin);
+        if (returnUrl) {
+          url.searchParams.set('returnUrl', returnUrl);
+        }
+
+        const response = await fetch(url.toString(), {
+          method: 'POST',
+          headers: JSON_HEADERS,
+          body: JSON.stringify({ email, csrfToken }),
+        });
+
+        if (!response.ok) {
+          setSsoError(await getStartErrorMessage(response));
+          isStartingSsoRef.current = false;
+          setIsStartingSso(false);
+          return false;
+        }
+
+        const { data } = SsoStartResponseSchema.parse(await response.json());
+
+        // The "last used" marker is deliberately not written here - the identity provider has not
+        // seen the user yet, and it now decides whether the whole login form is replaced by the SSO
+        // screen. The API sets it on the callback once the login actually succeeded.
+
+        // Intentionally stays in the starting state, the browser is navigating away
+        window.location.href = data.redirectUrl;
+        return true;
+      } catch (ex) {
+        console.error('Error starting SSO login', ex);
+        setSsoError(SSO_UNKNOWN_ERROR_MESSAGE);
+        isStartingSsoRef.current = false;
+        setIsStartingSso(false);
+        return false;
+      }
+    },
+    [csrfToken, returnUrl],
+  );
+
+  return { discoverSso, startSsoLogin, isCheckingSso, isStartingSso, ssoError, clearSsoError };
+}

--- a/apps/landing/tests/auth-storage.spec.tsx
+++ b/apps/landing/tests/auth-storage.spec.tsx
@@ -1,9 +1,20 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 import { getLastUsedLoginMethod, setLastUsedLoginMethod } from '../utils/utils';
 
+const LAST_LOGIN_METHOD_COOKIE = 'jetstream-auth.last-login-method';
+
+function setLastLoginMethodCookie(value: string) {
+  document.cookie = `${LAST_LOGIN_METHOD_COOKIE}=${encodeURIComponent(value)}; path=/`;
+}
+
+function readLastLoginMethodCookie() {
+  return document.cookie.split('; ').find((entry) => entry.startsWith(`${LAST_LOGIN_METHOD_COOKIE}=`));
+}
+
 describe('auth storage', () => {
   beforeEach(() => {
     localStorage.clear();
+    document.cookie = `${LAST_LOGIN_METHOD_COOKIE}=; path=/; max-age=0`;
   });
 
   it('clears remembered email state when no remembered email is provided', () => {
@@ -21,6 +32,71 @@ describe('auth storage', () => {
       lastUsedLogin: null,
       rememberedEmail: null,
       ssoAvailable: false,
+    });
+  });
+
+  /**
+   * The cookie is written by `setLastLoginMethodCookie` in the API auth controller after an identity
+   * provider authenticates the user - these cover the landing half of that cross-app contract.
+   */
+  describe('last login method cookie', () => {
+    it('promotes a successful SSO login into local storage and consumes the cookie', () => {
+      setLastLoginMethodCookie(JSON.stringify({ method: 'sso', email: 'sso@example.com' }));
+
+      expect(getLastUsedLoginMethod()).toEqual({
+        lastUsedLogin: 'sso',
+        rememberedEmail: 'sso@example.com',
+        ssoAvailable: true,
+      });
+
+      expect(readLastLoginMethodCookie()).toBeUndefined();
+
+      // The promoted values survive on their own now that the cookie is gone
+      expect(getLastUsedLoginMethod()).toEqual({
+        lastUsedLogin: 'sso',
+        rememberedEmail: 'sso@example.com',
+        ssoAvailable: true,
+      });
+    });
+
+    it('overwrites a previously remembered login method', () => {
+      setLastUsedLoginMethod({ lastUsedLogin: 'google', rememberedEmail: 'google@example.com' });
+      setLastLoginMethodCookie(JSON.stringify({ method: 'sso', email: 'sso@example.com' }));
+
+      expect(getLastUsedLoginMethod()).toEqual({
+        lastUsedLogin: 'sso',
+        rememberedEmail: 'sso@example.com',
+        ssoAvailable: true,
+      });
+    });
+
+    it.each([
+      ['malformed json', 'not-json'],
+      ['an unexpected method', JSON.stringify({ method: 'google', email: 'sso@example.com' })],
+      ['a missing email', JSON.stringify({ method: 'sso' })],
+      ['a non-string email', JSON.stringify({ method: 'sso', email: 123 })],
+      ['an empty email', JSON.stringify({ method: 'sso', email: '' })],
+    ])('ignores %s but still consumes the cookie', (_label, cookieValue) => {
+      setLastLoginMethodCookie(cookieValue);
+
+      expect(getLastUsedLoginMethod()).toEqual({
+        lastUsedLogin: null,
+        rememberedEmail: null,
+        ssoAvailable: false,
+      });
+
+      // Consumed either way so a bad value is not re-parsed on every page load
+      expect(readLastLoginMethodCookie()).toBeUndefined();
+    });
+
+    it('leaves existing local storage alone when no cookie is present', () => {
+      setLastUsedLoginMethod({ lastUsedLogin: 'google', rememberedEmail: 'google@example.com' });
+
+      expect(getLastUsedLoginMethod()).toEqual({
+        lastUsedLogin: 'google',
+        rememberedEmail: 'google@example.com',
+        ssoAvailable: false,
+      });
     });
   });
 });

--- a/apps/landing/tests/login-form-sso.spec.tsx
+++ b/apps/landing/tests/login-form-sso.spec.tsx
@@ -1,0 +1,188 @@
+import type { Providers } from '@jetstream/auth/types';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { LoginOrSignUp } from '../components/auth/LoginOrSignUp';
+import { setLastUsedLoginMethod } from '../utils/utils';
+
+const searchParams = new URLSearchParams();
+
+vi.mock('next/router', () => ({
+  useRouter: () => ({ push: vi.fn(), pathname: '/auth/login' }),
+}));
+
+vi.mock('next/navigation', () => ({
+  useSearchParams: () => searchParams,
+}));
+
+const PROVIDERS = {
+  google: { provider: 'google', signinUrl: 'https://example.com/signin/google', callbackUrl: 'https://example.com/callback/google' },
+  salesforce: {
+    provider: 'salesforce',
+    signinUrl: 'https://example.com/signin/salesforce',
+    callbackUrl: 'https://example.com/callback/salesforce',
+  },
+  credentials: { provider: 'credentials', signinUrl: 'https://example.com/signin', callbackUrl: 'https://example.com/callback' },
+} as unknown as Providers;
+
+const SSO_EMAIL = 'user@example.com';
+
+function renderLoginForm(action: 'login' | 'register' = 'login') {
+  return render(<LoginOrSignUp action={action} providers={PROVIDERS} csrfToken="csrf-token" currentTosVersion="2024-01-01" />);
+}
+
+function mockFetchJson(response: { ok: boolean; status?: number; body: unknown }) {
+  const fetchMock = vi.fn().mockResolvedValue({
+    ok: response.ok,
+    status: response.status ?? (response.ok ? 200 : 400),
+    json: () => Promise.resolve(response.body),
+  });
+  vi.stubGlobal('fetch', fetchMock);
+  return fetchMock;
+}
+
+function getEmailInputValue() {
+  return (screen.getByLabelText('Email Address') as HTMLInputElement).value;
+}
+
+describe('login form SSO experience', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    Array.from(searchParams.keys()).forEach((key) => searchParams.delete(key));
+    // jsdom does not implement navigation, so the SSO redirect is swallowed instead of erroring
+    vi.spyOn(window, 'location', 'get').mockReturnValue({ ...window.location, origin: 'https://example.com', href: '' } as Location);
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  describe('when the last login was SSO', () => {
+    beforeEach(() => {
+      setLastUsedLoginMethod({ lastUsedLogin: 'sso', rememberedEmail: SSO_EMAIL, ssoAvailable: true });
+    });
+
+    it('offers only the remembered SSO login and hides every other login option', () => {
+      renderLoginForm();
+
+      expect(screen.getByTestId('sso-last-used-login-button').textContent).toContain(SSO_EMAIL);
+      expect(screen.getByTestId('use-another-login-method-button')).toBeTruthy();
+
+      expect(screen.queryByRole('button', { name: /Google/ })).toBeNull();
+      expect(screen.queryByRole('button', { name: /Salesforce/ })).toBeNull();
+      expect(screen.queryByTestId('continue-with-sso-button')).toBeNull();
+      expect(screen.queryByLabelText('Email Address')).toBeNull();
+      expect(screen.queryByLabelText('Password')).toBeNull();
+    });
+
+    it('reveals all login options when another method is requested', async () => {
+      renderLoginForm();
+
+      await userEvent.click(screen.getByTestId('use-another-login-method-button'));
+
+      expect(screen.getByRole('button', { name: /Google/ })).toBeTruthy();
+      expect(screen.getByRole('button', { name: /Salesforce/ })).toBeTruthy();
+      expect(screen.getByTestId('continue-with-sso-button')).toBeTruthy();
+      expect(getEmailInputValue()).toBe(SSO_EMAIL);
+      expect(screen.queryByTestId('sso-last-used-login-button')).toBeNull();
+    });
+
+    it('keeps the other login options reachable when starting SSO fails', async () => {
+      mockFetchJson({ ok: false, status: 400, body: { error: true, errorType: 'InvalidProvider' } });
+      renderLoginForm();
+
+      await userEvent.click(screen.getByTestId('sso-last-used-login-button'));
+
+      await waitFor(() => expect(screen.getByText(/Single sign-on is not available/)).toBeTruthy());
+      expect(screen.getByTestId('use-another-login-method-button')).toBeTruthy();
+    });
+
+    it('shows the full form instead when the login link is for a different email address', () => {
+      searchParams.set('email', 'someone-else@example.com');
+
+      renderLoginForm();
+
+      expect(screen.queryByTestId('sso-last-used-login-button')).toBeNull();
+      expect(getEmailInputValue()).toBe('someone-else@example.com');
+    });
+
+    it('shows the full form on the sign-up page', () => {
+      renderLoginForm('register');
+
+      expect(screen.queryByTestId('sso-last-used-login-button')).toBeNull();
+      expect(screen.getByTestId('continue-with-sso-button')).toBeTruthy();
+    });
+  });
+
+  describe('SSO grouped with the social login options', () => {
+    it('collects only an email address after SSO is chosen', async () => {
+      renderLoginForm();
+
+      await userEvent.click(screen.getByTestId('continue-with-sso-button'));
+
+      expect(screen.getByTestId('sso-email-continue-button')).toBeTruthy();
+      expect(screen.getByLabelText('Email Address')).toBeTruthy();
+      expect(screen.queryByRole('button', { name: /Google/ })).toBeNull();
+      expect(screen.queryByRole('button', { name: 'Continue' })).toBeNull();
+    });
+
+    it('returns to all login options from the SSO email step', async () => {
+      renderLoginForm();
+
+      await userEvent.click(screen.getByTestId('continue-with-sso-button'));
+      await userEvent.click(screen.getByTestId('back-to-all-login-options-button'));
+
+      expect(screen.getByRole('button', { name: 'Continue' })).toBeTruthy();
+      expect(screen.queryByTestId('sso-email-continue-button')).toBeNull();
+    });
+
+    it('keeps focus on the email address across both view changes', async () => {
+      renderLoginForm();
+
+      await userEvent.click(screen.getByTestId('continue-with-sso-button'));
+      expect(document.activeElement).toBe(screen.getByLabelText('Email Address'));
+
+      await userEvent.click(screen.getByTestId('back-to-all-login-options-button'));
+      expect(document.activeElement).toBe(screen.getByLabelText('Email Address'));
+    });
+
+    it('starts SSO for the email address that was entered', async () => {
+      const fetchMock = mockFetchJson({ ok: true, body: { data: { redirectUrl: 'https://idp.example.com/login' } } });
+      renderLoginForm();
+
+      await userEvent.click(screen.getByTestId('continue-with-sso-button'));
+      await userEvent.type(screen.getByLabelText('Email Address'), SSO_EMAIL);
+      await userEvent.click(screen.getByTestId('sso-email-continue-button'));
+
+      await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+      const [url, options] = fetchMock.mock.calls[0];
+      expect(url).toContain('/api/auth/sso/start');
+      expect(JSON.parse(options.body)).toEqual({ email: SSO_EMAIL, csrfToken: 'csrf-token' });
+    });
+
+    it('reports when SSO is not configured for the email address', async () => {
+      mockFetchJson({ ok: false, status: 400, body: { error: true, data: { errorType: 'InvalidProvider' } } });
+      renderLoginForm();
+
+      await userEvent.click(screen.getByTestId('continue-with-sso-button'));
+      await userEvent.type(screen.getByLabelText('Email Address'), SSO_EMAIL);
+      await userEvent.click(screen.getByTestId('sso-email-continue-button'));
+
+      await waitFor(() => expect(screen.getByText(/Single sign-on is not available/)).toBeTruthy());
+      expect(screen.getByTestId('back-to-all-login-options-button')).toBeTruthy();
+    });
+
+    it('reports when SSO requests are rate limited', async () => {
+      mockFetchJson({ ok: false, status: 429, body: {} });
+      renderLoginForm();
+
+      await userEvent.click(screen.getByTestId('continue-with-sso-button'));
+      await userEvent.type(screen.getByLabelText('Email Address'), SSO_EMAIL);
+      await userEvent.click(screen.getByTestId('sso-email-continue-button'));
+
+      await waitFor(() => expect(screen.getByText(/Too many attempts/)).toBeTruthy());
+    });
+  });
+});

--- a/apps/landing/utils/utils.ts
+++ b/apps/landing/utils/utils.ts
@@ -16,10 +16,50 @@ const loginMethodLocalStorageKeys = {
   ssoAvailable: 'jetstream-sso-available',
 };
 
+/** Login methods that get a "Last Used" indicator on the login form - `sso` is not an entry in `Providers` */
+export type LastUsedLoginMethod = keyof Providers | 'sso';
+
+/**
+ * Set by the API only after an identity provider has authenticated the user. The login page cannot
+ * record a successful SSO login itself because it navigates away to the provider before knowing the
+ * outcome, so the marker comes back as a cookie and is promoted to local storage on the next visit.
+ * Shape is a contract with `setLastLoginMethodCookie` in the API auth controller.
+ */
+const LAST_LOGIN_METHOD_COOKIE = 'jetstream-auth.last-login-method';
+
+function consumeLastLoginMethodCookie(): { lastUsedLogin: LastUsedLoginMethod; rememberedEmail: string } | null {
+  const rawValue = document.cookie
+    .split('; ')
+    .find((entry) => entry.startsWith(`${LAST_LOGIN_METHOD_COOKIE}=`))
+    ?.slice(LAST_LOGIN_METHOD_COOKIE.length + 1);
+
+  if (!rawValue) {
+    return null;
+  }
+
+  // Consume it either way - a malformed value should not be re-parsed on every page load
+  document.cookie = `${LAST_LOGIN_METHOD_COOKIE}=; path=/; max-age=0`;
+
+  try {
+    const { method, email } = JSON.parse(decodeURIComponent(rawValue));
+    if (method !== 'sso' || typeof email !== 'string' || !email) {
+      return null;
+    }
+    return { lastUsedLogin: 'sso', rememberedEmail: email };
+  } catch {
+    return null;
+  }
+}
+
 export function getLastUsedLoginMethod() {
   try {
+    const successfulSsoLogin = consumeLastLoginMethodCookie();
+    if (successfulSsoLogin) {
+      setLastUsedLoginMethod({ ...successfulSsoLogin, ssoAvailable: true });
+    }
+
     return {
-      lastUsedLogin: localStorage.getItem(loginMethodLocalStorageKeys.lastUsedLogin) as keyof Providers | null,
+      lastUsedLogin: localStorage.getItem(loginMethodLocalStorageKeys.lastUsedLogin) as LastUsedLoginMethod | null,
       rememberedEmail: localStorage.getItem(loginMethodLocalStorageKeys.rememberedEmail),
       ssoAvailable: localStorage.getItem(loginMethodLocalStorageKeys.ssoAvailable) === 'true',
     };
@@ -37,7 +77,7 @@ export function setLastUsedLoginMethod({
   rememberedEmail = null,
   ssoAvailable = false,
 }: {
-  lastUsedLogin?: keyof Providers | 'sso' | null;
+  lastUsedLogin?: LastUsedLoginMethod | null;
   rememberedEmail?: string | null;
   ssoAvailable?: boolean;
 } = {}) {

--- a/apps/landing/vite.config.mts
+++ b/apps/landing/vite.config.mts
@@ -1,9 +1,12 @@
 /// <reference types='vitest' />
+import react from '@vitejs/plugin-react';
 import { defineConfig } from 'vite';
 
 export default defineConfig(() => ({
   root: import.meta.dirname,
   cacheDir: '../../node_modules/.vite/apps/landing',
+  // Only used by the vitest tests in this project - next builds the app itself
+  plugins: [react()],
   resolve: { tsconfigPaths: true },
   test: {
     name: 'landing',

--- a/libs/auth/server/src/lib/auth.utils.ts
+++ b/libs/auth/server/src/lib/auth.utils.ts
@@ -12,6 +12,7 @@ export const REMEMBER_DEVICE_DAYS = 30;
 
 const TIME_15_MIN = 60 * 15;
 const REMEMBER_DEVICE_MAX_AGE = REMEMBER_DEVICE_DAYS * 24 * 60 * 60;
+const LAST_LOGIN_METHOD_MAX_AGE = 400 * 24 * 60 * 60;
 
 /**
  * Name of the express-session cookie. Uses the `__Host-` prefix when cookies are secure so the
@@ -123,6 +124,23 @@ export function getCookieConfig(useSecureCookies: boolean): CookieConfig {
         path: '/',
         secure: useSecureCookies,
         maxAge: TIME_15_MIN,
+      },
+    },
+    /**
+     * Records which login method actually succeeded so the login form can offer it again on the next
+     * visit. Written only after the identity provider has authenticated the user, which is why it is
+     * a cookie rather than something the login page could set itself before redirecting away.
+     * Unprefixed and not httpOnly on purpose - the landing page reads it from JavaScript and does not
+     * know whether the API issued secure cookies, so the name has to be stable across environments.
+     */
+    lastLoginMethod: {
+      name: `jetstream-auth.last-login-method`,
+      options: {
+        httpOnly: false,
+        sameSite: 'lax',
+        path: '/',
+        secure: useSecureCookies,
+        maxAge: LAST_LOGIN_METHOD_MAX_AGE,
       },
     },
     teamInviteState: {

--- a/libs/auth/types/src/lib/auth-types.ts
+++ b/libs/auth/types/src/lib/auth-types.ts
@@ -389,6 +389,7 @@ export type CookiePrefixOptions = 'host' | 'secure';
 // Auth Related Cookies
 type CallbackUrlCookie = 'callbackUrl';
 type CsrfTokenCookie = 'csrfToken';
+type LastLoginMethodCookie = 'lastLoginMethod';
 type LinkIdentityCookie = 'linkIdentity';
 type NonceCookie = 'nonce';
 type PkceCodeVerifierCookie = 'pkceCodeVerifier';
@@ -403,6 +404,7 @@ type DoubleCSRFTokenCookie = 'doubleCSRFToken';
 type CookieConfigKey =
   | CallbackUrlCookie
   | CsrfTokenCookie
+  | LastLoginMethodCookie
   | LinkIdentityCookie
   | NonceCookie
   | PkceCodeVerifierCookie

--- a/libs/test/e2e-utils/src/lib/pageObjectModels/AuthenticationPage.model.ts
+++ b/libs/test/e2e-utils/src/lib/pageObjectModels/AuthenticationPage.model.ts
@@ -77,7 +77,8 @@ export class AuthenticationPage {
 
     this.signInButton = page.getByRole('button', { name: 'Sign in', exact: true });
     this.signUpButton = page.getByRole('button', { name: 'Sign up', exact: true });
-    this.continueButton = page.getByRole('button', { name: 'Continue' });
+    // Exact so it never resolves to the "Continue with SSO" button that sits next to it on the login form
+    this.continueButton = page.getByRole('button', { name: 'Continue', exact: true });
     this.submitButton = page.getByRole('button', { name: 'Submit' });
 
     this.showHidePasswordButton = page.getByRole('button', { name: /(Show|Hide) Password/ });


### PR DESCRIPTION
Single sign-on was previously only reachable by typing an email address and waiting for domain discovery to run. It is now offered directly:

- "Continue with SSO" sits alongside the Google and Salesforce buttons and opens a dedicated email step that resolves the identity provider. That step renders instead of the credentials form, so there is no password field, captcha, or submit path present on a screen that only ever redirects out.
- Returning users whose last successful login was SSO get a single-button screen for that account, with every other method one click away.

The "last used" marker is now written by the SAML and OIDC callbacks once the identity provider has actually authenticated the user, rather than when the redirect is issued. Writing it optimistically would leave a device showing an SSO-only login screen after a rejected or abandoned attempt. It travels back as a readable cookie because the login page navigates away before it can know the outcome.

Also in this change:

- Guard startSsoLogin against concurrent starts. A second start overwrote the single-valued PKCE/state/nonce cookies the first one set, which failed OIDC state validation after a full round trip to the provider.
- Discard SSO discovery results for an email address the user has since edited, which could otherwise report availability for an address never checked.
- Give Alert role="alert" so SSO failures are announced to screen readers.
- Drop the sign-up consent paragraph naming only Google and Salesforce. Every login method already passes through the /auth/accept-terms gate whenever tosAcceptedVersion is behind the current version.
- Scope the e2e continueButton locator with `exact` so it stops matching the new "Continue with SSO" button.