### PR TITLE
feat(query): add a navigator for jumping to any subquery

### DIFF
--- a/apps/jetstream-e2e/src/tests/query/query-builder.spec.ts
+++ b/apps/jetstream-e2e/src/tests/query/query-builder.spec.ts
@@ -177,6 +177,24 @@ test.describe('QUERY BUILDER', () => {
     }
   });
 
+  test('should jump to a nested subquery from the navigator', async ({ queryPage }) => {
+    await queryPage.goto();
+    await queryPage.selectObject('Account');
+
+    await queryPage.selectNestedSubquery([
+      { relationshipName: 'Contacts', childSObject: 'Contact', fieldLabels: ['Contact ID'] },
+      { relationshipName: 'Cases', childSObject: 'Case', fieldLabels: ['Case ID', 'Subject'] },
+    ]);
+
+    // Back at the top level the nested subquery is not listed, so the navigator is the only way to reach it
+    await queryPage.navigateToSubqueryBreadcrumb('Account');
+    await queryPage.navigateToSubqueryFromNavigator('Cases', 'Case');
+
+    for (const field of ['Case ID', 'Subject']) {
+      await expect(queryPage.getSelectedField(field)).toHaveAttribute('aria-selected', 'true');
+    }
+  });
+
   test('should restore queries', async ({ queryPage }) => {
     const query = `SELECT Id, Name,
     (

--- a/libs/features/query/src/QueryBuilder/QuerySubqueryLevel.tsx
+++ b/libs/features/query/src/QueryBuilder/QuerySubqueryLevel.tsx
@@ -1,15 +1,7 @@
 import { css } from '@emotion/react';
 import { MAX_SUBQUERY_DEPTH } from '@jetstream/shared/constants';
 import { formatNumber, queryFilterHasValue } from '@jetstream/shared/ui-utils';
-import {
-  getSubqueryPath,
-  getSubqueryPathDepth,
-  getSubqueryPathWithAncestors,
-  isDirectChildSubqueryPath,
-  isSubqueryPathBelow,
-  multiWordObjectFilter,
-  pluralizeFromNumber,
-} from '@jetstream/shared/utils';
+import { getSubqueryPath, getSubqueryPathDepth, multiWordObjectFilter, pluralizeFromNumber } from '@jetstream/shared/utils';
 import {
   ChildRelationship,
   ExpressionConditionType,
@@ -22,6 +14,7 @@ import { Accordion, Badge, EmptyState, Grid, GridCol, Icon, isExpressionConditio
 import { fromQueryState } from '@jetstream/ui-core';
 import { useAtomValue, useSetAtom } from 'jotai';
 import { Fragment, FunctionComponent, MutableRefObject, ReactNode, useMemo, useState } from 'react';
+import { SelectedSubqueryNode, SubqueryDrillLevel } from '../utils/subquery-navigation-utils';
 import QueryChildFields from './QueryChildFields';
 import QuerySubqueryFilter, { DEFAULT_SUBQUERY_OBJECT_FILTER, SubqueryObjectFilter } from './QuerySubqueryFilter';
 
@@ -156,6 +149,10 @@ function ButtonWithDisabledHint({
   );
 }
 
+function getSectionId(currentRelationshipPath: string, { relationshipName, childSObject, field }: ChildRelationship) {
+  return `${getSubqueryPath(currentRelationshipPath, relationshipName || '')}-${childSObject}.${field}`;
+}
+
 export interface QuerySubqueryLevelProps {
   org: SalesforceOrgUi;
   serverUrl: string;
@@ -166,9 +163,15 @@ export interface QuerySubqueryLevelProps {
   childRelationships: ChildRelationship[];
   /** Shared across levels so an expanded field picker survives navigating away and back */
   fieldPickerCacheRef: MutableRefObject<Record<string, ReactNode>>;
-  clearAllButton?: ReactNode;
+  /** Subquery to open and scroll to as this level is rendered, set when navigating from the navigator */
+  focusedRelationshipPath: string | null;
+  /**
+   * Every related object the query contains, keyed by lower cased relationship path. The level reads which of
+   * its relationships are in the query, and what is nested within each, from here rather than re-deriving it.
+   */
+  selectedSubqueryNodesByPath: Map<string, SelectedSubqueryNode>;
   onSelectionChanged: (relationshipPath: string, fields: QueryFieldWithPolymorphic[]) => void;
-  onDrillIn: (level: { relationshipPath: string; relationshipName: string; childSObject: string }) => void;
+  onDrillIn: (level: SubqueryDrillLevel) => void;
 }
 
 /**
@@ -184,7 +187,8 @@ export const QuerySubqueryLevel: FunctionComponent<QuerySubqueryLevelProps> = ({
   relationshipPath: currentRelationshipPath,
   childRelationships,
   fieldPickerCacheRef,
-  clearAllButton,
+  focusedRelationshipPath,
+  selectedSubqueryNodesByPath,
   onSelectionChanged,
   onDrillIn,
 }) => {
@@ -197,32 +201,38 @@ export const QuerySubqueryLevel: FunctionComponent<QuerySubqueryLevelProps> = ({
   const setConfigPanel = useSetAtom(fromQueryState.subqueryConfigPanelState);
   const clearSubqueryOptions = useSetAtom(fromQueryState.clearSubqueryOptionsForPath);
 
+  /** The node for one of this level's relationships, which exists only when the query contains it */
+  function getSelectedSubqueryNode(relationshipPath: string) {
+    return selectedSubqueryNodesByPath.get(relationshipPath.toLowerCase());
+  }
+
   /**
-   * Every relationship path that contributes to the query, including ancestors of a nested selection so that
-   * a parent still counts as selected when only something beneath it has fields.
+   * The accordion only honors initOpenIds as it mounts, and this component is remounted whenever navigation
+   * changes, so opening and scrolling to a subquery picked from the navigator happens as part of that mount.
    */
-  const selectedRelationshipPaths = useMemo(() => {
-    const paths = new Set<string>();
-    Object.keys(selectedFieldState).forEach((path) => {
-      if (selectedFieldState[path]?.length) {
-        getSubqueryPathWithAncestors(path).forEach((ancestorPath) => paths.add(ancestorPath.toLowerCase()));
-      }
-    });
-    return paths;
-  }, [selectedFieldState]);
+  const focusedSectionId = useMemo(() => {
+    const focusedChildRelationship =
+      focusedRelationshipPath &&
+      childRelationships.find(
+        ({ relationshipName }) =>
+          !!relationshipName &&
+          getSubqueryPath(currentRelationshipPath, relationshipName).toLowerCase() === focusedRelationshipPath.toLowerCase(),
+      );
+    return focusedChildRelationship ? getSectionId(currentRelationshipPath, focusedChildRelationship) : null;
+  }, [childRelationships, currentRelationshipPath, focusedRelationshipPath]);
 
   const visibleChildRelationships = useMemo(() => {
     let relationships = childRelationships;
     if (objectFilter === 'selected') {
-      relationships = relationships.filter((childRelationship) =>
-        selectedRelationshipPaths.has(getSubqueryPath(currentRelationshipPath, childRelationship.relationshipName || '').toLowerCase()),
+      relationships = relationships.filter(({ relationshipName }) =>
+        selectedSubqueryNodesByPath.has(getSubqueryPath(currentRelationshipPath, relationshipName || '').toLowerCase()),
       );
     }
     if (textFilter) {
       relationships = relationships.filter(multiWordObjectFilter(['relationshipName', 'childSObject', 'field'], textFilter));
     }
     return relationships;
-  }, [childRelationships, currentRelationshipPath, objectFilter, selectedRelationshipPaths, textFilter]);
+  }, [childRelationships, currentRelationshipPath, objectFilter, selectedSubqueryNodesByPath, textFilter]);
 
   function getContent(childRelationship: ChildRelationship) {
     return () => {
@@ -252,9 +262,7 @@ export const QuerySubqueryLevel: FunctionComponent<QuerySubqueryLevelProps> = ({
       const hasSelectedFields = (selectedFieldState[relationshipPath]?.length ?? 0) > 0;
       // A subquery stays in the query when only something nested within it has fields, so drilling in has to
       // stay available in that case - otherwise those nested objects become unreachable and unremovable.
-      const hasNestedSelections = Object.keys(selectedFieldState).some(
-        (path) => isSubqueryPathBelow(path, relationshipPath) && selectedFieldState[path]?.length,
-      );
+      const hasNestedSelections = (getSelectedSubqueryNode(relationshipPath)?.children.length ?? 0) > 0;
       const canDrillIn = hasSelectedFields || hasNestedSelections;
       const canNestFurther = getSubqueryPathDepth(relationshipPath) < MAX_SUBQUERY_DEPTH;
       const childSObject = childRelationship.childSObject;
@@ -367,11 +375,8 @@ export const QuerySubqueryLevel: FunctionComponent<QuerySubqueryLevelProps> = ({
     const relationshipPath = getSubqueryPath(currentRelationshipPath, childRelationship.relationshipName);
     const queryFields = selectedFieldState[relationshipPath];
     const summary = subquerySummary[relationshipPath];
-    // Surfaces nested subqueries on the collapsed row, which is the only hint they exist without drilling in.
-    // Counted from the ancestor-inclusive set so a child whose only selections are nested beneath it still shows.
-    const nestedSubqueryCount = Array.from(selectedRelationshipPaths).filter((path) =>
-      isDirectChildSubqueryPath(path, relationshipPath),
-    ).length;
+    // Surfaces nested subqueries on the collapsed row, which is the only hint they exist without drilling in
+    const nestedSubqueryCount = getSelectedSubqueryNode(relationshipPath)?.children.length ?? 0;
 
     if (!Array.isArray(queryFields) && !summary && !nestedSubqueryCount) {
       return;
@@ -417,23 +422,25 @@ export const QuerySubqueryLevel: FunctionComponent<QuerySubqueryLevelProps> = ({
   return (
     <Fragment>
       <SearchInput id="subquery-filter" className="slds-p-around_xx-small" placeholder="Filter child objects" onChange={setTextFilter} />
-      <Grid align="spread" verticalAlign="center" wrap className="slds-p-horizontal_xx-small slds-p-bottom_xx-small">
-        <GridCol className="slds-text-body_small slds-text-color_weak">
-          Showing {formatNumber(visibleChildRelationships.length)} of {formatNumber(childRelationships.length)} objects
-        </GridCol>
-        {clearAllButton}
-        <GridCol growNone>
-          <QuerySubqueryFilter selectedFilter={objectFilter} onChange={setObjectFilter} />
-        </GridCol>
-      </Grid>
+      <div className="slds-p-horizontal_xx-small slds-p-bottom_xx-small">
+        <Grid align="spread" verticalAlign="center">
+          <GridCol className="slds-text-body_small slds-text-color_weak">
+            Showing {formatNumber(visibleChildRelationships.length)} of {formatNumber(childRelationships.length)} objects
+          </GridCol>
+          <GridCol growNone>
+            <QuerySubqueryFilter selectedFilter={objectFilter} onChange={setObjectFilter} />
+          </GridCol>
+        </Grid>
+      </div>
       {visibleChildRelationships.length === 0 && (
         <EmptyState headline="There are no matching objects" subHeading="Adjust your selection."></EmptyState>
       )}
       <Accordion
-        initOpenIds={[]}
+        initOpenIds={focusedSectionId ? [focusedSectionId] : []}
+        scrollInitOpenIdIntoView
         allowMultiple={false}
         sections={visibleChildRelationships.map((childRelationship) => ({
-          id: `${getSubqueryPath(currentRelationshipPath, childRelationship.relationshipName || '')}-${childRelationship.childSObject}.${childRelationship.field}`,
+          id: getSectionId(currentRelationshipPath, childRelationship),
           testId: childRelationship.relationshipName,
           titleText: `${childRelationship.relationshipName} (${childRelationship.childSObject}.${childRelationship.field})`,
           title: (

--- a/libs/features/query/src/QueryBuilder/QuerySubqueryNavigator.tsx
+++ b/libs/features/query/src/QueryBuilder/QuerySubqueryNavigator.tsx
@@ -1,0 +1,115 @@
+import { css } from '@emotion/react';
+import { getSubqueryPathDepth, pluralizeFromNumber } from '@jetstream/shared/utils';
+import { Badge, Grid, Icon, Popover, PopoverRef } from '@jetstream/ui';
+import { Fragment, FunctionComponent, useMemo, useRef } from 'react';
+import { flattenSelectedSubqueryTree, SelectedSubqueryNode } from '../utils/subquery-navigation-utils';
+
+export interface QuerySubqueryNavigatorProps {
+  rootSObjectName: string;
+  selectedSubqueryTree: SelectedSubqueryNode[];
+  /** Relationship path being viewed, so the list can point out where the user currently is */
+  currentRelationshipPath: string;
+  /** Relationship path to jump to, empty for the root object */
+  onNavigate: (relationshipPath: string) => void;
+}
+
+/**
+ * Every related object in the query, since only one level of the subquery tree is listed at a time and nested
+ * subqueries are otherwise invisible from anywhere but the level they live on.
+ *
+ * A jump list rather than a collapsible tree - every row is a destination, so there is nothing to collapse.
+ * Nesting is shown by indenting each row to its depth. Only rendered when the query has at least one related object.
+ */
+export const QuerySubqueryNavigator: FunctionComponent<QuerySubqueryNavigatorProps> = ({
+  rootSObjectName,
+  selectedSubqueryTree,
+  currentRelationshipPath,
+  onNavigate,
+}) => {
+  const popoverRef = useRef<PopoverRef>(null);
+
+  // The root object leads the list so that navigating back out of every subquery is reachable from here too
+  const rows = useMemo(
+    () => [
+      { relationshipPath: '', label: rootSObjectName, childSObject: '', fieldCount: 0, depth: 0 },
+      ...flattenSelectedSubqueryTree(selectedSubqueryTree).map(({ relationshipPath, relationshipName, childSObject, fieldCount }) => ({
+        relationshipPath,
+        label: relationshipName,
+        childSObject,
+        fieldCount,
+        depth: getSubqueryPathDepth(relationshipPath),
+      })),
+    ],
+    [rootSObjectName, selectedSubqueryTree],
+  );
+  const subqueryCount = rows.length - 1;
+
+  function handleNavigate(relationshipPath: string) {
+    onNavigate(relationshipPath);
+    popoverRef.current?.close();
+  }
+
+  return (
+    <Popover
+      ref={popoverRef}
+      testId="subquery-navigator-popover"
+      size="medium"
+      placement="bottom-end"
+      tooltipProps={{ content: 'View and jump to any related object in the query', openDelay: 500 }}
+      header={
+        <header className="slds-popover__header">
+          <h2 className="slds-text-heading_small">Related objects in the query</h2>
+        </header>
+      }
+      content={
+        <Fragment>
+          <p className="slds-text-body_small slds-text-color_weak slds-m-bottom_x-small">Select a related object to jump to it.</p>
+          <ul
+            css={css`
+              max-height: 20rem;
+              overflow: auto;
+            `}
+          >
+            {rows.map(({ relationshipPath, label, childSObject, fieldCount, depth }) => (
+              <li key={relationshipPath || 'subquery-root'}>
+                <button
+                  className="slds-button slds-button_reset slds-p-vertical_xx-small"
+                  type="button"
+                  onClick={() => handleNavigate(relationshipPath)}
+                  css={css`
+                    width: 100%;
+                    text-align: left;
+                    padding-left: ${depth * 1.25}rem;
+                    &:hover {
+                      background-color: var(--slds-g-color-surface-2, #f3f2f2);
+                    }
+                  `}
+                >
+                  <Grid verticalAlign="center" className="slds-has-flexi-truncate">
+                    <span className="slds-truncate" title={childSObject ? `${label} (${childSObject})` : label}>
+                      {label}
+                    </span>
+                    {fieldCount > 0 && (
+                      <Badge className="slds-m-left_x-small" title={`${fieldCount} ${pluralizeFromNumber('field', fieldCount)} selected`}>
+                        {fieldCount}
+                      </Badge>
+                    )}
+                    {relationshipPath.toLowerCase() === currentRelationshipPath.toLowerCase() && (
+                      <span className="slds-m-left_x-small slds-text-body_small slds-text-color_weak">viewing</span>
+                    )}
+                  </Grid>
+                </button>
+              </li>
+            ))}
+          </ul>
+        </Fragment>
+      }
+      buttonProps={{ className: 'slds-button', 'data-testid': 'subquery-navigator-button' }}
+    >
+      <Icon type="utility" icon="hierarchy" className="slds-button__icon slds-button__icon_left" omitContainer />
+      Selected ({subqueryCount})
+    </Popover>
+  );
+};
+
+export default QuerySubqueryNavigator;

--- a/libs/features/query/src/QueryBuilder/QuerySubquerySObjects.tsx
+++ b/libs/features/query/src/QueryBuilder/QuerySubquerySObjects.tsx
@@ -1,6 +1,5 @@
 import { MAX_SUBQUERY_DEPTH } from '@jetstream/shared/constants';
 import { useNonInitialEffect } from '@jetstream/shared/ui-utils';
-import { isSubqueryPathBelow } from '@jetstream/shared/utils';
 import { ChildRelationship, QueryFieldWithPolymorphic, SalesforceOrgUi } from '@jetstream/types';
 import { Breadcrumbs, DesertIllustration, EmptyState, Grid, GridCol, Icon } from '@jetstream/ui';
 import { fromQueryState } from '@jetstream/ui-core';
@@ -8,14 +7,27 @@ import { getSubqueryFieldBaseKey } from '@jetstream/ui-core/shared';
 import { useAtomValue, useSetAtom } from 'jotai';
 import isNumber from 'lodash/isNumber';
 import { Fragment, FunctionComponent, ReactNode, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  buildSelectedSubqueryTree,
+  countSubqueriesBelow,
+  getAncestorDrillLevels,
+  getSelectedSubqueryNodesByPath,
+  getSubquerySObjectByPath,
+  SubqueryDrillLevel,
+} from '../utils/subquery-navigation-utils';
 import QuerySubqueryLevel from './QuerySubqueryLevel';
+import QuerySubqueryNavigator from './QuerySubqueryNavigator';
 
-/** One level of drill-in. An empty array means the base object's child relationships are being shown. */
-interface SubqueryDrillLevel {
-  relationshipPath: string;
-  relationshipName: string;
-  childSObject: string;
+interface SubqueryNavigationState {
+  /** Levels drilled into. An empty array means the base object's child relationships are being shown. */
+  levels: SubqueryDrillLevel[];
+  /** Set when arriving from the navigator so the subquery that was picked is opened rather than just listed */
+  focusedRelationshipPath: string | null;
+  /** Bumped on each jump from the navigator so picking the same subquery again re-opens it */
+  jumpCount: number;
 }
+
+const INITIAL_NAVIGATION: SubqueryNavigationState = { levels: [], focusedRelationshipPath: null, jumpCount: 0 };
 
 export interface QuerySubquerySObjectsProps {
   org: SalesforceOrgUi;
@@ -53,12 +65,13 @@ export const QuerySubquerySObjects: FunctionComponent<QuerySubquerySObjectsProps
     [],
   );
 
-  const [drillPath, setDrillPath] = useState<SubqueryDrillLevel[]>([]);
+  const [navigation, setNavigation] = useState<SubqueryNavigationState>(INITIAL_NAVIGATION);
   const selectedFieldState = useAtomValue(fromQueryState.selectedSubqueryFieldsState);
   const queryFieldsMap = useAtomValue(fromQueryState.queryFieldsMapState);
   const clearSubqueries = useSetAtom(fromQueryState.clearSubqueriesBelow);
 
-  const currentLevel = drillPath[drillPath.length - 1];
+  const { levels, focusedRelationshipPath, jumpCount } = navigation;
+  const currentLevel = levels[levels.length - 1];
   const currentRelationshipPath = currentLevel?.relationshipPath || '';
 
   // Child relationships of the object being viewed. Below the root these come from the fields already
@@ -71,19 +84,28 @@ export const QuerySubquerySObjects: FunctionComponent<QuerySubquerySObjectsProps
     [childRelationships, currentLevel, queryFieldsMap],
   );
 
+  /** Every related object the query contains, which the navigator, the clear action, and each level are scoped from */
+  const selectedSubqueryTree = useMemo(
+    () => buildSelectedSubqueryTree(selectedFieldState, getSubquerySObjectByPath(queryFieldsMap)),
+    [queryFieldsMap, selectedFieldState],
+  );
+  const selectedSubqueryNodesByPath = useMemo(() => getSelectedSubqueryNodesByPath(selectedSubqueryTree), [selectedSubqueryTree]);
+
   // Related objects that "Clear all" would remove: everything listed at this level plus anything nested beneath them
   const clearableSubqueryCount = useMemo(
-    () =>
-      Object.keys(selectedFieldState).filter(
-        (path) => isSubqueryPathBelow(path, currentRelationshipPath) && selectedFieldState[path]?.length,
-      ).length,
-    [currentRelationshipPath, selectedFieldState],
+    () => countSubqueriesBelow(selectedSubqueryTree, currentRelationshipPath),
+    [currentRelationshipPath, selectedSubqueryTree],
   );
 
   useNonInitialEffect(() => {
-    setDrillPath([]);
+    setNavigation(INITIAL_NAVIGATION);
     fieldPickerCacheRef.current = {};
   }, [childRelationships]);
+
+  /** Every move other than a navigator jump drops the focused subquery so that it is not re-opened on arrival */
+  function goToLevels(getLevels: (currentLevels: SubqueryDrillLevel[]) => SubqueryDrillLevel[]) {
+    setNavigation((prev) => ({ ...prev, levels: getLevels(prev.levels), focusedRelationshipPath: null }));
+  }
 
   /**
    * Nothing is left to configure at this level once it is cleared, so step back up to the level that
@@ -91,57 +113,85 @@ export const QuerySubquerySObjects: FunctionComponent<QuerySubquerySObjectsProps
    */
   function handleClearAll() {
     clearSubqueries(currentRelationshipPath);
-    setDrillPath((prev) => prev.slice(0, -1));
+    goToLevels((currentLevels) => currentLevels.slice(0, -1));
   }
 
   /**
-   * Link to remove every related object at the level being viewed and anything nested beneath it.
-   * Rendered next to the breadcrumb when drilled in, and in the object list header at the root.
+   * Jump straight to a related object picked from the navigator, which requires drilling into each of its
+   * ancestors so the level that lists it is the one being viewed.
    */
+  function handleNavigate(relationshipPath: string) {
+    setNavigation((prev) => ({
+      levels: getAncestorDrillLevels(selectedSubqueryTree, relationshipPath),
+      focusedRelationshipPath: relationshipPath || null,
+      jumpCount: prev.jumpCount + 1,
+    }));
+  }
+
+  /** Breadcrumb items carry the index of the level they navigate back to, and -1 for the root object */
+  function handleBreadcrumbClick(levelIndex: unknown) {
+    if (!isNumber(levelIndex)) {
+      return;
+    }
+    goToLevels((currentLevels) => currentLevels.slice(0, levelIndex + 1));
+  }
+
+  /** Only rendered when the level being viewed has something to clear */
   function renderClearAllButton() {
-    if (!clearableSubqueryCount) {
+    if (clearableSubqueryCount === 0) {
       return null;
     }
     return (
-      <GridCol growNone>
-        <button
-          className="slds-button"
-          type="button"
-          title={
-            currentLevel
-              ? `Remove all related objects nested under ${currentLevel.relationshipName}, including anything nested within them`
-              : 'Remove all related objects from the query, including nested ones'
-          }
-          onClick={handleClearAll}
-        >
-          <Icon type="utility" icon="clear" className="slds-button__icon slds-button__icon_left" omitContainer />
-          Clear all ({clearableSubqueryCount})
-        </button>
-      </GridCol>
+      <button
+        className="slds-button"
+        type="button"
+        title={
+          currentLevel
+            ? `Remove all related objects nested under ${currentLevel.relationshipName}, including anything nested within them`
+            : 'Remove all related objects from the query, including nested ones'
+        }
+        onClick={handleClearAll}
+      >
+        <Icon type="utility" icon="clear" className="slds-button__icon slds-button__icon_left" omitContainer />
+        Clear all ({clearableSubqueryCount})
+      </button>
     );
   }
 
   return (
     <Fragment>
-      {drillPath.length > 0 && (
+      {levels.length > 0 && (
         <div className="slds-p-around_x-small slds-border_bottom">
           <Breadcrumbs
             items={[
               { id: 'subquery-root', label: rootSObjectName, metadata: -1 },
-              ...drillPath.slice(0, -1).map((level, index) => ({
+              ...levels.slice(0, -1).map((level, index) => ({
                 id: level.relationshipPath,
                 label: level.relationshipName,
                 metadata: index,
               })),
             ]}
             currentItem={currentLevel?.relationshipName}
-            onClick={(item) => isNumber(item.metadata) && setDrillPath((prev) => prev.slice(0, item.metadata + 1))}
+            onClick={(item) => handleBreadcrumbClick(item.metadata)}
           />
-          <Grid align="spread" verticalAlign="center" wrap className="slds-m-top_xx-small">
-            <GridCol className="slds-text-body_small slds-text-color_weak">
-              Related objects of {currentLevel?.childSObject} · depth {drillPath.length + 1} of {MAX_SUBQUERY_DEPTH}
+          <div className="slds-text-body_small slds-text-color_weak slds-m-top_xx-small">
+            Related objects of {currentLevel?.childSObject} · depth {levels.length + 1} of {MAX_SUBQUERY_DEPTH}
+          </div>
+        </div>
+      )}
+      {/* Kept outside the level so that the navigator stays reachable even on a level with nothing to list */}
+      {selectedSubqueryTree.length > 0 && (
+        <div className="slds-p-horizontal_xx-small slds-p-top_xx-small">
+          <Grid align="spread" verticalAlign="center" wrap>
+            <GridCol growNone>
+              <QuerySubqueryNavigator
+                rootSObjectName={rootSObjectName}
+                selectedSubqueryTree={selectedSubqueryTree}
+                currentRelationshipPath={currentRelationshipPath}
+                onNavigate={handleNavigate}
+              />
             </GridCol>
-            {renderClearAllButton()}
+            <GridCol growNone>{renderClearAllButton()}</GridCol>
           </Grid>
         </div>
       )}
@@ -152,19 +202,20 @@ export const QuerySubquerySObjects: FunctionComponent<QuerySubquerySObjectsProps
         ></EmptyState>
       )}
       {currentChildRelationships.length > 0 && (
-        // Remounting on level change resets the per-level filters and collapses the accordion
+        // Remounting on navigation resets the per-level filters, collapses the accordion, and lets a subquery
+        // picked from the navigator be opened as the accordion initializes
         <QuerySubqueryLevel
-          key={`${rootSObjectName}:${currentRelationshipPath}`}
+          key={`${rootSObjectName}:${currentRelationshipPath}:${focusedRelationshipPath || ''}:${jumpCount}`}
           org={org}
           serverUrl={serverUrl}
           isTooling={isTooling}
           relationshipPath={currentRelationshipPath}
           childRelationships={currentChildRelationships}
           fieldPickerCacheRef={fieldPickerCacheRef}
-          // Once drilled in the clear action lives in the breadcrumb block instead, next to the level it applies to
-          clearAllButton={drillPath.length === 0 ? renderClearAllButton() : undefined}
+          focusedRelationshipPath={focusedRelationshipPath}
+          selectedSubqueryNodesByPath={selectedSubqueryNodesByPath}
           onSelectionChanged={handleSelectionChanged}
-          onDrillIn={(level) => setDrillPath((prev) => [...prev, level])}
+          onDrillIn={(level) => goToLevels((currentLevels) => [...currentLevels, level])}
         />
       )}
     </Fragment>

--- a/libs/features/query/src/QueryBuilder/__tests__/QuerySubqueryNavigator.spec.tsx
+++ b/libs/features/query/src/QueryBuilder/__tests__/QuerySubqueryNavigator.spec.tsx
@@ -1,0 +1,74 @@
+import { QueryFieldWithPolymorphic } from '@jetstream/types';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { buildSelectedSubqueryTree } from '../../utils/subquery-navigation-utils';
+import QuerySubqueryNavigator from '../QuerySubqueryNavigator';
+
+/** Only the number of selected fields matters to the tree, so the field metadata is not worth building out */
+function getFields(...fields: string[]): QueryFieldWithPolymorphic[] {
+  return fields.map((field) => ({ field }) as QueryFieldWithPolymorphic);
+}
+
+const selectedSubqueryTree = buildSelectedSubqueryTree(
+  {
+    Contacts: getFields('Id'),
+    'Contacts.Cases': getFields('Id', 'Subject'),
+    Opportunities: getFields('Id'),
+  },
+  { Contacts: 'Contact', 'Contacts.Cases': 'Case', Opportunities: 'Opportunity' },
+);
+
+function setup(currentRelationshipPath = '') {
+  const onNavigate = vi.fn();
+  render(
+    <QuerySubqueryNavigator
+      rootSObjectName="Account"
+      selectedSubqueryTree={selectedSubqueryTree}
+      currentRelationshipPath={currentRelationshipPath}
+      onNavigate={onNavigate}
+    />,
+  );
+  return { onNavigate, openNavigator: () => fireEvent.click(screen.getByTestId('subquery-navigator-button')) };
+}
+
+describe('QuerySubqueryNavigator', () => {
+  it('should count every related object in the query, including nested ones', () => {
+    setup();
+    expect(screen.getByTestId('subquery-navigator-button').textContent).toContain('Selected (3)');
+  });
+
+  it('should show nested related objects, which are not listed on the level being viewed', () => {
+    const { openNavigator } = setup();
+    openNavigator();
+
+    expect(screen.getByText('Account')).toBeTruthy();
+    expect(screen.getByText('Contacts')).toBeTruthy();
+    expect(screen.getByText('Cases')).toBeTruthy();
+    expect(screen.getByText('Opportunities')).toBeTruthy();
+  });
+
+  it('should navigate to a nested related object by its full relationship path', () => {
+    const { onNavigate, openNavigator } = setup();
+    openNavigator();
+
+    fireEvent.click(screen.getByText('Cases'));
+
+    expect(onNavigate).toHaveBeenCalledWith('Contacts.Cases');
+  });
+
+  it('should navigate back to the root object with an empty relationship path', () => {
+    const { onNavigate, openNavigator } = setup('Contacts');
+    openNavigator();
+
+    fireEvent.click(screen.getByText('Account'));
+
+    expect(onNavigate).toHaveBeenCalledWith('');
+  });
+
+  it('should point out the level currently being viewed', () => {
+    const { openNavigator } = setup('Contacts.Cases');
+    openNavigator();
+
+    expect(screen.getByText('Cases').closest('li')?.textContent).toContain('viewing');
+  });
+});

--- a/libs/features/query/src/utils/__tests__/subquery-navigation-utils.spec.ts
+++ b/libs/features/query/src/utils/__tests__/subquery-navigation-utils.spec.ts
@@ -1,0 +1,168 @@
+import { QueryFields, QueryFieldWithPolymorphic } from '@jetstream/types';
+import { getQueryFieldBaseKey, getSubqueryFieldBaseKey, initQueryFieldStateItem } from '@jetstream/ui-core/shared';
+import { describe, expect, it } from 'vitest';
+import {
+  buildSelectedSubqueryTree,
+  countSubqueriesBelow,
+  flattenSelectedSubqueryTree,
+  getAncestorDrillLevels,
+  getSelectedSubqueryNodesByPath,
+  getSubquerySObjectByPath,
+} from '../subquery-navigation-utils';
+
+/** Only the number of selected fields matters to the tree, so the field metadata is not worth building out */
+function getFields(...fields: string[]): QueryFieldWithPolymorphic[] {
+  return fields.map((field) => ({ field }) as QueryFieldWithPolymorphic);
+}
+
+function getQueryFieldsMap(entries: { key: string; sobject: string }[]): Record<string, QueryFields> {
+  return entries.reduce((output: Record<string, QueryFields>, { key, sobject }) => {
+    output[key] = initQueryFieldStateItem(key, sobject);
+    return output;
+  }, {});
+}
+
+describe('getSubquerySObjectByPath', () => {
+  it('should map each subquery path to the object it selects from', () => {
+    const queryFieldsMap = getQueryFieldsMap([
+      { key: getQueryFieldBaseKey('Account'), sobject: 'Account' },
+      { key: getSubqueryFieldBaseKey('Contact', 'Contacts'), sobject: 'Contact' },
+      { key: getSubqueryFieldBaseKey('Case', 'Contacts.Cases'), sobject: 'Case' },
+    ]);
+
+    expect(getSubquerySObjectByPath(queryFieldsMap)).toEqual({ Contacts: 'Contact', 'Contacts.Cases': 'Case' });
+  });
+
+  it('should ignore parent relationships expanded within a subquery, which share the subquery path', () => {
+    const queryFieldsMap = getQueryFieldsMap([
+      { key: getSubqueryFieldBaseKey('Contact', 'Contacts'), sobject: 'Contact' },
+      { key: `${getSubqueryFieldBaseKey('Contact', 'Contacts')}Owner.`, sobject: 'User' },
+    ]);
+
+    expect(getSubquerySObjectByPath(queryFieldsMap)).toEqual({ Contacts: 'Contact' });
+  });
+});
+
+describe('buildSelectedSubqueryTree', () => {
+  const sObjectByPath = {
+    Contacts: 'Contact',
+    'Contacts.Cases': 'Case',
+    'Contacts.Cases.CaseComments': 'CaseComment',
+    Opportunities: 'Opportunity',
+  };
+
+  it('should nest each subquery within its parent, ordered by relationship name', () => {
+    const tree = buildSelectedSubqueryTree(
+      {
+        Opportunities: getFields('Id'),
+        Contacts: getFields('Id', 'Name'),
+        'Contacts.Cases': getFields('Id'),
+      },
+      sObjectByPath,
+    );
+
+    expect(tree).toEqual([
+      {
+        relationshipPath: 'Contacts',
+        relationshipName: 'Contacts',
+        childSObject: 'Contact',
+        fieldCount: 2,
+        children: [{ relationshipPath: 'Contacts.Cases', relationshipName: 'Cases', childSObject: 'Case', fieldCount: 1, children: [] }],
+      },
+      {
+        relationshipPath: 'Opportunities',
+        relationshipName: 'Opportunities',
+        childSObject: 'Opportunity',
+        fieldCount: 1,
+        children: [],
+      },
+    ]);
+  });
+
+  it('should include ancestors of a nested selection even when they have no fields of their own', () => {
+    const tree = buildSelectedSubqueryTree({ 'Contacts.Cases.CaseComments': getFields('Id') }, sObjectByPath);
+
+    expect(flattenSelectedSubqueryTree(tree).map(({ relationshipPath, fieldCount }) => ({ relationshipPath, fieldCount }))).toEqual([
+      { relationshipPath: 'Contacts', fieldCount: 0 },
+      { relationshipPath: 'Contacts.Cases', fieldCount: 0 },
+      { relationshipPath: 'Contacts.Cases.CaseComments', fieldCount: 1 },
+    ]);
+  });
+
+  it('should omit subqueries that no longer have fields anywhere within them', () => {
+    expect(buildSelectedSubqueryTree({ Contacts: [], 'Contacts.Cases': [] }, sObjectByPath)).toEqual([]);
+  });
+});
+
+describe('countSubqueriesBelow', () => {
+  const tree = buildSelectedSubqueryTree(
+    {
+      Contacts: getFields('Id'),
+      'Contacts.Cases': getFields('Id'),
+      'Contacts.Cases.CaseComments': getFields('Id'),
+      Opportunities: getFields('Id'),
+    },
+    {},
+  );
+
+  it('should count every subquery in the query from the root object', () => {
+    expect(countSubqueriesBelow(tree, '')).toBe(4);
+  });
+
+  it('should count only what is nested beneath the level being viewed', () => {
+    expect(countSubqueriesBelow(tree, 'Contacts')).toBe(2);
+    expect(countSubqueriesBelow(tree, 'Contacts.Cases')).toBe(1);
+    expect(countSubqueriesBelow(tree, 'Opportunities')).toBe(0);
+  });
+});
+
+describe('getSelectedSubqueryNodesByPath', () => {
+  const tree = buildSelectedSubqueryTree({ Contacts: getFields('Id'), 'Contacts.Cases': getFields('Id') }, { Contacts: 'Contact' });
+
+  it('should find a node regardless of the casing the path is looked up with', () => {
+    const nodesByPath = getSelectedSubqueryNodesByPath(tree);
+
+    expect(nodesByPath.get('contacts.cases')?.relationshipPath).toBe('Contacts.Cases');
+    expect(nodesByPath.size).toBe(2);
+  });
+
+  it('should only hold the subqueries the query contains, so a missing node means it is not selected', () => {
+    expect(getSelectedSubqueryNodesByPath(tree).has('opportunities')).toBe(false);
+  });
+
+  it('should carry what is nested directly within each node', () => {
+    const nodesByPath = getSelectedSubqueryNodesByPath(tree);
+
+    expect(nodesByPath.get('contacts')?.children.length).toBe(1);
+    expect(nodesByPath.get('contacts.cases')?.children.length).toBe(0);
+  });
+});
+
+describe('getAncestorDrillLevels', () => {
+  const tree = buildSelectedSubqueryTree(
+    { 'Contacts.Cases.CaseComments': getFields('Id') },
+    { Contacts: 'Contact', 'Contacts.Cases': 'Case', 'Contacts.Cases.CaseComments': 'CaseComment' },
+  );
+
+  it('should drill into every ancestor, shallowest first, so the level that lists the target is shown', () => {
+    expect(getAncestorDrillLevels(tree, 'Contacts.Cases.CaseComments')).toEqual([
+      { relationshipPath: 'Contacts', relationshipName: 'Contacts', childSObject: 'Contact' },
+      { relationshipPath: 'Contacts.Cases', relationshipName: 'Cases', childSObject: 'Case' },
+    ]);
+  });
+
+  it('should stay on the root object for a top level subquery, which the root already lists', () => {
+    expect(getAncestorDrillLevels(tree, 'Contacts')).toEqual([]);
+  });
+
+  it('should navigate to the root object itself without any level drilled into', () => {
+    expect(getAncestorDrillLevels(tree, '')).toEqual([]);
+  });
+
+  it('should match ancestors case-insensitively, since paths carry whatever casing they were authored with', () => {
+    expect(getAncestorDrillLevels(tree, 'contacts.cases.casecomments').map(({ relationshipPath }) => relationshipPath)).toEqual([
+      'Contacts',
+      'Contacts.Cases',
+    ]);
+  });
+});

--- a/libs/features/query/src/utils/subquery-navigation-utils.ts
+++ b/libs/features/query/src/utils/subquery-navigation-utils.ts
@@ -1,0 +1,109 @@
+import {
+  getSubqueryPathWithAncestors,
+  getSubqueryRelationshipName,
+  isDirectChildSubqueryPath,
+  isSubqueryPathBelow,
+  orderValues,
+} from '@jetstream/shared/utils';
+import { QueryFields, QueryFieldWithPolymorphic } from '@jetstream/types';
+import { BASE_FIELD_SEPARATOR, getSubqueryPathFromFieldKey } from '@jetstream/ui-core/shared';
+
+/** One level of drill-in within the subquery tree. An empty relationship path is the root object. */
+export interface SubqueryDrillLevel {
+  relationshipPath: string;
+  relationshipName: string;
+  childSObject: string;
+}
+
+export interface SelectedSubqueryNode extends SubqueryDrillLevel {
+  /** Fields selected on the subquery itself, which can be zero when only something nested within it has fields */
+  fieldCount: number;
+  children: SelectedSubqueryNode[];
+}
+
+/**
+ * The object each subquery points at, keyed by relationship path.
+ *
+ * The fields map holds an entry per expanded parent relationship in addition to the subquery itself, and those
+ * entries carry the same relationship path, so only the base key identifies the object the subquery selects from.
+ */
+export function getSubquerySObjectByPath(queryFieldsMap: Record<string, QueryFields>): Record<string, string> {
+  return Object.values(queryFieldsMap).reduce((output: Record<string, string>, { key, sobject }) => {
+    const relationshipPath = getSubqueryPathFromFieldKey(key);
+    if (relationshipPath && key.endsWith(BASE_FIELD_SEPARATOR)) {
+      output[relationshipPath] = sobject;
+    }
+    return output;
+  }, {});
+}
+
+/**
+ * The subqueries that make up the query, as a tree.
+ *
+ * Mirrors how the SOQL is composed - a subquery is included when it, or anything nested within it, has fields
+ * selected - so the tree always matches the related objects the generated query contains.
+ */
+export function buildSelectedSubqueryTree(
+  selectedFieldsByPath: Record<string, QueryFieldWithPolymorphic[]>,
+  sObjectByPath: Record<string, string>,
+): SelectedSubqueryNode[] {
+  const allPaths = new Set<string>();
+  Object.keys(selectedFieldsByPath).forEach((relationshipPath) => {
+    if (selectedFieldsByPath[relationshipPath]?.length) {
+      getSubqueryPathWithAncestors(relationshipPath).forEach((path) => allPaths.add(path));
+    }
+  });
+
+  function buildNodes(parentRelationshipPath: string): SelectedSubqueryNode[] {
+    return orderValues(Array.from(allPaths).filter((path) => isDirectChildSubqueryPath(path, parentRelationshipPath))).map(
+      (relationshipPath) => ({
+        relationshipPath,
+        relationshipName: getSubqueryRelationshipName(relationshipPath),
+        childSObject: sObjectByPath[relationshipPath] || '',
+        fieldCount: selectedFieldsByPath[relationshipPath]?.length || 0,
+        children: buildNodes(relationshipPath),
+      }),
+    );
+  }
+
+  return buildNodes('');
+}
+
+/** Every node in the tree, depth first with each parent ahead of its own children. */
+export function flattenSelectedSubqueryTree(nodes: SelectedSubqueryNode[]): SelectedSubqueryNode[] {
+  return nodes.flatMap((node) => [node, ...flattenSelectedSubqueryTree(node.children)]);
+}
+
+/** Number of subqueries nested anywhere beneath `relationshipPath`, which is what clearing that level removes. */
+export function countSubqueriesBelow(nodes: SelectedSubqueryNode[], relationshipPath: string): number {
+  return flattenSelectedSubqueryTree(nodes).filter((node) => isSubqueryPathBelow(node.relationshipPath, relationshipPath)).length;
+}
+
+/**
+ * Every node in the tree keyed by lower cased relationship path, so that a level can answer whether a
+ * relationship is in the query and what is nested within it without re-deriving either.
+ */
+export function getSelectedSubqueryNodesByPath(nodes: SelectedSubqueryNode[]): Map<string, SelectedSubqueryNode> {
+  return new Map(flattenSelectedSubqueryTree(nodes).map((node) => [node.relationshipPath.toLowerCase(), node]));
+}
+
+/**
+ * The levels to drill into so that `relationshipPath` is listed, its ancestors shallowest first. Empty for a
+ * top level subquery, which the root object already lists.
+ */
+export function getAncestorDrillLevels(nodes: SelectedSubqueryNode[], relationshipPath: string): SubqueryDrillLevel[] {
+  const nodesByPath = getSelectedSubqueryNodesByPath(nodes);
+  return getSubqueryPathWithAncestors(relationshipPath)
+    .slice(0, -1)
+    .reduce((levels: SubqueryDrillLevel[], ancestorPath) => {
+      const ancestor = nodesByPath.get(ancestorPath.toLowerCase());
+      if (ancestor) {
+        levels.push({
+          relationshipPath: ancestor.relationshipPath,
+          relationshipName: ancestor.relationshipName,
+          childSObject: ancestor.childSObject,
+        });
+      }
+      return levels;
+    }, []);
+}

--- a/libs/icon-factory/src/lib/icon-factory.tsx
+++ b/libs/icon-factory/src/lib/icon-factory.tsx
@@ -25,8 +25,8 @@ import StandardIcon_Billing from './icons/standard/Billing';
 import StandardIcon_BundleConfig from './icons/standard/BundleConfig';
 import StandardIcon_Chart from './icons/standard/Chart';
 import StandardIcon_ConnectedApps from './icons/standard/ConnectedApps';
-import StandardIcon_Customers from './icons/standard/Customers';
 import StandardIcon_CustomerPortalUsers from './icons/standard/CustomerPortalUsers';
+import StandardIcon_Customers from './icons/standard/Customers';
 import StandardIcon_DataStreams from './icons/standard/DataStreams';
 import StandardIcon_EmployeeOrganization from './icons/standard/EmployeeOrganization';
 import StandardIcon_Entity from './icons/standard/Entity';
@@ -106,6 +106,7 @@ import UtilityIcon_Forward from './icons/utility/Forward';
 import UtilityIcon_Help from './icons/utility/Help';
 import UtilityIcon_HelpDocExt from './icons/utility/HelpDocExt';
 import UtilityIcon_Hide from './icons/utility/Hide';
+import UtilityIcon_Hierarchy from './icons/utility/Hierarchy';
 import UtilityIcon_Home from './icons/utility/Home';
 import UtilityIcon_Identity from './icons/utility/Identity';
 import UtilityIcon_Image from './icons/utility/Image';
@@ -312,6 +313,7 @@ const utilityIcons = {
   help: UtilityIcon_Help,
   help_doc_ext: UtilityIcon_HelpDocExt,
   hide: UtilityIcon_Hide,
+  hierarchy: UtilityIcon_Hierarchy,
   home: UtilityIcon_Home,
   identity: UtilityIcon_Identity,
   image: UtilityIcon_Image,

--- a/libs/test/e2e-utils/src/lib/pageObjectModels/QueryPage.model.ts
+++ b/libs/test/e2e-utils/src/lib/pageObjectModels/QueryPage.model.ts
@@ -146,6 +146,15 @@ export class QueryPage {
   }
 
   /**
+   * Jump to a related object from the tree of everything in the query, which is the only way to reach a nested
+   * subquery without drilling back into each of its ancestors.
+   */
+  async navigateToSubqueryFromNavigator(relationshipName: string, childSObject: string) {
+    await this.page.getByTestId('subquery-navigator-button').click();
+    await this.page.getByTestId('subquery-navigator-popover').getByTitle(`${relationshipName} (${childSObject})`).click();
+  }
+
+  /**
    * Author a subquery nested inside another, e.x. Account > Contacts > Cases.
    * Each entry selects its fields before drilling into the next level.
    */

--- a/libs/ui/src/lib/accordion/Accordion.tsx
+++ b/libs/ui/src/lib/accordion/Accordion.tsx
@@ -3,7 +3,7 @@
 import { UiSection } from '@jetstream/types';
 import classNames from 'classnames';
 import isFunction from 'lodash/isFunction';
-import { Fragment, FunctionComponent, ReactNode, useState } from 'react';
+import { Fragment, FunctionComponent, ReactNode, useEffect, useRef, useState } from 'react';
 import Icon from '../widgets/Icon';
 
 export interface AccordionProps {
@@ -18,6 +18,11 @@ export interface AccordionProps {
    * Additional content to display next to the expand/collapse all button.
    */
   expandAllExtraContent?: ReactNode;
+  /**
+   * Scroll the section opened by `initOpenIds` into view as the accordion mounts, for when the accordion is
+   * rendered already scrolled past the section that matters.
+   */
+  scrollInitOpenIdIntoView?: boolean;
   onActiveIdsChange?: (openIds: string[]) => void;
 }
 
@@ -30,9 +35,20 @@ export const Accordion: FunctionComponent<AccordionProps> = ({
   expandAllClassName,
   expandAllContainerClassName,
   expandAllExtraContent,
+  scrollInitOpenIdIntoView = false,
   onActiveIdsChange,
 }) => {
   const [openIds, setOpenIds] = useState<Set<string>>(new Set(initOpenIds));
+  // initOpenIds is only honored as the accordion mounts, so the section to scroll to is captured the same way
+  const scrollTargetIdRef = useRef(initOpenIds[0]);
+  const scrollTargetRef = useRef<HTMLLIElement | null>(null);
+
+  useEffect(() => {
+    if (scrollInitOpenIdIntoView) {
+      scrollTargetRef.current?.scrollIntoView({ block: 'nearest' });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   function handleClick(id: string) {
     if (allowMultiple) {
@@ -105,7 +121,12 @@ export const Accordion: FunctionComponent<AccordionProps> = ({
             }
           }
           return (
-            <li className={classNames('slds-accordion__list-item', item.className)} key={item.id} style={item.style || undefined}>
+            <li
+              className={classNames('slds-accordion__list-item', item.className)}
+              key={item.id}
+              ref={item.id === scrollTargetIdRef.current ? scrollTargetRef : undefined}
+              style={item.style || undefined}
+            >
               <section className={classNames('slds-accordion__section', { 'slds-is-open': isOpen })}>
                 <div className="slds-accordion__summary">
                   <h3 className="slds-accordion__summary-heading">

--- a/libs/ui/src/lib/accordion/__tests__/Accordion.spec.tsx
+++ b/libs/ui/src/lib/accordion/__tests__/Accordion.spec.tsx
@@ -9,6 +9,20 @@ const sections: UiSection[] = [
 ];
 
 describe('Accordion', () => {
+  // jsdom does not implement scrollIntoView, so the tests that cover it provide their own
+  const originalScrollIntoView = Element.prototype.scrollIntoView;
+  afterEach(() => {
+    Element.prototype.scrollIntoView = originalScrollIntoView;
+  });
+
+  function stubScrollIntoView() {
+    const scrolledElements: Element[] = [];
+    Element.prototype.scrollIntoView = vi.fn(function scrollIntoViewStub(this: Element) {
+      scrolledElements.push(this);
+    });
+    return scrolledElements;
+  }
+
   test('renders all section titles', () => {
     render(<Accordion sections={sections} initOpenIds={[]} />);
 
@@ -118,5 +132,22 @@ describe('Accordion', () => {
     sectionButtons.forEach((btn) => {
       expect(btn.getAttribute('aria-expanded')).toBe('false');
     });
+  });
+
+  test('scrollInitOpenIdIntoView scrolls the section opened on mount into view', () => {
+    const scrolledElements = stubScrollIntoView();
+
+    render(<Accordion sections={sections} initOpenIds={['section-2']} scrollInitOpenIdIntoView />);
+
+    expect(scrolledElements).toHaveLength(1);
+    expect(scrolledElements[0].contains(screen.getByText('Content Two'))).toBe(true);
+  });
+
+  test('nothing is scrolled into view without scrollInitOpenIdIntoView', () => {
+    const scrolledElements = stubScrollIntoView();
+
+    render(<Accordion sections={sections} initOpenIds={['section-2']} />);
+
+    expect(scrolledElements).toHaveLength(0);
   });
 });

--- a/libs/ui/src/lib/widgets/Breadcrumbs.tsx
+++ b/libs/ui/src/lib/widgets/Breadcrumbs.tsx
@@ -12,7 +12,9 @@ export function Breadcrumbs({ items, currentItem, onClick }: BreadcrumbsProps) {
       <ol className="slds-breadcrumb slds-list_horizontal slds-wrap">
         {items.map((item, i) => (
           <li key={`${item.id}_${i}`} className="slds-breadcrumb__item">
+            {/* Navigation is handled in JS, but the href is what makes this a link to a screen reader and reachable by keyboard */}
             <a
+              href="#"
               onClick={(event) => {
                 event.preventDefault();
                 onClick(item);

--- a/libs/ui/src/lib/widgets/__tests__/Widgets.spec.tsx
+++ b/libs/ui/src/lib/widgets/__tests__/Widgets.spec.tsx
@@ -102,6 +102,12 @@ describe('Breadcrumbs', () => {
     expect(screen.getByRole('navigation')).toBeTruthy();
   });
 
+  // An anchor without an href is exposed as generic instead of a link and cannot be focused with the keyboard
+  test('renders each item as a link', () => {
+    render(<Breadcrumbs items={items} currentItem="Current Page" onClick={() => {}} />);
+    expect(screen.getAllByRole('link').map((link) => link.textContent)).toEqual(['Home', 'Products', 'Detail']);
+  });
+
   test('renders currentItem when provided', () => {
     render(<Breadcrumbs items={items} currentItem="Current Page" onClick={() => {}} />);
     expect(screen.getByText('Current Page')).toBeTruthy();


### PR DESCRIPTION
The related objects tab shows one level of the subquery tree at a time, so a nested subquery was invisible - and unreachable - from anywhere but the level it lives on. A "Selected (N)" popover now shows every related object in the query as a tree, and picking one drills into its ancestors, opens it, and scrolls it into view.

- Tree nodes carry the fields selected on each subquery and mark the level being viewed
- "Clear all" moved out of the breadcrumb block so it sits in the same place at every level, right aligned next to the object filter, which also fixes it rendering centered at the root level
- Both the navigator and "Clear all" are scoped from the same tree, so the counts always agree. Note "Clear all" now also counts subqueries whose only selections are nested within them, which it previously skipped even though clearing removes them
- Register the `hierarchy` utility icon