### PR TITLE
fix(download): force the Bulk API for large downloads and report failures

### DIFF
--- a/libs/shared/ui-core/src/jobs/Jobs.tsx
+++ b/libs/shared/ui-core/src/jobs/Jobs.tsx
@@ -24,6 +24,7 @@ import {
   AsyncJobType,
   AsyncJobWorkerMessagePayload,
   AsyncJobWorkerMessageResponse,
+  BulkDownloadJob,
   ErrorResult,
   FileExtAllTypes,
   FileExtCsvXLSX,
@@ -59,6 +60,26 @@ function getGoogleAccessToken(): string | undefined {
     return getExternalGoogleAccessToken()?.accessToken ?? undefined;
   }
   return gapi?.client?.getToken()?.access_token;
+}
+
+/**
+ * Downloads are the one job type where the browser itself is regularly the limit - a standard download builds
+ * the whole file as a single string and throws `RangeError: Invalid string length` past ~512MB. The jobs popover
+ * only ever shows the raw message, so report the inputs needed to tell a browser limit apart from a Salesforce
+ * failure. The SOQL and the records themselves are deliberately left out.
+ */
+function trackDownloadFailure(job: AsyncJob, errorMessage: string) {
+  const { fileFormat, sObject, totalRecordCount, fields, useBulkApi, includeSubquery, isTooling } = (job.meta ||
+    {}) as Partial<BulkDownloadJob>;
+  tracker.error('Bulk download job failed', new Error(errorMessage), {
+    fileFormat,
+    sObject,
+    totalRecordCount,
+    fieldCount: fields?.length,
+    useBulkApi,
+    includeSubquery,
+    isTooling,
+  });
 }
 
 export const Jobs: FunctionComponent = () => {
@@ -292,6 +313,7 @@ export const Jobs: FunctionComponent = () => {
             };
             setJobs((prevJobs) => ({ ...prevJobs, [newJob.id]: newJob }));
             notifyUser(`Download records failed`, { body: newJob.statusMessage, tag: 'BulkDownload' });
+            trackDownloadFailure(newJob, error);
           } else if (data.lastActivityUpdate) {
             const progress = (data.results as { progress?: AsyncJobProgress } | undefined)?.progress;
             newJob = {
@@ -357,6 +379,7 @@ export const Jobs: FunctionComponent = () => {
                       };
                       setJobs((prevJobs) => ({ ...prevJobs, [newJob.id]: newJob }));
                       notifyUser(`Download records failed`, { body: newJob.statusMessage, tag: 'BulkDownload' });
+                      trackDownloadFailure(newJob, getErrorMessage(error));
                     });
                 } else {
                   fromJetstreamEvents.emit({

--- a/libs/ui/src/lib/file-download-modal/RecordDownloadModal.tsx
+++ b/libs/ui/src/lib/file-download-modal/RecordDownloadModal.tsx
@@ -124,6 +124,11 @@ export interface RecordDownloadModalProps {
 const PROHIBITED_BULK_APEX_TYPES = new Set(['Address', 'Location', 'complexvaluetype']);
 const FILE_FORMAT_ALLOWED_BULK_API = new Set<RecordDownloadFileFormat>(['csv', 'gdrive']);
 const ALLOW_BULK_API_COUNT = 5_000;
+/**
+ * A standard download is built entirely in the browser as a single string, so it fails with
+ * `RangeError: Invalid string length` once the generated file crosses the ~512MB max string length.
+ * XLSX reaches that ceiling first - its XML runs 2-3x the size of the equivalent CSV.
+ */
 const REQUIRE_BULK_API_COUNT = 500_000;
 
 const LS_KEY = 'RecordDownloadModal';
@@ -270,7 +275,11 @@ export const RecordDownloadModal: FunctionComponent<RecordDownloadModalProps> = 
     records?.[0]?.attributes?.type !== 'AggregateResult' &&
     downloadRecordsValue === RADIO_ALL_SERVER;
 
-  const requireBulkApi = allowBulkApiWithWarning && (totalRecordCount || 0) >= REQUIRE_BULK_API_COUNT;
+  /**
+   * Past this volume the browser cannot build the file at all, which is true of the lossless case as much as
+   * the lossy one - so both are forced onto the Bulk API rather than only `allowBulkApiWithWarning`.
+   */
+  const requireBulkApi = (allowBulkApi || allowBulkApiWithWarning) && (totalRecordCount || 0) >= REQUIRE_BULK_API_COUNT;
   const isBulkApi = downloadMethod === RADIO_DOWNLOAD_METHOD_BULK_API;
 
   useEffect(() => {
@@ -527,7 +536,12 @@ export const RecordDownloadModal: FunctionComponent<RecordDownloadModalProps> = 
       trackEvent(ANALYTICS_KEYS.file_download, { source, fileFormat, component: 'RecordDownloadModal' });
     } catch (ex) {
       logger.error('Error downloading file', ex);
-      tracker.error('Record download error', ex);
+      tracker.error('Record download error', ex, {
+        fileFormat,
+        recordCount: activeRecords.length,
+        fieldCount: fieldsToUse.length,
+        downloadMethod,
+      });
       // Cell values are truncated before writing, but other SheetJS limits (e.g. the 1,048,576-row cap) can still throw.
       if (getErrorMessage(ex).includes('32767')) {
         setErrorMessage(`One or more values exceed Excel's 32,767 character cell limit. Download as CSV or JSON to get full values.`);

--- a/libs/ui/src/lib/file-download-modal/__tests__/RecordDownloadModal.spec.tsx
+++ b/libs/ui/src/lib/file-download-modal/__tests__/RecordDownloadModal.spec.tsx
@@ -106,3 +106,31 @@ describe('RecordDownloadModal file format persistence', () => {
     expect(localStorage.getItem(LS_KEY)).toBe('csv');
   });
 });
+
+/**
+ * `requireBulkApi` used to be derived from the "bulk API with a warning" case, which is mutually exclusive with
+ * the clean case - so a query the bulk API could handle losslessly was never forced onto it, and a large enough
+ * download failed with `RangeError: Invalid string length` while the browser built the file.
+ */
+describe('RecordDownloadModal bulk API requirement', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.clearAllMocks();
+  });
+
+  test('forces the bulk API and CSV for a bulk-eligible query above the record threshold', () => {
+    localStorage.setItem(LS_KEY, 'xlsx');
+    setup({ totalRecordCount: 600_000 });
+
+    expect(screen.getByLabelText<HTMLInputElement>('Salesforce Bulk API').checked).toBe(true);
+    expect(screen.getByLabelText<HTMLInputElement>('Standard').disabled).toBe(true);
+    expect(screen.getByLabelText<HTMLInputElement>('CSV').checked).toBe(true);
+  });
+
+  test('leaves the download method up to the user below the record threshold', () => {
+    setup({ totalRecordCount: 10_000 });
+
+    expect(screen.getByLabelText<HTMLInputElement>('Standard').checked).toBe(true);
+    expect(screen.getByLabelText<HTMLInputElement>('Standard').disabled).toBe(false);
+  });
+});


### PR DESCRIPTION
`requireBulkApi` was derived from `allowBulkApiWithWarning`, which starts with `!allowBulkApi` - so the 500k threshold only forced the Bulk API when it would be lossy, and never for a clean query. Large downloads stayed on the standard path and failed with `RangeError: Invalid string length` once the file the browser was building crossed the ~512MB max string length.

Also report BulkDownload job failures to the error tracker with the file format and record count - they were previously not reported at all.