### PR TITLE
chore: temporarily disable error tracking for desktop, extension, and canvas

### DIFF
--- a/apps/jetstream-canvas/src/environments/environment.ts
+++ b/apps/jetstream-canvas/src/environments/environment.ts
@@ -10,7 +10,10 @@
 export const environment = {
   production: import.meta.env.PROD,
   serverUrl: 'http://localhost:3333',
-  sentryDsn: import.meta.env.NX_PUBLIC_SENTRY_DSN_CANVAS,
+  // TEMPORARILY DISABLED - error tracking is turned off for this app until crash report redaction
+  // can guarantee no customer data is included. A null dsn makes `initErrorTracker` a no-op.
+  // sentryDsn: import.meta.env.NX_PUBLIC_SENTRY_DSN_CANVAS,
+  sentryDsn: null,
   amplitudeToken: null,
   isWebExtension: false,
 };

--- a/apps/jetstream-desktop-client/src/environments/environment.ts
+++ b/apps/jetstream-desktop-client/src/environments/environment.ts
@@ -9,7 +9,10 @@
 export const environment = {
   name: 'JetstreamDev',
   production: import.meta.env.PROD,
-  sentryDsn: import.meta.env.NX_PUBLIC_SENTRY_DSN_DESKTOP,
+  // TEMPORARILY DISABLED - error tracking is turned off for this app until crash report redaction
+  // can guarantee no customer data is included. A null dsn makes `initErrorTracker` a no-op.
+  // sentryDsn: import.meta.env.NX_PUBLIC_SENTRY_DSN_DESKTOP,
+  sentryDsn: null,
   // FIXME: we do want this in
   amplitudeToken: undefined,
   STRIPE_PUBLIC_KEY: '',

--- a/apps/jetstream-desktop/src/services/menu.service.ts
+++ b/apps/jetstream-desktop/src/services/menu.service.ts
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { IpcEventChannel } from '@jetstream/desktop/types';
 import { truncateMiddle } from '@jetstream/shared/utils';
 import { app, BrowserWindow, Menu, shell } from 'electron';
 import logger from 'electron-log';
@@ -8,7 +7,10 @@ import { Browser } from '../browser/browser';
 import { checkForUpdates } from '../config/auto-updater';
 import { openExternalSafe } from '../utils/url.utils';
 import { isMac } from '../utils/utils';
-import { getUserPreferences, updateUserPreferences } from './persistence.service';
+import { getUserPreferences } from './persistence.service';
+
+// TEMPORARILY DISABLED - only used by the commented-out crash reporting menu item
+// import { IpcEventChannel } from '@jetstream/desktop/types';
 
 type MenuItem = Parameters<typeof Menu.buildFromTemplate>[0][0];
 
@@ -136,18 +138,20 @@ export function initAppMenu() {
           },
         },
         { type: 'separator' },
-        {
-          type: 'checkbox',
-          label: 'Send crash reports to Jetstream',
-          checked: getUserPreferences().crashReportingEnabled,
-          click: (menuItem) => {
-            const enabled = menuItem.checked;
-            updateUserPreferences({ crashReportingEnabled: enabled });
-            // Notify every renderer so their in-app error tracker and preferences state honor the
-            // change immediately. The main-process tracker reads the preference directly.
-            BrowserWindow.getAllWindows().forEach(({ webContents }) => webContents.send(IpcEventChannel.crashReportingChanged, enabled));
-          },
-        },
+        // TEMPORARILY DISABLED alongside the error tracker itself - there is nothing to opt out of
+        // while crash reporting is off, and offering the toggle would imply reports are still sent.
+        // {
+        //   type: 'checkbox',
+        //   label: 'Send crash reports to Jetstream',
+        //   checked: getUserPreferences().crashReportingEnabled,
+        //   click: (menuItem) => {
+        //     const enabled = menuItem.checked;
+        //     updateUserPreferences({ crashReportingEnabled: enabled });
+        //     // Notify every renderer so their in-app error tracker and preferences state honor the
+        //     // change immediately. The main-process tracker reads the preference directly.
+        //     BrowserWindow.getAllWindows().forEach(({ webContents }) => webContents.send(IpcEventChannel.crashReportingChanged, enabled));
+        //   },
+        // },
         {
           label: 'Open Log File',
           click: async () => {

--- a/apps/jetstream-web-extension/src/environments/environment.prod.ts
+++ b/apps/jetstream-web-extension/src/environments/environment.prod.ts
@@ -1,7 +1,10 @@
 export const environment = {
   production: true,
   serverUrl: 'https://getjetstream.app',
-  sentryDsn: import.meta.env.NX_PUBLIC_SENTRY_DSN_EXTENSION,
+  // TEMPORARILY DISABLED - error tracking is turned off for this app until crash report redaction
+  // can guarantee no customer data is included. A null dsn makes `initErrorTracker` a no-op.
+  // sentryDsn: import.meta.env.NX_PUBLIC_SENTRY_DSN_EXTENSION,
+  sentryDsn: null,
   amplitudeToken: import.meta.env.NX_PUBLIC_AMPLITUDE_KEY,
   isWebExtension: true,
 };

--- a/apps/jetstream-web-extension/src/environments/environment.staging.ts
+++ b/apps/jetstream-web-extension/src/environments/environment.staging.ts
@@ -1,7 +1,10 @@
 export const environment = {
   production: true,
   serverUrl: 'https://staging.jetstream-app.com',
-  sentryDsn: import.meta.env.NX_PUBLIC_SENTRY_DSN_EXTENSION,
+  // TEMPORARILY DISABLED - error tracking is turned off for this app until crash report redaction
+  // can guarantee no customer data is included. A null dsn makes `initErrorTracker` a no-op.
+  // sentryDsn: import.meta.env.NX_PUBLIC_SENTRY_DSN_EXTENSION,
+  sentryDsn: null,
   amplitudeToken: import.meta.env.NX_PUBLIC_AMPLITUDE_KEY,
   isWebExtension: true,
 };

--- a/apps/jetstream-web-extension/src/environments/environment.ts
+++ b/apps/jetstream-web-extension/src/environments/environment.ts
@@ -4,7 +4,10 @@
 export const environment = {
   production: false,
   serverUrl: 'http://localhost:3333',
-  sentryDsn: import.meta.env.NX_PUBLIC_SENTRY_DSN_EXTENSION,
+  // TEMPORARILY DISABLED - error tracking is turned off for this app until crash report redaction
+  // can guarantee no customer data is included. A null dsn makes `initErrorTracker` a no-op.
+  // sentryDsn: import.meta.env.NX_PUBLIC_SENTRY_DSN_EXTENSION,
+  sentryDsn: null,
   amplitudeToken: import.meta.env.NX_PUBLIC_AMPLITUDE_KEY,
   isWebExtension: true,
 };

--- a/apps/jetstream-web-extension/src/pages/additional-settings/AdditionalSettings.tsx
+++ b/apps/jetstream-web-extension/src/pages/additional-settings/AdditionalSettings.tsx
@@ -33,8 +33,9 @@ export function AdditionalSettings() {
     setEnabled,
     recordSyncEnabled,
     setRecordSyncEnabled,
-    crashReportingEnabled,
-    setCrashReportingEnabled,
+    // TEMPORARILY DISABLED - see the commented-out toggle below
+    // crashReportingEnabled,
+    // setCrashReportingEnabled,
     soqlQueryFormatOptions,
     setSoqlQueryFormatOptions,
     authError,
@@ -78,6 +79,8 @@ export function AdditionalSettings() {
                 onChange={(value) => setEnabled(value)}
               />
 
+              {/* TEMPORARILY DISABLED alongside the error tracker itself - there is nothing to opt out of
+                  while crash reporting is off, and offering the toggle would imply reports are still sent.
               <CheckboxToggle
                 id="enable-crash-reporting"
                 checked={crashReportingEnabled}
@@ -85,7 +88,7 @@ export function AdditionalSettings() {
                 labelHelp="Automatically send error and crash reports to help us diagnose and fix issues."
                 labelPosition="right"
                 onChange={(value) => setCrashReportingEnabled(value)}
-              />
+              /> */}
 
               <SoqlQueryFormatConfig
                 className="slds-m-top_large"


### PR DESCRIPTION
Null out the per-app Sentry DSN so the tracker never initializes, and comment out the crash reporting opt-out settings that no longer have anything to disable. Error tracking remains enabled for the core web app.

Temporary until crash report redaction can guarantee no customer data is included in reports.