### PR TITLE
feat: bulk org connection refresh, plus query field loading race fixes

### DIFF
--- a/libs/features/org-groups/src/lib/DeleteOrgsModal.tsx
+++ b/libs/features/org-groups/src/lib/DeleteOrgsModal.tsx
@@ -1,8 +1,10 @@
 import { css } from '@emotion/react';
+import { ANALYTICS_KEYS } from '@jetstream/shared/constants';
 import { deleteOrg } from '@jetstream/shared/data';
 import { pluralizeFromNumber } from '@jetstream/shared/utils';
 import { SalesforceOrgUi } from '@jetstream/types';
 import { Badge, Checkbox, Grid, Icon, Modal, RadioButton, RadioGroup, Spinner, fireToast } from '@jetstream/ui';
+import { useAmplitude } from '@jetstream/ui-core';
 import classNames from 'classnames';
 import groupBy from 'lodash/groupBy';
 import sortBy from 'lodash/sortBy';
@@ -15,6 +17,7 @@ interface DeleteOrgsModalProps {
 }
 
 export const DeleteOrgsModal = ({ orgs, onClose, onDeleted }: DeleteOrgsModalProps) => {
+  const { trackEvent } = useAmplitude();
   const [selectedOrgIds, setSelectedOrgIds] = useState<Set<string>>(new Set());
   const [confirmDelete, setConfirmDelete] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
@@ -81,6 +84,13 @@ export const DeleteOrgsModal = ({ orgs, onClose, onDeleted }: DeleteOrgsModalPro
     }
 
     setIsDeleting(false);
+    trackEvent(ANALYTICS_KEYS.sfdc_org_bulk_deleted, {
+      selectedCount: orgsToDelete.length,
+      successCount,
+      errorCount,
+      filterMode,
+      totalOrgCount: orgs.length,
+    });
 
     if (successCount > 0) {
       fireToast({

--- a/libs/features/org-groups/src/lib/OrgGroups.tsx
+++ b/libs/features/org-groups/src/lib/OrgGroups.tsx
@@ -35,6 +35,7 @@ import { DraggableSfdcCard, SfdcCardDropTarget } from './organization-group.type
 import OrgGroupCardCard from './OrgGroupCard';
 import { OrgGroupCardNoOrganization } from './OrgGroupCardNoOrganization';
 import { OrgGroupModal } from './OrgGroupModal';
+import { RefreshAllOrgsButton } from './RefreshAllOrgsButton';
 import { SalesforceOrgsActions } from './SalesforceOrgsActions';
 
 export function OrgGroups({ onAddOrgHandlerFn }: { onAddOrgHandlerFn?: AddOrgHandlerFn }) {
@@ -138,10 +139,10 @@ export function OrgGroups({ onAddOrgHandlerFn }: { onAddOrgHandlerFn?: AddOrgHan
   const handleCreateOrUpdate = async (orgGroup: OrgGroupCreateUpdatePayload, groupToUpdateId?: string) => {
     let createdOrgGroup: OrgGroup;
     if (groupToUpdateId) {
-      trackEvent(ANALYTICS_KEYS.organizations_created, { priorCount: groups.length });
+      trackEvent(ANALYTICS_KEYS.organizations_updated, { count: groups.length });
       createdOrgGroup = await updateOrgGroup(groupToUpdateId, orgGroup);
     } else {
-      trackEvent(ANALYTICS_KEYS.organizations_updated, { count: groups.length });
+      trackEvent(ANALYTICS_KEYS.organizations_created, { priorCount: groups.length });
       createdOrgGroup = await createOrgGroup(orgGroup);
     }
     setOrgGroupsFromDb(async (_prevGroups) => {
@@ -225,6 +226,7 @@ export function OrgGroups({ onAddOrgHandlerFn }: { onAddOrgHandlerFn?: AddOrgHan
 
   const handleOrgGroupChange = useCallback(
     (group?: Maybe<OrgGroupWithOrgs>) => {
+      trackEvent(ANALYTICS_KEYS.organizations_selected, { hasGroup: !!group, orgCount: group?.orgs.length ?? 0 });
       setActiveOrgGroupId(group?.id);
       if (group && (!selectedOrg || !group.orgs.find(({ uniqueId }) => uniqueId === selectedOrg.uniqueId))) {
         // Try to select the recently selected org for this group
@@ -252,7 +254,7 @@ export function OrgGroups({ onAddOrgHandlerFn }: { onAddOrgHandlerFn?: AddOrgHan
         }
       }
     },
-    [allOrgs, selectedOrg, setActiveOrgGroupId, setSelectedOrgId],
+    [allOrgs, selectedOrg, setActiveOrgGroupId, setSelectedOrgId, trackEvent],
   );
 
   const handleOpenCreateOrganizationModal = async () => {
@@ -260,16 +262,21 @@ export function OrgGroups({ onAddOrgHandlerFn }: { onAddOrgHandlerFn?: AddOrgHan
     setModalState({ open: true });
   };
 
+  const handleOpenEditOrganizationModal = async (organization: OrgGroupWithOrgs) => {
+    trackEvent(ANALYTICS_KEYS.organizations_edit_modal_open, { orgCount: organization.orgs.length });
+    setModalState({ open: true, organization });
+  };
+
   const handleCloseOrganizationModal = async () => {
     setModalState({ open: false });
     setSelectedOrgGroup(null);
   };
 
+  // Deletion itself is tracked in DeleteOrgsModal where the success/failure counts are known
   const handleOrgsDeleted = async () => {
     setOrgGroupsFromDb(getOrgGroups());
     const refreshedOrgs = await getOrgs();
     setOrgs(refreshedOrgs);
-    trackEvent(ANALYTICS_KEYS.organizations_deleted, { priorCount: allOrgs.length });
   };
 
   return (
@@ -289,6 +296,7 @@ export function OrgGroups({ onAddOrgHandlerFn }: { onAddOrgHandlerFn?: AddOrgHan
               onAddOrg={handleAddOrg}
               onAddOrgHandlerFn={onAddOrgHandlerFn}
             />
+            {allOrgs.length > 0 && <RefreshAllOrgsButton className="slds-button_middle" orgs={allOrgs} />}
             <button
               className={classNames('slds-button slds-button_brand', { 'slds-button_last': allOrgs.length === 0 })}
               onClick={() => handleOpenCreateOrganizationModal()}
@@ -321,9 +329,7 @@ export function OrgGroups({ onAddOrgHandlerFn }: { onAddOrgHandlerFn?: AddOrgHan
                   group={organization}
                   activeSalesforceOrgId={selectedOrg?.uniqueId}
                   onSelected={() => handleOrgGroupChange(organization)}
-                  onEditOrg={() => {
-                    setModalState({ open: true, organization });
-                  }}
+                  onEditOrg={() => handleOpenEditOrganizationModal(organization)}
                   onDeleteOrg={() => handleDelete(organization)}
                   onDeleteOrgWithOrgs={() => handleDeleteAll(organization)}
                   onAddOrgHandlerFn={onAddOrgHandlerFn}

--- a/libs/features/org-groups/src/lib/RefreshAllOrgsButton.tsx
+++ b/libs/features/org-groups/src/lib/RefreshAllOrgsButton.tsx
@@ -1,0 +1,96 @@
+import { logger } from '@jetstream/shared/client-logger';
+import { ANALYTICS_KEYS } from '@jetstream/shared/constants';
+import { checkOrgHealth, getOrgs } from '@jetstream/shared/data';
+import { ORG_INACTIVITY_EXPIRATION_DAYS, pluralizeFromNumber } from '@jetstream/shared/utils';
+import { SalesforceOrgUi } from '@jetstream/types';
+import { Icon, Spinner, Tooltip, fireToast } from '@jetstream/ui';
+import { useAmplitude } from '@jetstream/ui-core';
+import { fromAppState } from '@jetstream/ui/app-state';
+import classNames from 'classnames';
+import { useSetAtom } from 'jotai';
+import PQueue from 'p-queue';
+import { useState } from 'react';
+
+/** Each health check is a round trip to Salesforce, so fan out enough to stay quick without flooding the user's orgs */
+const REFRESH_CONCURRENCY = 4;
+
+interface RefreshAllOrgsButtonProps {
+  className?: string;
+  orgs: SalesforceOrgUi[];
+}
+
+/**
+ * Runs a connection health check against every org, which both surfaces broken connections and resets
+ * Salesforce's inactivity clock (the server treats any org access as activity).
+ */
+export const RefreshAllOrgsButton = ({ className, orgs }: RefreshAllOrgsButtonProps) => {
+  const { trackEvent } = useAmplitude();
+  const setOrgs = useSetAtom(fromAppState.salesforceOrgsAsyncState);
+  const [completedCount, setCompletedCount] = useState<number | null>(null);
+  const isRefreshing = completedCount !== null;
+
+  async function handleRefreshAllOrgs() {
+    setCompletedCount(0);
+    let successCount = 0;
+    let errorCount = 0;
+
+    try {
+      const queue = new PQueue({ concurrency: REFRESH_CONCURRENCY });
+      await queue.addAll(
+        orgs.map((org) => async () => {
+          try {
+            await checkOrgHealth(org);
+            successCount++;
+          } catch (ex) {
+            errorCount++;
+            logger.warn('Error refreshing org connection', org.uniqueId, ex);
+          } finally {
+            setCompletedCount((prevValue) => (prevValue ?? 0) + 1);
+          }
+        }),
+      );
+
+      // The health check updates connection errors and clears expiration dates server-side, re-fetch to pick both up
+      setOrgs(await getOrgs());
+
+      if (errorCount === 0) {
+        fireToast({
+          type: 'success',
+          message: `Refreshed ${successCount} ${pluralizeFromNumber('org', successCount)}. The ${ORG_INACTIVITY_EXPIRATION_DAYS}-day inactivity clock has been reset.`,
+        });
+      } else if (successCount === 0) {
+        fireToast({
+          type: 'error',
+          message: `Unable to refresh ${errorCount} ${pluralizeFromNumber('org', errorCount)}. Reconnect the orgs with a connection error to continue using them.`,
+        });
+      } else {
+        fireToast({
+          type: 'warning',
+          message: `Refreshed ${successCount} of ${orgs.length} orgs. The remaining ${errorCount} ${pluralizeFromNumber('org', errorCount)} must be reconnected.`,
+        });
+      }
+    } catch (ex) {
+      logger.error('Error refreshing all orgs', ex);
+      fireToast({ type: 'error', message: 'There was a problem refreshing your orgs. Please try again.' });
+    } finally {
+      setCompletedCount(null);
+      trackEvent(ANALYTICS_KEYS.sfdc_org_refresh_all, { orgCount: orgs.length, successCount, errorCount });
+    }
+  }
+
+  return (
+    <Tooltip
+      content={`Salesforce ends a connection when an org has not been used for ${ORG_INACTIVITY_EXPIRATION_DAYS} days. Refreshing checks every connection and resets the ${ORG_INACTIVITY_EXPIRATION_DAYS}-day clock so your orgs stay connected.`}
+    >
+      <button
+        className={classNames('slds-button slds-button_neutral slds-is-relative', className)}
+        onClick={handleRefreshAllOrgs}
+        disabled={isRefreshing}
+      >
+        <Icon type="utility" icon="refresh" className="slds-button__icon slds-button__icon_left" omitContainer />
+        {isRefreshing ? `Refreshing ${completedCount} of ${orgs.length}` : 'Refresh All Orgs'}
+        {isRefreshing && <Spinner size="small" />}
+      </button>
+    </Tooltip>
+  );
+};

--- a/libs/features/org-groups/src/lib/SalesforceOrgCardConnectionRefresh.tsx
+++ b/libs/features/org-groups/src/lib/SalesforceOrgCardConnectionRefresh.tsx
@@ -1,9 +1,10 @@
 import { logger } from '@jetstream/shared/client-logger';
+import { ANALYTICS_KEYS } from '@jetstream/shared/constants';
 import { checkOrgHealth, getOrgs } from '@jetstream/shared/data';
 import { ORG_INACTIVITY_EXPIRATION_DAYS, pluralizeFromNumber } from '@jetstream/shared/utils';
 import { AddOrgHandlerFn, BadgeType, Maybe, SalesforceOrgUi } from '@jetstream/types';
 import { Badge, ConfirmationModalPromise, Grid, Icon, Spinner, Tooltip, fireToast } from '@jetstream/ui';
-import { AddOrg, OrgExpirationStatus, useOrgExpiration, useUpdateOrgs } from '@jetstream/ui-core';
+import { AddOrg, OrgExpirationStatus, useAmplitude, useOrgExpiration, useUpdateOrgs } from '@jetstream/ui-core';
 import { fromAppState } from '@jetstream/ui/app-state';
 import { useSetAtom } from 'jotai';
 import { useState } from 'react';
@@ -58,33 +59,49 @@ export function SalesforceOrgCardConnectionRefresh({
   onRemoveOrg,
 }: SalesforceOrgCardConnectionRefreshProps) {
   const orgExpiration = useOrgExpiration(org);
+  const { trackEvent } = useAmplitude();
   const [isRefreshing, setIsRefreshing] = useState(false);
   const setOrgs = useSetAtom(fromAppState.salesforceOrgsAsyncState);
 
   const handleRefreshOrg = async () => {
     setIsRefreshing(true);
+    let success = true;
     try {
       await checkOrgHealth(org);
-      // Re-fetch orgs to update state
-      const updatedOrgs = await getOrgs();
-      setOrgs(updatedOrgs);
       fireToast({
         type: 'success',
         message: 'Org connection refreshed successfully',
       });
     } catch (error) {
+      success = false;
       logger.error('Error refreshing org', error);
       fireToast({
         type: 'error',
         message: 'Failed to refresh org connection. Reconnect the org to continue using it.',
       });
     } finally {
+      /**
+       * Re-fetch on failure as well as success - a failed health check is exactly when the server records the
+       * connection error, and without this the card keeps showing stale status until the page is reloaded.
+       */
+      try {
+        setOrgs(await getOrgs());
+      } catch (error) {
+        logger.error('Error re-fetching orgs after refresh', error);
+      }
       setIsRefreshing(false);
+      trackEvent(ANALYTICS_KEYS.sfdc_org_refresh_connection, {
+        success,
+        isExpiring: orgExpiration.isExpiring,
+        isExpired: orgExpiration.isExpired,
+        hadConnectionError: !!org.connectionError,
+      });
     }
   };
 
   const handleRemoveOrg = async () => {
     if (await ConfirmationModalPromise({ content: 'Are you sure you want to remove this org from Jetstream?', confirm: 'Remove Org' })) {
+      trackEvent(ANALYTICS_KEYS.sfdc_org_removed, { source: 'org-groups-card', isExpired: orgExpiration.isExpired });
       onRemoveOrg(org);
     }
   };

--- a/libs/features/org-groups/src/lib/SalesforceOrgCardDraggable.tsx
+++ b/libs/features/org-groups/src/lib/SalesforceOrgCardDraggable.tsx
@@ -82,6 +82,7 @@ export function SalesforceOrgCardDraggable({ org, isActive, onAddOrgHandlerFn }:
                 />
               )}
               <OrgInfoPopover
+                source="org-groups"
                 org={org}
                 loading={orgLoading}
                 disableOrgActions={actionInProgress}

--- a/libs/features/org-groups/src/lib/SalesforceOrgsActions.tsx
+++ b/libs/features/org-groups/src/lib/SalesforceOrgsActions.tsx
@@ -1,5 +1,7 @@
+import { ANALYTICS_KEYS } from '@jetstream/shared/constants';
 import { SalesforceOrgUi } from '@jetstream/types';
 import { DropDown } from '@jetstream/ui';
+import { useAmplitude } from '@jetstream/ui-core';
 import { useState } from 'react';
 import { DeleteOrgsModal } from './DeleteOrgsModal';
 
@@ -9,11 +11,16 @@ interface SalesforceOrgsActionsProps {
 }
 
 export const SalesforceOrgsActions = ({ orgs, onOrgsDeleted }: SalesforceOrgsActionsProps) => {
+  const { trackEvent } = useAmplitude();
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
 
   function handleAction(action: string) {
     switch (action) {
       case 'DELETE_ORGS':
+        trackEvent(ANALYTICS_KEYS.sfdc_org_delete_modal_open, {
+          orgCount: orgs.length,
+          orgsWithErrorCount: orgs.filter(({ connectionError }) => !!connectionError).length,
+        });
         setIsDeleteModalOpen(true);
         break;
     }

--- a/libs/features/org-groups/src/lib/__tests__/RefreshAllOrgsButton.spec.tsx
+++ b/libs/features/org-groups/src/lib/__tests__/RefreshAllOrgsButton.spec.tsx
@@ -1,0 +1,113 @@
+import { ANALYTICS_KEYS } from '@jetstream/shared/constants';
+import { SalesforceOrgUi } from '@jetstream/types';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { atom } from 'jotai';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { RefreshAllOrgsButton } from '../RefreshAllOrgsButton';
+
+const checkOrgHealth = vi.fn();
+const getOrgs = vi.fn();
+const fireToast = vi.fn();
+const trackEvent = vi.fn();
+
+vi.mock('@jetstream/shared/data', () => ({
+  checkOrgHealth: (org: SalesforceOrgUi) => checkOrgHealth(org),
+  getOrgs: () => getOrgs(),
+}));
+
+vi.mock('@jetstream/ui-core', () => ({
+  useAmplitude: () => ({ trackEvent }),
+}));
+
+vi.mock('@jetstream/ui/app-state', () => ({
+  fromAppState: { salesforceOrgsAsyncState: atom<SalesforceOrgUi[]>([]) },
+}));
+
+vi.mock('@jetstream/ui', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@jetstream/ui')>()),
+  fireToast: (payload: unknown) => fireToast(payload),
+}));
+
+const orgs = ['org-1', 'org-2', 'org-3'].map((uniqueId) => ({ uniqueId }) as SalesforceOrgUi);
+
+function setup() {
+  render(<RefreshAllOrgsButton orgs={orgs} />);
+  const button = screen.getByRole('button');
+  // The refresh queue keeps updating progress state after the click settles, so let act() flush it
+  return {
+    button,
+    clickRefresh: () =>
+      act(async () => {
+        fireEvent.click(button);
+      }),
+  };
+}
+
+describe('RefreshAllOrgsButton', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getOrgs.mockResolvedValue(orgs);
+  });
+
+  it('should refresh every org and report success', async () => {
+    checkOrgHealth.mockResolvedValue(undefined);
+    const { clickRefresh } = setup();
+
+    await clickRefresh();
+
+    await waitFor(() => expect(getOrgs).toHaveBeenCalledTimes(1));
+    expect(checkOrgHealth).toHaveBeenCalledTimes(3);
+    expect(fireToast).toHaveBeenCalledWith(expect.objectContaining({ type: 'success' }));
+    expect(trackEvent).toHaveBeenCalledWith(ANALYTICS_KEYS.sfdc_org_refresh_all, { orgCount: 3, successCount: 3, errorCount: 0 });
+  });
+
+  it('should keep refreshing the remaining orgs when one fails and report the partial result', async () => {
+    checkOrgHealth.mockImplementation((org: SalesforceOrgUi) =>
+      org.uniqueId === 'org-2' ? Promise.reject(new Error('expired')) : Promise.resolve(),
+    );
+    const { clickRefresh } = setup();
+
+    await clickRefresh();
+
+    await waitFor(() => expect(getOrgs).toHaveBeenCalledTimes(1));
+    expect(checkOrgHealth).toHaveBeenCalledTimes(3);
+    expect(fireToast).toHaveBeenCalledWith(expect.objectContaining({ type: 'warning' }));
+    expect(trackEvent).toHaveBeenCalledWith(ANALYTICS_KEYS.sfdc_org_refresh_all, { orgCount: 3, successCount: 2, errorCount: 1 });
+  });
+
+  it('should report an error and still re-fetch orgs when every org fails', async () => {
+    checkOrgHealth.mockRejectedValue(new Error('expired'));
+    const { clickRefresh } = setup();
+
+    await clickRefresh();
+
+    await waitFor(() => expect(getOrgs).toHaveBeenCalledTimes(1));
+    expect(fireToast).toHaveBeenCalledWith(expect.objectContaining({ type: 'error' }));
+    expect(trackEvent).toHaveBeenCalledWith(ANALYTICS_KEYS.sfdc_org_refresh_all, { orgCount: 3, successCount: 0, errorCount: 3 });
+  });
+
+  it('should show progress and prevent a second refresh while one is in flight', async () => {
+    const pendingHealthChecks: Array<() => void> = [];
+    checkOrgHealth.mockImplementation(() => new Promise<void>((resolve) => pendingHealthChecks.push(resolve)));
+    const { button, clickRefresh } = setup();
+
+    await clickRefresh();
+
+    expect(button.hasAttribute('disabled')).toBe(true);
+    expect(button.textContent).toContain('Refreshing 0 of 3');
+
+    await act(async () => pendingHealthChecks.forEach((resolve) => resolve()));
+    await waitFor(() => expect(button.hasAttribute('disabled')).toBe(false));
+  });
+
+  it('should explain the inactivity expiration in a tooltip', async () => {
+    const { button } = setup();
+
+    await userEvent.hover(button);
+
+    const tooltip = await screen.findByRole('tooltip');
+    expect(tooltip.textContent).toContain('has not been used for 30 days');
+    expect(tooltip.textContent).toContain('resets the 30-day clock');
+  });
+});

--- a/libs/features/org-groups/vite.config.mts
+++ b/libs/features/org-groups/vite.config.mts
@@ -10,6 +10,7 @@ export default defineConfig(() => ({
     watch: false,
     globals: true,
     environment: 'jsdom',
+    setupFiles: ['../../test-utils/src/test-setup-dom.ts'],
     include: ['{src,tests}/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
     reporters: ['default'],
     passWithNoTests: true,

--- a/libs/features/query/src/QueryBuilder/QueryChildFields.tsx
+++ b/libs/features/query/src/QueryBuilder/QueryChildFields.tsx
@@ -4,11 +4,11 @@ import { multiWordObjectFilter } from '@jetstream/shared/utils';
 import { FieldWrapper, QueryFieldWithPolymorphic, QueryFields, SalesforceOrgUi } from '@jetstream/types';
 import { SobjectFieldList } from '@jetstream/ui';
 import { fromQueryState } from '@jetstream/ui-core';
-import { getSubqueryFieldBaseKey } from '@jetstream/ui-core/shared';
+import { getSubqueryFieldBaseKey, initQueryFieldStateItem, removeInFlightQueryFields } from '@jetstream/ui-core/shared';
 import { selectedOrgState } from '@jetstream/ui/app-state';
 import { useAtom, useAtomValue } from 'jotai';
 import isEmpty from 'lodash/isEmpty';
-import { Fragment, FunctionComponent, useEffect, useState } from 'react';
+import { Fragment, FunctionComponent, useEffect } from 'react';
 
 export interface QueryChildFieldsProps {
   org: SalesforceOrgUi;
@@ -29,57 +29,53 @@ export const QueryChildFields: FunctionComponent<QueryChildFieldsProps> = ({
   onSelectionChanged,
 }) => {
   const [queryFieldsMap, setQueryFieldsMap] = useAtom(fromQueryState.queryFieldsMapState);
-  const [baseKey, setBaseKey] = useState<string>(getSubqueryFieldBaseKey(selectedSObject, relationshipPath));
   const selectedOrg = useAtomValue(selectedOrgState);
+  const baseKey = getSubqueryFieldBaseKey(selectedSObject, relationshipPath);
 
   // Fetch fields for base object if the selected object changes
   useEffect(() => {
     const BASE_KEY = getSubqueryFieldBaseKey(selectedSObject, relationshipPath);
+    let abandoned = false;
 
-    let baseQueryFieldsMap: QueryFields = queryFieldsMap[BASE_KEY];
-
-    if (isEmpty(baseQueryFieldsMap)) {
-      setBaseKey(BASE_KEY);
-      // clone so we can mutate
-      let tempQueryFieldsMap = { ...queryFieldsMap };
-      // clone so we can mutate
-      baseQueryFieldsMap = { ...baseQueryFieldsMap };
-      baseQueryFieldsMap = {
-        key: BASE_KEY,
-        isPolymorphic: false,
-        expanded: true,
-        loading: true,
-        hasError: false,
-        filterTerm: '',
-        sobject: selectedSObject,
-        fields: {},
-        visibleFields: new Set(),
-        selectedFields: new Set(),
-      };
+    if (isEmpty(queryFieldsMap[BASE_KEY])) {
+      const baseFieldsPlaceholder = initQueryFieldStateItem(BASE_KEY, selectedSObject, { loading: true });
       // set to loading state while base fields are fetched
-      tempQueryFieldsMap[BASE_KEY] = baseQueryFieldsMap;
-      setQueryFieldsMap(tempQueryFieldsMap);
+      setQueryFieldsMap((priorFieldsMap) => ({ ...priorFieldsMap, [BASE_KEY]: baseFieldsPlaceholder }));
       (async () => {
-        tempQueryFieldsMap = { ...queryFieldsMap };
-        baseQueryFieldsMap = { ...baseQueryFieldsMap };
+        let baseQueryFields: QueryFields;
         try {
-          // fetch fields
-          baseQueryFieldsMap = await fetchFields(selectedOrg, baseQueryFieldsMap, BASE_KEY, isTooling);
-          // clone and set to loading
-          baseQueryFieldsMap = { ...baseQueryFieldsMap, loading: false };
-          // update object on core state
-          tempQueryFieldsMap[BASE_KEY] = baseQueryFieldsMap;
+          baseQueryFields = { ...(await fetchFields(selectedOrg, baseFieldsPlaceholder, BASE_KEY, isTooling)), loading: false };
         } catch (ex) {
           logger.warn('[SUBQUERY] Query SObject error', ex);
-          baseQueryFieldsMap = { ...baseQueryFieldsMap, loading: false, hasError: true };
-          tempQueryFieldsMap[BASE_KEY] = baseQueryFieldsMap;
-        } finally {
-          setQueryFieldsMap(tempQueryFieldsMap);
+          baseQueryFields = { ...baseFieldsPlaceholder, loading: false, hasError: true };
         }
+        if (abandoned) {
+          return;
+        }
+        setQueryFieldsMap((priorFieldsMap) => ({ ...priorFieldsMap, [BASE_KEY]: baseQueryFields }));
       })();
     }
+
+    return () => {
+      abandoned = true;
+      // Drop the placeholders for any fetch that will never write its result, otherwise the guards
+      // above and in handleToggleFieldExpand treat them as loaded and the spinner never clears
+      setQueryFieldsMap((priorFieldsMap) => removeInFlightQueryFields(priorFieldsMap, BASE_KEY));
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectedOrg, selectedSObject]);
+  }, [selectedOrg, selectedSObject, relationshipPath, isTooling]);
+
+  async function fetchRelatedFields(key: string, relatedFieldsPlaceholder: QueryFields) {
+    let relatedQueryFields: QueryFields;
+    try {
+      relatedQueryFields = { ...(await fetchFields(selectedOrg, relatedFieldsPlaceholder, key, isTooling)), loading: false };
+    } catch (ex) {
+      logger.warn('Query SObject error', ex);
+      relatedQueryFields = { ...relatedFieldsPlaceholder, loading: false, hasError: true };
+    }
+    // Replace only this key - sibling expansions may have resolved while this fetch was in flight
+    setQueryFieldsMap((priorFieldsMap) => (priorFieldsMap[key] ? { ...priorFieldsMap, [key]: relatedQueryFields } : priorFieldsMap));
+  }
 
   /**
    * FIXME: This is rather complicated to follow the code path
@@ -104,67 +100,39 @@ export const QueryChildFields: FunctionComponent<QueryChildFieldsProps> = ({
     onSelectionChanged(fields);
   }
 
-  async function handleToggleFieldExpand(parentKey: string, field: FieldWrapper, relatedSobject: string) {
+  function handleToggleFieldExpand(parentKey: string, field: FieldWrapper, relatedSobject: string) {
     // FIXME: should be centralized:
     // const key = `${parentKey}${field.metadata.relationshipName}.`;
     const key = getFieldKey(parentKey, field.metadata);
+    const existingFields = queryFieldsMap[key];
     // if field is already initialized
-    const clonedQueryFieldsMap = { ...queryFieldsMap };
-    if (clonedQueryFieldsMap[key]) {
-      clonedQueryFieldsMap[key] = { ...clonedQueryFieldsMap[key], expanded: !clonedQueryFieldsMap[key].expanded };
-    } else {
-      // this is a new expansion that we have not seen, we need to fetch the fields and init the object
-      clonedQueryFieldsMap[key] = {
-        key,
-        expanded: true,
-        loading: true,
-        hasError: false,
-        filterTerm: '',
-        sobject: relatedSobject,
-        isPolymorphic: Array.isArray(field.relatedSobject),
-        fields: {},
-        visibleFields: new Set(),
-        selectedFields: new Set(),
-      };
-      // fetch fields and update once resolved
-      (async () => {
-        try {
-          clonedQueryFieldsMap[key] = await fetchFields(selectedOrg, clonedQueryFieldsMap[key], key, isTooling);
-          // ensure selected object did not change
-          if (clonedQueryFieldsMap[key]) {
-            clonedQueryFieldsMap[key] = { ...clonedQueryFieldsMap[key], loading: false };
-            setQueryFieldsMap(clonedQueryFieldsMap);
-          }
-        } catch (ex) {
-          logger.warn('Query SObject error', ex);
-          clonedQueryFieldsMap[key] = { ...clonedQueryFieldsMap[key], loading: false, hasError: true };
-        } finally {
-          setQueryFieldsMap(clonedQueryFieldsMap);
-        }
-      })();
+    if (existingFields) {
+      // Toggle against the published map rather than this render's snapshot - a sibling fetch may
+      // have resolved into it since, and rewriting the snapshot would undo that
+      setQueryFieldsMap((priorFieldsMap) => {
+        const currentFields = priorFieldsMap[key] || existingFields;
+        return { ...priorFieldsMap, [key]: { ...currentFields, expanded: !currentFields.expanded } };
+      });
+      return;
     }
-    setQueryFieldsMap({ ...clonedQueryFieldsMap });
+    // this is a new expansion that we have not seen, we need to fetch the fields and init the object
+    const relatedFieldsPlaceholder = initQueryFieldStateItem(key, relatedSobject, {
+      loading: true,
+      isPolymorphic: Array.isArray(field.relatedSobject),
+    });
+    setQueryFieldsMap((priorFieldsMap) => ({ ...priorFieldsMap, [key]: relatedFieldsPlaceholder }));
+    // fetch fields and update once resolved
+    fetchRelatedFields(key, relatedFieldsPlaceholder);
   }
 
-  async function handleErrorReattempt(key: string) {
-    const clonedQueryFieldsMap = { ...queryFieldsMap };
-    clonedQueryFieldsMap[key] = { ...clonedQueryFieldsMap[key], loading: true, hasError: false };
-    setQueryFieldsMap({ ...clonedQueryFieldsMap });
-
-    // This is a candidate to pull into shared function
-    try {
-      clonedQueryFieldsMap[key] = await fetchFields(selectedOrg, clonedQueryFieldsMap[key], key, isTooling);
-      // ensure selected object did not change
-      if (clonedQueryFieldsMap[key]) {
-        clonedQueryFieldsMap[key] = { ...clonedQueryFieldsMap[key], loading: false };
-        setQueryFieldsMap(clonedQueryFieldsMap);
-      }
-    } catch (ex) {
-      logger.warn('Query SObject error', ex);
-      clonedQueryFieldsMap[key] = { ...clonedQueryFieldsMap[key], loading: false, hasError: true };
-    } finally {
-      setQueryFieldsMap(clonedQueryFieldsMap);
+  function handleErrorReattempt(key: string) {
+    if (!queryFieldsMap[key]) {
+      return;
     }
+    const relatedFieldsPlaceholder = { ...queryFieldsMap[key], loading: true, hasError: false };
+    setQueryFieldsMap((priorFieldsMap) => ({ ...priorFieldsMap, [key]: relatedFieldsPlaceholder }));
+
+    fetchRelatedFields(key, relatedFieldsPlaceholder);
   }
 
   function handleFieldSelection(key: string, field: FieldWrapper) {

--- a/libs/features/query/src/QueryBuilder/QueryFields.tsx
+++ b/libs/features/query/src/QueryBuilder/QueryFields.tsx
@@ -9,11 +9,12 @@ import {
   getQueryFieldKey,
   getSelectedFieldsFromQueryFields,
   initQueryFieldStateItem,
+  removeInFlightQueryFields,
 } from '@jetstream/ui-core/shared';
 import { applicationCookieState, selectedOrgState } from '@jetstream/ui/app-state';
 import { useAtom, useAtomValue, useSetAtom } from 'jotai';
 import isEmpty from 'lodash/isEmpty';
-import { Fragment, FunctionComponent, useCallback, useEffect, useRef, useState } from 'react';
+import { Fragment, FunctionComponent, useCallback, useEffect, useRef } from 'react';
 
 export interface QueryFieldsProps {
   selectedSObject: Maybe<string>;
@@ -24,15 +25,14 @@ export interface QueryFieldsProps {
 export const QueryFieldsComponent: FunctionComponent<QueryFieldsProps> = ({ selectedSObject, isTooling, onSelectionChanged }) => {
   const [{ serverUrl }] = useAtom(applicationCookieState);
   const isMounted = useRef(true);
-  const _selectedSObject = useRef(selectedSObject);
   const [queryFieldsMap, setQueryFieldsMap] = useAtom(fromQueryState.queryFieldsMapState);
   const [queryFieldsKey, setQueryFieldsKey] = useAtom(fromQueryState.queryFieldsKey);
   const setFilterFields = useSetAtom(fromQueryState.filterQueryFieldsState);
   const setOrderByFields = useSetAtom(fromQueryState.orderByQueryFieldsState);
   const setGroupByFields = useSetAtom(fromQueryState.groupByQueryFieldsState);
   const setChildRelationships = useSetAtom(fromQueryState.queryChildRelationships);
-  const [baseKey, setBaseKey] = useState<string>(`${selectedSObject}|`);
   const selectedOrg = useAtomValue(selectedOrgState);
+  const baseKey = selectedSObject ? getQueryFieldBaseKey(selectedSObject) : '';
 
   useEffect(() => {
     isMounted.current = true;
@@ -41,89 +41,89 @@ export const QueryFieldsComponent: FunctionComponent<QueryFieldsProps> = ({ sele
     };
   }, []);
 
-  useEffect(() => {
-    _selectedSObject.current = selectedSObject;
-  }, [selectedSObject]);
-
-  // Fetch fields for base object if the selected object changes
-  useEffect(() => {
-    if (!selectedSObject) {
-      return;
-    }
-    const fieldKey = getQueryFieldKey(selectedOrg, selectedSObject);
-    if (isEmpty(queryFieldsMap) || fieldKey !== queryFieldsKey) {
-      // init query fields when object changes
-      let tempQueryFieldsMap: Record<string, QueryFields> = {};
-      setQueryFieldsMap(tempQueryFieldsMap);
-      if (selectedSObject) {
-        const BASE_KEY = getQueryFieldBaseKey(selectedSObject);
-        setBaseKey(BASE_KEY);
-        tempQueryFieldsMap = { ...tempQueryFieldsMap };
-        tempQueryFieldsMap[BASE_KEY] = initQueryFieldStateItem(BASE_KEY, selectedSObject, { loading: true });
-        setChildRelationships([]);
-        setQueryFieldsMap(tempQueryFieldsMap);
-        setQueryFieldsKey(fieldKey);
-
-        queryBaseFields(fieldKey, BASE_KEY, tempQueryFieldsMap);
-      }
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectedOrg, selectedSObject, isTooling]);
-
   const queryBaseFields = useCallback(
-    async (fieldKey: string, BASE_KEY: string, tempQueryFieldsMap: Record<string, QueryFields>) => {
-      tempQueryFieldsMap = { ...tempQueryFieldsMap };
+    async (fieldKey: string, baseFieldKey: string, sobject: string, isAbandoned: () => boolean) => {
+      let baseQueryFields = initQueryFieldStateItem(baseFieldKey, sobject, { loading: true });
       try {
-        tempQueryFieldsMap[BASE_KEY] = await fetchFields(selectedOrg, tempQueryFieldsMap[BASE_KEY], BASE_KEY, isTooling);
-        if (isMounted.current) {
-          // set filter fields and order by fields
-          const fields = Object.values(tempQueryFieldsMap[BASE_KEY].fields).map((item) => item.metadata);
-          setFilterFields(getListItemsFromFieldWithRelatedItems(sortQueryFields(fields.filter((field) => field.filterable))));
-          setOrderByFields(getListItemsFromFieldWithRelatedItems(sortQueryFields(fields.filter((field) => field.sortable))));
-          setGroupByFields(
-            getListItemsFromFieldWithRelatedItems(sortQueryFields(fields.filter((field) => field.groupable || field.type === 'datetime'))),
-          );
-
-          tempQueryFieldsMap[BASE_KEY] = { ...tempQueryFieldsMap[BASE_KEY], loading: false };
-          setChildRelationships(tempQueryFieldsMap[BASE_KEY].childRelationships || []);
-          if (tempQueryFieldsMap[BASE_KEY].fields.Id) {
-            tempQueryFieldsMap[BASE_KEY].selectedFields.add('Id');
-            emitSelectedFieldsChanged(tempQueryFieldsMap);
-          }
-        }
+        baseQueryFields = { ...(await fetchFields(selectedOrg, baseQueryFields, baseFieldKey, isTooling)), loading: false };
       } catch (ex) {
         logger.warn('Query SObject error', ex);
-        tempQueryFieldsMap[BASE_KEY] = { ...tempQueryFieldsMap[BASE_KEY], loading: false, hasError: true };
-      } finally {
-        if (isMounted.current) {
-          setQueryFieldsMap(tempQueryFieldsMap);
-          setQueryFieldsKey(fieldKey);
+        baseQueryFields = { ...baseQueryFields, loading: false, hasError: true };
+      }
+
+      // A newer org/object was selected, or the component went away, while this fetch was in flight.
+      // Writing now would replace the current object's fields with fields nobody asked for.
+      if (isAbandoned()) {
+        return;
+      }
+
+      if (!baseQueryFields.hasError) {
+        // set filter fields and order by fields
+        const fields = Object.values(baseQueryFields.fields).map(({ metadata }) => metadata);
+        setFilterFields(getListItemsFromFieldWithRelatedItems(sortQueryFields(fields.filter((field) => field.filterable))));
+        setOrderByFields(getListItemsFromFieldWithRelatedItems(sortQueryFields(fields.filter((field) => field.sortable))));
+        setGroupByFields(
+          getListItemsFromFieldWithRelatedItems(sortQueryFields(fields.filter((field) => field.groupable || field.type === 'datetime'))),
+        );
+        setChildRelationships(baseQueryFields.childRelationships || []);
+        if (baseQueryFields.fields.Id) {
+          baseQueryFields.selectedFields.add('Id');
         }
+      }
+
+      const updatedQueryFieldsMap = { [baseFieldKey]: baseQueryFields };
+      setQueryFieldsMap(updatedQueryFieldsMap);
+      // Only claim the key once the fields behind it actually landed, otherwise an abandoned fetch
+      // leaves the key pointing at fields that were never loaded
+      setQueryFieldsKey(fieldKey);
+      if (baseQueryFields.fields.Id) {
+        emitSelectedFieldsChanged(updatedQueryFieldsMap);
       }
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [selectedOrg, isTooling],
   );
 
+  // Fetch fields for base object if the selected object changes
+  useEffect(() => {
+    if (!selectedSObject) {
+      return;
+    }
+    const BASE_KEY = getQueryFieldBaseKey(selectedSObject);
+    const fieldKey = getQueryFieldKey(selectedOrg, selectedSObject);
+    let abandoned = false;
+
+    // Anything already in the map under this exact org + object was loaded (or restored) previously
+    if (fieldKey !== queryFieldsKey || isEmpty(queryFieldsMap[BASE_KEY])) {
+      setChildRelationships([]);
+      setQueryFieldsMap({ [BASE_KEY]: initQueryFieldStateItem(BASE_KEY, selectedSObject, { loading: true }) });
+      queryBaseFields(fieldKey, BASE_KEY, selectedSObject, () => abandoned);
+    }
+
+    return () => {
+      abandoned = true;
+      setQueryFieldsMap((priorFieldsMap) => removeInFlightQueryFields(priorFieldsMap, BASE_KEY));
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedOrg, selectedSObject, isTooling]);
+
   const queryRelatedFields = useCallback(
-    async (fieldKey: string, tempQueryFieldsMap: Record<string, QueryFields>) => {
+    async (fieldKey: string, relatedFieldsPlaceholder: QueryFields) => {
+      let relatedQueryFields: QueryFields;
       try {
-        tempQueryFieldsMap[fieldKey] = await fetchFields(selectedOrg, tempQueryFieldsMap[fieldKey], fieldKey, isTooling);
-        if (isMounted.current) {
-          // ensure selected object did not change
-          if (tempQueryFieldsMap[fieldKey]) {
-            tempQueryFieldsMap[fieldKey] = { ...tempQueryFieldsMap[fieldKey], loading: false };
-            setQueryFieldsMap(tempQueryFieldsMap);
-          }
-        }
+        relatedQueryFields = { ...(await fetchFields(selectedOrg, relatedFieldsPlaceholder, fieldKey, isTooling)), loading: false };
       } catch (ex) {
         logger.warn('Query SObject error', ex);
-        tempQueryFieldsMap = { ...tempQueryFieldsMap, [fieldKey]: { ...tempQueryFieldsMap[fieldKey], loading: false, hasError: true } };
-      } finally {
-        if (isMounted.current) {
-          setQueryFieldsMap(tempQueryFieldsMap);
-        }
+        relatedQueryFields = { ...relatedFieldsPlaceholder, loading: false, hasError: true };
       }
+      if (!isMounted.current) {
+        return;
+      }
+      // Replace only this key - sibling expansions may have resolved, and the base object may have
+      // been swapped out entirely, while this fetch was in flight
+      setQueryFieldsMap((priorFieldsMap) =>
+        priorFieldsMap[fieldKey] ? { ...priorFieldsMap, [fieldKey]: relatedQueryFields } : priorFieldsMap,
+      );
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [selectedOrg, isTooling],
@@ -135,30 +135,37 @@ export const QueryFieldsComponent: FunctionComponent<QueryFieldsProps> = ({ sele
     onSelectionChanged(fields);
   }
 
-  async function handleToggleFieldExpand(parentKey: string, field: FieldWrapper, relatedSobject: string) {
+  function handleToggleFieldExpand(parentKey: string, field: FieldWrapper, relatedSobject: string) {
     const key = getFieldKey(parentKey, field.metadata);
+    const existingFields = queryFieldsMap[key];
     // if field is already initialized
-    const tempQueryFieldsMap = { ...queryFieldsMap };
-    if (tempQueryFieldsMap[key] && tempQueryFieldsMap[key].sobject === relatedSobject) {
-      tempQueryFieldsMap[key] = { ...tempQueryFieldsMap[key], expanded: !tempQueryFieldsMap[key].expanded };
-    } else {
-      // this is a new expansion that we have not seen, we need to fetch the fields and init the object
-      tempQueryFieldsMap[key] = initQueryFieldStateItem(key, relatedSobject, {
-        loading: true,
-        isPolymorphic: Array.isArray(field.relatedSobject),
+    if (existingFields && existingFields.sobject === relatedSobject) {
+      // Toggle against the published map rather than this render's snapshot - a sibling fetch may
+      // have resolved into it since, and rewriting the snapshot would undo that
+      setQueryFieldsMap((priorFieldsMap) => {
+        const currentFields = priorFieldsMap[key] || existingFields;
+        return { ...priorFieldsMap, [key]: { ...currentFields, expanded: !currentFields.expanded } };
       });
-      // fetch fields and update once resolved
-      queryRelatedFields(key, tempQueryFieldsMap);
+      return;
     }
-    setQueryFieldsMap({ ...tempQueryFieldsMap });
+    // this is a new expansion that we have not seen, we need to fetch the fields and init the object
+    const relatedFieldsPlaceholder = initQueryFieldStateItem(key, relatedSobject, {
+      loading: true,
+      isPolymorphic: Array.isArray(field.relatedSobject),
+    });
+    setQueryFieldsMap((priorFieldsMap) => ({ ...priorFieldsMap, [key]: relatedFieldsPlaceholder }));
+    // fetch fields and update once resolved
+    queryRelatedFields(key, relatedFieldsPlaceholder);
   }
 
-  async function handleErrorReattempt(key: string) {
-    const tempQueryFieldsMap = { ...queryFieldsMap };
-    tempQueryFieldsMap[key] = { ...tempQueryFieldsMap[key], loading: true, hasError: false };
-    setQueryFieldsMap({ ...tempQueryFieldsMap });
+  function handleErrorReattempt(key: string) {
+    if (!queryFieldsMap[key]) {
+      return;
+    }
+    const relatedFieldsPlaceholder = { ...queryFieldsMap[key], loading: true, hasError: false };
+    setQueryFieldsMap((priorFieldsMap) => ({ ...priorFieldsMap, [key]: relatedFieldsPlaceholder }));
 
-    queryRelatedFields(key, tempQueryFieldsMap);
+    queryRelatedFields(key, relatedFieldsPlaceholder);
   }
 
   function handleFieldSelection(key: string, field: FieldWrapper) {

--- a/libs/features/query/src/QueryBuilder/QuerySubqueryConfigPanel.tsx
+++ b/libs/features/query/src/QueryBuilder/QuerySubqueryConfigPanel.tsx
@@ -5,7 +5,7 @@ import { groupByFlat } from '@jetstream/shared/utils';
 import { ExpressionType, Field, ListItem, QueryFields, QueryOrderByClause, SalesforceOrgUi } from '@jetstream/types';
 import { Panel, Spinner } from '@jetstream/ui';
 import { fromQueryState } from '@jetstream/ui-core';
-import { getSubqueryFieldBaseKey } from '@jetstream/ui-core/shared';
+import { getSubqueryFieldBaseKey, removeInFlightQueryFields } from '@jetstream/ui-core/shared';
 import { useAtom, useAtomValue, useSetAtom } from 'jotai';
 import isEmpty from 'lodash/isEmpty';
 import { Fragment, FunctionComponent, useCallback, useEffect, useMemo, useState } from 'react';
@@ -107,14 +107,7 @@ export const QuerySubqueryConfigPanel: FunctionComponent<QuerySubqueryConfigPane
       cancelled = true;
       // If the fetch hasn't resolved, drop the loading placeholder so the next
       // mount retries instead of short-circuiting on a stale `{ loading: true }` entry.
-      setQueryFieldsMap((prev) => {
-        if (prev[childBaseKey]?.loading) {
-          const next = { ...prev };
-          delete next[childBaseKey];
-          return next;
-        }
-        return prev;
-      });
+      setQueryFieldsMap((prev) => removeInFlightQueryFields(prev, childBaseKey));
     };
     // We intentionally depend only on open + base key; queryFieldsMap is a moving target
     // and isTooling is stable for the life of a panel instance.

--- a/libs/features/query/src/QueryBuilder/__tests__/QueryFields.race.spec.tsx
+++ b/libs/features/query/src/QueryBuilder/__tests__/QueryFields.race.spec.tsx
@@ -1,0 +1,123 @@
+import { QueryFields, SalesforceOrgUi } from '@jetstream/types';
+import { fromQueryState } from '@jetstream/ui-core';
+import { render, waitFor } from '@testing-library/react';
+import { createStore, Provider } from 'jotai';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import QueryFieldsComponent from '../QueryFields';
+
+/** Field fetches are held open so the tests control the order they resolve in */
+const { deferredFetches, mockOrg } = vi.hoisted(() => ({
+  deferredFetches: new Map<string, { resolve: (value: any) => void; reject: (err: Error) => void }>(),
+  mockOrg: { uniqueId: 'org-1', label: 'Org 1' },
+}));
+
+vi.mock('@jetstream/ui/app-state', async () => {
+  const { atom } = await import('jotai');
+  return {
+    applicationCookieState: atom({ serverUrl: 'http://localhost' }),
+    selectedOrgState: atom(mockOrg),
+  };
+});
+
+vi.mock('@jetstream/ui', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@jetstream/ui')>()),
+  AutoFullHeightContainer: ({ children }: any) => <div>{children}</div>,
+  SobjectFieldList: ({ itemKey, queryFieldsMap }: any) => (
+    <div data-testid="field-list" data-item-key={itemKey} data-loading={String(!!queryFieldsMap[itemKey]?.loading)} />
+  ),
+}));
+
+vi.mock('@jetstream/shared/ui-utils', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@jetstream/shared/ui-utils')>()),
+  fetchFields: vi.fn(
+    (_org: SalesforceOrgUi, queryFields: QueryFields) =>
+      new Promise<QueryFields>((resolve, reject) => {
+        deferredFetches.set(queryFields.sobject, { resolve, reject });
+      }),
+  ),
+}));
+
+function buildFetchedFields(sobject: string): QueryFields {
+  return {
+    key: `${sobject}|`,
+    expanded: true,
+    loading: true,
+    isPolymorphic: false,
+    hasError: false,
+    filterTerm: '',
+    sobject,
+    fields: { Id: { name: 'Id', label: 'Id', type: 'Id', sobject, filterText: 'id', metadata: { name: 'Id' } as any } as any },
+    visibleFields: new Set(['Id']),
+    selectedFields: new Set<string>(),
+    childRelationships: [],
+  } as unknown as QueryFields;
+}
+
+describe('QueryFields async races (github issues #233 / #364)', () => {
+  beforeEach(() => {
+    deferredFetches.clear();
+  });
+
+  it('#233 - an out-of-order field fetch clobbers the currently selected object', async () => {
+    const store = createStore();
+    const { rerender, getByTestId } = render(
+      <Provider store={store}>
+        <QueryFieldsComponent selectedSObject="Account" isTooling={false} onSelectionChanged={vi.fn()} />
+      </Provider>,
+    );
+
+    await waitFor(() => expect(deferredFetches.has('Account')).toBe(true));
+
+    // user quickly switches to a different object before the first fetch resolves
+    rerender(
+      <Provider store={store}>
+        <QueryFieldsComponent selectedSObject="Contact" isTooling={false} onSelectionChanged={vi.fn()} />
+      </Provider>,
+    );
+    await waitFor(() => expect(deferredFetches.has('Contact')).toBe(true));
+
+    // Contact (the current selection) resolves first, Account (abandoned) resolves last
+    deferredFetches.get('Contact')?.resolve(buildFetchedFields('Contact'));
+    await waitFor(() => expect(getByTestId('field-list').getAttribute('data-loading')).toBe('false'));
+
+    deferredFetches.get('Account')?.resolve(buildFetchedFields('Account'));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    // the abandoned Account fetch must not overwrite state belonging to Contact
+    expect(Object.keys(store.get(fromQueryState.queryFieldsMapState))).toEqual(['Contact|']);
+    expect(store.get(fromQueryState.queryFieldsKey)).toBe('org-1-Contact');
+    expect(getByTestId('field-list').getAttribute('data-item-key')).toBe('Contact|');
+  });
+
+  it('#364 - unmounting mid-fetch leaves a permanent loading entry that the next mount will not retry', async () => {
+    const store = createStore();
+    const { unmount } = render(
+      <Provider store={store}>
+        <QueryFieldsComponent selectedSObject="Account" isTooling={false} onSelectionChanged={vi.fn()} />
+      </Provider>,
+    );
+
+    await waitFor(() => expect(deferredFetches.has('Account')).toBe(true));
+    expect(store.get(fromQueryState.queryFieldsMapState)['Account|'].loading).toBe(true);
+
+    // navigate away (execute query / change org) before fields come back
+    unmount();
+    deferredFetches.get('Account')?.resolve(buildFetchedFields('Account'));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    deferredFetches.clear();
+
+    // navigate back
+    const { getByTestId } = render(
+      <Provider store={store}>
+        <QueryFieldsComponent selectedSObject="Account" isTooling={false} onSelectionChanged={vi.fn()} />
+      </Provider>,
+    );
+
+    // the abandoned fetch must not be mistaken for a completed one - the fields have to be fetched again
+    await waitFor(() => expect(deferredFetches.has('Account')).toBe(true));
+    deferredFetches.get('Account')?.resolve(buildFetchedFields('Account'));
+
+    await waitFor(() => expect(getByTestId('field-list').getAttribute('data-loading')).toBe('false'));
+  });
+});

--- a/libs/shared/constants/src/lib/shared-constants.ts
+++ b/libs/shared/constants/src/lib/shared-constants.ts
@@ -356,14 +356,24 @@ export const ANALYTICS_KEYS = {
 
   /** ORGANIZATIONS */
   organizations_create_modal_open: 'organizations_create_modal_open',
+  organizations_edit_modal_open: 'organizations_edit_modal_open',
   organizations_created: 'organizations_created',
   organizations_deleted: 'organizations_deleted',
   organizations_deleted_with_orgs: 'organizations_deleted_with_orgs',
   organizations_updated: 'organizations_updated',
   organizations_moved: 'organizations_moved',
+  organizations_selected: 'organizations_selected',
 
   /** SFDC ORGS */
   sfdc_org_add_org: 'sfdc_org_add_org',
+  sfdc_org_info_opened: 'sfdc_org_info_opened',
+  sfdc_org_updated: 'sfdc_org_updated',
+  sfdc_org_clear_cache: 'sfdc_org_clear_cache',
+  sfdc_org_removed: 'sfdc_org_removed',
+  sfdc_org_refresh_connection: 'sfdc_org_refresh_connection',
+  sfdc_org_refresh_all: 'sfdc_org_refresh_all',
+  sfdc_org_delete_modal_open: 'sfdc_org_delete_modal_open',
+  sfdc_org_bulk_deleted: 'sfdc_org_bulk_deleted',
 
   /** FEEDBACK */
   donate_popover_open: 'donate_popover_open',

--- a/libs/shared/ui-core-shared/src/query-fields-utils.ts
+++ b/libs/shared/ui-core-shared/src/query-fields-utils.ts
@@ -53,6 +53,22 @@ export function initQueryFieldStateItem(key: string, sobject: string, props: Par
   };
 }
 
+/**
+ * A fetch that never writes its result - the component unmounted, or a newer org/object was selected -
+ * leaves a `{ loading: true }` entry behind. Every caller treats the presence of an entry as
+ * "already loaded", so the abandoned entry becomes a spinner that nothing ever retries.
+ * Dropping the entry lets the next render start the fetch over.
+ */
+export function removeInFlightQueryFields(fieldsMap: Record<string, QueryFields>, keyPrefix: string): Record<string, QueryFields> {
+  const inFlightKeys = Object.keys(fieldsMap).filter((key) => key.startsWith(keyPrefix) && fieldsMap[key]?.loading);
+  if (!inFlightKeys.length) {
+    return fieldsMap;
+  }
+  const updatedFieldsMap = { ...fieldsMap };
+  inFlightKeys.forEach((key) => delete updatedFieldsMap[key]);
+  return updatedFieldsMap;
+}
+
 export function getSelectedFieldsFromQueryFields(fieldsMap: Record<string, QueryFields>): QueryFieldWithPolymorphic[] {
   const fields: QueryFieldWithPolymorphic[] = orderObjectsBy(
     Object.values(fieldsMap)

--- a/libs/shared/ui-core/src/orgs/AddOrg.tsx
+++ b/libs/shared/ui-core/src/orgs/AddOrg.tsx
@@ -102,6 +102,7 @@ export const AddOrg: FunctionComponent<AddOrgProps> = ({
       advancedOptionsEnabled,
       addLoginTrue,
       addToActiveOrganization: addToActiveOrgGroup,
+      isReconnect: !!existingOrg,
     });
   }
 

--- a/libs/shared/ui-core/src/orgs/OrgInfoPopover.tsx
+++ b/libs/shared/ui-core/src/orgs/OrgInfoPopover.tsx
@@ -1,4 +1,5 @@
 import { css } from '@emotion/react';
+import { ANALYTICS_KEYS } from '@jetstream/shared/constants';
 import { clearCacheForOrg } from '@jetstream/shared/data';
 import { addOrg, isEnterKey, isEscapeKey } from '@jetstream/shared/ui-utils';
 import { SalesforceOrgUi } from '@jetstream/types';
@@ -26,6 +27,7 @@ import isString from 'lodash/isString';
 import startCase from 'lodash/startCase';
 import { Fragment, FunctionComponent, ReactNode, useEffect, useRef, useState } from 'react';
 import { useResizeDetector } from 'react-resize-detector';
+import { useAmplitude } from '..';
 
 const EMPTY_COLOR = '_none_';
 
@@ -52,6 +54,8 @@ export interface OrgInfoPopoverProps {
   loading?: boolean;
   disableOrgActions?: boolean;
   isReadOnly?: boolean;
+  /** Identifies where the popover was rendered from so org management usage can be attributed in analytics */
+  source?: 'org-groups' | 'org-dropdown' | 'read-only';
   dropdownIconProps?: Partial<IconProps>;
   iconButtonClassName?: string;
   onAddOrg?: (org: SalesforceOrgUi, switchActiveOrg: boolean) => void;
@@ -165,12 +169,14 @@ export const OrgInfoPopover: FunctionComponent<OrgInfoPopoverProps> = ({
   loading,
   disableOrgActions,
   isReadOnly = false,
+  source,
   dropdownIconProps,
   iconButtonClassName,
   onAddOrg,
   onRemoveOrg,
   onUpdateOrg,
 }) => {
+  const { trackEvent } = useAmplitude();
   const { serverUrl } = useAtomValue(applicationCookieState);
   const skipFrontDoorAuth = useAtomValue(selectSkipFrontdoorAuth);
   const [orgLabel, setOrgLabel] = useState(org.label || org.username);
@@ -197,6 +203,7 @@ export const OrgInfoPopover: FunctionComponent<OrgInfoPopoverProps> = ({
   const minWidth = Math.max(POPOVER_MIN_WIDTH, (tableWidth || 0) + POPOVER_PADDING);
 
   function handleFixOrg() {
+    trackEvent(ANALYTICS_KEYS.sfdc_org_add_org, { source, isReconnect: true });
     addOrg({ serverUrl, loginUrl: org.instanceUrl, loginHint: org.username }, (addedOrg: SalesforceOrgUi) => {
       onAddOrg?.(addedOrg, true);
     });
@@ -221,17 +228,20 @@ export const OrgInfoPopover: FunctionComponent<OrgInfoPopoverProps> = ({
   }
 
   function handleSave() {
+    trackEvent(ANALYTICS_KEYS.sfdc_org_updated, { source, field: 'label' });
     onUpdateOrg?.(org, { label: orgLabel, color: getColor(orgColor) });
     // Save/Undo buttons unmount once the label is no longer dirty, so move focus back to the input to avoid losing it
     labelInputRef.current?.focus();
   }
 
   function handleColorSelection(color: ColorSwatchItem) {
+    trackEvent(ANALYTICS_KEYS.sfdc_org_updated, { source, field: 'color', clearedColor: !getColor(color.id) });
     setOrgColor(color.id);
     onUpdateOrg?.(org, { label: org.label, color: getColor(color.id) });
   }
 
   async function handleClearCache() {
+    trackEvent(ANALYTICS_KEYS.sfdc_org_clear_cache, { source });
     try {
       setDidClearCache(true);
       await clearCacheForOrg(org);
@@ -240,7 +250,15 @@ export const OrgInfoPopover: FunctionComponent<OrgInfoPopoverProps> = ({
     }
   }
 
+  function handleRemoveOrg() {
+    trackEvent(ANALYTICS_KEYS.sfdc_org_removed, { source, hasConnectionError: hasError });
+    onRemoveOrg?.(org);
+  }
+
   function handlePopoverClose(isOpen: boolean) {
+    if (isOpen) {
+      trackEvent(ANALYTICS_KEYS.sfdc_org_info_opened, { source, isReadOnly, hasConnectionError: hasError });
+    }
     if (!isOpen && isDirty) {
       setOrgLabel(org.username);
     }
@@ -412,7 +430,7 @@ export const OrgInfoPopover: FunctionComponent<OrgInfoPopoverProps> = ({
                       <button className="slds-button slds-button_neutral" onClick={() => setRemoveOrgActive(false)}>
                         Keep Org
                       </button>
-                      <button className="slds-button slds-button_brand" onClick={() => onRemoveOrg?.(org)}>
+                      <button className="slds-button slds-button_brand" onClick={() => handleRemoveOrg()}>
                         Remove Org
                       </button>
                     </GridCol>

--- a/libs/shared/ui-core/src/orgs/OrgsDropdown.tsx
+++ b/libs/shared/ui-core/src/orgs/OrgsDropdown.tsx
@@ -130,6 +130,7 @@ export const OrgsDropdown: FunctionComponent<OrgsDropdownProps> = ({
           {selectedOrg && (
             <div className="slds-col slds-m-horizontal--xx-small org-info-button">
               <OrgInfoPopover
+                source="org-dropdown"
                 org={selectedOrg}
                 loading={orgLoading}
                 disableOrgActions={actionInProgress}

--- a/libs/shared/ui-core/src/orgs/SelectedOrgReadOnly.tsx
+++ b/libs/shared/ui-core/src/orgs/SelectedOrgReadOnly.tsx
@@ -40,7 +40,7 @@ export const SelectedOrgReadOnly = () => {
         <p className="slds-box slds-box_xx-small">{selectedOrg?.label}</p>
         {selectedOrg && (
           <div className="slds-col slds-m-left--xx-small org-info-button">
-            {<OrgInfoPopover org={selectedOrg} disableOrgActions={actionInProgress} isReadOnly />}
+            {<OrgInfoPopover source="read-only" org={selectedOrg} disableOrgActions={actionInProgress} isReadOnly />}
           </div>
         )}
       </Grid>

--- a/libs/ui/src/lib/sobject-list/ConnectedSobjectList.tsx
+++ b/libs/ui/src/lib/sobject-list/ConnectedSobjectList.tsx
@@ -61,6 +61,7 @@ export const ConnectedSobjectList: FunctionComponent<ConnectedSobjectListProps> 
   onSearchTermChange,
 }) => {
   const isMounted = useRef(true);
+  const latestRequestId = useRef(0);
   const [loading, setLoading] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [lastRefreshed, setLastRefreshed] = useState<string>(_lastRefreshed);
@@ -98,13 +99,16 @@ export const ConnectedSobjectList: FunctionComponent<ConnectedSobjectListProps> 
   }, [recentItems, selectedFilters, sobjects]);
 
   const loadObjects = useCallback(async () => {
-    const uniqueId = selectedOrg.uniqueId;
-    const priorToolingValue = isTooling;
+    // The org or api can change while the describe is in flight - a superseded request must not
+    // publish the prior org's objects. `selectedOrg` cannot be re-read for this because it is
+    // captured in this closure, so requests are tracked by id instead.
+    const requestId = ++latestRequestId.current;
+    const isSuperseded = () => !isMounted.current || requestId !== latestRequestId.current;
     try {
       setLoading(true);
       const resultsWithCache = await describeGlobal(selectedOrg, isTooling);
       const results = resultsWithCache.data;
-      if (!isMounted.current || uniqueId !== selectedOrg.uniqueId || priorToolingValue !== isTooling) {
+      if (isSuperseded()) {
         return;
       }
       if (resultsWithCache.cache) {
@@ -114,12 +118,16 @@ export const ConnectedSobjectList: FunctionComponent<ConnectedSobjectListProps> 
       onSobjects(orderObjectsBy(results.sobjects.filter(filterFn), 'label'));
     } catch (ex) {
       logger.error(ex);
-      if (!isMounted.current || uniqueId !== selectedOrg.uniqueId || priorToolingValue !== isTooling) {
+      if (isSuperseded()) {
         return;
       }
       setErrorMessage(getErrorMessage(ex));
     } finally {
-      setLoading(false);
+      // The newest request owns the loading state - a superseded one clearing it would let the
+      // load effect fire again while that newer describe is still in flight
+      if (!isSuperseded()) {
+        setLoading(false);
+      }
     }
   }, [filterFn, onSobjects, selectedOrg, isTooling]);
 


### PR DESCRIPTION
Two unrelated pieces of work that happened to land on the same branch.

## Org management (#1445)

- **Refresh All Orgs** button on `/org-groups` — health-checks every org at once
  with progress, which both surfaces broken connections and resets Salesforce's
  30-day inactivity clock. Tooltip explains that so it reads as maintenance, not
  a plain reload.
- Fixed the original bug in the issue: refreshing a single org only re-fetched on
  success, but a *failed* check is exactly when the server records the connection
  error — so the card kept showing stale status until a page reload.
- Instrumented the rest of the page (group select/edit, bulk delete, refreshes,
  Org Info popover actions) so we can see what actually gets used.

⚠️ Two pre-existing analytics defects are fixed here, which changes how the
historical data reads: `organizations_created`/`organizations_updated` were
swapped, and `organizations_deleted` was also firing for bulk *org* deletion.

## Query field loading (#233, #364)

A describe can outlive the selection that started it, and nothing tied results
back to the request that asked for them. That let a slow fetch overwrite the
object the user had since switched to, and left abandoned `{ loading: true }`
placeholders that nothing ever retried (permanent spinner). Fetches now check for
abandonment before writing, cleanup drops stale placeholders, and writes go
through the functional setter instead of a stale snapshot.

## Testing

Unit tests for both areas; typecheck and lint clean.

Closes #1445
Closes #233
Closes #364
