### PR TITLE
fix: correct Batch load failure classification and surface capture failures

### DIFF
--- a/libs/features/load-records/src/components/load-results/LoadRecordsBatchApiResults.tsx
+++ b/libs/features/load-records/src/components/load-results/LoadRecordsBatchApiResults.tsx
@@ -246,6 +246,14 @@ export const LoadRecordsBatchApiResults = ({
       return;
     }
 
+    /**
+     * Whether any batch was submitted, which decides how a thrown load settles its history entry.
+     * `loadBatchApiData` converts every per-batch request failure into failed rows instead of
+     * throwing, so a throw that reaches the catch below comes from either batch preparation (a bad
+     * zip — nothing was sent) or the results callback (batches were already sent).
+     */
+    let anyBatchSubmitted = false;
+
     try {
       const loadDataPayload: LoadDataPayload = {
         org: selectedOrg,
@@ -264,6 +272,7 @@ export const LoadRecordsBatchApiResults = ({
       await loadBatchApiData(
         loadDataPayload,
         (records) => {
+          anyBatchSubmitted = true;
           const batchRecords = records || [];
           if (!batchRecords.length) {
             return;
@@ -310,7 +319,7 @@ export const LoadRecordsBatchApiResults = ({
       if (isMounted.current) {
         setEndTime(dateString);
       }
-      failLoad(getErrorMessage(ex), { reached: 'unknown' });
+      failLoad(getErrorMessage(ex), { reached: anyBatchSubmitted ? 'unknown' : 'none' });
       tracker.error('Error loading batches', ex);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/libs/features/load-records/src/utils/data-history-capture.ts
+++ b/libs/features/load-records/src/utils/data-history-capture.ts
@@ -60,7 +60,12 @@ export function apiModeToDataHistoryApi(apiMode: ApiMode): DataHistoryApi {
 /**
  * Whether any record may have reached Salesforce when a load failed. 'none' — a pre-processing/query
  * error, a thrown prepare step, a Bulk job that accepted no batch. 'unknown' — a throw after records
- * were sent (a Batch request mid-load, the Bulk job-status read after every batch was submitted).
+ * were sent (the Batch results callback once batches were submitted, the Bulk job-status read after
+ * every batch was submitted).
+ *
+ * Both APIs turn a failed request for one batch into failed rows rather than a throw, so neither
+ * reaches a call site's catch — 'unknown' is about the throws that happen around submission, not
+ * about a batch Salesforce rejected.
  */
 export type LoadFailureReach = 'none' | 'unknown';
 

--- a/libs/shared/ui-core/src/app/useInitDataHistory.ts
+++ b/libs/shared/ui-core/src/app/useInitDataHistory.ts
@@ -1,7 +1,27 @@
+import { tracker } from '@jetstream/shared/ui-utils';
+import { getErrorMessage } from '@jetstream/shared/utils';
 import { dataHistoryCaptureEnabledState, dataHistoryLimitsState } from '@jetstream/ui/app-state';
-import { initDataHistory } from '@jetstream/ui/data-history';
+import { DataHistoryFailureInfo, initDataHistory, setDataHistoryFailureReporter } from '@jetstream/ui/data-history';
 import { useSetAtom } from 'jotai';
 import { useCallback } from 'react';
+
+/**
+ * Data history swallows its failures so a broken capture can never break the user's data operation,
+ * which leaves nothing behind to notice: `logger.warn` is a no-op unless logging is turned on. Send
+ * them to the error tracker instead, keyed by operation so each code path stays a single issue
+ * rather than fragmenting on whatever wording the storage API used. The tracker only reports where a
+ * DSN is configured, so this is inert on desktop, the extension, and canvas.
+ *
+ * Expected conditions (denied permission, aborted streams) are filtered before they get here.
+ */
+function reportDataHistoryFailureToTracker({ operation, error, entryKey, backend }: DataHistoryFailureInfo): void {
+  tracker.error(`[DATA_HISTORY] ${operation} failed`, error, {
+    entryKey,
+    backend,
+    // Included explicitly: FSA and OPFS reject with DOMException, which the tracker cannot unwrap
+    errorMessage: getErrorMessage(error),
+  });
+}
 
 /**
  * Returns a stable callback that runs `initDataHistory()` and seeds the app-state atoms
@@ -17,6 +37,7 @@ export function useInitDataHistory() {
 
   const initDataHistoryAndSeedState = useCallback(
     async (options: { userId: string; hasPaidPlan?: boolean }) => {
+      setDataHistoryFailureReporter(reportDataHistoryFailureToTracker);
       const { captureEnabled, limits } = await initDataHistory(options);
       setCaptureEnabled(captureEnabled);
       setLimits(limits);

--- a/libs/shared/ui-data-history/src/index.ts
+++ b/libs/shared/ui-data-history/src/index.ts
@@ -8,6 +8,14 @@
 export * from './lib/data-history-backends';
 export * from './lib/data-history-bulk-results';
 export * from './lib/data-history.service';
+// Lets the host app point swallowed capture failures at its error tracker (this lib cannot import
+// one — see `failure-reporter.ts`)
+export {
+  setDataHistoryFailureReporter,
+  type DataHistoryFailureInfo,
+  type DataHistoryFailureOperation,
+  type DataHistoryFailureReporter,
+} from './lib/failure-reporter';
 // The only internals consumers legitimately need: the test seam on the real factory, the cross-document
 // "backend changed elsewhere" subscription, the "is storage bound to a user yet" gate, and the error
 // type read paths surface to the UI

--- a/libs/shared/ui-data-history/src/lib/__tests__/failure-reporter.spec.ts
+++ b/libs/shared/ui-data-history/src/lib/__tests__/failure-reporter.spec.ts
@@ -1,0 +1,64 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { DataHistoryFailureInfo, reportDataHistoryFailure, setDataHistoryFailureReporter } from '../failure-reporter';
+import { DataHistoryDirectoryPermissionError } from '../file-store/fsa-types';
+
+function captureReports() {
+  const reports: DataHistoryFailureInfo[] = [];
+  setDataHistoryFailureReporter((info) => reports.push(info));
+  return reports;
+}
+
+describe('data history failure reporter', () => {
+  afterEach(() => {
+    setDataHistoryFailureReporter(null);
+  });
+
+  it('reports unexpected failures with the operation and context', () => {
+    const reports = captureReports();
+    const error = new TypeError('records.map is not a function');
+
+    reportDataHistoryFailure({ operation: 'capture-step', error, entryKey: 'entry-1', backend: 'opfs' });
+
+    expect(reports).toEqual([{ operation: 'capture-step', error, entryKey: 'entry-1', backend: 'opfs' }]);
+  });
+
+  it.each([
+    ['a revoked folder permission', new DataHistoryDirectoryPermissionError()],
+    ['a denied permission prompt', Object.assign(new Error('User denied'), { name: 'NotAllowedError' })],
+    ['a stream aborted on backend switch', Object.assign(new Error('Aborted'), { name: 'AbortError' })],
+    ['a picker outside a user gesture', Object.assign(new Error('gesture'), { name: 'SecurityError' })],
+    ['a file that is already gone', Object.assign(new Error('missing'), { name: 'NotFoundError' })],
+  ])('does not report %s', (_label, error) => {
+    const reports = captureReports();
+
+    reportDataHistoryFailure({ operation: 'capture-step', error });
+
+    expect(reports).toHaveLength(0);
+  });
+
+  it('still reports a quota failure, which means capture silently stopped working', () => {
+    const reports = captureReports();
+    const error = Object.assign(new Error('quota'), { name: 'QuotaExceededError' });
+
+    reportDataHistoryFailure({ operation: 'capture-step', error });
+
+    expect(reports).toHaveLength(1);
+  });
+
+  it('never throws when the reporter itself fails', () => {
+    setDataHistoryFailureReporter(() => {
+      throw new Error('tracker exploded');
+    });
+
+    expect(() => reportDataHistoryFailure({ operation: 'init', error: new Error('boom') })).not.toThrow();
+  });
+
+  it('stops reporting once the reporter is unset', () => {
+    const reporter = vi.fn();
+    setDataHistoryFailureReporter(reporter);
+    setDataHistoryFailureReporter(null);
+
+    expect(() => reportDataHistoryFailure({ operation: 'init', error: new Error('boom') })).not.toThrow();
+    expect(reporter).not.toHaveBeenCalled();
+  });
+});

--- a/libs/shared/ui-data-history/src/lib/data-history.service.ts
+++ b/libs/shared/ui-data-history/src/lib/data-history.service.ts
@@ -36,6 +36,7 @@ import {
   requestPersistOnce,
   setTierLimits,
 } from './data-history-state';
+import { reportDataHistoryFailure } from './failure-reporter';
 import { getFileStoreForBackend, getHistoryFileStore, resetHistoryFileStores } from './file-store/file-store-factory';
 import { HistoryFileStore, HistoryWriteStream } from './file-store/file-store.types';
 import { getOrgFolderName } from './file-store/hashed-dir-names';
@@ -161,6 +162,7 @@ export async function initDataHistory(options: {
     return { captureEnabled, limits: getTierLimits() };
   } catch (ex) {
     logger.warn('[DATA_HISTORY] Error initializing data history', ex);
+    reportDataHistoryFailure({ operation: 'init', error: ex });
     return { captureEnabled: false, limits: getTierLimits() };
   }
 }
@@ -428,6 +430,7 @@ export class DataHistoryEntryHandle {
       await task();
     } catch (ex) {
       logger.warn('[DATA_HISTORY] Finalize task failed for entry', this.key, ex);
+      reportDataHistoryFailure({ operation: 'finalize', error: ex, entryKey: this.key, backend: this.store?.type });
     }
     // `finish()` is queued, so awaiting it also waits out every write the task enqueued
     await this.finish(outcome);
@@ -566,6 +569,7 @@ export class DataHistoryEntryHandle {
       void pruneEntryCountOverage();
     } catch (ex) {
       logger.warn('[DATA_HISTORY] Unable to start history entry', ex);
+      reportDataHistoryFailure({ operation: 'start-entry', error: ex, entryKey: this.key, backend: this.item.storageBackend });
       markEntryInactive(this.key);
     }
   }
@@ -599,6 +603,7 @@ export class DataHistoryEntryHandle {
         await task(store);
       } catch (ex) {
         logger.warn('[DATA_HISTORY] Capture step failed for entry', this.key, ex);
+        reportDataHistoryFailure({ operation: 'capture-step', error: ex, entryKey: this.key, backend: store.type });
         await this.markFailed(getErrorMessage(ex));
       }
     });

--- a/libs/shared/ui-data-history/src/lib/failure-reporter.ts
+++ b/libs/shared/ui-data-history/src/lib/failure-reporter.ts
@@ -1,0 +1,70 @@
+import { DataHistoryStorageBackend } from '@jetstream/types';
+
+/**
+ * Where a swallowed failure happened. A closed set rather than a free-form string so the error
+ * tracker groups by the code path instead of by whatever message the underlying storage API used.
+ */
+export type DataHistoryFailureOperation = 'init' | 'start-entry' | 'capture-step' | 'finalize';
+
+export interface DataHistoryFailureInfo {
+  operation: DataHistoryFailureOperation;
+  error: unknown;
+  entryKey?: string;
+  backend?: DataHistoryStorageBackend;
+}
+
+export type DataHistoryFailureReporter = (info: DataHistoryFailureInfo) => void;
+
+/**
+ * Conditions where the environment said no rather than Jetstream being broken: the user revoked or
+ * denied folder access, a picker ran outside a user gesture, or a stream was aborted because the
+ * user cancelled or the backend switched. Every one of these has a UI affordance already and is
+ * expected in normal use, so reporting them would bury the defects worth investigating.
+ *
+ * Names are matched instead of types because the FSA and OPFS APIs reject with `DOMException`,
+ * which is not reliably `instanceof Error` across engines.
+ */
+const IGNORED_ERROR_NAMES = new Set([
+  'DataHistoryDirectoryPermissionError',
+  'NotAllowedError',
+  'NotFoundError',
+  'SecurityError',
+  'AbortError',
+]);
+
+let reporter: DataHistoryFailureReporter | null = null;
+
+/**
+ * Give data history somewhere to send failures it had to swallow. Injected rather than imported
+ * because the error tracker lives in `@jetstream/shared/ui-utils`, which pulls in Sentry — this lib
+ * keeps its import graph small enough for the browser extension (see `platform.ts`).
+ *
+ * Pass null to unset (tests, teardown).
+ */
+export function setDataHistoryFailureReporter(value: DataHistoryFailureReporter | null): void {
+  reporter = value;
+}
+
+function isExpectedCondition(error: unknown): boolean {
+  const name = typeof error === 'object' && error !== null ? (error as { name?: unknown }).name : undefined;
+  return typeof name === 'string' && IGNORED_ERROR_NAMES.has(name);
+}
+
+/**
+ * Capture failures are swallowed so they can never break the user's data operation, which also makes
+ * them invisible: `logger.warn` is a no-op unless the user turns logging on, so a systemic failure
+ * (an exhausted quota, a backend broken on one platform) otherwise surfaces only as a support ticket.
+ *
+ * Only unexpected failures are reported — see `IGNORED_ERROR_NAMES`. Reporting must never throw:
+ * this is called from catch blocks whose whole purpose is to not fail.
+ */
+export function reportDataHistoryFailure(info: DataHistoryFailureInfo): void {
+  if (!reporter || isExpectedCondition(info.error)) {
+    return;
+  }
+  try {
+    reporter(info);
+  } catch {
+    // A broken reporter cannot be allowed to break capture
+  }
+}


### PR DESCRIPTION
A Batch API load that threw before anything reached Salesforce — a corrupt attachment zip failing `getBatchApiBatches` — settled its Data History entry as "N submitted, 0 failed" while the results screen reported N failed, leaving a permanent record that contradicted what the user was shown.

- Derive `reached` from whether any batch reported instead of hardcoding 'unknown', matching how the Bulk path derives it. Every per-batch request failure is converted to failed rows rather than thrown, so a throw reaching the catch means either preparation failed (nothing was sent) or batches were already submitted, and only the latter must avoid claiming they all failed
- Correct the `LoadFailureReach` comment, which claimed a mid-load Batch request could reach that catch

Capture failures are swallowed so a broken capture can never break the user's data operation, which also left them invisible — `logger.warn` is a no-op unless the user turns logging on, so an exhausted quota or a backend broken on one platform surfaced only as a support ticket.

- `setDataHistoryFailureReporter` injects a reporter rather than importing the tracker: `@jetstream/shared/ui-utils` pulls in Sentry, and this lib keeps its import graph small enough for the browser extension
- Only genuine defects are reported — denied or revoked permission, aborted streams, and already-missing files are filtered out. Quota exhaustion still reports, since it means capture silently stopped working
- A fixed message per operation keeps each code path a single grouped issue instead of fragmenting on whatever wording the storage API used
- Wired in `useInitDataHistory`, the init point all four apps already share. The tracker no-ops without a DSN, so this stays inert on desktop, the extension, and canvas until their DSNs are restored