### PR TITLE
fix: show objects that only support field permissions

### DIFF
--- a/libs/features/manage-permissions/src/ManagePermissionsSelection.tsx
+++ b/libs/features/manage-permissions/src/ManagePermissionsSelection.tsx
@@ -115,8 +115,9 @@ export const ManagePermissionsSelection: FunctionComponent<ManagePermissionsSele
 
   const profilesAndPermSetsData = useProfilesAndPermSets(selectedOrg, profiles, permissionSets);
 
-  // Objects that cannot have an ObjectPermissions record (Task, ApexClass, Attachment, ...) fail on save
-  // with INVALID_OR_NULL_FOR_RESTRICTED_PICKLIST, so they are excluded from the picker entirely.
+  // Objects Salesforce will not accept any permission record for (ApexClass, Attachment, ...) are excluded
+  // from the picker. Objects that support only field-level security (PricebookEntry, Task, ...) are kept,
+  // and the object permission table marks them read-only.
   const {
     permissionableSobjects,
     loading: permissionableSobjectsLoading,

--- a/libs/features/manage-permissions/src/usePermissionRecords.tsx
+++ b/libs/features/manage-permissions/src/usePermissionRecords.tsx
@@ -75,6 +75,8 @@ export function usePermissionRecords(selectedOrg: SalesforceOrgUi, sobjects: str
       // query all data and transform into state maps
       const output = await Promise.all([
         limit(() => describeSObject(selectedOrg, 'FieldPermissions')),
+        // Cached from the object picker - identifies objects with no ObjectPermissions record (PricebookEntry, Task, ...)
+        limit(() => describeSObject(selectedOrg, 'ObjectPermissions')),
         queryPermissionableFields(limit, selectedOrg, sobjects),
         queryAndCombineResults<ObjectPermissionRecord>(
           limit,
@@ -98,6 +100,7 @@ export function usePermissionRecords(selectedOrg: SalesforceOrgUi, sobjects: str
       ]).then(
         ([
           fieldPermissionMetadata,
+          objectPermissionMetadata,
           fieldDefinition,
           objectPermissions,
           fieldPermissions,
@@ -113,10 +116,23 @@ export function usePermissionRecords(selectedOrg: SalesforceOrgUi, sobjects: str
           fieldDefinition = availableFields.size
             ? fieldDefinition.filter((field) => availableFields.has(`${field.EntityDefinition.QualifiedApiName}.${field.QualifiedApiName}`))
             : fieldDefinition;
+          // `active` is omitted on some describe responses - only drop values explicitly marked inactive
+          const objectPermissionableSobjects = new Set<string>(
+            objectPermissionMetadata.data.fields
+              .find((field) => field.name === 'SobjectType')
+              ?.picklistValues?.filter(({ active }) => active !== false)
+              .map(({ value }) => value),
+          );
           return {
             fieldsByObject: getAllFieldsByObject(fieldDefinition),
             fieldsByKey: groupFields(fieldDefinition),
-            objectPermissionMap: getObjectPermissionMap(sobjects, profilePermSetIds, permSetIds, objectPermissions),
+            objectPermissionMap: getObjectPermissionMap(
+              sobjects,
+              profilePermSetIds,
+              permSetIds,
+              objectPermissions,
+              objectPermissionableSobjects,
+            ),
             fieldPermissionMap: getFieldPermissionMap(fieldDefinition, profilePermSetIds, permSetIds, fieldPermissions),
             tabVisibilityPermissionMap: getTabVisibilityPermissionMap(
               sobjects,
@@ -345,11 +361,16 @@ function groupFields(fields: EntityParticlePermissionsRecord[]): Record<string, 
   }, {});
 }
 
+/**
+ * @param objectPermissionableSobjects `ObjectPermissions.SobjectType` allow-list. An empty set means the
+ * describe gave us nothing to filter on, so every object is treated as supported rather than none.
+ */
 function getObjectPermissionMap(
   sobjects: string[],
   selectedProfiles: string[],
   selectedPermissionSets: string[],
   permissions: ObjectPermissionRecord[],
+  objectPermissionableSobjects: Set<string>,
 ): Record<string, ObjectPermissionDefinitionMap> {
   const objectPermissionsByFieldByParentId = permissions.reduce((output: Record<string, Record<string, ObjectPermissionRecord>>, item) => {
     output[item.SobjectType] = output[item.SobjectType] || {};
@@ -362,6 +383,7 @@ function getObjectPermissionMap(
       apiName: item,
       label: item, // FIXME:
       metadata: item,
+      supportsObjectPermissions: !objectPermissionableSobjects.size || objectPermissionableSobjects.has(item),
       permissions: {},
       permissionKeys: [],
     };

--- a/libs/features/manage-permissions/src/usePermissionableSobjects.ts
+++ b/libs/features/manage-permissions/src/usePermissionableSobjects.ts
@@ -1,9 +1,9 @@
 import { SalesforceOrgUi } from '@jetstream/types';
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { getPermissionableSobjects } from './utils/permission-manager-utils';
+import { PermissionableSobjects, getPermissionableSobjects } from './utils/permission-manager-utils';
 
 /**
- * Loads the set of objects that can have an `ObjectPermissions` record in the selected org.
+ * Loads the set of objects that can have permissions assigned in the selected org.
  *
  * `permissionableSobjects` is `null` when the allow-list could not be determined, which callers treat
  * as "fall back to the heuristic filter" rather than "no objects". `loading` stays `true` until the
@@ -12,7 +12,7 @@ import { getPermissionableSobjects } from './utils/permission-manager-utils';
 export function usePermissionableSobjects(selectedOrg: SalesforceOrgUi) {
   const isMounted = useRef(true);
   const [refreshCount, setRefreshCount] = useState(0);
-  const [loaded, setLoaded] = useState<{ key: string; permissionableSobjects: Set<string> | null } | null>(null);
+  const [loaded, setLoaded] = useState<{ key: string; permissionableSobjects: PermissionableSobjects | null } | null>(null);
 
   const orgUniqueId = selectedOrg?.uniqueId || null;
   // Changing the key marks the current results stale without a synchronous state update

--- a/libs/features/manage-permissions/src/utils/__tests__/permission-manager-object-permission-support.spec.ts
+++ b/libs/features/manage-permissions/src/utils/__tests__/permission-manager-object-permission-support.spec.ts
@@ -1,0 +1,128 @@
+import {
+  BulkActionCheckbox,
+  ObjectPermissionDefinitionMap,
+  PermissionSetNoProfileRecord,
+  PermissionSetWithProfileRecord,
+} from '@jetstream/types';
+import { describe, expect, it } from 'vitest';
+import { getObjectColumns, getObjectRows, updateRowsFromColumnAction, updateRowsFromRowAction } from '../permission-manager-table-utils';
+
+/**
+ * Objects such as PricebookEntry and Task accept `FieldPermissions` but have no `ObjectPermissions`
+ * record, so they belong in the object picker (for their fields) while the object permission table has
+ * nothing for the user to set.
+ */
+
+const PARENT_ID = '0PS1t000000PermSet';
+
+function buildPermissionMap(apiName: string, supportsObjectPermissions: boolean): Record<string, ObjectPermissionDefinitionMap> {
+  return {
+    [apiName]: {
+      apiName,
+      label: apiName,
+      metadata: '',
+      supportsObjectPermissions,
+      permissionKeys: [PARENT_ID],
+      permissions: {
+        [PARENT_ID]: { create: false, read: false, edit: false, delete: false, viewAll: false, modifyAll: false, viewAllFields: false },
+      },
+    },
+  };
+}
+
+describe('getObjectRows', () => {
+  it.each([
+    ['Account', true],
+    ['PricebookEntry', false],
+  ])('carries supportsObjectPermissions onto the %s row', (apiName, supportsObjectPermissions) => {
+    const [row] = getObjectRows([apiName], buildPermissionMap(apiName, supportsObjectPermissions));
+
+    expect(row.allowObjectPermission).toBe(supportsObjectPermissions);
+  });
+});
+
+describe('object permission columns', () => {
+  const columns = getObjectColumns([], [PARENT_ID], {} as Record<string, PermissionSetWithProfileRecord>, {
+    [PARENT_ID]: { Label: 'Sales User', Name: 'Sales_User' } as PermissionSetNoProfileRecord,
+  });
+  const permissionColumns = columns.filter((column) => column.key.startsWith(PARENT_ID));
+
+  it.each([
+    ['Account', true],
+    ['PricebookEntry', false],
+  ])('makes every permission cell editable=%s for %s', (apiName, supportsObjectPermissions) => {
+    const [row] = getObjectRows([apiName], buildPermissionMap(apiName, supportsObjectPermissions));
+
+    permissionColumns.forEach((column) => {
+      expect(typeof column.editable === 'function' && column.editable(row)).toBe(supportsObjectPermissions);
+    });
+  });
+
+  it('greys the object label when object permissions cannot be set', () => {
+    const [labelColumn] = columns;
+    const [supported] = getObjectRows(['Account'], buildPermissionMap('Account', true));
+    const [unsupported] = getObjectRows(['PricebookEntry'], buildPermissionMap('PricebookEntry', false));
+
+    expect(typeof labelColumn.cellClass === 'function' && labelColumn.cellClass(supported)).toBeUndefined();
+    expect(typeof labelColumn.cellClass === 'function' && labelColumn.cellClass(unsupported)).toBe('slds-text-color_weak');
+  });
+});
+
+/**
+ * Bulk/row actions must respect the same `allowObjectPermission` guard as per-cell editing, otherwise
+ * "Select All" / "Edit Row" / "Edit All" can save ObjectPermissions on objects Salesforce rejects.
+ */
+describe('bulk/row actions respect allowObjectPermission', () => {
+  it('updateRowsFromColumnAction leaves an unsupported row untouched on selectAll', () => {
+    const [unsupported] = getObjectRows(['PricebookEntry'], buildPermissionMap('PricebookEntry', false));
+
+    const [updated] = updateRowsFromColumnAction('object', 'selectAll', 'create', PARENT_ID, [unsupported]);
+
+    expect(updated.permissions[PARENT_ID].create).toBe(false);
+    expect(updated.permissions[PARENT_ID].createIsDirty).toBe(false);
+  });
+
+  it('updateRowsFromRowAction leaves an unsupported row untouched', () => {
+    const [unsupported] = getObjectRows(['PricebookEntry'], buildPermissionMap('PricebookEntry', false));
+    const checkboxesById: Record<string, BulkActionCheckbox> = {
+      create: { id: 'create', label: 'Create', value: true, disabled: false },
+      read: { id: 'read', label: 'Read', value: true, disabled: false },
+      edit: { id: 'edit', label: 'Edit', value: true, disabled: false },
+      delete: { id: 'delete', label: 'Delete', value: true, disabled: false },
+      viewAll: { id: 'viewAll', label: 'View All', value: true, disabled: false },
+      modifyAll: { id: 'modifyAll', label: 'Modify All', value: true, disabled: false },
+      viewAllFields: { id: 'viewAllFields', label: 'View All Fields', value: true, disabled: false },
+    };
+
+    const [updated] = updateRowsFromRowAction('object', checkboxesById, [unsupported]);
+
+    expect(updated.permissions[PARENT_ID]).toMatchObject({
+      create: false,
+      read: false,
+      edit: false,
+      delete: false,
+      viewAll: false,
+      modifyAll: false,
+      viewAllFields: false,
+    });
+  });
+
+  it('updateRowsFromColumnAction and updateRowsFromRowAction still apply to a supported row', () => {
+    const [supported] = getObjectRows(['Account'], buildPermissionMap('Account', true));
+
+    const [updatedFromColumn] = updateRowsFromColumnAction('object', 'selectAll', 'create', PARENT_ID, [supported]);
+    expect(updatedFromColumn.permissions[PARENT_ID].create).toBe(true);
+
+    const checkboxesById: Record<string, BulkActionCheckbox> = {
+      create: { id: 'create', label: 'Create', value: true, disabled: false },
+      read: { id: 'read', label: 'Read', value: true, disabled: false },
+      edit: { id: 'edit', label: 'Edit', value: true, disabled: false },
+      delete: { id: 'delete', label: 'Delete', value: true, disabled: false },
+      viewAll: { id: 'viewAll', label: 'View All', value: true, disabled: false },
+      modifyAll: { id: 'modifyAll', label: 'Modify All', value: true, disabled: false },
+      viewAllFields: { id: 'viewAllFields', label: 'View All Fields', value: true, disabled: false },
+    };
+    const [updatedFromRow] = updateRowsFromRowAction('object', checkboxesById, [supported]);
+    expect(updatedFromRow.permissions[PARENT_ID].create).toBe(true);
+  });
+});

--- a/libs/features/manage-permissions/src/utils/__tests__/permission-manager-sobject-filter.spec.ts
+++ b/libs/features/manage-permissions/src/utils/__tests__/permission-manager-sobject-filter.spec.ts
@@ -16,14 +16,29 @@ function buildSobject(name: string, overrides: Partial<DescribeGlobalSObjectResu
   return { name, label: name, createable: true, updateable: true, ...overrides } as DescribeGlobalSObjectResult;
 }
 
-function mockSobjectTypePicklist(picklistValues: Partial<PicklistEntry>[] | null | undefined) {
-  describeSObject.mockResolvedValue({
-    data: {
-      fields: [
-        { name: 'ParentId', picklistValues: null },
-        { name: 'SobjectType', picklistValues },
-      ],
-    } as unknown as DescribeSObjectResult,
+/**
+ * The permission manager reads two independent allow-lists, both from a `SobjectType` restricted picklist:
+ * object CRUD on `ObjectPermissions` and field level security on `FieldPermissions`.
+ */
+function mockAllowLists(options: {
+  objectPermissions?: Partial<PicklistEntry>[] | null;
+  fieldPermissions?: Partial<PicklistEntry>[] | null;
+  rejectObjectPermissions?: boolean;
+  rejectFieldPermissions?: boolean;
+}) {
+  describeSObject.mockImplementation((_org: SalesforceOrgUi, sobject: string) => {
+    const isObjectPermissions = sobject === 'ObjectPermissions';
+    if (isObjectPermissions ? options.rejectObjectPermissions : options.rejectFieldPermissions) {
+      return Promise.reject(new Error('INVALID_SESSION_ID'));
+    }
+    return Promise.resolve({
+      data: {
+        fields: [
+          { name: 'ParentId', picklistValues: null },
+          { name: 'SobjectType', picklistValues: isObjectPermissions ? options.objectPermissions : options.fieldPermissions },
+        ],
+      } as unknown as DescribeSObjectResult,
+    });
   });
 }
 
@@ -32,50 +47,102 @@ describe('getPermissionableSobjects', () => {
     describeSObject.mockReset();
   });
 
-  it('returns the SobjectType picklist values', async () => {
-    mockSobjectTypePicklist([
-      { value: 'Account', active: true },
-      { value: 'Contact', active: true },
-    ]);
+  it('reads the SobjectType picklist from both describes', async () => {
+    mockAllowLists({
+      objectPermissions: [
+        { value: 'Account', active: true },
+        { value: 'Contact', active: true },
+      ],
+      fieldPermissions: [{ value: 'Account', active: true }],
+    });
 
     const results = await getPermissionableSobjects(org);
 
     expect(describeSObject).toHaveBeenCalledWith(org, 'ObjectPermissions');
-    expect(results).toEqual(new Set(['Account', 'Contact']));
+    expect(describeSObject).toHaveBeenCalledWith(org, 'FieldPermissions');
+    expect(results?.objectPermissions).toEqual(new Set(['Account', 'Contact']));
+  });
+
+  // Salesforce omits children whose record access rolls up to a parent from ObjectPermissions, but they
+  // still accept FieldPermissions - the reported bug was PricebookEntry disappearing from the object picker.
+  it('includes objects that only support field permissions', async () => {
+    mockAllowLists({
+      objectPermissions: [{ value: 'Account', active: true }],
+      fieldPermissions: [
+        { value: 'Account', active: true },
+        { value: 'PricebookEntry', active: true },
+        { value: 'OpportunityLineItem', active: true },
+      ],
+    });
+
+    const results = await getPermissionableSobjects(org);
+
+    expect(results?.all).toEqual(new Set(['Account', 'PricebookEntry', 'OpportunityLineItem']));
+    expect(results?.objectPermissions).toEqual(new Set(['Account']));
   });
 
   it('omits values explicitly marked inactive but keeps values with no active flag', async () => {
-    mockSobjectTypePicklist([{ value: 'Account', active: true }, { value: 'Retired__c', active: false }, { value: 'Contact' }]);
+    mockAllowLists({
+      objectPermissions: [{ value: 'Account', active: true }, { value: 'Retired__c', active: false }, { value: 'Contact' }],
+      fieldPermissions: [{ value: 'Archived__c', active: false }, { value: 'Task' }],
+    });
 
-    expect(await getPermissionableSobjects(org)).toEqual(new Set(['Account', 'Contact']));
+    const results = await getPermissionableSobjects(org);
+
+    expect(results?.objectPermissions).toEqual(new Set(['Account', 'Contact']));
+    expect(results?.all).toEqual(new Set(['Account', 'Contact', 'Task']));
   });
 
   it.each([
     ['no picklist values', []],
     ['a missing picklist', null],
     ['every value inactive', [{ value: 'Account', active: false }]],
-  ])('returns null when describe returns %s so callers fall back to the heuristic', async (_label, picklistValues) => {
-    mockSobjectTypePicklist(picklistValues);
+  ])('returns null when both describes return %s so callers fall back to the heuristic', async (_label, picklistValues) => {
+    mockAllowLists({ objectPermissions: picklistValues, fieldPermissions: picklistValues });
 
     expect(await getPermissionableSobjects(org)).toBeNull();
   });
 
-  it('returns null when describe fails', async () => {
-    describeSObject.mockRejectedValue(new Error('INVALID_SESSION_ID'));
+  it('returns null when both describes fail', async () => {
+    mockAllowLists({ rejectObjectPermissions: true, rejectFieldPermissions: true });
 
     expect(await getPermissionableSobjects(org)).toBeNull();
+  });
+
+  it('still returns the object permission allow-list when the FieldPermissions describe fails', async () => {
+    mockAllowLists({ objectPermissions: [{ value: 'Account', active: true }], rejectFieldPermissions: true });
+
+    const results = await getPermissionableSobjects(org);
+
+    expect(results?.all).toEqual(new Set(['Account']));
+    expect(results?.objectPermissions).toEqual(new Set(['Account']));
+  });
+
+  it('still returns field-only objects when the ObjectPermissions describe fails', async () => {
+    mockAllowLists({ rejectObjectPermissions: true, fieldPermissions: [{ value: 'PricebookEntry', active: true }] });
+
+    const results = await getPermissionableSobjects(org);
+
+    expect(results?.all).toEqual(new Set(['PricebookEntry']));
+    expect(results?.objectPermissions).toEqual(new Set());
   });
 });
 
 describe('getPermissionsSobjectFilter', () => {
   it('keeps only objects present in the allow-list', () => {
-    const filterFn = getPermissionsSobjectFilter(new Set(['Account', 'Idea', 'Custom__c']));
+    const filterFn = getPermissionsSobjectFilter({
+      objectPermissions: new Set(['Account', 'Idea', 'Custom__c']),
+      all: new Set(['Account', 'Idea', 'Custom__c', 'Task', 'PricebookEntry']),
+    });
 
-    expect(filterPermissionsSobjects(buildSobject('Task'))).toBe(true);
     expect(filterFn(buildSobject('Account'))).toBe(true);
     expect(filterFn(buildSobject('Custom__c'))).toBe(true);
+    // Field permissions only. PricebookEntry exposes no settable field, but stays in the picker so the
+    // list matches Salesforce and tab visibility remains reachable.
+    expect(filterFn(buildSobject('Task'))).toBe(true);
+    expect(filterFn(buildSobject('PricebookEntry'))).toBe(true);
     // Objects that fail on save with INVALID_OR_NULL_FOR_RESTRICTED_PICKLIST despite being createable
-    expect(filterFn(buildSobject('Task'))).toBe(false);
+    expect(filterPermissionsSobjects(buildSobject('ApexClass'))).toBe(true);
     expect(filterFn(buildSobject('ApexClass'))).toBe(false);
     expect(filterFn(buildSobject('Attachment'))).toBe(false);
     expect(filterFn(null)).toBe(false);

--- a/libs/features/manage-permissions/src/utils/__tests__/permission-manager-table-label-column.spec.ts
+++ b/libs/features/manage-permissions/src/utils/__tests__/permission-manager-table-label-column.spec.ts
@@ -21,6 +21,7 @@ function buildObjectRow(label: string, apiName: string): PermissionTableObjectCe
     tableLabel: `${label} (${apiName})`,
     allowEditPermission: true,
     allowViewAllModifyAllPermission: true,
+    allowObjectPermission: true,
     permissions: {},
   };
 }

--- a/libs/features/manage-permissions/src/utils/__tests__/permission-manager-view-all-modify-all.spec.ts
+++ b/libs/features/manage-permissions/src/utils/__tests__/permission-manager-view-all-modify-all.spec.ts
@@ -22,6 +22,7 @@ function buildPermissionMap(apiName: string): Record<string, ObjectPermissionDef
       apiName,
       label: apiName,
       metadata: '',
+      supportsObjectPermissions: true,
       permissionKeys: [PARENT_ID],
       permissions: { [PARENT_ID]: buildPermissionItem() },
     },
@@ -38,6 +39,7 @@ function buildRow(apiName: string, permissionOverrides: Partial<PermissionTableO
     tableLabel: `${apiName} (${apiName})`,
     allowEditPermission: true,
     allowViewAllModifyAllPermission: supportsViewAllModifyAll(apiName),
+    allowObjectPermission: true,
     permissions: {
       [PARENT_ID]: {
         rowKey: apiName,

--- a/libs/features/manage-permissions/src/utils/object-permission-support.ts
+++ b/libs/features/manage-permissions/src/utils/object-permission-support.ts
@@ -17,3 +17,10 @@ export const VIEW_ALL_MODIFY_ALL_UNSUPPORTED_MESSAGE =
 export function supportsViewAllModifyAll(sobject: string): boolean {
   return !OBJECTS_WITHOUT_VIEW_ALL_MODIFY_ALL.has(sobject);
 }
+
+/**
+ * Shown in place of the checkboxes for objects that accept `FieldPermissions` but have no
+ * `ObjectPermissions` record (PricebookEntry, OpportunityLineItem, Task, ...). They stay in the object
+ * list because their field permissions are still editable on the Field Permissions tab.
+ */
+export const OBJECT_PERMISSIONS_UNSUPPORTED_MESSAGE = 'Access is inherited from the parent object. Only field permissions can be set.';

--- a/libs/features/manage-permissions/src/utils/permission-manager-table-utils.tsx
+++ b/libs/features/manage-permissions/src/utils/permission-manager-table-utils.tsx
@@ -55,7 +55,11 @@ import classNames from 'classnames';
 import startCase from 'lodash/startCase';
 import { Fragment, useContext, useMemo, useRef, useState } from 'react';
 import { PermissionColumnGroupHeader } from '../PermissionColumnGroupHeader';
-import { supportsViewAllModifyAll, VIEW_ALL_MODIFY_ALL_UNSUPPORTED_MESSAGE } from './object-permission-support';
+import {
+  OBJECT_PERMISSIONS_UNSUPPORTED_MESSAGE,
+  supportsViewAllModifyAll,
+  VIEW_ALL_MODIFY_ALL_UNSUPPORTED_MESSAGE,
+} from './object-permission-support';
 import {
   SYSTEM_PERMISSION_DEPENDENCY_TOOLTIP,
   SYSTEM_PERMISSION_DEPENDENT_CLOSURE,
@@ -104,8 +108,17 @@ function isBlockedViewAllModifyAll(which: PermissionTypes, row: PermissionTableC
   return 'allowViewAllModifyAllPermission' in row && !row.allowViewAllModifyAllPermission;
 }
 
+/**
+ * True when the row's object has no `ObjectPermissions` record to write to (field-only objects like
+ * PricebookEntry/Task). Every path that writes an object permission value routes through this so a bulk
+ * action can never set what the checkbox refuses to set.
+ */
+function isBlockedObjectPermission(row: PermissionTableCellExtended): boolean {
+  return 'allowObjectPermission' in row && !row.allowObjectPermission;
+}
+
 function setObjectValue(which: ObjectPermissionTypes, row: PermissionTableObjectCell, permissionId: string, value: boolean) {
-  if (isBlockedViewAllModifyAll(which, row)) {
+  if (isBlockedViewAllModifyAll(which, row) || isBlockedObjectPermission(row)) {
     return row;
   }
   const newRow = { ...row, permissions: { ...row.permissions, [permissionId]: { ...row.permissions[permissionId] } } };
@@ -389,6 +402,11 @@ export function getObjectColumns(
         }
         return undefined;
       },
+      cellClass: (row) => {
+        if (!row.allowObjectPermission) {
+          return 'slds-text-color_weak';
+        }
+      },
     },
     {
       name: '',
@@ -456,6 +474,7 @@ export function getObjectRows(selectedSObjects: string[], objectPermissionMap: R
       tableLabel: `${objectPermission.label} (${objectPermission.apiName})`,
       allowEditPermission: true,
       allowViewAllModifyAllPermission: supportsViewAllModifyAll(objectPermission.apiName),
+      allowObjectPermission: objectPermission.supportsObjectPermissions,
       permissions: {},
     };
 
@@ -669,6 +688,9 @@ function getColumnForProfileOrPermSet<T extends PermissionType>({
       if (permissionType === 'tabVisibility' && 'canSetPermission' in row && !row.canSetPermission) {
         return false;
       }
+      if (permissionType === 'object' && 'allowObjectPermission' in row && !row.allowObjectPermission) {
+        return false;
+      }
       if (isBlockedViewAllModifyAll(actionKey as PermissionTypes, row)) {
         return false;
       }
@@ -679,6 +701,9 @@ function getColumnForProfileOrPermSet<T extends PermissionType>({
     },
     cellClass: (row) => {
       if (permissionType === 'object') {
+        if ('allowObjectPermission' in row && !row.allowObjectPermission) {
+          return 'is-disabled';
+        }
         const permission = row.permissions[id] as PermissionTableObjectCellPermission;
         if (
           (actionKey === 'create' && permission.createIsDirty) ||
@@ -720,12 +745,21 @@ function getColumnForProfileOrPermSet<T extends PermissionType>({
       if (args.type === 'ROW' && permissionType === 'tabVisibility' && 'canSetPermission' in args.row && !args.row.canSetPermission) {
         return numItems;
       }
+      if (args.type === 'ROW' && permissionType === 'object' && 'allowObjectPermission' in args.row && !args.row.allowObjectPermission) {
+        return numItems;
+      }
       return undefined;
     },
     renderCell: ({ row, commitEdit }) => {
       // If the row is not editable, then we don't want to show the checkbox
       if (permissionType === 'tabVisibility' && 'canSetPermission' in row && !row.canSetPermission) {
         return null;
+      }
+      // Objects that only support field-level security have no object permissions to set
+      if (permissionType === 'object' && 'allowObjectPermission' in row && !row.allowObjectPermission) {
+        return (
+          <div className="slds-text-color_weak slds-text-body_small slds-p-left_x-small">{OBJECT_PERMISSIONS_UNSUPPORTED_MESSAGE}</div>
+        );
       }
 
       const errorMessage = row.permissions[id].errorMessage;
@@ -1420,6 +1454,9 @@ export function updateRowsFromColumnAction<TRows extends PermissionTableCellExte
 ): TRows[] {
   const newRows = [...rows];
   return newRows.map((row, _index) => {
+    if (isBlockedObjectPermission(row)) {
+      return row;
+    }
     // Reset restores the saved value, so it stays allowed even where the permission cannot be set
     if (action !== 'reset' && isBlockedViewAllModifyAll(which, row)) {
       return row;
@@ -1505,7 +1542,7 @@ export function updateRowsFromRowAction<TRows extends PermissionTableCellExtende
     row.permissions = { ...row.permissions };
     for (const permissionId in row.permissions) {
       row.permissions = { ...row.permissions, [permissionId]: { ...row.permissions[permissionId] } } as any;
-      if (type === 'object') {
+      if (type === 'object' && !isBlockedObjectPermission(row)) {
         const permission = row.permissions[permissionId] as PermissionTableObjectCellPermission;
         permission.create = checkboxesById['create'].value;
         permission.read = checkboxesById['read'].value;
@@ -1722,15 +1759,16 @@ export function applyPastedPermissionCells<T extends PermissionTableCellExtended
 function defaultRowActionCheckboxes(type: PermissionType, row?: PermissionTableCellExtended): BulkActionCheckbox[] {
   const allowEditPermission = !row || !('allowEditPermission' in row) || row.allowEditPermission;
   const allowViewAllModifyAll = !row || !isBlockedViewAllModifyAll('viewAll', row);
+  const allowObjectPermission = !row || !isBlockedObjectPermission(row);
   if (type === 'object') {
     return [
-      { id: 'create', label: 'Create', value: false, disabled: false },
-      { id: 'read', label: 'Read', value: false, disabled: false },
-      { id: 'edit', label: 'Edit', value: false, disabled: !allowEditPermission },
-      { id: 'delete', label: 'Delete', value: false, disabled: false },
-      { id: 'viewAll', label: 'View All', value: false, disabled: !allowViewAllModifyAll },
-      { id: 'modifyAll', label: 'Modify All', value: false, disabled: !allowViewAllModifyAll },
-      { id: 'viewAllFields', label: 'View All Fields', value: false, disabled: false },
+      { id: 'create', label: 'Create', value: false, disabled: !allowObjectPermission },
+      { id: 'read', label: 'Read', value: false, disabled: !allowObjectPermission },
+      { id: 'edit', label: 'Edit', value: false, disabled: !allowObjectPermission || !allowEditPermission },
+      { id: 'delete', label: 'Delete', value: false, disabled: !allowObjectPermission },
+      { id: 'viewAll', label: 'View All', value: false, disabled: !allowObjectPermission || !allowViewAllModifyAll },
+      { id: 'modifyAll', label: 'Modify All', value: false, disabled: !allowObjectPermission || !allowViewAllModifyAll },
+      { id: 'viewAllFields', label: 'View All Fields', value: false, disabled: !allowObjectPermission },
     ];
   } else if (type === 'field') {
     return [
@@ -2016,7 +2054,10 @@ export const BulkActionRenderer = () => {
   const [isOpen, setIsOpen] = useState(false);
   const [checkboxes, setCheckboxes] = useState(() => defaultRowActionCheckboxes(type));
 
-  const rowCount = useMemo(() => rows.filter((row) => !('canSetPermission' in row) || row.canSetPermission).length, [rows]);
+  const rowCount = useMemo(
+    () => rows.filter((row) => (!('canSetPermission' in row) || row.canSetPermission) && !isBlockedObjectPermission(row)).length,
+    [rows],
+  );
 
   /**
    * Set all dependencies when fields change

--- a/libs/features/manage-permissions/src/utils/permission-manager-utils.ts
+++ b/libs/features/manage-permissions/src/utils/permission-manager-utils.ts
@@ -58,43 +58,84 @@ export function filterPermissionsSobjects(sobject: DescribeGlobalSObjectResult |
 }
 
 /**
- * Reads the org's allow-list of objects that can have an `ObjectPermissions` record.
+ * The objects the permission manager can manage, split by what each one actually supports.
  *
- * `ObjectPermissions.SobjectType` is a restricted picklist whose values are exactly those objects.
- * Objects with no independent CRUD are absent - setup/metadata objects (ApexClass, Profile, RecordType),
- * children whose access rolls up to a parent (Task/Event, OpportunityLineItem, PricebookEntry, Attachment)
- * and platform junctions (Group, FeedItem, User). Saving against any of them fails with
- * `INVALID_OR_NULL_FOR_RESTRICTED_PICKLIST`, so they must never reach the permission editor.
- *
- * Returns `null` when the allow-list cannot be determined, which signals callers to fall back to the
- * name/CRUD heuristic rather than showing an empty object list.
+ * Salesforce models object CRUD and field-level security as two independent allow-lists. Neither is a
+ * subset of the other: `PricebookEntry`, `Task`, `Event`, `OpportunityLineItem`, `OrderItem` and `User`
+ * accept `FieldPermissions` but have no `ObjectPermissions` record, because their record-level access
+ * rolls up to a parent object.
  */
-export async function getPermissionableSobjects(org: SalesforceOrgUi): Promise<Set<string> | null> {
+export interface PermissionableSobjects {
+  /** Objects that accept an `ObjectPermissions` record, so object-level CRUD can be granted. */
+  objectPermissions: Set<string>;
+  /** Every manageable object - object CRUD, field-level security, or both. Drives the object picker. */
+  all: Set<string>;
+}
+
+/**
+ * Reads the active values of a restricted picklist that Salesforce uses as a permissions allow-list.
+ * Returns `null` when the describe fails or the picklist is empty, which callers treat as "unknown"
+ * rather than "nothing is allowed".
+ */
+async function getPermissionAllowList(org: SalesforceOrgUi, sobject: string, fieldName: string): Promise<string[] | null> {
   try {
-    const { data } = await describeSObject(org, 'ObjectPermissions');
-    const picklistValues = data.fields.find(({ name }) => name === 'SobjectType')?.picklistValues;
+    const { data } = await describeSObject(org, sobject);
+    const picklistValues = data.fields.find(({ name }) => name === fieldName)?.picklistValues;
     if (!picklistValues?.length) {
-      logger.warn('[PERMISSIONS] ObjectPermissions.SobjectType returned no picklist values, falling back to heuristic filter');
+      logger.warn(`[PERMISSIONS] ${sobject}.${fieldName} returned no picklist values`);
       return null;
     }
     // `active` is omitted on some describe responses - only drop values explicitly marked inactive
-    const permissionableSobjects = new Set(picklistValues.filter(({ active }) => active !== false).map(({ value }) => value));
-    return permissionableSobjects.size ? permissionableSobjects : null;
+    return picklistValues.filter(({ active }) => active !== false).map(({ value }) => value);
   } catch (ex) {
-    logger.warn('[PERMISSIONS] Unable to describe ObjectPermissions, falling back to heuristic filter', ex);
+    logger.warn(`[PERMISSIONS] Unable to describe ${sobject}`, ex);
     return null;
   }
 }
 
 /**
- * Object list filter for the permission manager. Prefers the org's `ObjectPermissions.SobjectType`
- * allow-list and falls back to the name/CRUD heuristic when it is unavailable.
+ * Reads the org's allow-lists of objects that can have permissions assigned.
+ *
+ * `ObjectPermissions.SobjectType` covers object CRUD and omits anything with no independent access -
+ * setup/metadata objects (ApexClass, Profile, RecordType) and children whose access rolls up to a parent
+ * (PricebookEntry, OpportunityLineItem, Task). Saving object permissions against those fails with
+ * `INVALID_OR_NULL_FOR_RESTRICTED_PICKLIST`.
+ *
+ * Many of those children still support field-level security, so `FieldPermissions.SobjectType` is unioned
+ * in. It is the same list Salesforce's own permission set UI shows, which includes objects that expose no
+ * settable field (PricebookEntry, CampaignMember, User, ...). Those are kept deliberately: tab visibility
+ * may still apply, and it leaves room for per-object settings we add later. `FieldPermissions.Field` would
+ * be the narrower "has at least one settable field" signal, but filtering on it would hide those objects
+ * entirely and diverge from Salesforce.
+ *
+ * Returns `null` when neither allow-list can be determined, which signals callers to fall back to the
+ * name/CRUD heuristic rather than showing an empty object list.
  */
-export function getPermissionsSobjectFilter(permissionableSobjects: Maybe<Set<string>>) {
+export async function getPermissionableSobjects(org: SalesforceOrgUi): Promise<PermissionableSobjects | null> {
+  const [objectPermissionValues, fieldPermissionValues] = await Promise.all([
+    getPermissionAllowList(org, 'ObjectPermissions', 'SobjectType'),
+    getPermissionAllowList(org, 'FieldPermissions', 'SobjectType'),
+  ]);
+
+  const objectPermissions = new Set(objectPermissionValues || []);
+  const all = new Set([...objectPermissions, ...(fieldPermissionValues || [])]);
+
+  if (!all.size) {
+    logger.warn('[PERMISSIONS] No permissionable objects could be determined, falling back to heuristic filter');
+    return null;
+  }
+  return { objectPermissions, all };
+}
+
+/**
+ * Object list filter for the permission manager. Prefers the org's allow-lists and falls back to the
+ * name/CRUD heuristic when they are unavailable.
+ */
+export function getPermissionsSobjectFilter(permissionableSobjects: Maybe<PermissionableSobjects>) {
   if (!permissionableSobjects) {
     return filterPermissionsSobjects;
   }
-  return (sobject: DescribeGlobalSObjectResult | null) => !!sobject && permissionableSobjects.has(sobject.name);
+  return (sobject: DescribeGlobalSObjectResult | null) => !!sobject && permissionableSobjects.all.has(sobject.name);
 }
 
 export function getFieldDefinitionKey(record: EntityParticlePermissionsRecord) {

--- a/libs/types/src/lib/ui/permission-manager-types.ts
+++ b/libs/types/src/lib/ui/permission-manager-types.ts
@@ -33,6 +33,8 @@ export interface ObjectPermissionDefinitionMap {
   apiName: string;
   label: string;
   metadata: string; // FIXME: this should probably be Describe metadata
+  /** False for objects that only support field-level security (PricebookEntry, Task, ...) */
+  supportsObjectPermissions: boolean;
   // used to retain order of permissions
   permissionKeys: string[]; // this is permission set ids, which could apply to profile or perm set
   permissions: Record<string, ObjectPermissionItem>;
@@ -162,6 +164,8 @@ export interface PermissionTableObjectCell extends PermissionTableCell<Permissio
   allowEditPermission: boolean; // TODO: what other permissions may be restricted here??
   /** False for objects where Salesforce silently drops View All / Modify All (Idea, Product2, ...) */
   allowViewAllModifyAllPermission: boolean;
+  /** False for objects that accept field permissions but have no ObjectPermissions record (PricebookEntry, Task, ...) */
+  allowObjectPermission: boolean;
 }
 
 export interface PermissionTableFieldCell extends PermissionTableCell<PermissionTableFieldCellPermission> {


### PR DESCRIPTION
A user reported that Price Book Entry was missing from the object list in manage permissions even though Salesforce offers it for field level security. It was not alone - 43 objects were unreachable, including Task, Event, Opportunity Product, Order Product and User.

Salesforce keeps two independent allow-lists and neither is a subset of the other. ObjectPermissions.SobjectType covers object CRUD and omits any object whose record access rolls up to a parent, while FieldPermissions.SobjectType covers field level security and includes those children. We only read the first one, and it gated the object picker for all four tabs, so an object with no ObjectPermissions record vanished from the field and tab visibility tabs too. The picker now shows the union of both.

FieldPermissions.Field would be the narrower signal - it identifies the 15 of those 43 that actually expose a settable field - but filtering on it would hide the rest entirely and diverge from Salesforce's own object list. Objects such as Price Book Entry are kept even though their field tab comes up empty, because tab visibility may still apply and we expect to add more per-object settings here later.

Objects with no ObjectPermissions record now render read-only on the object permissions tab rather than offering checkboxes that fail on save with INVALID_OR_NULL_FOR_RESTRICTED_PICKLIST. This follows the existing treatment for objects without a tab and for View All / Modify All where Salesforce silently drops the value.

Also removes a stray console.log left behind in filterPermissionsSobjects.

Resolves #1981