### PR TITLE
feat: add record limit to update records

### DIFF
--- a/apps/docs/docs/load/update-records.mdx
+++ b/apps/docs/docs/load/update-records.mdx
@@ -46,6 +46,20 @@ After selecting an object, you need to configure the fields that you would like 
   - **Only if not blank**
   - **Customer criteria** allows you to provide a custom `soql` WHERE clause to target the exact records you want. If you are unfamiliar with doing this by hand, you can use the Query Builder to build this for you.
 
+### Limiting how many records are updated
+
+If you are working with a very large number of records, you can limit how many are updated at one time.
+
+**Maximum records to update** limits how many records will be included. Leave this blank to update every record that meets your criteria.
+
+The number of impacted records shown when you validate takes the limit into account, so you will always see exactly how many records will be updated.
+
+:::tip
+
+To work through a large data volume in chunks, use criteria that no longer matches a record once it has been updated, for example **Only if blank** or a custom criteria, and run the update again to process the next set of records.
+
+:::
+
 After you have configured your field, you will need to validate the results. Validating the results will make sure your configuration is accurate and let you know how many records will be modified with this change.
 
 If you have specified a custom criteria that is not valid, Salesforce will return an error message. You will need to resolve this before continuing.

--- a/libs/features/data-history/src/lib/data-history-page.utils.ts
+++ b/libs/features/data-history/src/lib/data-history-page.utils.ts
@@ -271,6 +271,7 @@ const CONFIG_DISPLAY_FIELDS: Array<{
   },
   { key: 'batchSize', label: 'Batch Size' },
   { key: 'serialMode', label: 'Serial Mode' },
+  { key: 'recordLimit', label: 'Record Limit' },
   { key: 'insertNulls', label: 'Insert Null Values' },
   // Only meaningful when a date field was part of the load
   { key: 'dateFormat', label: 'Date Format', show: (_, config) => config.hasDateFieldMapped !== false },

--- a/libs/features/update-records/src/deployment/MassUpdateRecordsDeployment.tsx
+++ b/libs/features/update-records/src/deployment/MassUpdateRecordsDeployment.tsx
@@ -190,6 +190,7 @@ export const MassUpdateRecordsDeployment = () => {
             deployResults={row.deployResults}
             sobject={row.sobject}
             configuration={row.configuration}
+            limit={row.limit}
             validationResults={row.validationResults}
             batchSize={batchSize ?? 1000}
           />

--- a/libs/features/update-records/src/selection/MassUpdateRecordsObject.tsx
+++ b/libs/features/update-records/src/selection/MassUpdateRecordsObject.tsx
@@ -1,4 +1,4 @@
-import { ListItem, SalesforceOrgUi } from '@jetstream/types';
+import { ListItem, Maybe, SalesforceOrgUi } from '@jetstream/types';
 import { Grid, GridCol, Tooltip } from '@jetstream/ui';
 import { MassUpdateRecordObjectHeading, MassUpdateRecordsObjectRow, MetadataRow } from '@jetstream/ui-core';
 import { FunctionComponent, useCallback } from 'react';
@@ -10,6 +10,7 @@ export interface MassUpdateRecordsObjectProps {
   commonFields: ListItem[];
   onFieldSelected: ReturnType<typeof useMassUpdateFieldItems>['onFieldSelected'];
   handleOptionChange: ReturnType<typeof useMassUpdateFieldItems>['handleOptionChange'];
+  handleRecordLimitChange: (sobject: string, limit: Maybe<number>) => void;
   onLoadChildFields: (sobject: string, item: ListItem) => Promise<ListItem[]>;
   validateRowRecords: (sobject: string) => void;
   handleAddField: (sobject: string) => void;
@@ -24,6 +25,7 @@ export const MassUpdateRecordsObject: FunctionComponent<MassUpdateRecordsObjectP
   onFieldSelected,
   onLoadChildFields,
   handleOptionChange,
+  handleRecordLimitChange,
   validateRowRecords,
   handleAddField,
   handleRemoveField,
@@ -45,6 +47,10 @@ export const MassUpdateRecordsObject: FunctionComponent<MassUpdateRecordsObjectP
         valueFields={row.valueFields}
         fieldConfigurations={row.configuration}
         validationResults={row.validationResults}
+        recordLimit={{
+          limit: row.limit,
+          onChange: (limit) => handleRecordLimitChange(row.sobject, limit),
+        }}
         onFieldChange={(index, selectedField) => onFieldSelected(index, row.sobject, selectedField)}
         onOptionsChange={(index, sobject, options) => handleOptionChange(index, sobject, options)}
         onLoadChildFields={handleLoadChildFields}

--- a/libs/features/update-records/src/selection/MassUpdateRecordsObjects.tsx
+++ b/libs/features/update-records/src/selection/MassUpdateRecordsObjects.tsx
@@ -1,4 +1,4 @@
-import { ListItem, SalesforceOrgUi } from '@jetstream/types';
+import { ListItem, Maybe, SalesforceOrgUi } from '@jetstream/types';
 import { AutoFullHeightContainer, EmptyState, OpenRoadIllustration } from '@jetstream/ui';
 import { MetadataRow, TransformationOptions } from '@jetstream/ui-core';
 import { Fragment, FunctionComponent } from 'react';
@@ -16,6 +16,7 @@ export interface MassUpdateRecordsObjectsProps {
   applyCommonOption: ReturnType<typeof useMassUpdateFieldItems>['applyCommonOption'];
   applyCommonCriteria: ReturnType<typeof useMassUpdateFieldItems>['applyCommonCriteria'];
   handleOptionChange: (configIndex: number, sobject: string, transformationOptions: TransformationOptions) => void;
+  handleRecordLimitChange: (sobject: string, limit: Maybe<number>) => void;
   handleAddField: (sobject: string) => void;
   handleRemoveField: (sobject: string, configIndex: number) => void;
   validateRowRecords: (sobject: string) => void;
@@ -31,6 +32,7 @@ export const MassUpdateRecordsObjects: FunctionComponent<MassUpdateRecordsObject
   applyCommonOption,
   applyCommonCriteria,
   handleOptionChange,
+  handleRecordLimitChange,
   handleAddField,
   handleRemoveField,
   validateRowRecords,
@@ -57,6 +59,7 @@ export const MassUpdateRecordsObjects: FunctionComponent<MassUpdateRecordsObject
                 onFieldSelected={onFieldSelected}
                 onLoadChildFields={onLoadChildFields}
                 handleOptionChange={handleOptionChange}
+                handleRecordLimitChange={handleRecordLimitChange}
                 validateRowRecords={validateRowRecords}
                 handleAddField={handleAddField}
                 handleRemoveField={handleRemoveField}

--- a/libs/features/update-records/src/selection/MassUpdateRecordsSelection.tsx
+++ b/libs/features/update-records/src/selection/MassUpdateRecordsSelection.tsx
@@ -50,6 +50,7 @@ export const MassUpdateRecordsSelection: FunctionComponent<MassUpdateRecordsSele
     applyCommonOption,
     applyCommonCriteria,
     handleOptionChange,
+    handleRecordLimitChange,
     handleAddField,
     handleRemoveField,
     validateAllRowRecords,
@@ -183,6 +184,7 @@ export const MassUpdateRecordsSelection: FunctionComponent<MassUpdateRecordsSele
                 applyCommonOption={applyCommonOption}
                 applyCommonCriteria={applyCommonCriteria}
                 handleOptionChange={handleOptionChange}
+                handleRecordLimitChange={handleRecordLimitChange}
                 handleAddField={handleAddField}
                 handleRemoveField={handleRemoveField}
                 validateRowRecords={validateRowRecords}

--- a/libs/features/update-records/src/selection/useMassUpdateFieldItems.ts
+++ b/libs/features/update-records/src/selection/useMassUpdateFieldItems.ts
@@ -41,6 +41,7 @@ type Action =
       type: 'TRANSFORMATION_OPTION_CHANGED';
       payload: { sobject: string; transformationOptions: TransformationOptions; configIndex: number };
     }
+  | { type: 'RECORD_LIMIT_CHANGED'; payload: { sobject: string; limit: Maybe<number> } }
   | { type: 'ADD_FIELD'; payload: { sobject: string } }
   | { type: 'REMOVE_FIELD'; payload: { sobject: string; configIndex: number } }
   | { type: 'METADATA_LOADED'; payload: { sobject: string; metadata: DescribeSObjectResult } }
@@ -186,6 +187,17 @@ function reducer(state: State, action: Action): State {
       const prevRow = state.rowsMap.get(sobject)!;
       const row: MetadataRow = { ...prevRow, validationResults: null, configuration: [...prevRow.configuration] };
       row.configuration[configIndex] = { ...row.configuration[configIndex], transformationOptions };
+      row.isValid = isValidRow(row);
+      rowsMap.set(sobject, row);
+      return { ...state, rowsMap, allRowsValid: Array.from(rowsMap.values()).every((row) => row.isValid) };
+    }
+    case 'RECORD_LIMIT_CHANGED': {
+      const { sobject, limit } = action.payload;
+      const rowsMap = new Map(state.rowsMap);
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      const prevRow = state.rowsMap.get(sobject)!;
+      // The prior validation counted a different set of records, so it has to be re-run
+      const row: MetadataRow = { ...prevRow, limit, validationResults: null };
       row.isValid = isValidRow(row);
       rowsMap.set(sobject, row);
       return { ...state, rowsMap, allRowsValid: Array.from(rowsMap.values()).every((row) => row.isValid) };
@@ -494,6 +506,10 @@ export function useMassUpdateFieldItems(org: SalesforceOrgUi, selectedSObjects: 
     dispatch({ type: 'TRANSFORMATION_OPTION_CHANGED', payload: { sobject, transformationOptions, configIndex } });
   }
 
+  function handleRecordLimitChange(sobject: string, limit: Maybe<number>) {
+    dispatch({ type: 'RECORD_LIMIT_CHANGED', payload: { sobject, limit } });
+  }
+
   function handleAddField(sobject: string) {
     dispatch({ type: 'ADD_FIELD', payload: { sobject } });
   }
@@ -513,6 +529,7 @@ export function useMassUpdateFieldItems(org: SalesforceOrgUi, selectedSObjects: 
     applyCommonOption,
     applyCommonCriteria,
     handleOptionChange,
+    handleRecordLimitChange,
     handleAddField,
     handleRemoveField,
     validateAllRowRecords,

--- a/libs/shared/ui-core/src/index.ts
+++ b/libs/shared/ui-core/src/index.ts
@@ -66,6 +66,7 @@ export * from './mass-update-records/MassUpdateRecordsDeploymentRow';
 export * from './mass-update-records/MassUpdateRecordsObjectRow';
 export * from './mass-update-records/MassUpdateRecordsObjectRowCriteria';
 export * from './mass-update-records/MassUpdateRecordsObjectRowField';
+export * from './mass-update-records/MassUpdateRecordsObjectRowLimit';
 export * from './mass-update-records/MassUpdateRecordsObjectRowValue';
 export * from './mass-update-records/MassUpdateRecordsObjectRowValueStaticInput';
 export * from './mass-update-records/useDeployRecords';

--- a/libs/shared/ui-core/src/mass-update-records/MassUpdateRecordsDeploymentRow.tsx
+++ b/libs/shared/ui-core/src/mass-update-records/MassUpdateRecordsDeploymentRow.tsx
@@ -18,6 +18,7 @@ import MassUpdateRecordTransformationText from './MassUpdateRecordTransformation
 import { MetadataRow } from './mass-update-records.types';
 import {
   buildMassUpdateCombinedResults,
+  getEffectiveRecordLimit,
   getMassUpdateBatchSourceRecords,
   getMassUpdateQueriedFieldsHeader,
   getMassUpdateResultsHeader,
@@ -41,13 +42,14 @@ export type MassUpdateRecordsDeploymentRowProps = {
   batchSize: number;
   omitTransformationText?: boolean;
   onModalOpenChange?: (isOpen: boolean) => void;
-} & Pick<MetadataRow, 'sobject' | 'deployResults' | 'configuration'>;
+} & Pick<MetadataRow, 'sobject' | 'deployResults' | 'configuration' | 'limit'>;
 
 export const MassUpdateRecordsDeploymentRow = ({
   selectedOrg,
   sobject,
   deployResults,
   configuration,
+  limit,
   hasExternalWhereClause,
   validationResults,
   batchSize,
@@ -62,6 +64,7 @@ export const MassUpdateRecordsDeploymentRow = ({
   const skipFrontDoorAuth = useAtomValue(selectSkipFrontdoorAuth);
 
   const { done, processingErrors, status, fatalErrorMessage, jobInfo, processingEndTime, processingStartTime } = deployResults;
+  const effectiveLimit = getEffectiveRecordLimit(limit);
 
   useEffect(() => {
     onModalOpenChange && onModalOpenChange(downloadModalData.open || resultsModalData.open);
@@ -218,6 +221,12 @@ export const MassUpdateRecordsDeploymentRow = ({
               {formatNumber(validationResults?.impactedRecords)} {pluralizeFromNumber('record', validationResults?.impactedRecords)}
             </span>{' '}
             were found matching this criteria.
+          </div>
+        )}
+        {!processingStartTime && !!effectiveLimit && (
+          <div className="slds-m-left_medium">
+            At most <span className="text-bold">{formatNumber(effectiveLimit)}</span> {pluralizeFromNumber('record', effectiveLimit)} will
+            be updated.
           </div>
         )}
         <div className="slds-scrollable_x">

--- a/libs/shared/ui-core/src/mass-update-records/MassUpdateRecordsObjectRow.tsx
+++ b/libs/shared/ui-core/src/mass-update-records/MassUpdateRecordsObjectRow.tsx
@@ -1,6 +1,5 @@
 import { logger } from '@jetstream/shared/client-logger';
 import { ANALYTICS_KEYS } from '@jetstream/shared/constants';
-import { queryAll } from '@jetstream/shared/data';
 import { formatNumber } from '@jetstream/shared/ui-utils';
 import { getErrorMessage, pluralizeFromNumber } from '@jetstream/shared/utils';
 import { Field, ListItem, Maybe, SalesforceOrgUi } from '@jetstream/types';
@@ -14,13 +13,10 @@ import { fromJetstreamEvents } from '../jetstream-events';
 import MassUpdateRecordTransformationText from './MassUpdateRecordTransformationText';
 import MassUpdateRecordsObjectRowCriteria from './MassUpdateRecordsObjectRowCriteria';
 import MassUpdateRecordsObjectRowField from './MassUpdateRecordsObjectRowField';
+import MassUpdateRecordsObjectRowLimit from './MassUpdateRecordsObjectRowLimit';
 import MassUpdateRecordsObjectRowValue from './MassUpdateRecordsObjectRowValue';
 import { MetadataRow, MetadataRowConfiguration, TransformationOptions, ValidationResults } from './mass-update-records.types';
-import {
-  composeSoqlQueryCustomWhereClause,
-  composeSoqlQueryOptionalCustomWhereClause,
-  getFieldsToQuery,
-} from './mass-update-records.utils';
+import { getFieldsToQuery, queryRecordsForRow } from './mass-update-records.utils';
 
 export interface MassUpdateRecordsObjectRowProps {
   org: SalesforceOrgUi;
@@ -32,6 +28,11 @@ export interface MassUpdateRecordsObjectRowProps {
   fieldConfigurations: MetadataRowConfiguration[];
   validationResults?: Maybe<ValidationResults>;
   hasExternalWhereClause?: boolean;
+  /**
+   * When provided, inputs to limit / skip records are shown. Omitted where the records to update are
+   * already scoped by something else, such as the query results entry point.
+   */
+  recordLimit?: { limit: Maybe<number>; onChange: (limit: Maybe<number>) => void };
   disabled?: boolean;
   onFieldChange: (index: number, selectedField: string, fieldMetadata: Field) => void;
   onOptionsChange: (index: number, sobject: string, options: TransformationOptions) => void;
@@ -53,6 +54,7 @@ export const MassUpdateRecordsObjectRow: FunctionComponent<MassUpdateRecordsObje
   fieldConfigurations,
   validationResults,
   hasExternalWhereClause,
+  recordLimit,
   disabled,
   onFieldChange,
   onOptionsChange,
@@ -78,33 +80,18 @@ export const MassUpdateRecordsObjectRow: FunctionComponent<MassUpdateRecordsObje
     try {
       setDownloadRecordsLoading(true);
       const fieldsToQuery = getFieldsToQuery(fieldConfigurations);
-      const row = { sobject, configuration: fieldConfigurations } as MetadataRow;
-      const standardQuery = composeSoqlQueryOptionalCustomWhereClause(row, fieldsToQuery);
-      const customQuery = composeSoqlQueryCustomWhereClause(row, fieldsToQuery);
-
-      const recordsById: Record<string, any> = {};
-
-      if (standardQuery) {
-        const result = await queryAll(org, standardQuery);
-        result.queryResults.records.forEach((record) => {
-          recordsById[record.Id] = record;
-        });
-      }
-
-      if (customQuery) {
-        const result = await queryAll(org, customQuery);
-        result.queryResults.records.forEach((record) => {
-          recordsById[record.Id] = record;
-        });
-      }
+      const row = { sobject, configuration: fieldConfigurations, limit: recordLimit?.limit } as MetadataRow;
+      // Shares the deploy path's fetch so the previewed records are exactly the records that will be updated.
+      // Custom criteria membership is skipped because the download shows the raw queried records.
+      const { records } = await queryRecordsForRow(row, fieldsToQuery, org, { resolveCustomCriteria: false });
 
       setDownloadModalData({
         open: true,
-        data: Object.values(recordsById),
+        data: records,
         header: fieldsToQuery,
         fileNameParts: ['mass-update', sobject.toLowerCase(), 'validation-records'],
       });
-      trackEvent(ANALYTICS_KEYS.mass_update_DownloadRecords, { type: 'validation', numRows: Object.keys(recordsById).length });
+      trackEvent(ANALYTICS_KEYS.mass_update_DownloadRecords, { type: 'validation', numRows: records.length });
     } catch (ex) {
       logger.error('[DOWNLOAD VALIDATION RECORDS]', ex);
       fireToast({ type: 'error', message: `Failed to download records. ${getErrorMessage(ex)}` });
@@ -181,6 +168,16 @@ export const MassUpdateRecordsObjectRow: FunctionComponent<MassUpdateRecordsObje
             </button>
           </div>
         </GridCol>
+        {recordLimit && (
+          <GridCol size={12} className="slds-m-top_small">
+            <MassUpdateRecordsObjectRowLimit
+              sobject={sobject}
+              limit={recordLimit.limit}
+              disabled={disabled}
+              onChange={recordLimit.onChange}
+            />
+          </GridCol>
+        )}
       </Grid>
       {validationResults && (
         <footer className="slds-card__footer">

--- a/libs/shared/ui-core/src/mass-update-records/MassUpdateRecordsObjectRowLimit.tsx
+++ b/libs/shared/ui-core/src/mass-update-records/MassUpdateRecordsObjectRowLimit.tsx
@@ -1,0 +1,66 @@
+import { css } from '@emotion/react';
+import { useIntegerInput } from '@jetstream/shared/ui-utils';
+import { Maybe } from '@jetstream/types';
+import { Grid, Input } from '@jetstream/ui';
+import { FunctionComponent } from 'react';
+import { getRecordLimitError } from './mass-update-records.utils';
+
+export interface MassUpdateRecordsObjectRowLimitProps {
+  sobject: string;
+  limit: Maybe<number>;
+  disabled?: boolean;
+  onChange: (limit: Maybe<number>) => void;
+}
+
+/**
+ * Optional per-object `LIMIT`, which allows updating a data volume that is too large to process in
+ * one pass by working through it a chunk at a time.
+ */
+export const MassUpdateRecordsObjectRowLimit: FunctionComponent<MassUpdateRecordsObjectRowLimitProps> = ({
+  sobject,
+  limit,
+  disabled,
+  onChange,
+}) => {
+  const limitInput = useIntegerInput(limit, onChange);
+  const limitError = getRecordLimitError(limit);
+
+  return (
+    <Grid verticalAlign="end">
+      <Grid verticalAlign="end" className="text-bold slds-m-horizontal_medium slds-m-bottom_x-small">
+        LIMIT
+      </Grid>
+      <Grid
+        verticalAlign="end"
+        css={css`
+          min-width: 240px;
+          max-width: 500px;
+        `}
+      >
+        <div className="slds-m-horizontal_x-small slds-grow">
+          <Input
+            id={`${sobject}-limit`}
+            label="Maximum records to update"
+            hasError={!!limitError}
+            errorMessage={limitError}
+            errorMessageId={`${sobject}-limit-error`}
+            labelHelp="Limit how many records are updated at one time. Leave blank to update every record that meets your criteria."
+          >
+            <input
+              id={`${sobject}-limit`}
+              className="slds-input"
+              placeholder="All matching records"
+              value={limitInput.inputValue}
+              aria-describedby={limitError ? `${sobject}-limit-error` : undefined}
+              disabled={disabled}
+              onChange={limitInput.handleChange}
+              onBlur={limitInput.handleBlur}
+            />
+          </Input>
+        </div>
+      </Grid>
+    </Grid>
+  );
+};
+
+export default MassUpdateRecordsObjectRowLimit;

--- a/libs/shared/ui-core/src/mass-update-records/__tests__/MassUpdateRecordsObjectRowLimit.spec.tsx
+++ b/libs/shared/ui-core/src/mass-update-records/__tests__/MassUpdateRecordsObjectRowLimit.spec.tsx
@@ -1,0 +1,29 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import MassUpdateRecordsObjectRowLimit from '../MassUpdateRecordsObjectRowLimit';
+
+describe('MassUpdateRecordsObjectRowLimit', () => {
+  it('Should emit the parsed limit', () => {
+    const onChange = vi.fn();
+    render(<MassUpdateRecordsObjectRowLimit sobject="Account" limit={null} onChange={onChange} />);
+
+    fireEvent.change(screen.getByLabelText('Maximum records to update'), { target: { value: '5000' } });
+
+    expect(onChange).toHaveBeenCalledWith(5000);
+  });
+
+  it('Should clear the value when the input is emptied', () => {
+    const onChange = vi.fn();
+    render(<MassUpdateRecordsObjectRowLimit sobject="Account" limit={5000} onChange={onChange} />);
+
+    fireEvent.change(screen.getByLabelText('Maximum records to update'), { target: { value: '' } });
+
+    expect(onChange).toHaveBeenCalledWith(null);
+  });
+
+  it('Should show an error when the limit is below one', () => {
+    render(<MassUpdateRecordsObjectRowLimit sobject="Account" limit={0} onChange={vi.fn()} />);
+
+    expect(screen.getByText(/limit must be 1 or greater/i)).toBeTruthy();
+  });
+});

--- a/libs/shared/ui-core/src/mass-update-records/__tests__/mass-update-records.utils.spec.ts
+++ b/libs/shared/ui-core/src/mass-update-records/__tests__/mass-update-records.utils.spec.ts
@@ -5,12 +5,16 @@ import {
   composeSoqlQueryCustomWhereClause,
   composeSoqlQueryOptionalCustomWhereClause,
   fetchRecordsWithRequiredFields,
+  getEffectiveRecordLimit,
   getFieldsToQuery,
+  getRecordLimitError,
+  getValidationSoqlQuery,
   isValidRow,
   isValidWhereClause,
   MAX_ID_QUERY_LENGTH,
   normalizeWhereClause,
   prepareRecords,
+  queryAndPrepareRecordsForUpdate,
 } from '../mass-update-records.utils';
 
 vi.mock('@jetstream/shared/data');
@@ -287,7 +291,7 @@ describe('mass-update-records.utils#composeSoqlQueryOptionalCustomWhereClause', 
 
     expect(soql).toBe(`SELECT Id, FirstName, LastName, Fax FROM Contact WHERE (FirstName = NULL) OR (LastName != NULL)`);
 
-    soql = composeSoqlQueryOptionalCustomWhereClause(config, ['Count()'], true);
+    soql = composeSoqlQueryOptionalCustomWhereClause(config, ['Count()'], { includeCustom: true });
     expect(soql).toBe(`SELECT Count() FROM Contact WHERE (FirstName = NULL) OR (LastName != NULL) OR (Id = '12345')`);
   });
 
@@ -590,6 +594,188 @@ describe('mass-update-records.utils#prepareRecords', () => {
     expect(record1.Name).toBe('Jenny Jenny');
     expect(record2.Name).toBe(null);
     expect(record3.Name).toBe('Jenny Jenny');
+  });
+});
+
+describe('mass-update-records.utils#record limit', () => {
+  const selectedOrg = { uniqueId: 'org1' } as any;
+
+  function buildRow({ criteria = 'all', limit }: { criteria?: string; limit?: number | null }) {
+    return {
+      sobject: 'Account',
+      limit,
+      configuration: [
+        {
+          selectedField: 'Industry',
+          transformationOptions: {
+            criteria,
+            option: 'staticValue',
+            staticValue: 'Tech',
+            alternateField: null,
+            whereClause: `Id = '12345'`,
+          },
+        },
+      ],
+    } as any;
+  }
+
+  /** A row that mixes standard criteria with custom criteria - the case a limit has to window as a union */
+  function buildMixedCriteriaRow({ limit }: { limit?: number | null }) {
+    return {
+      sobject: 'Account',
+      limit,
+      configuration: [
+        {
+          selectedField: 'Industry',
+          transformationOptions: { criteria: 'onlyIfBlank', option: 'staticValue', staticValue: 'Tech', whereClause: '' },
+        },
+        {
+          selectedField: 'Rating',
+          transformationOptions: { criteria: 'custom', option: 'staticValue', staticValue: 'Hot', whereClause: `Id = '12345'` },
+        },
+      ],
+    } as any;
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('Should append the limit after the where clause', () => {
+    expect(composeSoqlQueryOptionalCustomWhereClause(buildRow({ criteria: 'onlyIfBlank', limit: 5000 }), ['Id'])).toBe(
+      `SELECT Id FROM Account WHERE (Industry = NULL) LIMIT 5000`,
+    );
+  });
+
+  it('Should never apply the limit to the standalone custom criteria query', () => {
+    expect(composeSoqlQueryCustomWhereClause(buildRow({ criteria: 'custom', limit: 5000 }), ['Id'])).toBe(
+      `SELECT Id FROM Account WHERE (Id = '12345')`,
+    );
+  });
+
+  it('Should append the limit when there is no where clause', () => {
+    expect(composeSoqlQueryOptionalCustomWhereClause(buildRow({ limit: 5000 }), ['Id'])).toBe(`SELECT Id FROM Account LIMIT 5000`);
+  });
+
+  it('Should include the limit in the validation query', () => {
+    expect(getValidationSoqlQuery(buildRow({ limit: 5000 }))).toBe(`SELECT Count() FROM Account LIMIT 5000`);
+  });
+
+  it('Should omit the limit when not provided or not meaningful', () => {
+    expect(composeSoqlQueryOptionalCustomWhereClause(buildRow({}), ['Id'])).toBe(`SELECT Id FROM Account`);
+    expect(composeSoqlQueryOptionalCustomWhereClause(buildRow({ limit: null }), ['Id'])).toBe(`SELECT Id FROM Account`);
+    expect(composeSoqlQueryOptionalCustomWhereClause(buildRow({ limit: 0 }), ['Id'])).toBe(`SELECT Id FROM Account`);
+  });
+
+  it('Should window the union of both criteria with a single query when the row has a limit', async () => {
+    // A limit must window the union that validation counted. Limiting each criteria's query separately
+    // would overshoot the limit that validation counted.
+    const row = buildMixedCriteriaRow({ limit: 3 });
+
+    vi.mocked(clientData.queryAll).mockResolvedValueOnce({
+      queryResults: { records: [{ Id: '001a' }, { Id: '001b' }, { Id: '001d' }], totalSize: 3, done: true },
+    } as any);
+    vi.mocked(clientData.queryAllFromList).mockResolvedValueOnce({
+      queryResults: { records: [{ Id: '001d' }], totalSize: 1, done: true },
+    } as any);
+
+    const records = await queryAndPrepareRecordsForUpdate(row, ['Id', 'Industry', 'Rating'], selectedOrg);
+
+    expect(clientData.queryAll).toHaveBeenCalledTimes(1);
+    expect(clientData.queryAll).toHaveBeenCalledWith(
+      selectedOrg,
+      `SELECT Id, Industry, Rating FROM Account WHERE (Industry = NULL) OR (Id = '12345') LIMIT 3`,
+    );
+    expect(records.map(({ Id }) => Id)).toEqual(['001a', '001b', '001d']);
+  });
+
+  it('Should resolve custom criteria membership within the windowed records', async () => {
+    const row = buildMixedCriteriaRow({ limit: 3 });
+
+    vi.mocked(clientData.queryAll).mockResolvedValueOnce({
+      queryResults: { records: [{ Id: '001a' }, { Id: '001d' }], totalSize: 2, done: true },
+    } as any);
+    vi.mocked(clientData.queryAllFromList).mockResolvedValueOnce({
+      queryResults: { records: [{ Id: '001d' }], totalSize: 1, done: true },
+    } as any);
+
+    const records = await queryAndPrepareRecordsForUpdate(row, ['Id', 'Industry', 'Rating'], selectedOrg);
+
+    expect(clientData.queryAllFromList).toHaveBeenCalledWith(selectedOrg, [
+      `SELECT Id FROM Account WHERE Id IN ('001a','001d') AND ((Id = '12345'))`,
+    ]);
+    // Only the record matching the custom criteria gets the custom field's value; the other is left untouched
+    expect(records).toEqual([
+      { Id: '001a', Industry: 'Tech', Rating: null },
+      { Id: '001d', Industry: 'Tech', Rating: 'Hot' },
+    ]);
+  });
+
+  it('Should merge both criteria queries without an extra membership query when the row has no limit', async () => {
+    const row = buildMixedCriteriaRow({});
+
+    vi.mocked(clientData.queryAll)
+      .mockResolvedValueOnce({
+        queryResults: { records: [{ Id: '001a' }, { Id: '001b' }], totalSize: 2, done: true },
+      } as any)
+      .mockResolvedValueOnce({
+        queryResults: { records: [{ Id: '001d' }], totalSize: 1, done: true },
+      } as any);
+
+    const records = await queryAndPrepareRecordsForUpdate(row, ['Id', 'Industry', 'Rating'], selectedOrg);
+
+    expect(clientData.queryAll).toHaveBeenCalledTimes(2);
+    expect(clientData.queryAllFromList).not.toHaveBeenCalled();
+    expect(records.map(({ Id }) => Id)).toEqual(['001a', '001b', '001d']);
+  });
+
+  it('Should treat every windowed record as a custom match when all criteria are custom', async () => {
+    const row = {
+      sobject: 'Account',
+      limit: 2,
+      configuration: [
+        {
+          selectedField: 'Rating',
+          transformationOptions: { criteria: 'custom', option: 'staticValue', staticValue: 'Hot', whereClause: `Id = '12345'` },
+        },
+      ],
+    } as any;
+
+    vi.mocked(clientData.queryAll).mockResolvedValueOnce({
+      queryResults: { records: [{ Id: '001a' }, { Id: '001b' }], totalSize: 2, done: true },
+    } as any);
+
+    const records = await queryAndPrepareRecordsForUpdate(row, ['Id', 'Rating'], selectedOrg);
+
+    expect(clientData.queryAllFromList).not.toHaveBeenCalled();
+    expect(records.map(({ Rating }) => Rating)).toEqual(['Hot', 'Hot']);
+  });
+
+  it('Should normalize a limit that cannot mean anything to a query', () => {
+    expect(getEffectiveRecordLimit(10)).toBe(10);
+    expect(getEffectiveRecordLimit(null)).toBeNull();
+    expect(getEffectiveRecordLimit(undefined)).toBeNull();
+    expect(getEffectiveRecordLimit(0)).toBeNull();
+    expect(getEffectiveRecordLimit(-1)).toBeNull();
+  });
+
+  it('Should only allow a limit of one or greater', () => {
+    expect(getRecordLimitError(null)).toBeNull();
+    expect(getRecordLimitError(1)).toBeNull();
+    expect(getRecordLimitError(0)).toEqual(expect.any(String));
+    expect(getRecordLimitError(-1)).toEqual(expect.any(String));
+  });
+
+  it('Should treat a row with an unusable limit as invalid', () => {
+    const configuration = [
+      {
+        selectedField: 'Industry',
+        transformationOptions: { criteria: 'all', option: 'staticValue', staticValue: 'Tech' },
+      },
+    ];
+    expect(isValidRow({ configuration } as any)).toBe(true);
+    expect(isValidRow({ configuration, limit: 100 } as any)).toBe(true);
+    expect(isValidRow({ configuration, limit: 0 } as any)).toBe(false);
   });
 });
 

--- a/libs/shared/ui-core/src/mass-update-records/data-history-capture.ts
+++ b/libs/shared/ui-core/src/mass-update-records/data-history-capture.ts
@@ -1,4 +1,4 @@
-import { BulkJobWithBatches, SalesforceOrgUi } from '@jetstream/types';
+import { BulkJobWithBatches, Maybe, SalesforceOrgUi } from '@jetstream/types';
 import {
   appendBulkJobBatchResults,
   buildBulkJobHistoryCounts,
@@ -6,7 +6,12 @@ import {
   startDataHistoryEntry,
 } from '@jetstream/ui/data-history';
 import { MetadataRowConfiguration } from './mass-update-records.types';
-import { buildMassUpdateCombinedResults, getMassUpdateBatchSourceRecords, getMassUpdateResultsHeader } from './mass-update-records.utils';
+import {
+  buildMassUpdateCombinedResults,
+  getEffectiveRecordLimit,
+  getMassUpdateBatchSourceRecords,
+  getMassUpdateResultsHeader,
+} from './mass-update-records.utils';
 
 /**
  * Helpers that adapt the mass-update deploy flow to the `@jetstream/ui/data-history` capture API.
@@ -41,6 +46,7 @@ export function startMassUpdateHistory({
   batchSize,
   serialMode,
   configuration,
+  limit,
   skipHistory,
 }: {
   org: SalesforceOrgUi;
@@ -49,6 +55,7 @@ export function startMassUpdateHistory({
   batchSize: number;
   serialMode: boolean;
   configuration: MetadataRowConfiguration[];
+  limit?: Maybe<number>;
   skipHistory?: boolean;
 }): DataHistoryEntryHandle {
   return startDataHistoryEntry({
@@ -61,6 +68,8 @@ export function startMassUpdateHistory({
     config: {
       serialMode,
       batchSize,
+      // Recorded so an entry that updated a subset does not read as though it processed everything
+      recordLimit: getEffectiveRecordLimit(limit) ?? undefined,
       transformations: configuration.map(({ selectedField, transformationOptions }) => ({
         field: selectedField,
         option: transformationOptions.option,

--- a/libs/shared/ui-core/src/mass-update-records/mass-update-records.types.tsx
+++ b/libs/shared/ui-core/src/mass-update-records/mass-update-records.types.tsx
@@ -10,6 +10,11 @@ export interface MetadataRow {
   fields: ListItem[];
   valueFields: ListItem[];
   configuration: MetadataRowConfiguration[];
+  /**
+   * Optional SOQL `LIMIT` applied to every query for this object, which lets a user work through a
+   * data volume that is too large to update in one pass.
+   */
+  limit?: Maybe<number>;
   validationResults?: Maybe<ValidationResults>;
   deployResults: DeployResults;
 }

--- a/libs/shared/ui-core/src/mass-update-records/mass-update-records.utils.tsx
+++ b/libs/shared/ui-core/src/mass-update-records/mass-update-records.utils.tsx
@@ -7,6 +7,7 @@ import { BulkJobResultRecord, DescribeGlobalSObjectResult, ListItem, Maybe, Sale
 import { Query, composeQuery, getField, isQueryValid } from '@jetstreamapp/soql-parser-js';
 import lodashGet from 'lodash/get';
 import isNil from 'lodash/isNil';
+import isNumber from 'lodash/isNumber';
 import { MetadataRow, MetadataRowConfiguration } from './mass-update-records.types';
 
 /**
@@ -18,19 +19,46 @@ import { MetadataRow, MetadataRowConfiguration } from './mass-update-records.typ
  */
 export const MAX_ID_QUERY_LENGTH = 9500;
 
+/** Validation message for a row's record limit, or null when the limit is unset or usable */
+export function getRecordLimitError(limit: Maybe<number>): string | null {
+  if (isNumber(limit) && limit < 1) {
+    return 'The limit must be 1 or greater';
+  }
+  return null;
+}
+
+/**
+ * Normalized `LIMIT` for a row. `Maybe<number>` admits `null`, `undefined`, `0` and negative values,
+ * none of which mean anything to a query, so every consumer reads the limit through here and checks
+ * plain truthiness instead of restating which values count.
+ */
+export function getEffectiveRecordLimit(limit: Maybe<number>): number | null {
+  return isNumber(limit) && limit > 0 ? limit : null;
+}
+
+/**
+ * `LIMIT` suffix for a row. Appended by hand instead of through `composeQuery` because the WHERE
+ * clauses are composed as raw strings after the query is built, and the limit must follow them.
+ */
+function getLimitClause(row: Pick<MetadataRow, 'limit'>): string {
+  const limit = getEffectiveRecordLimit(row.limit);
+  return limit ? ` LIMIT ${limit}` : '';
+}
+
 /**
  * Split a set of record Ids into as few `WHERE Id IN (...)` queries as possible while keeping each query
  * under {@link MAX_ID_QUERY_LENGTH} so it does not blow past Salesforce's query-URL length limit.
  */
-function buildChunkedIdInQueries(baseSoql: string, ids: string[]): string[] {
+function buildChunkedIdInQueries(baseSoql: string, ids: string[], additionalWhereClause?: Maybe<string>): string[] {
   const queries: string[] = [];
-  const wrapperLength = baseSoql.length + ' WHERE Id IN ()'.length;
+  const additionalClause = additionalWhereClause ? ` AND (${additionalWhereClause})` : '';
+  const wrapperLength = baseSoql.length + ' WHERE Id IN ()'.length + additionalClause.length;
   let chunk: string[] = [];
   let chunkLength = wrapperLength;
 
   const flushChunk = () => {
     if (chunk.length > 0) {
-      queries.push(`${baseSoql} WHERE Id IN (${chunk.join(',')})`);
+      queries.push(`${baseSoql} WHERE Id IN (${chunk.join(',')})${additionalClause}`);
       chunk = [];
       chunkLength = wrapperLength;
     }
@@ -111,6 +139,9 @@ export const transformationCriteriaListItems: ListItem[] = [
  */
 export function isValidRow(row: Maybe<MetadataRow>) {
   if (!row?.configuration?.length) {
+    return false;
+  }
+  if (getRecordLimitError(row.limit)) {
     return false;
   }
   return row.configuration.every(({ selectedField, transformationOptions }) => {
@@ -195,10 +226,84 @@ export function getMassUpdateBatchSourceRecords(
 }
 
 export function getValidationSoqlQuery(row: MetadataRow) {
-  return composeSoqlQueryOptionalCustomWhereClause(row, [`Count()`], true);
+  return composeSoqlQueryOptionalCustomWhereClause(row, [`Count()`], { includeCustom: true });
 }
 
-export async function queryAndPrepareRecordsForUpdate(row: MetadataRow, fields: string[], org: SalesforceOrgUi) {
+/**
+ * The `(clause) OR (clause)` WHERE fragment for the row's custom criteria, or null when it has none.
+ */
+function getCustomCriteriaWhereClause(row: Pick<MetadataRow, 'configuration'>): string | null {
+  const whereClauses = row.configuration
+    .filter(
+      ({ transformationOptions }) => transformationOptions.criteria === 'custom' && isValidWhereClause(transformationOptions.whereClause),
+    )
+    .map(({ transformationOptions }) => `(${normalizeWhereClause(transformationOptions.whereClause)})`)
+    .join(' OR ');
+  return whereClauses || null;
+}
+
+/**
+ * Which of the already-fetched `records` match the row's custom criteria, resolved with `WHERE Id IN (...)`
+ * queries scoped to those records. Short-circuited when every criteria on the row is custom, because the
+ * fetched records are then all custom matches by construction and there is nothing to narrow.
+ */
+async function queryCustomCriteriaRecordIds(
+  row: MetadataRow,
+  records: SalesforceRecord[],
+  customWhereClause: string,
+  org: SalesforceOrgUi,
+): Promise<Set<string>> {
+  const recordIds = records.map(({ Id }) => Id);
+  if (!recordIds.length) {
+    return new Set();
+  }
+  if (row.configuration.every(({ transformationOptions }) => transformationOptions.criteria === 'custom')) {
+    return new Set(recordIds);
+  }
+
+  const baseSoql = composeQuery({ fields: [getField('Id')], sObject: row.sobject });
+  const { queryResults } = await queryAllFromList<SalesforceRecord>(org, buildChunkedIdInQueries(baseSoql, recordIds, customWhereClause));
+  return new Set(queryResults.records.map(({ Id }) => Id));
+}
+
+/**
+ * The records a row will update, plus which of them matched the row's custom criteria (which
+ * {@link prepareRecords} needs to decide per-field whether the criteria was met).
+ *
+ * A row can mix custom criteria with `all` / `onlyIfBlank` / `onlyIfNotBlank` criteria, and a single
+ * query cannot both union the two and report which records matched which - so without a limit this is
+ * just two queries merged. With a limit it cannot be, because a `LIMIT` on each query windows each
+ * criteria independently rather than windowing the union that validation counted: the merged set would
+ * overshoot the limit. A limited row therefore fetches the same unioned window validation counted,
+ * then resolves custom-criteria membership within that window by Id.
+ *
+ * Pass `resolveCustomCriteria: false` when only the records themselves are needed (the validation
+ * records download): membership does not change which records are returned, and resolving it costs an
+ * extra chunked `WHERE Id IN (...)` query for every ~450 records in the window.
+ */
+export async function queryRecordsForRow(
+  row: MetadataRow,
+  fields: string[],
+  org: SalesforceOrgUi,
+  { resolveCustomCriteria = true }: { resolveCustomCriteria?: boolean } = {},
+): Promise<{ records: SalesforceRecord[]; customCriteriaRecordIds: Set<string> }> {
+  const limit = getEffectiveRecordLimit(row.limit);
+  const customWhereClause = getCustomCriteriaWhereClause(row);
+
+  if (limit) {
+    const windowQuery = composeSoqlQueryOptionalCustomWhereClause(row, fields, { includeCustom: true });
+    if (!windowQuery) {
+      return { records: [], customCriteriaRecordIds: new Set() };
+    }
+    const { queryResults } = await queryAll<SalesforceRecord>(org, windowQuery);
+    const records = queryResults.records;
+    return {
+      records,
+      customCriteriaRecordIds:
+        resolveCustomCriteria && customWhereClause ? await queryCustomCriteriaRecordIds(row, records, customWhereClause, org) : new Set(),
+    };
+  }
+
   const standardQuery = composeSoqlQueryOptionalCustomWhereClause(row, fields);
   const customWhereClauseQuery = composeSoqlQueryCustomWhereClause(row, fields);
 
@@ -222,10 +327,19 @@ export async function queryAndPrepareRecordsForUpdate(row: MetadataRow, fields: 
     );
   }
 
-  return prepareRecords(Object.values(recordsById), row.configuration, customCriteriaRecordIds);
+  return { records: Object.values(recordsById), customCriteriaRecordIds };
 }
 
-export function composeSoqlQueryOptionalCustomWhereClause(row: MetadataRow, fields: string[], includeCustom = false) {
+export async function queryAndPrepareRecordsForUpdate(row: MetadataRow, fields: string[], org: SalesforceOrgUi) {
+  const { records, customCriteriaRecordIds } = await queryRecordsForRow(row, fields, org);
+  return prepareRecords(records, row.configuration, customCriteriaRecordIds);
+}
+
+export function composeSoqlQueryOptionalCustomWhereClause(
+  row: MetadataRow,
+  fields: string[],
+  { includeCustom = false }: { includeCustom?: boolean } = {},
+) {
   const query: Query = {
     fields: fields.map((field) => getField(field)),
     sObject: row.sobject,
@@ -257,6 +371,8 @@ export function composeSoqlQueryOptionalCustomWhereClause(row: MetadataRow, fiel
     soql += ` WHERE ${whereClauses}`;
   }
 
+  soql += getLimitClause(row);
+
   logger.info('composeSoqlQueryExceptCustomWhereClause()', { soql });
   return soql;
 }
@@ -267,17 +383,13 @@ export function composeSoqlQueryCustomWhereClause(row: MetadataRow, fields: stri
     sObject: row.sobject,
   };
 
-  const whereClauses = row.configuration
-    .filter(
-      ({ transformationOptions }) => transformationOptions.criteria === 'custom' && isValidWhereClause(transformationOptions.whereClause),
-    )
-    .map(({ transformationOptions }) => `(${normalizeWhereClause(transformationOptions.whereClause)})`)
-    .join(' OR ');
+  const whereClauses = getCustomCriteriaWhereClause(row);
 
   if (!whereClauses) {
     return null;
   }
 
+  // Never limited: a limit is only meaningful on the unioned query (see queryRecordsForRow)
   const soql = `${composeQuery(query)} WHERE ${whereClauses}`;
 
   logger.info('composeSoqlQueryCustomWhereClause()', { soql });

--- a/libs/shared/ui-core/src/mass-update-records/useDeployRecords.ts
+++ b/libs/shared/ui-core/src/mass-update-records/useDeployRecords.ts
@@ -3,7 +3,7 @@ import { ANALYTICS_KEYS } from '@jetstream/shared/constants';
 import { bulkApiAddBatchToJob, bulkApiCreateJob, bulkApiGetJob } from '@jetstream/shared/data';
 import { checkIfBulkApiJobIsDone, convertDateToLocale, generateCsv, tracker, useBrowserNotifications } from '@jetstream/shared/ui-utils';
 import { delay, getErrorMessage, splitArrayToMaxSize } from '@jetstream/shared/utils';
-import { BulkJobBatchInfo, SalesforceOrgUi } from '@jetstream/types';
+import { BulkJobBatchInfo, Maybe, SalesforceOrgUi } from '@jetstream/types';
 import { applicationCookieState } from '@jetstream/ui/app-state';
 import { DataHistoryEntryHandle } from '@jetstream/ui/data-history';
 import { formatDate } from 'date-fns/format';
@@ -12,7 +12,7 @@ import { useCallback, useEffect, useRef } from 'react';
 import { useAmplitude } from '../analytics';
 import { captureMassUpdateResults, MassUpdateHistoryContext, MassUpdateSource, startMassUpdateHistory } from './data-history-capture';
 import { DeployResults, MetadataRow, MetadataRowConfiguration } from './mass-update-records.types';
-import { getFieldsToQuery, prepareRecords, queryAndPrepareRecordsForUpdate } from './mass-update-records.utils';
+import { getEffectiveRecordLimit, getFieldsToQuery, prepareRecords, queryAndPrepareRecordsForUpdate } from './mass-update-records.utils';
 
 export function useDeployRecords(
   org: SalesforceOrgUi,
@@ -42,15 +42,17 @@ export function useDeployRecords(
       batchSize,
       serialMode,
       configuration,
+      limit,
       skipHistory,
     }: {
       sobject: string;
       batchSize: number;
       serialMode: boolean;
       configuration: MetadataRowConfiguration[];
+      limit?: Maybe<number>;
       skipHistory?: boolean;
     }): DataHistoryEntryHandle => {
-      const handle = startMassUpdateHistory({ org, source, sobject, batchSize, serialMode, configuration, skipHistory });
+      const handle = startMassUpdateHistory({ org, source, sobject, batchSize, serialMode, configuration, limit, skipHistory });
       historyCaptureRef.current[sobject] = { handle, batchSize, configuration };
       return handle;
     },
@@ -192,6 +194,7 @@ export function useDeployRecords(
         batchSize,
         serialMode,
         configuration: row.configuration,
+        limit: row.limit,
         skipHistory,
       });
 
@@ -245,6 +248,7 @@ export function useDeployRecords(
         batchSize: options.batchSize,
         serialMode: options.serialMode,
         numObjects: rows.length,
+        hasRecordLimit: rows.some((row) => !!getEffectiveRecordLimit(row.limit)),
         source,
       });
       for (const row of rows) {


### PR DESCRIPTION
Updating records without a file had no way to work on a subset of an object. Every matching record is queried into the browser before anything is submitted, so a user with 9M records could not use the tool at all.

Each object now takes an optional maximum number of records to update, which lets a large data volume be worked through a chunk at a time by pairing it with criteria that stop matching once a record is updated (e.g. **Only if blank**) and re-running. The limit is applied to the SOQL rather than filtering client side, so the validated impacted record count, the Download Records button and the update itself all see the identical set.

An `OFFSET` / skip-records option was considered but Salesforce caps it at 2,000, which makes it useless for the data volumes this is meant for.

Closes #1030