### PR TITLE
feat: allow one file column to be mapped to multiple Salesforce fields

### DIFF
--- a/apps/docs/docs/load/load.mdx
+++ b/apps/docs/docs/load/load.mdx
@@ -106,6 +106,20 @@ This will add a row to the mapping table and you will need to select a field and
 
 <img src={require('./field-mapping-manual-value.png').default} alt="Map using a manual value" />
 
+### Map one column to multiple fields
+
+A column in your file can be loaded into more than one Salesforce field. Use the `+` button on any row to add an
+additional mapping for that column, which appears directly beneath it.
+
+Some common uses:
+
+- Load the same value into two different fields.
+- Use one column as a normal value and also as a **reference** to set a lookup field, using the related field options
+  described above.
+- Populate both `Label` and `DeveloperName` on Custom Metadata records from a single column.
+
+Each Salesforce field can still only be mapped once, so every additional mapping must point to a different field.
+
 ## Load data
 
 There are some final options available before loading your data to Salesforce.

--- a/libs/features/load-records/src/LoadRecords.tsx
+++ b/libs/features/load-records/src/LoadRecords.tsx
@@ -348,9 +348,14 @@ export const LoadRecords = () => {
       }
 
       if (inputFileHeader) {
-        const fieldMappingItems = Object.values(fieldMapping);
-        const numItemsMapped = fieldMappingItems.filter((item) => item.targetField).length;
-        text.push(`${formatNumber(numItemsMapped)} of ${formatNumber(inputFileHeader.length)} fields mapped`);
+        // Counts distinct file columns rather than mapped rows, otherwise static values and additional
+        // mappings push the count above the number of columns in the file
+        const mappedColumns = new Set(
+          Object.values(fieldMapping)
+            .filter((item) => item.type === 'CSV' && item.targetField)
+            .map(({ csvField }) => csvField),
+        );
+        text.push(`${formatNumber(mappedColumns.size)} of ${formatNumber(inputFileHeader.length)} fields mapped`);
       }
     }
 

--- a/libs/features/load-records/src/components/LoadRecordsFieldMappingRelatedObject.tsx
+++ b/libs/features/load-records/src/components/LoadRecordsFieldMappingRelatedObject.tsx
@@ -10,14 +10,14 @@ import LoadRecordsFieldMappingRowLookupOption from './LoadRecordsFieldMappingRow
 export interface LoadRecordsFieldMappingRelatedObjectProps {
   org: SalesforceOrgUi;
   fieldMappingItem: FieldMappingItemCsv;
-  csvField: string;
-  onSelectionChanged: (csvField: string, fieldMappingItem: FieldMappingItemCsv) => void;
+  mappingKey: string;
+  onSelectionChanged: (mappingKey: string, fieldMappingItem: FieldMappingItemCsv) => void;
 }
 
 export const LoadRecordsFieldMappingRelatedObject: FunctionComponent<LoadRecordsFieldMappingRelatedObjectProps> = ({
   org,
   fieldMappingItem,
-  csvField,
+  mappingKey,
   onSelectionChanged,
 }) => {
   const [relatedFields, setRelatedFields] = useState<ListItem<string, FieldRelatedEntity>[]>([]);
@@ -80,7 +80,7 @@ export const LoadRecordsFieldMappingRelatedObject: FunctionComponent<LoadRecords
   );
 
   function handleRelatedObjectSelectionChanged(field: string) {
-    onSelectionChanged(csvField, {
+    onSelectionChanged(mappingKey, {
       ...fieldMappingItem,
       mappedToLookup: true,
       selectedReferenceTo: field,
@@ -104,7 +104,7 @@ export const LoadRecordsFieldMappingRelatedObject: FunctionComponent<LoadRecords
       newFieldMappingItem.lookupOptionUseFirstMatch = 'ERROR_IF_MULTIPLE';
     }
 
-    onSelectionChanged(csvField, newFieldMappingItem);
+    onSelectionChanged(mappingKey, newFieldMappingItem);
   }
 
   return (
@@ -157,10 +157,10 @@ export const LoadRecordsFieldMappingRelatedObject: FunctionComponent<LoadRecords
       </Grid>
       {fieldMappingItem.targetLookupField && (
         <LoadRecordsFieldMappingRowLookupOption
-          csvField={csvField}
+          mappingKey={mappingKey}
           fieldMappingItem={fieldMappingItem}
           disabled={!!fieldMappingItem.relatedFieldMetadata?.isExternalId && fieldMappingItem.relationshipName !== SELF_LOOKUP_KEY}
-          onSelectionChanged={(csvField, fieldMappingItem) => onSelectionChanged(csvField, fieldMappingItem as FieldMappingItemCsv)}
+          onSelectionChanged={(mappingKey, fieldMappingItem) => onSelectionChanged(mappingKey, fieldMappingItem as FieldMappingItemCsv)}
         />
       )}
     </Fragment>

--- a/libs/features/load-records/src/components/LoadRecordsFieldMappingRow.tsx
+++ b/libs/features/load-records/src/components/LoadRecordsFieldMappingRow.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/react';
 import { useNonInitialEffect } from '@jetstream/shared/ui-utils';
 import { FieldMappingItemCsv, FieldWithRelatedEntities, ListItem, Maybe, SalesforceOrgUi } from '@jetstream/types';
-import { Checkbox, ComboboxWithItems, Icon } from '@jetstream/ui';
+import { Checkbox, ComboboxWithItems, Grid, Icon, Tooltip } from '@jetstream/ui';
 import classNames from 'classnames';
 import isNil from 'lodash/isNil';
 import { Fragment, FunctionComponent, useState } from 'react';
@@ -24,9 +24,15 @@ export interface LoadRecordsFieldMappingRowProps {
   fields: FieldWithRelatedEntities[];
   fieldMappingItem: FieldMappingItemCsv;
   csvField: string;
+  /** Key this row occupies in the FieldMapping object. Matches csvField unless this is an additional mapping for an already mapped column. */
+  mappingKey: string;
   csvRowData: string;
   binaryAttachmentBodyField?: Maybe<string>;
-  onSelectionChanged: (csvField: string, fieldMappingItem: FieldMappingItemCsv) => void;
+  /** An additional mapping can be removed, a column's own row can spawn more */
+  isAdditionalMapping: boolean;
+  onRemoveRow?: () => void;
+  onAddAdditionalMapping?: () => void;
+  onSelectionChanged: (mappingKey: string, fieldMappingItem: FieldMappingItemCsv) => void;
 }
 
 export const LoadRecordsFieldMappingRow: FunctionComponent<LoadRecordsFieldMappingRowProps> = ({
@@ -35,8 +41,12 @@ export const LoadRecordsFieldMappingRow: FunctionComponent<LoadRecordsFieldMappi
   fields,
   fieldMappingItem,
   csvField,
+  mappingKey,
   csvRowData,
   binaryAttachmentBodyField,
+  isAdditionalMapping,
+  onRemoveRow,
+  onAddAdditionalMapping,
   onSelectionChanged,
 }) => {
   const [fieldListItems, setFieldListItems] = useState<ListItem<string, FieldWithRelatedEntities>[]>(() => getFieldListItems(fields));
@@ -47,7 +57,7 @@ export const LoadRecordsFieldMappingRow: FunctionComponent<LoadRecordsFieldMappi
 
   function handleSelectionChanged(field: Maybe<FieldWithRelatedEntities>) {
     if (!field) {
-      onSelectionChanged(csvField, {
+      onSelectionChanged(mappingKey, {
         type: 'CSV',
         csvField,
         targetField: null,
@@ -59,7 +69,7 @@ export const LoadRecordsFieldMappingRow: FunctionComponent<LoadRecordsFieldMappi
         isBinaryBodyField: false,
       });
     } else if (field.name !== fieldMappingItem.targetField) {
-      onSelectionChanged(csvField, {
+      onSelectionChanged(mappingKey, {
         ...fieldMappingItem,
         targetField: field.name,
         mappedToLookup: false,
@@ -77,7 +87,7 @@ export const LoadRecordsFieldMappingRow: FunctionComponent<LoadRecordsFieldMappi
     if (fieldMappingItem.selectedReferenceTo && referenceToItems.includes(fieldMappingItem.selectedReferenceTo)) {
       selectedReferenceTo = fieldMappingItem.selectedReferenceTo;
     }
-    onSelectionChanged(csvField, {
+    onSelectionChanged(mappingKey, {
       ...fieldMappingItem,
       mappedToLookup: value,
       selectedReferenceTo,
@@ -109,6 +119,14 @@ export const LoadRecordsFieldMappingRow: FunctionComponent<LoadRecordsFieldMappi
       </td>
       <th scope="row" className="slds-align-top">
         <div className="slds-line-clamp_medium slds-m-top_x-small" title={csvField}>
+          {isAdditionalMapping && (
+            <Icon
+              type="utility"
+              icon="arrow_right"
+              className="slds-icon slds-icon-text-default slds-icon_xx-small slds-m-right_x-small"
+              description="Additional mapping for this field"
+            />
+          )}
           {csvField}
         </div>
       </th>
@@ -136,7 +154,7 @@ export const LoadRecordsFieldMappingRow: FunctionComponent<LoadRecordsFieldMappi
             label: 'Salesforce Fields',
             hasError: !!fieldMappingItem.fieldErrorMsg,
             errorMessage: fieldMappingItem.fieldErrorMsg,
-            errorMessageId: `${csvField}-${fieldMappingItem.targetField}-mapping-error`,
+            errorMessageId: `${mappingKey}-${fieldMappingItem.targetField}-mapping-error`,
           }}
           items={fieldListItems}
           selectedItemId={fieldMappingItem.targetField}
@@ -161,7 +179,7 @@ export const LoadRecordsFieldMappingRow: FunctionComponent<LoadRecordsFieldMappi
           <Fragment>
             <div>
               <Checkbox
-                id={`${csvField}-${fieldMappingItem.targetField}-map-to-related`}
+                id={`${mappingKey}-${fieldMappingItem.targetField}-map-to-related`}
                 checked={fieldMappingItem.mappedToLookup}
                 label="Map using related field"
                 labelHelp={
@@ -180,7 +198,7 @@ export const LoadRecordsFieldMappingRow: FunctionComponent<LoadRecordsFieldMappi
               <LoadRecordsFieldMappingRelatedObject
                 org={org}
                 fieldMappingItem={fieldMappingItem}
-                csvField={csvField}
+                mappingKey={mappingKey}
                 onSelectionChanged={onSelectionChanged}
               />
             )}
@@ -188,7 +206,7 @@ export const LoadRecordsFieldMappingRow: FunctionComponent<LoadRecordsFieldMappi
         )}
       </td>
       <td className="slds-align-top">
-        <div>
+        <Grid>
           <button
             className={classNames('slds-button slds-button_icon slds-button_icon-border', {
               'slds-button_icon-error': fieldMappingItem.targetField,
@@ -202,7 +220,30 @@ export const LoadRecordsFieldMappingRow: FunctionComponent<LoadRecordsFieldMappi
             <Icon type="utility" icon="clear" className="slds-button__icon" omitContainer />
             <span className="slds-assistive-text">Clear Mapping</span>
           </button>
-        </div>
+          {isAdditionalMapping ? (
+            <Tooltip content="Remove this additional mapping">
+              <button
+                className="slds-button slds-button_icon slds-button_icon-border slds-button_icon-error slds-m-left_xx-small"
+                onClick={onRemoveRow}
+              >
+                <Icon type="utility" icon="delete" className="slds-button__icon" omitContainer />
+                <span className="slds-assistive-text">Remove Additional Mapping</span>
+              </button>
+            </Tooltip>
+          ) : (
+            onAddAdditionalMapping && (
+              <Tooltip content={`Map ${csvField} to an additional Salesforce field`}>
+                <button
+                  className="slds-button slds-button_icon slds-button_icon-border slds-m-left_xx-small"
+                  onClick={onAddAdditionalMapping}
+                >
+                  <Icon type="utility" icon="add" className="slds-button__icon" omitContainer />
+                  <span className="slds-assistive-text">Map to another field</span>
+                </button>
+              </Tooltip>
+            )
+          )}
+        </Grid>
       </td>
     </tr>
   );

--- a/libs/features/load-records/src/components/LoadRecordsFieldMappingRowLookupOption.tsx
+++ b/libs/features/load-records/src/components/LoadRecordsFieldMappingRowLookupOption.tsx
@@ -4,26 +4,26 @@ import { FunctionComponent } from 'react';
 
 export interface LoadRecordsFieldMappingRowLookupOptionProps {
   fieldMappingItem: FieldMappingItem;
-  csvField: string;
+  mappingKey: string;
   disabled: boolean;
-  onSelectionChanged: (csvField: string, fieldMappingItem: FieldMappingItem) => void;
+  onSelectionChanged: (mappingKey: string, fieldMappingItem: FieldMappingItem) => void;
 }
 
 export const LoadRecordsFieldMappingRowLookupOption: FunctionComponent<LoadRecordsFieldMappingRowLookupOptionProps> = ({
   fieldMappingItem,
-  csvField,
+  mappingKey,
   disabled,
   onSelectionChanged,
 }) => {
   function handleLookupOptionChange(lookupOptionUseFirstMatch: NonExtIdLookupOption) {
-    onSelectionChanged(csvField, { ...fieldMappingItem, lookupOptionUseFirstMatch });
+    onSelectionChanged(mappingKey, { ...fieldMappingItem, lookupOptionUseFirstMatch });
   }
 
   function handleLookupOptionNullIfNoMatch(lookupOptionNullIfNoMatch: boolean) {
-    onSelectionChanged(csvField, { ...fieldMappingItem, lookupOptionNullIfNoMatch } as FieldMappingItem);
+    onSelectionChanged(mappingKey, { ...fieldMappingItem, lookupOptionNullIfNoMatch } as FieldMappingItem);
   }
 
-  const idPrefix = `multiple-match-${fieldMappingItem.csvField}`;
+  const idPrefix = `multiple-match-${mappingKey}`;
 
   return (
     <div className="slds-cell-wrap">

--- a/libs/features/load-records/src/components/load-mapping-storage/LoadMappingPopover.tsx
+++ b/libs/features/load-records/src/components/load-mapping-storage/LoadMappingPopover.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/react';
 import { logger } from '@jetstream/shared/client-logger';
 import { LoadSavedMappingItem } from '@jetstream/types';
 import { BadgeNotification, EmptyState, fireToast, Icon, Popover, PopoverRef } from '@jetstream/ui';
-import { STATIC_MAPPING_PREFIX } from '@jetstream/ui-core';
+import { isStaticValuePlaceholder } from '@jetstream/ui-core';
 import { getDexieDb, withReopenOnDatabaseClosed } from '@jetstream/ui/db';
 import classNames from 'classnames';
 import { useLiveQuery } from 'dexie-react-hooks';
@@ -26,7 +26,7 @@ export const LoadMappingPopover: FunctionComponent<LoadMappingPopoverProps> = ({
         .equalsIgnoreCase(sobject)
         .filter(
           (item) =>
-            item.csvFields.filter((field) => !field.startsWith(STATIC_MAPPING_PREFIX)).every((field) => csvFields.has(field)) &&
+            item.csvFields.filter((field) => !isStaticValuePlaceholder(field)).every((field) => csvFields.has(field)) &&
             item.sobjectFields.every((field) => objectFields.has(field)),
         )
         .toArray(),

--- a/libs/features/load-records/src/components/load-mapping-storage/SaveMappingItem.tsx
+++ b/libs/features/load-records/src/components/load-mapping-storage/SaveMappingItem.tsx
@@ -3,7 +3,7 @@ import { formatNumber } from '@jetstream/shared/ui-utils';
 import { pluralizeIfMultiple } from '@jetstream/shared/utils';
 import { FieldMappingItem, LoadSavedMappingItem } from '@jetstream/types';
 import { ButtonGroupContainer, DropDown, Grid, Tooltip } from '@jetstream/ui';
-import { SELF_LOOKUP_KEY } from '@jetstream/ui-core';
+import { isStaticValuePlaceholder, SELF_LOOKUP_KEY } from '@jetstream/ui-core';
 import { formatDate } from 'date-fns/format';
 import isDate from 'lodash/isDate';
 import { FunctionComponent } from 'react';
@@ -67,14 +67,15 @@ function getTargetField(item: Omit<FieldMappingItem, 'fieldMetadata'>): string {
 }
 
 const TooltipContent = ({ mapping }: { mapping: LoadSavedMappingItem }) => {
-  const items: Omit<FieldMappingItem, 'fieldMetadata'>[] = Object.values(mapping.mapping);
+  // Keyed by mapping key rather than csvField, since one column can be mapped to multiple fields
+  const items: [string, Omit<FieldMappingItem, 'fieldMetadata'>][] = Object.entries(mapping.mapping);
   const visibleItems = items.slice(0, 25);
   const remainingItems = items.length - visibleItems.length;
   return (
     <ul>
-      {visibleItems.map((item) => (
-        <li key={item.csvField}>
-          <span>{item.csvField}</span> {'->'} <span>{getTargetField(item)}</span>
+      {visibleItems.map(([mappingKey, item]) => (
+        <li key={mappingKey}>
+          <span>{isStaticValuePlaceholder(item.csvField) ? 'Manual value' : item.csvField}</span> {'->'} <span>{getTargetField(item)}</span>
         </li>
       ))}
       {items.length > visibleItems.length && <li>...{formatNumber(remainingItems)} more...</li>}

--- a/libs/features/load-records/src/components/load-mapping-storage/SaveMappingPopover.tsx
+++ b/libs/features/load-records/src/components/load-mapping-storage/SaveMappingPopover.tsx
@@ -46,7 +46,8 @@ export const SaveMappingPopover: FunctionComponent<SaveMappingPopoverProps> = ({
       Object.keys(fieldMapping).reduce((acc: LoadSavedMappingItem, key) => {
         const field = fieldMapping[key];
         if (field.targetField) {
-          acc.csvFields.push(key);
+          // csvField rather than key so additional mappings record the real column, keeping availability checks accurate
+          acc.csvFields.push(field.csvField);
           acc.sobjectFields.push(field.targetField);
           acc.mapping[key] = omit({ ...field }, 'fieldMetadata');
         }

--- a/libs/features/load-records/src/steps/FieldMapping.tsx
+++ b/libs/features/load-records/src/steps/FieldMapping.tsx
@@ -28,14 +28,15 @@ import {
 import {
   autoMapFields,
   checkFieldsForMappingError,
-  checkForDuplicateFieldMappings,
+  initAdditionalFieldMappingItem,
   initStaticFieldMappingItem,
+  isAdditionalMapping,
   loadFieldMappingFromSavedMapping,
   resetFieldMapping,
   useAmplitude,
 } from '@jetstream/ui-core';
 import classNames from 'classnames';
-import { memo, useEffect, useRef, useState } from 'react';
+import { memo, useEffect, useMemo, useRef, useState } from 'react';
 import LoadRecordsFieldMappingRow from '../components/LoadRecordsFieldMappingRow';
 import LoadRecordsFieldMappingStaticRow from '../components/LoadRecordsFieldMappingStaticRow';
 import { LoadMappingPopover } from '../components/load-mapping-storage/LoadMappingPopover';
@@ -86,11 +87,6 @@ export const LoadRecordsFieldMapping = memo<LoadRecordsFieldMappingProps>(
     const [csvFields, setCsvFields] = useState(() => new Set(inputHeader));
     const [objectFields, setObjectFields] = useState(() => new Set(fields.map((field) => field.name)));
     const [visibleHeaders, setVisibleHeaders] = useState(inputHeader);
-    const [staticRowHeaders, setStaticRowHeaders] = useState<string[]>(() =>
-      Object.values(fieldMappingInit)
-        .filter((item) => item.type === 'STATIC')
-        .map((item) => item.csvField),
-    );
     const [activeRowIndex, setActiveRowIndex] = useState(0);
     const [activeRow, setActiveRow] = useState<Record<string, any>>(() => fileData[activeRowIndex]);
     // hack to force child re-render when fields are re-mapped
@@ -102,6 +98,28 @@ export const LoadRecordsFieldMapping = memo<LoadRecordsFieldMappingProps>(
     const [searchTerm, setSearchTerm] = useState('');
 
     const debouncedSelectedValue = useDebounce(activeRowIndex, 150);
+
+    /**
+     * Static rows and additional mappings are derived from the mapping object rather than tracked in their own
+     * state arrays, which keeps them correct through clear/reset/load-saved without any extra bookkeeping.
+     * Key insertion order is the order the user added them.
+     */
+    const staticMappingKeys = useMemo(
+      () => Object.keys(fieldMapping).filter((mappingKey) => fieldMapping[mappingKey].type === 'STATIC'),
+      [fieldMapping],
+    );
+
+    const additionalMappingKeysByCsvField = useMemo(
+      () =>
+        Object.entries(fieldMapping).reduce<Record<string, string[]>>((output, [mappingKey, fieldMappingItem]) => {
+          if (isAdditionalMapping(mappingKey, fieldMappingItem)) {
+            output[fieldMappingItem.csvField] = output[fieldMappingItem.csvField] || [];
+            output[fieldMappingItem.csvField].push(mappingKey);
+          }
+          return output;
+        }, {}),
+      [fieldMapping],
+    );
 
     useNonInitialEffect(() => {
       setActiveRow(fileData[debouncedSelectedValue] || fileData[0]);
@@ -149,9 +167,17 @@ export const LoadRecordsFieldMapping = memo<LoadRecordsFieldMappingProps>(
     }, [externalId, fieldMapping, isCustomMetadataObject, loadType]);
 
     useNonInitialEffect(() => {
+      /**
+       * The two filters are intentionally asymmetric.
+       * Mapped considers a column and its additional mappings as a unit, otherwise a hidden additional row could
+       * block the next step with no visible error. Unmapped only looks at the column's own row, since a blank
+       * additional row is inert - it is skipped by the load, by saved mappings, and by every next-step check.
+       */
       let tempVisibleHeaders = inputHeader;
       if (filter === FILTER_MAPPED) {
-        tempVisibleHeaders = tempVisibleHeaders.filter((header) => !!fieldMapping[header]?.targetField);
+        const rowGroup = (header: string) =>
+          [fieldMapping[header], ...(additionalMappingKeysByCsvField[header] || []).map((key) => fieldMapping[key])].filter(Boolean);
+        tempVisibleHeaders = tempVisibleHeaders.filter((header) => rowGroup(header).some((item) => !!item.targetField));
       } else if (filter === FILTER_UNMAPPED) {
         tempVisibleHeaders = tempVisibleHeaders.filter((header) => !fieldMapping[header]?.targetField);
       }
@@ -169,21 +195,19 @@ export const LoadRecordsFieldMapping = memo<LoadRecordsFieldMappingProps>(
      * comboboxes are expensive to re-render if there are many on the page
      *
      */
-    function handleFieldMappingChange(csvField: string, fieldMappingItem: FieldMappingItem) {
+    function handleFieldMappingChange(mappingKey: string, fieldMappingItem: FieldMappingItem) {
       setFieldMapping((fieldMapping) =>
-        checkFieldsForMappingError({ ...fieldMapping, [csvField]: fieldMappingItem }, loadType, externalId),
+        checkFieldsForMappingError({ ...fieldMapping, [mappingKey]: fieldMappingItem }, loadType, externalId),
       );
     }
 
     function handleAction(id: DropDownAction) {
       switch (id) {
         case MAPPING_CLEAR:
-          setStaticRowHeaders([]);
           setFieldMapping(resetFieldMapping(inputHeader));
           trackEvent(ANALYTICS_KEYS.load_MappingAutomationChanged, { action: id });
           break;
         case MAPPING_RESET:
-          setStaticRowHeaders([]);
           autoMapFields(org, inputHeader, fields, binaryAttachmentBodyField, loadType, externalId).then(setFieldMapping);
           setFilter(FILTER_ALL);
           trackEvent(ANALYTICS_KEYS.load_MappingAutomationChanged, { action: id });
@@ -203,11 +227,6 @@ export const LoadRecordsFieldMapping = memo<LoadRecordsFieldMappingProps>(
     function handleLoadMapping(savedMapping: LoadSavedMappingItem) {
       const newMapping = loadFieldMappingFromSavedMapping(savedMapping, inputHeader, fields, binaryAttachmentBodyField);
       setFieldMapping(newMapping);
-      setStaticRowHeaders(
-        Object.values(newMapping)
-          .filter((item) => item.type === 'STATIC')
-          .map((item) => item.csvField),
-      );
       trackEvent(ANALYTICS_KEYS.load_SavedMappingLoaded);
       setKeyPrefix(new Date().getTime());
     }
@@ -233,18 +252,23 @@ export const LoadRecordsFieldMapping = memo<LoadRecordsFieldMappingProps>(
     }
 
     function handleAddRow() {
-      const fieldMappingItem = initStaticFieldMappingItem();
-      setFieldMapping((fieldMapping) => ({ ...fieldMapping, [fieldMappingItem.csvField]: fieldMappingItem }));
-      setStaticRowHeaders((prevValue) => [...prevValue, fieldMappingItem.csvField]);
+      const { mappingKey, fieldMappingItem } = initStaticFieldMappingItem();
+      setFieldMapping((fieldMapping) => ({ ...fieldMapping, [mappingKey]: fieldMappingItem }));
     }
 
-    function handleRemoveRow(csvField: string) {
+    function handleRemoveRow(mappingKey: string) {
       setFieldMapping((fieldMapping) => {
         const clonedMapping = { ...fieldMapping };
-        delete clonedMapping[csvField];
-        return checkForDuplicateFieldMappings(clonedMapping);
+        delete clonedMapping[mappingKey];
+        return checkFieldsForMappingError(clonedMapping, loadType, externalId);
       });
-      setStaticRowHeaders((prevValue) => prevValue.filter((value) => value !== csvField));
+    }
+
+    /** Map a file column that is already mapped to an additional Salesforce field */
+    function handleAddAdditionalMapping(csvField: string) {
+      const { mappingKey, fieldMappingItem } = initAdditionalFieldMappingItem(csvField);
+      setFieldMapping((fieldMapping) => ({ ...fieldMapping, [mappingKey]: fieldMappingItem }));
+      trackEvent(ANALYTICS_KEYS.load_MappingAdditionalFieldAdded);
     }
 
     return (
@@ -387,39 +411,58 @@ export const LoadRecordsFieldMapping = memo<LoadRecordsFieldMappingProps>(
               </tr>
             </thead>
             <tbody>
-              {visibleHeaders.map((header, i) => {
+              {visibleHeaders.flatMap((header) => {
                 const mappingItem = fieldMapping[header] as FieldMappingItemCsv | undefined;
                 if (!mappingItem) {
-                  return null;
+                  return [];
                 }
-                return (
+                return [
                   <LoadRecordsFieldMappingRow
-                    key={`${keyPrefix}-csv-${i}`}
+                    key={`${keyPrefix}-${header}`}
                     org={org}
                     isCustomMetadataObject={isCustomMetadataObject}
                     fields={fields}
                     fieldMappingItem={mappingItem}
                     csvField={header}
+                    mappingKey={header}
                     csvRowData={activeRow?.[header]}
                     binaryAttachmentBodyField={binaryAttachmentBodyField}
+                    isAdditionalMapping={false}
+                    onAddAdditionalMapping={() => handleAddAdditionalMapping(header)}
                     onSelectionChanged={handleFieldMappingChange}
-                  />
-                );
+                  />,
+                  ...(additionalMappingKeysByCsvField[header] || []).map((mappingKey) => (
+                    <LoadRecordsFieldMappingRow
+                      key={`${keyPrefix}-${mappingKey}`}
+                      org={org}
+                      isCustomMetadataObject={isCustomMetadataObject}
+                      fields={fields}
+                      fieldMappingItem={fieldMapping[mappingKey] as FieldMappingItemCsv}
+                      csvField={header}
+                      mappingKey={mappingKey}
+                      csvRowData={activeRow?.[header]}
+                      binaryAttachmentBodyField={binaryAttachmentBodyField}
+                      isAdditionalMapping
+                      onRemoveRow={() => handleRemoveRow(mappingKey)}
+                      onSelectionChanged={handleFieldMappingChange}
+                    />
+                  )),
+                ];
               })}
-              {staticRowHeaders.map((header, i) => {
-                const mappingItem = fieldMapping[header] as FieldMappingItemStatic | undefined;
+              {staticMappingKeys.map((mappingKey) => {
+                const mappingItem = fieldMapping[mappingKey] as FieldMappingItemStatic | undefined;
                 if (!mappingItem) {
                   return null;
                 }
                 return (
                   <LoadRecordsFieldMappingStaticRow
-                    key={`${keyPrefix}-static-${i}`}
+                    key={`${keyPrefix}-${mappingKey}`}
                     org={org}
                     fields={fields}
                     fieldMappingItem={mappingItem}
                     isCustomMetadata={isCustomMetadataObject}
-                    onSelectionChanged={(value) => handleFieldMappingChange(header, value)}
-                    onRemoveRow={() => handleRemoveRow(header)}
+                    onSelectionChanged={(value) => handleFieldMappingChange(mappingKey, value)}
+                    onRemoveRow={() => handleRemoveRow(mappingKey)}
                   />
                 );
               })}

--- a/libs/shared/constants/src/lib/shared-constants.ts
+++ b/libs/shared/constants/src/lib/shared-constants.ts
@@ -277,6 +277,7 @@ export const ANALYTICS_KEYS = {
   load_GoBackToPrevStep: 'load_GoBackToPrevStep',
   load_MappingAutomationChanged: 'load_MappingAutomationChanged',
   load_SavedMappingLoaded: 'load_SavedMappingLoaded',
+  load_MappingAdditionalFieldAdded: 'load_MappingAdditionalFieldAdded',
   load_MappingFilterChanged: 'load_MappingFilterChanged',
   load_MappingRowPreviewChanged: 'load_MappingRowPreviewChanged',
   load_StartOver: 'load_StartOver',

--- a/libs/shared/ui-core/src/load/__tests__/load-records-utils.spec.ts
+++ b/libs/shared/ui-core/src/load/__tests__/load-records-utils.spec.ts
@@ -1,8 +1,29 @@
+import { SFDC_BULK_API_NULL_VALUE } from '@jetstream/shared/constants';
 import * as clientData from '@jetstream/shared/data';
 import { sfdcFieldsFactory } from '@jetstream/test-utils';
-import { EntityParticleRecord, QueryResults, SalesforceOrgUi } from '@jetstream/types';
+import {
+  EntityParticleRecord,
+  FieldMapping,
+  FieldMappingItem,
+  FieldMappingItemCsv,
+  LoadSavedMappingItem,
+  PrepareDataPayload,
+  QueryResults,
+  SalesforceOrgUi,
+} from '@jetstream/types';
 import { vi } from 'vitest';
-import { autoMapFields } from '../load-records-utils';
+import {
+  ADDITIONAL_MAPPING_PREFIX,
+  autoMapFields,
+  checkForDuplicateFieldMappings,
+  initAdditionalFieldMappingItem,
+  isAdditionalMapping,
+  isStaticValuePlaceholder,
+  loadFieldMappingFromSavedMapping,
+  SavedFieldMapping,
+  STATIC_MAPPING_PREFIX,
+  transformData,
+} from '../load-records-utils';
 
 vi.mock('@jetstream/shared/data');
 
@@ -172,5 +193,323 @@ describe('autoMapFields', () => {
         }),
       );
     });
+  });
+});
+
+function buildCsvMappingItem(overrides: Partial<FieldMappingItemCsv> & { csvField: string }): FieldMappingItemCsv {
+  return {
+    type: 'CSV',
+    targetField: null,
+    mappedToLookup: false,
+    fieldMetadata: undefined,
+    selectedReferenceTo: undefined,
+    lookupOptionUseFirstMatch: 'ERROR_IF_MULTIPLE',
+    lookupOptionNullIfNoMatch: false,
+    isBinaryBodyField: false,
+    ...overrides,
+  };
+}
+
+function getPayload(overrides: Partial<PrepareDataPayload>): PrepareDataPayload {
+  return {
+    org: { id: 'org1' } as unknown as SalesforceOrgUi,
+    data: [],
+    fieldMapping: {},
+    sObject: 'Account',
+    dateFormat: 'MM-DD-YYYY',
+    apiMode: 'BATCH',
+    ...overrides,
+  };
+}
+
+describe('transformData', () => {
+  const [accountField, , nameField, externalIdField] = sfdcFieldsFactory.buildFieldsWithRelated();
+
+  test('should read values from csvField instead of the mapping key', async () => {
+    const fieldMapping: FieldMapping = {
+      [`${ADDITIONAL_MAPPING_PREFIX}1`]: buildCsvMappingItem({
+        csvField: 'Company',
+        targetField: 'Name',
+        fieldMetadata: nameField,
+      }),
+    };
+
+    const [record] = await transformData(getPayload({ data: [{ Company: 'Acme Corp' }], fieldMapping }));
+
+    expect(record.Name).toBe('Acme Corp');
+  });
+
+  test('should map one file column to multiple Salesforce fields', async () => {
+    const fieldMapping: FieldMapping = {
+      Company: buildCsvMappingItem({ csvField: 'Company', targetField: 'Name', fieldMetadata: nameField }),
+      [`${ADDITIONAL_MAPPING_PREFIX}1`]: buildCsvMappingItem({
+        csvField: 'Company',
+        targetField: 'External_Id__c',
+        fieldMetadata: externalIdField,
+      }),
+    };
+
+    const [batchRecord] = await transformData(getPayload({ data: [{ Company: 'Acme Corp' }], fieldMapping }));
+    expect(batchRecord).toEqual(expect.objectContaining({ Name: 'Acme Corp', External_Id__c: 'Acme Corp' }));
+
+    const [bulkRecord] = await transformData(getPayload({ data: [{ Company: 'Acme Corp' }], fieldMapping, apiMode: 'BULK' }));
+    expect(bulkRecord).toEqual(expect.objectContaining({ Name: 'Acme Corp', External_Id__c: 'Acme Corp' }));
+  });
+
+  test('should set the batch api attributes exactly once', async () => {
+    const fieldMapping: FieldMapping = {
+      Company: buildCsvMappingItem({ csvField: 'Company', targetField: 'Name', fieldMetadata: nameField }),
+      [`${ADDITIONAL_MAPPING_PREFIX}1`]: buildCsvMappingItem({
+        csvField: 'Company',
+        targetField: 'External_Id__c',
+        fieldMetadata: externalIdField,
+      }),
+    };
+
+    const [record] = await transformData(getPayload({ data: [{ Company: 'Acme Corp' }], fieldMapping }));
+
+    expect(record.attributes).toEqual({ type: 'Account' });
+  });
+
+  test('should use the static value for static mappings and the row value for csv mappings', async () => {
+    const fieldMapping: FieldMapping = {
+      Company: buildCsvMappingItem({ csvField: 'Company', targetField: 'Name', fieldMetadata: nameField }),
+      [`${STATIC_MAPPING_PREFIX}1`]: {
+        type: 'STATIC',
+        csvField: `${STATIC_MAPPING_PREFIX}1`,
+        staticValue: 'Imported',
+        targetField: 'External_Id__c',
+        mappedToLookup: false,
+        fieldMetadata: externalIdField,
+        lookupOptionUseFirstMatch: 'ERROR_IF_MULTIPLE',
+        lookupOptionNullIfNoMatch: false,
+        isBinaryBodyField: false,
+      },
+    };
+
+    const [record] = await transformData(getPayload({ data: [{ Company: 'Acme Corp' }], fieldMapping }));
+
+    expect(record).toEqual(expect.objectContaining({ Name: 'Acme Corp', External_Id__c: 'Imported' }));
+  });
+
+  test('should emit a nested relationship object for an additional mapping to an external id lookup using the batch api', async () => {
+    const fieldMapping: FieldMapping = {
+      Company: buildCsvMappingItem({ csvField: 'Company', targetField: 'Name', fieldMetadata: nameField }),
+      [`${ADDITIONAL_MAPPING_PREFIX}1`]: buildCsvMappingItem({
+        csvField: 'Company',
+        targetField: 'Account',
+        fieldMetadata: accountField,
+        mappedToLookup: true,
+        relationshipName: 'Account',
+        targetLookupField: 'External_Id__c',
+        selectedReferenceTo: 'Account',
+        relatedFieldMetadata: { name: 'External_Id__c', label: 'External Id', type: 'string', isExternalId: true },
+      }),
+    };
+
+    const [record] = await transformData(getPayload({ data: [{ Company: 'Acme Corp' }], fieldMapping }));
+
+    expect(record.Name).toBe('Acme Corp');
+    expect(record.Account).toEqual({ External_Id__c: 'Acme Corp' });
+  });
+
+  test('should emit a flattened relationship column for an additional mapping to an external id lookup using the bulk api', async () => {
+    const fieldMapping: FieldMapping = {
+      [`${ADDITIONAL_MAPPING_PREFIX}1`]: buildCsvMappingItem({
+        csvField: 'Company',
+        targetField: 'Account',
+        fieldMetadata: accountField,
+        mappedToLookup: true,
+        relationshipName: 'Account',
+        targetLookupField: 'External_Id__c',
+        selectedReferenceTo: 'Account',
+        relatedFieldMetadata: { name: 'External_Id__c', label: 'External Id', type: 'string', isExternalId: true },
+      }),
+    };
+
+    const [record] = await transformData(getPayload({ data: [{ Company: 'Acme Corp' }], fieldMapping, apiMode: 'BULK' }));
+
+    expect(record['Account.External_Id__c']).toBe('Acme Corp');
+  });
+
+  test('should apply insertNulls per target field when one column maps to both a text field and a checkbox', async () => {
+    const checkboxField = sfdcFieldsFactory.buildFieldsWithRelated().find((field) => field.type === 'boolean');
+    const fieldMapping: FieldMapping = {
+      Company: buildCsvMappingItem({ csvField: 'Company', targetField: 'Name', fieldMetadata: nameField }),
+      [`${ADDITIONAL_MAPPING_PREFIX}1`]: buildCsvMappingItem({
+        csvField: 'Company',
+        targetField: 'IsActive',
+        fieldMetadata: checkboxField,
+      }),
+    };
+
+    const [batchRecord] = await transformData(getPayload({ data: [{ Company: '' }], fieldMapping, insertNulls: true }));
+    expect(batchRecord.Name).toBeNull();
+    expect(batchRecord.IsActive).toBe(false);
+
+    const [bulkRecord] = await transformData(getPayload({ data: [{ Company: '' }], fieldMapping, insertNulls: true, apiMode: 'BULK' }));
+    expect(bulkRecord.Name).toBe(SFDC_BULK_API_NULL_VALUE);
+    expect(bulkRecord.IsActive).toBe(false);
+  });
+
+  test('should omit blank values entirely for the batch api when insertNulls is false', async () => {
+    const fieldMapping: FieldMapping = {
+      Company: buildCsvMappingItem({ csvField: 'Company', targetField: 'Name', fieldMetadata: nameField }),
+      [`${ADDITIONAL_MAPPING_PREFIX}1`]: buildCsvMappingItem({
+        csvField: 'Company',
+        targetField: 'External_Id__c',
+        fieldMetadata: externalIdField,
+      }),
+    };
+
+    const [record] = await transformData(getPayload({ data: [{ Company: '' }], fieldMapping }));
+
+    expect(record).not.toHaveProperty('Name');
+    expect(record).not.toHaveProperty('External_Id__c');
+  });
+});
+
+describe('checkForDuplicateFieldMappings', () => {
+  test('should not flag two rows that share a file column but map to different Salesforce fields', () => {
+    const fieldMapping: FieldMapping = {
+      Company: buildCsvMappingItem({ csvField: 'Company', targetField: 'Name' }),
+      [`${ADDITIONAL_MAPPING_PREFIX}1`]: buildCsvMappingItem({ csvField: 'Company', targetField: 'External_Id__c' }),
+    };
+
+    const result = checkForDuplicateFieldMappings(fieldMapping);
+
+    expect(result['Company'].isDuplicateMappedField).toBe(false);
+    expect(result[`${ADDITIONAL_MAPPING_PREFIX}1`].isDuplicateMappedField).toBe(false);
+    expect(result['Company'].fieldErrorMsg).toBeUndefined();
+  });
+
+  test('should still flag two rows that map to the same Salesforce field', () => {
+    const fieldMapping: FieldMapping = {
+      Company: buildCsvMappingItem({ csvField: 'Company', targetField: 'Name' }),
+      [`${ADDITIONAL_MAPPING_PREFIX}1`]: buildCsvMappingItem({ csvField: 'Company', targetField: 'Name' }),
+    };
+
+    const result = checkForDuplicateFieldMappings(fieldMapping);
+
+    expect(result['Company'].isDuplicateMappedField).toBe(true);
+    expect(result[`${ADDITIONAL_MAPPING_PREFIX}1`].isDuplicateMappedField).toBe(true);
+    expect(result['Company'].fieldErrorMsg).toBe('Each Salesforce field should only be mapped once');
+  });
+});
+
+describe('initAdditionalFieldMappingItem', () => {
+  test('should mint a unique synthetic key that points at the real file column', () => {
+    const first = initAdditionalFieldMappingItem('Company');
+    const second = initAdditionalFieldMappingItem('Company');
+
+    expect(first.mappingKey).toMatch(ADDITIONAL_MAPPING_PREFIX);
+    expect(first.mappingKey).not.toEqual(second.mappingKey);
+    expect(first.fieldMappingItem).toEqual(expect.objectContaining({ type: 'CSV', csvField: 'Company', targetField: null }));
+    expect(isAdditionalMapping(first.mappingKey, first.fieldMappingItem)).toBe(true);
+  });
+});
+
+describe('isStaticValuePlaceholder', () => {
+  test('should only match the placeholder static rows store in csvField', () => {
+    expect(isStaticValuePlaceholder(`${STATIC_MAPPING_PREFIX}1`)).toBe(true);
+    expect(isStaticValuePlaceholder('Company')).toBe(false);
+    // additional mappings record the real column, so they must stay in the column-availability check
+    expect(isStaticValuePlaceholder(initAdditionalFieldMappingItem('Company').fieldMappingItem.csvField)).toBe(false);
+  });
+});
+
+describe('loadFieldMappingFromSavedMapping', () => {
+  const fields = sfdcFieldsFactory.buildFieldsWithRelated();
+
+  function getSavedMapping(mapping: SavedFieldMapping): LoadSavedMappingItem {
+    return { mapping } as unknown as LoadSavedMappingItem;
+  }
+
+  test('should restore an additional mapping when the file still has its column', () => {
+    const savedMapping = getSavedMapping({
+      Company: buildCsvMappingItem({ csvField: 'Company', targetField: 'Name' }),
+      [`${ADDITIONAL_MAPPING_PREFIX}1`]: buildCsvMappingItem({ csvField: 'Company', targetField: 'External_Id__c' }),
+    });
+
+    const result = loadFieldMappingFromSavedMapping(savedMapping, ['Company'], fields, undefined);
+
+    const additional = Object.entries(result).filter(([key]) => key.startsWith(ADDITIONAL_MAPPING_PREFIX));
+    expect(additional).toHaveLength(1);
+    expect(additional[0][1]).toEqual(expect.objectContaining({ type: 'CSV', csvField: 'Company', targetField: 'External_Id__c' }));
+    expect(additional[0][1].fieldMetadata).toEqual(expect.objectContaining({ name: 'External_Id__c' }));
+    expect(result['Company'].targetField).toBe('Name');
+  });
+
+  test('should drop an additional mapping when the file no longer has its column', () => {
+    const savedMapping = getSavedMapping({
+      [`${ADDITIONAL_MAPPING_PREFIX}1`]: buildCsvMappingItem({ csvField: 'Company', targetField: 'External_Id__c' }),
+    });
+
+    const result = loadFieldMappingFromSavedMapping(savedMapping, ['SomethingElse'], fields, undefined);
+
+    expect(Object.keys(result).filter((key) => key.startsWith(ADDITIONAL_MAPPING_PREFIX))).toHaveLength(0);
+  });
+
+  test('should re-key synthetic rows so a later uniqueId cannot overwrite them', () => {
+    const savedMapping = getSavedMapping({
+      [`${STATIC_MAPPING_PREFIX}1`]: {
+        ...buildCsvMappingItem({ csvField: `${STATIC_MAPPING_PREFIX}1`, targetField: 'Name' }),
+        type: 'STATIC',
+        staticValue: 'Imported',
+      },
+      [`${ADDITIONAL_MAPPING_PREFIX}1`]: buildCsvMappingItem({ csvField: 'Company', targetField: 'External_Id__c' }),
+    });
+
+    const result = loadFieldMappingFromSavedMapping(savedMapping, ['Company'], fields, undefined);
+
+    const [staticKey, staticItem] = Object.entries(result).find(([key]) => key.startsWith(STATIC_MAPPING_PREFIX)) as [
+      string,
+      FieldMappingItem,
+    ];
+    const [duplicateKey] = Object.entries(result).find(([key]) => key.startsWith(ADDITIONAL_MAPPING_PREFIX)) as [string, FieldMappingItem];
+
+    expect(staticKey).not.toBe(`${STATIC_MAPPING_PREFIX}1`);
+    expect(duplicateKey).not.toBe(`${ADDITIONAL_MAPPING_PREFIX}1`);
+    // static rows use their key as the csvField placeholder, so both must move together
+    expect(staticItem.csvField).toBe(staticKey);
+  });
+
+  test('should clear validation state so a mapping saved while in an error state is not permanently broken', () => {
+    const savedMapping = getSavedMapping({
+      Company: buildCsvMappingItem({
+        csvField: 'Company',
+        targetField: 'Name',
+        fieldErrorMsg: 'Including a Record Id in an upsert will cause the load to fail',
+        isDuplicateMappedField: true,
+      }),
+      [`${ADDITIONAL_MAPPING_PREFIX}1`]: buildCsvMappingItem({
+        csvField: 'Company',
+        targetField: 'External_Id__c',
+        fieldErrorMsg: 'This field is mapped more than once',
+        isDuplicateMappedField: true,
+      }),
+    });
+
+    const result = loadFieldMappingFromSavedMapping(savedMapping, ['Company'], fields, undefined);
+
+    const [, additionalItem] = Object.entries(result).find(([key]) => key.startsWith(ADDITIONAL_MAPPING_PREFIX)) as [
+      string,
+      FieldMappingItem,
+    ];
+
+    expect(result['Company'].fieldErrorMsg).toBeUndefined();
+    expect(result['Company'].isDuplicateMappedField).toBe(false);
+    expect(additionalItem.fieldErrorMsg).toBeUndefined();
+    expect(additionalItem.isDuplicateMappedField).toBe(false);
+  });
+
+  test('should force csvField to the header so a stale saved value cannot redirect the transform', () => {
+    const savedMapping = getSavedMapping({
+      Company: buildCsvMappingItem({ csvField: 'SomethingStale', targetField: 'Name' }),
+    });
+
+    const result = loadFieldMappingFromSavedMapping(savedMapping, ['Company'], fields, undefined);
+
+    expect(result['Company'].csvField).toBe('Company');
   });
 });

--- a/libs/shared/ui-core/src/load/load-records-utils.tsx
+++ b/libs/shared/ui-core/src/load/load-records-utils.tsx
@@ -34,6 +34,7 @@ export interface SavedFieldMapping {
 
 export const SELF_LOOKUP_KEY = '~SELF_LOOKUP~';
 export const STATIC_MAPPING_PREFIX = '~STATIC~MAPPING~';
+export const ADDITIONAL_MAPPING_PREFIX = '~ADDITIONAL~MAPPING~';
 export const BATCH_RECOMMENDED_THRESHOLD = 2000;
 export const MAX_BULK = 10000;
 export const MAX_BATCH = 200;
@@ -275,19 +276,85 @@ export function resetFieldMapping(inputHeader: string[]): FieldMapping {
   }, {});
 }
 
-export function initStaticFieldMappingItem(): FieldMappingItemStatic {
-  const csvValuePlaceholder = uniqueId(STATIC_MAPPING_PREFIX);
+/**
+ * Static value row, which has no file column at all.
+ * The generated key doubles as the csvField placeholder so the two can never drift apart.
+ */
+export function initStaticFieldMappingItem(): { mappingKey: string; fieldMappingItem: FieldMappingItemStatic } {
+  const mappingKey = uniqueId(STATIC_MAPPING_PREFIX);
   return {
-    type: 'STATIC',
-    csvField: csvValuePlaceholder,
-    staticValue: '',
-    targetField: null,
-    mappedToLookup: false,
-    fieldMetadata: undefined,
-    selectedReferenceTo: undefined,
-    lookupOptionUseFirstMatch: DEFAULT_NON_EXT_ID_MAPPING_OPT,
-    lookupOptionNullIfNoMatch: DEFAULT_NULL_IF_NO_MATCH_MAPPING_OPT,
-    isBinaryBodyField: false,
+    mappingKey,
+    fieldMappingItem: {
+      type: 'STATIC',
+      csvField: mappingKey,
+      staticValue: '',
+      targetField: null,
+      mappedToLookup: false,
+      fieldMetadata: undefined,
+      selectedReferenceTo: undefined,
+      lookupOptionUseFirstMatch: DEFAULT_NON_EXT_ID_MAPPING_OPT,
+      lookupOptionNullIfNoMatch: DEFAULT_NULL_IF_NO_MATCH_MAPPING_OPT,
+      isBinaryBodyField: false,
+    },
+  };
+}
+
+/**
+ * Additional mapping for a file column that is already mapped, allowing one column to be loaded into multiple Salesforce fields.
+ * The FieldMapping key is synthetic so the column can appear more than once, while csvField still points at the real column.
+ */
+export function initAdditionalFieldMappingItem(csvField: string): { mappingKey: string; fieldMappingItem: FieldMappingItemCsv } {
+  return {
+    mappingKey: uniqueId(ADDITIONAL_MAPPING_PREFIX),
+    fieldMappingItem: {
+      type: 'CSV',
+      csvField,
+      targetField: null,
+      mappedToLookup: false,
+      fieldMetadata: undefined,
+      selectedReferenceTo: undefined,
+      lookupOptionUseFirstMatch: DEFAULT_NON_EXT_ID_MAPPING_OPT,
+      lookupOptionNullIfNoMatch: DEFAULT_NULL_IF_NO_MATCH_MAPPING_OPT,
+      isBinaryBodyField: false,
+    },
+  };
+}
+
+/**
+ * True for the placeholder value that static rows store in `csvField` - it is a generated key, not a real file column.
+ * Saved mappings record that placeholder in `csvFields`, so column-availability checks have to skip it.
+ */
+export function isStaticValuePlaceholder(csvField: string): boolean {
+  return csvField.startsWith(STATIC_MAPPING_PREFIX);
+}
+
+/** An extra mapping row that reads from a file column already mapped by another row */
+export function isAdditionalMapping(mappingKey: string, fieldMappingItem: FieldMappingItem): fieldMappingItem is FieldMappingItemCsv {
+  return fieldMappingItem.type === 'CSV' && mappingKey.startsWith(ADDITIONAL_MAPPING_PREFIX);
+}
+
+/**
+ * Rebuilds a mapping item from a saved record, which is stored without field metadata.
+ * csvField is always supplied by the caller because the stored value is never trusted - it is the matched file
+ * column for CSV rows and a freshly generated placeholder for static rows.
+ */
+function hydrateSavedMappingItem(
+  savedMappingItem: Omit<FieldMappingItem, 'fieldMetadata'>,
+  {
+    csvField,
+    fieldMetadata,
+    binaryBodyField,
+  }: { csvField: string; fieldMetadata: FieldWithRelatedEntities; binaryBodyField: Maybe<string> },
+) {
+  return {
+    ...savedMappingItem,
+    csvField,
+    fieldMetadata: { ...fieldMetadata },
+    isBinaryBodyField: !!binaryBodyField && savedMappingItem.targetField === binaryBodyField,
+    // Validation state is transient - it is re-calculated against the current file and object instead of restored,
+    // otherwise a mapping saved while in an error state comes back permanently broken
+    fieldErrorMsg: undefined,
+    isDuplicateMappedField: false,
   };
 }
 
@@ -298,47 +365,54 @@ export function loadFieldMappingFromSavedMapping(
   binaryBodyField: Maybe<string>,
 ): FieldMapping {
   const fieldMetadataByName = groupByFlat(fields, 'name');
-  const newMapping = inputHeader.reduce((output: FieldMapping, field) => {
-    const matchedMapping = savedMapping.mapping[field];
-    if (matchedMapping && matchedMapping.targetField && fieldMetadataByName[matchedMapping.targetField]) {
-      output[field] = {
-        ...savedMapping.mapping[field],
-        fieldMetadata: {
-          ...fieldMetadataByName[matchedMapping.targetField],
-        },
-        isBinaryBodyField: !!binaryBodyField && matchedMapping.targetField === binaryBodyField,
-      } as FieldMappingItemCsv;
-    } else {
-      output[field] = {
-        type: 'CSV',
-        csvField: field,
-        targetField: null,
-        mappedToLookup: false,
-        fieldMetadata: undefined,
-        selectedReferenceTo: undefined,
-        lookupOptionUseFirstMatch: DEFAULT_NON_EXT_ID_MAPPING_OPT,
-        lookupOptionNullIfNoMatch: DEFAULT_NULL_IF_NO_MATCH_MAPPING_OPT,
-        isBinaryBodyField: false,
-      };
-    }
-    return output;
-  }, {});
+  const inputHeaderSet = new Set(inputHeader);
 
-  Object.keys(savedMapping.mapping)
-    .filter((key) => key.startsWith(STATIC_MAPPING_PREFIX))
-    .forEach((field) => {
-      const mapping = savedMapping.mapping[field];
-      if (mapping.targetField) {
-        newMapping[field] = {
-          ...mapping,
-          type: 'STATIC',
-          fieldMetadata: {
-            ...fieldMetadataByName[mapping.targetField],
-          },
-          isBinaryBodyField: false,
-        } as FieldMappingItemStatic;
-      }
-    });
+  // Every file column gets a row; it is only restored from the saved record if the target field still exists on the object
+  const newMapping = resetFieldMapping(inputHeader);
+  inputHeader.forEach((field) => {
+    const matchedMapping = savedMapping.mapping[field];
+    if (matchedMapping?.targetField && fieldMetadataByName[matchedMapping.targetField]) {
+      newMapping[field] = hydrateSavedMappingItem(matchedMapping, {
+        csvField: field,
+        fieldMetadata: fieldMetadataByName[matchedMapping.targetField],
+        binaryBodyField,
+      }) as FieldMappingItemCsv;
+    }
+  });
+
+  /**
+   * Synthetic keys are re-generated instead of being restored verbatim.
+   * `uniqueId` restarts at 1 each page load, so a saved key such as `~STATIC~MAPPING~3` would otherwise be
+   * silently overwritten by the third row the user adds by hand during the same session.
+   */
+  Object.entries(savedMapping.mapping).forEach(([savedKey, savedMappingItem]) => {
+    const { targetField } = savedMappingItem;
+    if (!targetField || !fieldMetadataByName[targetField]) {
+      return;
+    }
+    if (savedKey.startsWith(STATIC_MAPPING_PREFIX)) {
+      // Static rows use their key as the csvField placeholder, so both have to move together
+      const mappingKey = uniqueId(STATIC_MAPPING_PREFIX);
+      newMapping[mappingKey] = {
+        ...hydrateSavedMappingItem(savedMappingItem, {
+          csvField: mappingKey,
+          fieldMetadata: fieldMetadataByName[targetField],
+          binaryBodyField: null,
+        }),
+        type: 'STATIC',
+      } as FieldMappingItemStatic;
+    } else if (savedKey.startsWith(ADDITIONAL_MAPPING_PREFIX) && inputHeaderSet.has(savedMappingItem.csvField)) {
+      // Additional mappings are only restored if the file still has the column they read from
+      newMapping[uniqueId(ADDITIONAL_MAPPING_PREFIX)] = {
+        ...hydrateSavedMappingItem(savedMappingItem, {
+          csvField: savedMappingItem.csvField,
+          fieldMetadata: fieldMetadataByName[targetField],
+          binaryBodyField,
+        }),
+        type: 'CSV',
+      } as FieldMappingItemCsv;
+    }
+  });
 
   return newMapping;
 }
@@ -495,7 +569,8 @@ export async function transformData({ data, fieldMapping, sObject, insertNulls, 
         const fieldMappingItem = fieldMapping[field];
         const isCheckbox = fieldMappingItem.fieldMetadata?.type === 'boolean';
         // SFDC handles automatic type conversion with both bulk and batch apis (if possible, otherwise the record errors)
-        let value = fieldMappingItem.type === 'STATIC' ? fieldMappingItem.staticValue : row[field];
+        // csvField is read instead of the mapping key so that additional mappings, which have a synthetic key, resolve to the real column
+        let value = fieldMappingItem.type === 'STATIC' ? fieldMappingItem.staticValue : row[fieldMappingItem.csvField];
 
         if (isNil(value) || (isString(value) && !value)) {
           if (apiMode === 'BULK' && insertNulls) {


### PR DESCRIPTION
allow one file column to be mapped to multiple Salesforce fields

Loading the same column into two Salesforce fields, or using
it both as a value and as a lookup reference, previously required
duplicating the column in the source file.

Closes #646