### PR TITLE
feat: hide unchanged files when comparing metadata between orgs

### DIFF
--- a/libs/features/deploy/src/view-or-compare-metadata/ViewOrCompareMetadataModal.tsx
+++ b/libs/features/deploy/src/view-or-compare-metadata/ViewOrCompareMetadataModal.tsx
@@ -346,6 +346,7 @@ export const ViewOrCompareMetadataModal = ({ sourceOrg, selectedMetadata, onClos
                           <Checkbox
                             id="hide-unchanged-regions"
                             label="Hide Unchanged Regions"
+                            labelHelp="Collapse matching lines within the file comparison."
                             checked={hideUnchangedRegions}
                             onChange={(enabled) => {
                               setHideUnchangedRegions(enabled);

--- a/libs/features/deploy/src/view-or-compare-metadata/ViewOrCompareMetadataSidebar.tsx
+++ b/libs/features/deploy/src/view-or-compare-metadata/ViewOrCompareMetadataSidebar.tsx
@@ -1,10 +1,12 @@
+import { formatNumber } from '@jetstream/shared/ui-utils';
 import { Maybe, SalesforceOrgUi } from '@jetstream/types';
-import { RadioButton, RadioGroup, ScopedNotification, Spinner, Tree, TreeItems } from '@jetstream/ui';
+import { Checkbox, RadioButton, RadioGroup, ScopedNotification, Spinner, Tree, TreeItems } from '@jetstream/ui';
 import { OrgsCombobox } from '@jetstream/ui-core';
 import { salesforceOrgsOmitSelectedState } from '@jetstream/ui/app-state';
 import { useAtomValue } from 'jotai';
-import { FunctionComponent } from 'react';
+import { FunctionComponent, useMemo, useState } from 'react';
 import { FileItemMetadata } from './viewOrCompareMetadataTypes';
+import { countMetadataFiles, filterUnchangedFiles } from './viewOrCompareMetadataUtils';
 
 export interface ViewOrCompareMetadataSidebarProps {
   editorType: 'SOURCE' | 'TARGET' | 'DIFF';
@@ -38,6 +40,17 @@ export const ViewOrCompareMetadataSidebar: FunctionComponent<ViewOrCompareMetada
   onTargetOrgChange,
 }) => {
   const orgs = useAtomValue(salesforceOrgsOmitSelectedState);
+  const [hideUnchangedFiles, setHideUnchangedFiles] = useState(false);
+
+  const allFiles = useMemo(() => files ?? [], [files]);
+  const hasErrors = !!sourceError || !!targetError;
+  // The filter is only meaningful once a target org has been compared - without comparison data every file reads as changed, so the toggle would do nothing
+  const allowHideUnchangedFiles = hasTargetResults && !hasErrors;
+  const isFilterActive = allowHideUnchangedFiles && hideUnchangedFiles;
+
+  const visibleFiles = useMemo(() => (isFilterActive ? filterUnchangedFiles(allFiles) : allFiles), [allFiles, isFilterActive]);
+  const visibleFileCount = useMemo(() => countMetadataFiles(visibleFiles), [visibleFiles]);
+  const totalFileCount = useMemo(() => countMetadataFiles(allFiles), [allFiles]);
 
   function handleSelectedFile(item: TreeItems<FileItemMetadata>) {
     if (item.meta) {
@@ -48,8 +61,8 @@ export const ViewOrCompareMetadataSidebar: FunctionComponent<ViewOrCompareMetada
   return (
     <>
       {!isSingleOrgMode && (
-        <>
-          <div className="slds-is-relative slds-m-bottom_x-small slds-m-right_x-small">
+        <div className="slds-m-horizontal_x-small">
+          <div className="slds-is-relative slds-m-bottom_x-small">
             {targetLoading && <Spinner />}
             <OrgsCombobox
               label="Compare metadata with different org"
@@ -90,7 +103,7 @@ export const ViewOrCompareMetadataSidebar: FunctionComponent<ViewOrCompareMetada
               />
             </RadioGroup>
           </div>
-        </>
+        </div>
       )}
       {sourceError && (
         <ScopedNotification theme="error" className="slds-m-top_medium">
@@ -102,17 +115,38 @@ export const ViewOrCompareMetadataSidebar: FunctionComponent<ViewOrCompareMetada
           There was an error getting metadata from the target org: {targetError}
         </ScopedNotification>
       )}
-      {treeSettingsContent && !sourceError && !targetError && treeSettingsContent}
-      {!!files?.length && (
+      {allowHideUnchangedFiles && (
+        <div className="slds-m-top_x-small slds-p-left_xx-small">
+          <Checkbox
+            id="hide-unchanged-files"
+            label="Hide Unchanged Files"
+            labelHelp="Only show metadata files that are different from or missing in the target org."
+            checked={hideUnchangedFiles}
+            onChange={setHideUnchangedFiles}
+          />
+        </div>
+      )}
+      {treeSettingsContent && !hasErrors && treeSettingsContent}
+      {allowHideUnchangedFiles && (
+        <div className="slds-text-body_small slds-text-color_weak slds-p-left_xx-small slds-m-bottom_x-small">
+          Showing {formatNumber(visibleFileCount)} of {formatNumber(totalFileCount)} files
+        </div>
+      )}
+      {!!totalFileCount && (
         <Tree
           header="Metadata Files"
-          items={files}
+          items={visibleFiles}
           expandAllOnInit
           onlyEmitOnLeafNodeClick
           selectFirstLeafNodeOnInit
           reEmitSelectionOnItemsChange
           onSelected={handleSelectedFile}
         />
+      )}
+      {isFilterActive && !!totalFileCount && !visibleFiles.length && (
+        <ScopedNotification theme="light" className="slds-m-top_small">
+          All metadata matches the target org.
+        </ScopedNotification>
       )}
     </>
   );

--- a/libs/features/deploy/src/view-or-compare-metadata/__tests__/ViewOrCompareMetadataSidebar.spec.tsx
+++ b/libs/features/deploy/src/view-or-compare-metadata/__tests__/ViewOrCompareMetadataSidebar.spec.tsx
@@ -1,0 +1,147 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { atom } from 'jotai';
+import { describe, expect, it, vi } from 'vitest';
+import ViewOrCompareMetadataSidebar, { ViewOrCompareMetadataSidebarProps } from '../ViewOrCompareMetadataSidebar';
+import { FilePropertiesWithContent } from '../viewOrCompareMetadataTypes';
+import { buildTree } from '../viewOrCompareMetadataUtils';
+
+vi.mock('@jetstream/ui-core', () => ({ OrgsCombobox: () => null }));
+vi.mock('@jetstream/ui/app-state', () => ({ salesforceOrgsOmitSelectedState: atom([]) }));
+
+function getFile(fileName: string, content: string): FilePropertiesWithContent {
+  return {
+    type: fileName.split('/')[0],
+    createdById: '005000000000000',
+    createdByName: 'Test User',
+    createdDate: '2026-01-01T00:00:00.000Z',
+    fileName,
+    fullName: fileName.split('/').pop() as string,
+    id: '01p000000000000',
+    lastModifiedById: '005000000000000',
+    lastModifiedByName: 'Test User',
+    lastModifiedDate: '2026-01-01T00:00:00.000Z',
+    content,
+  };
+}
+
+const sourceFiles = [
+  getFile('classes/Matching.cls', 'shared'),
+  getFile('classes/Different.cls', 'from source'),
+  getFile('triggers/Matching.trigger', 'shared'),
+];
+
+const targetFiles = [
+  getFile('classes/Matching.cls', 'shared'),
+  getFile('classes/Different.cls', 'from target'),
+  getFile('triggers/Matching.trigger', 'shared'),
+];
+
+function setup(props: Partial<ViewOrCompareMetadataSidebarProps> = {}) {
+  return render(
+    <ViewOrCompareMetadataSidebar
+      editorType="DIFF"
+      files={buildTree(sourceFiles, targetFiles)}
+      targetLoading={false}
+      hasSourceResults
+      hasTargetResults
+      isSingleOrgMode={false}
+      onEditorTypeChange={vi.fn()}
+      onSelectedFile={vi.fn()}
+      onTargetOrgChange={vi.fn()}
+      {...props}
+    />,
+  );
+}
+
+function getHideUnchangedCheckbox() {
+  return screen.getByLabelText('Hide Unchanged Files');
+}
+
+describe('ViewOrCompareMetadataSidebar', () => {
+  it('does not offer the filter until a target org has been compared', () => {
+    setup({ files: buildTree(sourceFiles), hasTargetResults: false });
+
+    expect(screen.queryByLabelText('Hide Unchanged Files')).toBeNull();
+    expect(screen.queryByText(/Showing .* files/)).toBeNull();
+    expect(screen.getByText('Different.cls')).toBeTruthy();
+  });
+
+  it('does not offer the filter when metadata failed to load', () => {
+    setup({ targetError: 'Something went wrong' });
+
+    expect(screen.queryByLabelText('Hide Unchanged Files')).toBeNull();
+  });
+
+  it('shows every file with the filter turned off', () => {
+    setup();
+
+    expect(getHideUnchangedCheckbox()).toHaveProperty('checked', false);
+    expect(screen.getByText('Showing 3 of 3 files')).toBeTruthy();
+    expect(screen.getByText('Different.cls')).toBeTruthy();
+    expect(screen.getByText('Matching.cls')).toBeTruthy();
+    expect(screen.getByText('Matching.trigger')).toBeTruthy();
+  });
+
+  it('hides matching files and any folder left empty when enabled', () => {
+    setup();
+
+    fireEvent.click(getHideUnchangedCheckbox());
+
+    expect(screen.getByText('Showing 1 of 3 files')).toBeTruthy();
+    expect(screen.getByText('Different.cls')).toBeTruthy();
+    expect(screen.queryByText('Matching.cls')).toBeNull();
+    expect(screen.getByText('classes')).toBeTruthy();
+    expect(screen.queryByText('triggers')).toBeNull();
+  });
+
+  it('restores the full list when turned back off', () => {
+    setup();
+
+    fireEvent.click(getHideUnchangedCheckbox());
+    fireEvent.click(getHideUnchangedCheckbox());
+
+    expect(screen.getByText('Showing 3 of 3 files')).toBeTruthy();
+    expect(screen.getByText('Matching.cls')).toBeTruthy();
+    expect(screen.getByText('Matching.trigger')).toBeTruthy();
+  });
+
+  it('explains the empty list when every file matches the target org', () => {
+    setup({ files: buildTree(sourceFiles, sourceFiles) });
+
+    fireEvent.click(getHideUnchangedCheckbox());
+
+    expect(screen.getByText('Showing 0 of 3 files')).toBeTruthy();
+    expect(screen.getByText('All metadata matches the target org.')).toBeTruthy();
+    expect(screen.queryByText('Matching.cls')).toBeNull();
+  });
+
+  it('keeps the selected file when the filter empties the list and is then turned back off', () => {
+    const onSelectedFile = vi.fn();
+    setup({ files: buildTree(sourceFiles, sourceFiles), onSelectedFile });
+    fireEvent.click(screen.getByText('Matching.trigger'));
+    onSelectedFile.mockClear();
+
+    fireEvent.click(getHideUnchangedCheckbox());
+    fireEvent.click(getHideUnchangedCheckbox());
+
+    // The tree stays mounted while empty, otherwise remounting would reset the selection to the first file
+    expect(onSelectedFile).toHaveBeenLastCalledWith(expect.objectContaining({ id: 'triggers/Matching.trigger' }));
+  });
+
+  it('selects the first remaining file when the active file is filtered out', () => {
+    const onSelectedFile = vi.fn();
+    // Files are sorted by name, so the file the tree auto-selects on init is one that matches the target org
+    const files = buildTree(
+      [getFile('classes/Alpha.cls', 'shared'), getFile('classes/Beta.cls', 'from source')],
+      [getFile('classes/Alpha.cls', 'shared'), getFile('classes/Beta.cls', 'from target')],
+    );
+    setup({ files, onSelectedFile });
+
+    expect(onSelectedFile).toHaveBeenLastCalledWith(expect.objectContaining({ id: 'classes/Alpha.cls' }));
+    onSelectedFile.mockClear();
+
+    fireEvent.click(getHideUnchangedCheckbox());
+
+    expect(onSelectedFile).toHaveBeenLastCalledWith(expect.objectContaining({ id: 'classes/Beta.cls' }));
+  });
+});

--- a/libs/features/deploy/src/view-or-compare-metadata/__tests__/viewOrCompareMetadataUtils.spec.ts
+++ b/libs/features/deploy/src/view-or-compare-metadata/__tests__/viewOrCompareMetadataUtils.spec.ts
@@ -1,0 +1,156 @@
+import { FileProperties } from '@jetstream/types';
+import { TreeItems } from '@jetstream/ui';
+import { FileItemMetadata } from '../viewOrCompareMetadataTypes';
+import { countMetadataFiles, filterUnchangedFiles } from '../viewOrCompareMetadataUtils';
+
+function getFileProperties(fileName: string): FileProperties {
+  return {
+    type: 'ApexClass',
+    createdById: '005000000000000',
+    createdByName: 'Test User',
+    createdDate: '2026-01-01T00:00:00.000Z',
+    fileName,
+    fullName: fileName.split('/').pop() as string,
+    id: '01p000000000000',
+    lastModifiedById: '005000000000000',
+    lastModifiedByName: 'Test User',
+    lastModifiedDate: '2026-01-01T00:00:00.000Z',
+  };
+}
+
+function getFileNode(
+  fileName: string,
+  sourceAndTargetMatch: boolean,
+  existsInTarget = sourceAndTargetMatch,
+  { hasContent = true }: { hasContent?: boolean } = {},
+): TreeItems<FileItemMetadata | null> {
+  const name = fileName.split('/').pop() as string;
+  const content = hasContent ? 'source' : undefined;
+  return {
+    id: fileName,
+    label: name,
+    title: name,
+    meta: {
+      type: 'ApexClass',
+      filename: fileName,
+      source: { ...getFileProperties(fileName), content },
+      target: existsInTarget ? { ...getFileProperties(fileName), content } : undefined,
+      targetHasLoaded: true,
+      sourceAndTargetMatch,
+    },
+    treeItems: [],
+  };
+}
+
+function getFolderNode(name: string, treeItems: TreeItems<FileItemMetadata | null>[]): TreeItems<FileItemMetadata | null> {
+  return { id: `FOLDER|${name}|0|${name}`, label: name, title: name, meta: null, treeItems };
+}
+
+describe('filterUnchangedFiles', () => {
+  it('removes files that match the target org and keeps the ones that do not', () => {
+    const files = [
+      getFolderNode('classes', [
+        getFileNode('classes/Matching.cls', true),
+        getFileNode('classes/Different.cls', false),
+        getFileNode('classes/AlsoMatching.cls', true),
+      ]),
+    ];
+
+    const results = filterUnchangedFiles(files);
+
+    expect(results).toHaveLength(1);
+    expect(results[0].treeItems?.map(({ id }) => id)).toEqual(['classes/Different.cls']);
+  });
+
+  it('prunes folders that no longer have any files', () => {
+    const files = [
+      getFolderNode('classes', [getFileNode('classes/Different.cls', false)]),
+      getFolderNode('triggers', [getFileNode('triggers/Matching.trigger', true)]),
+    ];
+
+    const results = filterUnchangedFiles(files);
+
+    expect(results.map(({ id }) => id)).toEqual(['FOLDER|classes|0|classes']);
+  });
+
+  it('keeps nested folders that still have a changed descendant', () => {
+    const files = [
+      getFolderNode('reports', [
+        getFolderNode('MyFolder', [
+          getFileNode('reports/MyFolder/Changed.report', false),
+          getFileNode('reports/MyFolder/Same.report', true),
+        ]),
+        getFolderNode('OtherFolder', [getFileNode('reports/OtherFolder/Same.report', true)]),
+      ]),
+    ];
+
+    const results = filterUnchangedFiles(files);
+
+    expect(results).toHaveLength(1);
+    expect(results[0].treeItems?.map(({ id }) => id)).toEqual(['FOLDER|MyFolder|0|MyFolder']);
+    expect(results[0].treeItems?.[0].treeItems?.map(({ id }) => id)).toEqual(['reports/MyFolder/Changed.report']);
+  });
+
+  it('preserves the id, label and metadata of retained nodes', () => {
+    const changedFile = getFileNode('classes/Different.cls', false);
+    const folder = getFolderNode('classes', [changedFile, getFileNode('classes/Matching.cls', true)]);
+
+    const [resultFolder] = filterUnchangedFiles([folder]);
+
+    expect(resultFolder.id).toBe(folder.id);
+    expect(resultFolder.label).toBe(folder.label);
+    expect(resultFolder.treeItems?.[0]).toBe(changedFile);
+  });
+
+  it('handles files that are not inside a folder', () => {
+    const files = [getFileNode('Different.cls', false), getFileNode('Matching.cls', true)];
+
+    expect(filterUnchangedFiles(files).map(({ id }) => id)).toEqual(['Different.cls']);
+  });
+
+  it('keeps files that are missing from the target org even if they compare as matching', () => {
+    // Content is undefined when a file could not be read out of the zip, which compares equal to an absent target file
+    const files = [getFolderNode('classes', [getFileNode('classes/Missing.cls', true, false), getFileNode('classes/Matching.cls', true)])];
+
+    const results = filterUnchangedFiles(files);
+
+    expect(results[0].treeItems?.map(({ id }) => id)).toEqual(['classes/Missing.cls']);
+  });
+
+  it('keeps files where neither side has content even though they compare as matching', () => {
+    // Content is undefined when a file could not be read out of the zip - undefined compares equal to undefined,
+    // so the file may actually be different and must not be hidden
+    const files = [
+      getFolderNode('classes', [
+        getFileNode('classes/Unreadable.cls', true, true, { hasContent: false }),
+        getFileNode('classes/Matching.cls', true),
+      ]),
+    ];
+
+    const results = filterUnchangedFiles(files);
+
+    expect(results[0].treeItems?.map(({ id }) => id)).toEqual(['classes/Unreadable.cls']);
+  });
+
+  it('returns an empty array when every file matches', () => {
+    const files = [getFolderNode('classes', [getFileNode('classes/Matching.cls', true)])];
+
+    expect(filterUnchangedFiles(files)).toEqual([]);
+  });
+});
+
+describe('countMetadataFiles', () => {
+  it('counts files and ignores folders at any depth', () => {
+    const files = [
+      getFolderNode('classes', [getFileNode('classes/One.cls', true), getFileNode('classes/Two.cls', false)]),
+      getFolderNode('reports', [getFolderNode('MyFolder', [getFileNode('reports/MyFolder/One.report', false)])]),
+      getFileNode('Root.cls', false),
+    ];
+
+    expect(countMetadataFiles(files)).toBe(4);
+  });
+
+  it('returns zero for an empty tree', () => {
+    expect(countMetadataFiles([])).toBe(0);
+  });
+});

--- a/libs/features/deploy/src/view-or-compare-metadata/useViewOrCompareMetadata.tsx
+++ b/libs/features/deploy/src/view-or-compare-metadata/useViewOrCompareMetadata.tsx
@@ -50,6 +50,7 @@ function reducer(state: State, action: Action): State {
           sourceStatus: 'Loading',
           sourceLastChecked: new Date(),
           sourceResults: null,
+          sourceError: null,
           targetLoading: false,
           targetStatus: 'Not Started',
           targetResults: null,
@@ -67,6 +68,7 @@ function reducer(state: State, action: Action): State {
           targetStatus: 'Loading',
           targetLastChecked: new Date(),
           targetResults: null,
+          targetError: null,
           files,
         };
       }

--- a/libs/features/deploy/src/view-or-compare-metadata/viewOrCompareMetadataUtils.tsx
+++ b/libs/features/deploy/src/view-or-compare-metadata/viewOrCompareMetadataUtils.tsx
@@ -132,6 +132,39 @@ export function compare(sourceFile: FilePropertiesWithContent, targetFiles: Reco
   return match;
 }
 
+/**
+ * Remove files that match the target org, along with any folders that are left empty.
+ * Node ids and labels are carried over untouched so that the tree's expansion state survives the filter.
+ *
+ * Anything that could not actually be compared is retained - a file missing from the target org, or a file whose
+ * content could not be read out of the retrieve zip, compares as undefined on both sides. Treating that as a match
+ * would hide a file that may very well be different.
+ */
+export function filterUnchangedFiles(files: TreeItems<FileItemMetadata | null>[]): TreeItems<FileItemMetadata | null>[] {
+  return files.reduce<TreeItems<FileItemMetadata | null>[]>((output, item) => {
+    // Files have metadata, folders do not
+    if (item.meta) {
+      const { sourceAndTargetMatch, source, target } = item.meta;
+      if (!sourceAndTargetMatch || !target || source?.content == null || target.content == null) {
+        output.push(item);
+      }
+      return output;
+    }
+    const treeItems = filterUnchangedFiles(item.treeItems ?? []);
+    if (treeItems.length) {
+      output.push({ ...item, treeItems });
+    }
+    return output;
+  }, []);
+}
+
+/**
+ * Number of files in the tree, folders are not counted
+ */
+export function countMetadataFiles(files: TreeItems<FileItemMetadata | null>[]): number {
+  return files.reduce((count, item) => (item.meta ? count + 1 : count + countMetadataFiles(item.treeItems ?? [])), 0);
+}
+
 export function getDeployMetadataFromComparisonTree(files: TreeItems<FileItemMetadata | null>[]): DeployFromCompareMetadataItem[] {
   return files
     .map((metadata) => ({

--- a/libs/features/deploy/vite.config.mts
+++ b/libs/features/deploy/vite.config.mts
@@ -10,6 +10,7 @@ export default defineConfig(() => ({
     watch: false,
     globals: true,
     environment: 'jsdom',
+    setupFiles: ['../../test-utils/src/test-setup-dom.ts'],
     include: ['{src,tests}/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
     reporters: ['default'],
     passWithNoTests: true,

--- a/libs/ui/src/lib/tree/Tree.tsx
+++ b/libs/ui/src/lib/tree/Tree.tsx
@@ -20,7 +20,10 @@ export interface TreeProps {
   selectFirstLeafNodeOnInit?: boolean;
   /** If true, don't call onSelected when an expandable node is called */
   onlyEmitOnLeafNodeClick?: boolean;
-  /** If the list of items changes, then re-emit the selected item. Existing use-case is that some additional metadata is added to items and parent needs to know about it */
+  /**
+   * If the list of items changes, then re-emit the selected item. Existing use-case is that some additional metadata is added to items and parent needs to know about it.
+   * If the selected item is no longer in the list of items (e.g. it was filtered out), the first remaining leaf node is selected and emitted instead.
+   */
   reEmitSelectionOnItemsChange?: boolean;
   onSelected?: (item: TreeItems) => void;
 }
@@ -47,6 +50,10 @@ function getAllIds(
   return output;
 }
 
+function getFirstLeafNodeId(ids: Set<string>, idMap: Record<string, TreeItems>): string | undefined {
+  return Array.from(ids).find((id) => !idMap[id].treeItems?.length);
+}
+
 export const Tree = forwardRef<any, TreeProps>(
   (
     {
@@ -67,12 +74,21 @@ export const Tree = forwardRef<any, TreeProps>(
     onSelectedRef.current = onSelected;
 
     useNonInitialEffect(() => {
-      if (onSelectedRef.current && reEmitSelectionOnItemsChange && items?.length > 0 && selectedItem) {
-        const { idMap } = getAllIds(items);
-        const item = idMap[selectedItem];
-        if (item) {
-          onSelectedRef.current(item);
-        }
+      if (!onSelectedRef.current || !reEmitSelectionOnItemsChange || !items?.length || !selectedItem) {
+        return;
+      }
+      const { ids, idMap } = getAllIds(items);
+      const item = idMap[selectedItem];
+      if (item) {
+        onSelectedRef.current(item);
+        return;
+      }
+      // The selected item is no longer in the tree (e.g. it was filtered out), fall back to the first remaining leaf node.
+      // Updating the selection re-runs this effect, which is what emits the new selection.
+      const firstLeafNode = getFirstLeafNodeId(ids, idMap);
+      if (firstLeafNode) {
+        // eslint-disable-next-line react-hooks/set-state-in-effect
+        setSelectedItem(firstLeafNode);
       }
     }, [items, reEmitSelectionOnItemsChange, selectedItem]);
 
@@ -84,7 +100,7 @@ export const Tree = forwardRef<any, TreeProps>(
           setExpandedItems(new Set(Array.from(ids).filter((id) => idMap[id].treeItems?.length)));
         }
         if (selectFirstLeafNodeOnInit) {
-          const firstLeafNode = Array.from(ids).find((id) => !idMap[id].treeItems?.length);
+          const firstLeafNode = getFirstLeafNodeId(ids, idMap);
           if (firstLeafNode) {
             setSelectedItem(firstLeafNode);
             onSelectedRef.current && onSelectedRef.current(idMap[firstLeafNode]);

--- a/libs/ui/src/lib/tree/__tests__/Tree.spec.tsx
+++ b/libs/ui/src/lib/tree/__tests__/Tree.spec.tsx
@@ -112,6 +112,33 @@ describe('Tree', () => {
     expect(screen.getByText('Child 1A')).toBeTruthy();
   });
 
+  test('reEmitSelectionOnItemsChange re-emits the selected item when the items change', () => {
+    const onSelected = vi.fn();
+    const { rerender } = render(<Tree items={nestedItems} expandAllOnInit reEmitSelectionOnItemsChange onSelected={onSelected} />);
+    fireEvent.click(screen.getByText('Child 2A'));
+    onSelected.mockClear();
+
+    rerender(
+      <Tree items={nestedItems.map((item) => ({ ...item }))} expandAllOnInit reEmitSelectionOnItemsChange onSelected={onSelected} />,
+    );
+
+    expect(onSelected).toHaveBeenCalledTimes(1);
+    expect(onSelected).toHaveBeenCalledWith(expect.objectContaining({ id: 'child-2a' }));
+  });
+
+  test('reEmitSelectionOnItemsChange selects the first remaining leaf when the selected item is removed', () => {
+    const onSelected = vi.fn();
+    const { rerender } = render(<Tree items={nestedItems} expandAllOnInit reEmitSelectionOnItemsChange onSelected={onSelected} />);
+    fireEvent.click(screen.getByText('Child 2A'));
+    onSelected.mockClear();
+
+    const filteredItems = nestedItems.filter((item) => item.id !== 'parent-2');
+    rerender(<Tree items={filteredItems} expandAllOnInit reEmitSelectionOnItemsChange onSelected={onSelected} />);
+
+    expect(onSelected).toHaveBeenCalledTimes(1);
+    expect(onSelected).toHaveBeenCalledWith(expect.objectContaining({ id: 'child-1a' }));
+  });
+
   test('each tree item has role=treeitem', () => {
     render(<Tree items={flatItems} />);
     const treeItems = screen.getAllByRole('treeitem');


### PR DESCRIPTION
When comparing metadata across two orgs, the sidebar colors every file green or red, but a retrieve routinely returns hundreds or thousands of components and nearly all of them match. The handful of differences the user opened the modal to find are buried, and the tree had no filter of any kind.

Closes #1334