### PR TITLE
feat: suggest combining repeated query filters into In / Not In

### DIFF
--- a/apps/jetstream-e2e/src/tests/query/query-builder.spec.ts
+++ b/apps/jetstream-e2e/src/tests/query/query-builder.spec.ts
@@ -92,6 +92,28 @@ test.describe('QUERY BUILDER', () => {
     ]);
   });
 
+  test('should combine repeated conditions into an In condition', async ({ queryPage, page }) => {
+    await queryPage.goto();
+    await queryPage.selectObject('Account');
+    await queryPage.selectFields(['Account Name']);
+
+    await queryPage.setFilterAction('OR');
+    await queryPage.addFilter({ conditionNumber: 1 }, 'Account Name', 'eq', { type: 'text', value: 'Acme' });
+    await queryPage.addCondition();
+    await queryPage.addFilter({ conditionNumber: 2 }, 'Account Name', 'eq', { type: 'text', value: 'Initech' });
+
+    await expect(page.getByText(/appears in 2 conditions/)).toBeVisible();
+
+    await page.getByRole('button', { name: 'Use In operator for Name' }).click();
+
+    // the two conditions collapse into one row using the multi value textarea
+    await expect(page.getByText(/appears in 2 conditions/)).toBeHidden();
+    await expect(page.getByRole('group', { name: 'Condition 2' })).toBeHidden();
+    await expect(page.getByRole('group', { name: 'Condition 1' }).getByLabel('Value')).toHaveValue('Acme\nInitech');
+
+    await expect(page.getByRole('code').locator('div').filter({ hasText: `WHERE Name IN ('Acme', 'Initech')` }).first()).toBeVisible();
+  });
+
   // eslint-disable-next-line playwright/expect-expect
   test('should work with subqueries', async ({ queryPage }) => {
     await queryPage.goto();

--- a/libs/features/query/src/QueryOptions/QueryFilter.tsx
+++ b/libs/features/query/src/QueryOptions/QueryFilter.tsx
@@ -1,6 +1,8 @@
+import { ANALYTICS_KEYS } from '@jetstream/shared/constants';
 import { useNonInitialEffect } from '@jetstream/shared/ui-utils';
 import { ExpressionType, ListItem, QueryFilterOperator, SalesforceOrgUi } from '@jetstream/types';
-import { ExpressionContainer } from '@jetstream/ui';
+import { ExpressionContainer, ListOperatorSuggestion } from '@jetstream/ui';
+import { useAmplitude } from '@jetstream/ui-core';
 import { QUERY_FIELD_FUNCTIONS, QUERY_OPERATORS, getResourceTypeFnsFromFields } from '@jetstream/ui-core/shared';
 import { FunctionComponent, useCallback, useEffect, useRef, useState } from 'react';
 
@@ -26,6 +28,7 @@ export const QueryFilter: FunctionComponent<QueryFilterProps> = ({
   onLoadRelatedFields,
 }) => {
   const isMounted = useRef(true);
+  const { trackEvent } = useAmplitude();
 
   const [initialQueryFilters] = useState(filtersOrHaving);
   const [getResourceTypeFns, setResourceTypeFns] = useState(() => getResourceTypeFnsFromFields(fields));
@@ -51,6 +54,17 @@ export const QueryFilter: FunctionComponent<QueryFilterProps> = ({
     [setFiltersOrHaving],
   );
 
+  const handleConvertToListOperator = useCallback(
+    ({ toOperator, rowKeys }: ListOperatorSuggestion) => {
+      trackEvent(ANALYTICS_KEYS.query_FilterConvertedToListOperator, {
+        operator: toOperator,
+        rowCount: rowKeys.length,
+        isHavingClause: !!isHavingClause,
+      });
+    },
+    [isHavingClause, trackEvent],
+  );
+
   return (
     <ExpressionContainer
       org={org}
@@ -65,6 +79,7 @@ export const QueryFilter: FunctionComponent<QueryFilterProps> = ({
       operators={QUERY_OPERATORS}
       getResourceTypeFns={getResourceTypeFns}
       disableValueForOperators={disableValueForOperators}
+      onConvertToListOperator={handleConvertToListOperator}
       onChange={handleChange}
     />
   );

--- a/libs/features/query/src/QueryOptions/__tests__/query-filter-list-operator.spec.tsx
+++ b/libs/features/query/src/QueryOptions/__tests__/query-filter-list-operator.spec.tsx
@@ -1,0 +1,208 @@
+import { convertFiltersToWhereClause } from '@jetstream/shared/ui-utils';
+import {
+  ExpressionConditionType,
+  ExpressionRowValueType,
+  ExpressionType,
+  Field,
+  ListItem,
+  QueryFilterOperator,
+  SalesforceOrgUi,
+} from '@jetstream/types';
+import { ExpressionContainer, getListOperatorSuggestions, ListOperatorSuggestion } from '@jetstream/ui';
+import { getResourceTypeFnsFromFields, getTypeFromMetadata, QUERY_OPERATORS } from '@jetstream/ui-core/shared';
+import { composeQuery, WhereClause } from '@jetstreamapp/soql-parser-js';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+/**
+ * Exercises the suggestion end to end against the real field metadata rules the query builder uses, rather
+ * than a stand-in: detection, the conversion the expression builder performs when the offer is accepted,
+ * and the SOQL that comes out the other side. Field shapes are trimmed from an actual Opportunity describe.
+ */
+const FIELDS: Partial<Field>[] = [
+  { name: 'Name', label: 'Name', type: 'string' },
+  {
+    name: 'StageName',
+    label: 'Stage',
+    type: 'picklist',
+    picklistValues: [
+      { label: 'Prospecting', value: 'Prospecting', active: true, defaultValue: false },
+      { label: 'Qualification', value: 'Qualification', active: true, defaultValue: false },
+      { label: 'Closed Won', value: 'Closed Won', active: true, defaultValue: false },
+    ],
+  },
+  { name: 'AccountId', label: 'Account ID', type: 'reference', referenceTo: ['Account'] },
+  { name: 'CloseDate', label: 'Close Date', type: 'date' },
+  { name: 'IsWon', label: 'Won', type: 'boolean' },
+  { name: 'Amount', label: 'Amount', type: 'currency' },
+];
+
+const RESOURCES: ListItem[] = FIELDS.map((field) => ({
+  id: field.name as string,
+  label: field.label as string,
+  value: field.name as string,
+  meta: field,
+}));
+
+const ORG = {} as SalesforceOrgUi;
+const getResourceTypeFns = getResourceTypeFnsFromFields(RESOURCES);
+
+/**
+ * `resourceType` normally comes from the field metadata, but fields that offer a Type dropdown let the user
+ * override it - pass `resourceType` to stand in for that choice.
+ */
+function createRow(
+  key: number,
+  resource: string,
+  operator: QueryFilterOperator,
+  value: string | string[],
+  resourceTypeOverride?: ExpressionRowValueType,
+): ExpressionConditionType {
+  const field = FIELDS.find(({ name }) => name === resource) as Field;
+  // matches how the builder derives the row's value input when a field and operator are picked
+  const resourceType: ExpressionRowValueType = resourceTypeOverride ?? getTypeFromMetadata(field.type, operator, value);
+  return {
+    key,
+    resourceType,
+    selected: { resource, resourceGroup: null, function: null, operator, value, resourceType, resourceMeta: field },
+  };
+}
+
+function getSuggestions(expression: ExpressionType): ListOperatorSuggestion[] {
+  return getListOperatorSuggestions(expression, getResourceTypeFns, QUERY_OPERATORS);
+}
+
+/** Accepts the suggestion through the real expression builder - render it, click the offer, and return the emitted expression */
+async function convertViaExpressionBuilder(expression: ExpressionType, suggestion: ListOperatorSuggestion): Promise<ExpressionType> {
+  const onChange = vi.fn();
+  const { unmount } = render(
+    <ExpressionContainer
+      org={ORG}
+      actionLabel="Filter When"
+      resources={RESOURCES}
+      operators={QUERY_OPERATORS}
+      expressionInitValue={expression}
+      getResourceTypeFns={getResourceTypeFns}
+      onChange={onChange}
+    />,
+  );
+
+  const { resource, toOperatorLabel, rowKeys } = suggestion;
+  fireEvent.click(screen.getByRole('button', { name: `Use ${toOperatorLabel} operator for ${resource}` }));
+
+  const expectedRowCount = expression.rows.length - rowKeys.length + 1;
+  await waitFor(() => expect((onChange.mock.calls.at(-1)?.[0] as ExpressionType | undefined)?.rows).toHaveLength(expectedRowCount));
+  const converted = onChange.mock.calls.at(-1)?.[0] as ExpressionType;
+  unmount();
+
+  return converted;
+}
+
+/** Composes the SOQL the query builder would produce from the expression left behind by the conversion */
+async function composeAfterConversion(expression: ExpressionType, suggestion: ListOperatorSuggestion) {
+  return composeQuery({
+    sObject: 'Opportunity',
+    fields: [{ type: 'Field', field: 'Id' }],
+    where: convertFiltersToWhereClause<WhereClause>(await convertViaExpressionBuilder(expression, suggestion)),
+  });
+}
+
+describe('list operator suggestions against real field metadata', () => {
+  it('combines repeated picklist equals conditions into an IN clause with the same values', async () => {
+    const expression: ExpressionType = {
+      action: 'OR',
+      rows: [
+        createRow(0, 'StageName', 'eq', 'Prospecting'),
+        createRow(1, 'StageName', 'eq', 'Qualification'),
+        createRow(2, 'StageName', 'eq', 'Closed Won'),
+      ],
+    };
+
+    const [suggestion] = getSuggestions(expression);
+    expect(suggestion).toMatchObject({ toOperator: 'in', targetResourceType: 'SELECT-MULTI' });
+    expect(await composeAfterConversion(expression, suggestion)).toBe(
+      `SELECT Id FROM Opportunity WHERE StageName IN ('Prospecting', 'Qualification', 'Closed Won')`,
+    );
+  });
+
+  it('keeps the merged values separate when a picklist field uses the text input', async () => {
+    const expression: ExpressionType = {
+      action: 'OR',
+      rows: [createRow(0, 'StageName', 'eq', 'Prospecting', 'TEXT'), createRow(1, 'StageName', 'eq', 'Qualification', 'TEXT')],
+    };
+
+    const [suggestion] = getSuggestions(expression);
+    expect(suggestion).toMatchObject({ toOperator: 'in', targetResourceType: 'TEXTAREA' });
+    // switching the row back to the picklist input must not offer the newline joined value as an option
+    const [row] = (await convertViaExpressionBuilder(expression, suggestion)).rows as ExpressionConditionType[];
+    expect(row.resourceSelectItems?.map(({ value }) => value)).toEqual(['Prospecting', 'Qualification', 'Closed Won']);
+    // the field metadata rules normalize picklist values into an array, which would otherwise turn the
+    // newline separated textarea value into a single literal containing a newline
+    expect(await composeAfterConversion(expression, suggestion)).toBe(
+      `SELECT Id FROM Opportunity WHERE StageName IN ('Prospecting', 'Qualification')`,
+    );
+  });
+
+  it('combines repeated text does-not-equal conditions into a NOT IN clause', async () => {
+    const expression: ExpressionType = {
+      action: 'AND',
+      rows: [createRow(0, 'Name', 'ne', 'Acme'), createRow(1, 'Name', 'ne', 'Initech')],
+    };
+
+    const [suggestion] = getSuggestions(expression);
+    expect(suggestion).toMatchObject({ toOperator: 'notIn', targetResourceType: 'TEXTAREA' });
+    expect(await composeAfterConversion(expression, suggestion)).toBe(`SELECT Id FROM Opportunity WHERE Name NOT IN ('Acme', 'Initech')`);
+  });
+
+  it('combines lookup conditions into a NOT IN of ids', async () => {
+    const expression: ExpressionType = {
+      action: 'AND',
+      rows: [createRow(0, 'AccountId', 'ne', '001000000000001'), createRow(1, 'AccountId', 'ne', '001000000000002')],
+    };
+
+    const [suggestion] = getSuggestions(expression);
+    expect(suggestion).toMatchObject({ toOperator: 'notIn', targetResourceType: 'TEXTAREA' });
+    expect(await composeAfterConversion(expression, suggestion)).toBe(
+      `SELECT Id FROM Opportunity WHERE AccountId NOT IN ('001000000000001', '001000000000002')`,
+    );
+  });
+
+  it('combines currency conditions into an unquoted IN clause', async () => {
+    const expression: ExpressionType = {
+      action: 'OR',
+      rows: [createRow(0, 'Amount', 'eq', '100'), createRow(1, 'Amount', 'eq', '200')],
+    };
+
+    const [suggestion] = getSuggestions(expression);
+    expect(await composeAfterConversion(expression, suggestion)).toBe(`SELECT Id FROM Opportunity WHERE Amount IN (100, 200)`);
+  });
+
+  it('combines boolean conditions into an unquoted IN clause', async () => {
+    const expression: ExpressionType = {
+      action: 'OR',
+      rows: [createRow(0, 'IsWon', 'eq', 'true'), createRow(1, 'IsWon', 'eq', 'false')],
+    };
+
+    const [suggestion] = getSuggestions(expression);
+    expect(suggestion).toMatchObject({ targetResourceType: 'SELECT-MULTI' });
+    expect(await composeAfterConversion(expression, suggestion)).toBe(`SELECT Id FROM Opportunity WHERE IsWon IN (true, false)`);
+  });
+
+  it('combines relative date conditions but leaves the date picker alone', async () => {
+    const relativeDates: ExpressionType = {
+      action: 'OR',
+      rows: [createRow(0, 'CloseDate', 'eq', 'LAST_WEEK'), createRow(1, 'CloseDate', 'eq', 'TODAY')],
+    };
+    const pickedDates: ExpressionType = {
+      action: 'OR',
+      rows: [createRow(0, 'CloseDate', 'eq', '2026-01-01'), createRow(1, 'CloseDate', 'eq', '2026-02-01')],
+    };
+
+    const [suggestion] = getSuggestions(relativeDates);
+    expect(suggestion).toMatchObject({ targetResourceType: 'SELECT-MULTI' });
+    expect(await composeAfterConversion(relativeDates, suggestion)).toBe(
+      `SELECT Id FROM Opportunity WHERE CloseDate IN (LAST_WEEK, TODAY)`,
+    );
+    expect(getSuggestions(pickedDates)).toEqual([]);
+  });
+});

--- a/libs/shared/constants/src/lib/shared-constants.ts
+++ b/libs/shared/constants/src/lib/shared-constants.ts
@@ -249,6 +249,7 @@ export const ANALYTICS_KEYS = {
   query_ResetPage: 'query_ResetPage',
   query_InlineEditSave: 'query_InlineEditSave',
   query_FieldMetadataViewed: 'query_FieldMetadataViewed',
+  query_FilterConvertedToListOperator: 'query_FilterConvertedToListOperator',
   query_FieldMetadataDownloaded: 'query_FieldMetadataDownloaded',
   query_InlineEditPaste: 'query_InlineEditPaste',
   query_InlineEditClear: 'query_InlineEditClear',

--- a/libs/test/e2e-utils/src/lib/pageObjectModels/QueryPage.model.ts
+++ b/libs/test/e2e-utils/src/lib/pageObjectModels/QueryPage.model.ts
@@ -1,5 +1,5 @@
 import { isRecordWithId } from '@jetstream/shared/utils';
-import { QueryFilterOperator, QueryResults } from '@jetstream/types';
+import { AndOr, QueryFilterOperator, QueryResults } from '@jetstream/types';
 import { Locator, Page, expect } from '@playwright/test';
 import { isNumber } from 'lodash';
 import type { editor } from 'monaco-editor';
@@ -191,7 +191,8 @@ export class QueryPage {
     await condition.getByRole('option', { name: field }).first().click();
 
     await condition.getByLabel('Operator').click();
-    await condition.locator(`#${operator}`).click();
+    // The operator dropdown renders in a portal, so it lives outside the condition group - only one is ever open at a time
+    await this.page.getByRole('listbox').locator(`#${operator}`).click();
 
     await condition.getByLabel('Value').click();
     if (value.type === 'text') {
@@ -199,6 +200,12 @@ export class QueryPage {
     } else {
       await condition.getByRole('option', { name: value.value }).click();
     }
+  }
+
+  /** Switches the top level filter between "All conditions are met" (AND) and "Any conditions are met" (OR) */
+  async setFilterAction(action: AndOr) {
+    await this.page.getByLabel('Filter When').click();
+    await this.page.getByRole('option', { name: action === 'AND' ? 'All conditions are met' : 'Any conditions are met' }).click();
   }
 
   async addCondition() {

--- a/libs/ui/src/index.ts
+++ b/libs/ui/src/index.ts
@@ -31,6 +31,7 @@ export * from './lib/data-table/gridExport';
 export * from './lib/data-table/PreviewChangesModal';
 export * from './lib/data-table/SalesforceRecordDataTable';
 export * from './lib/docked-composer/DockedComposer';
+export * from './lib/expression-group/expression-list-operator-utils';
 export * from './lib/expression-group/expression-utils';
 export * from './lib/expression-group/ExpressionContainer';
 export * from './lib/file-download-modal/download-modal-utils';

--- a/libs/ui/src/lib/expression-group/Expression.tsx
+++ b/libs/ui/src/lib/expression-group/Expression.tsx
@@ -12,6 +12,8 @@ export interface ExpressionProps {
   actionHelpText?: string;
   actionLabel: string;
   ancillaryOptions?: React.ReactNode;
+  /** Rendered between the action dropdown and the condition rows (e.x. filter suggestions) */
+  notification?: React.ReactNode;
   onActionChange: (value: AndOr) => void;
   onAddCondition: () => void;
   onAddGroup: () => void;
@@ -24,6 +26,7 @@ export const Expression: FunctionComponent<ExpressionProps> = ({
   actionLabel,
   actionHelpText,
   ancillaryOptions,
+  notification,
   children,
   onActionChange,
   onAddCondition,
@@ -56,6 +59,7 @@ export const Expression: FunctionComponent<ExpressionProps> = ({
           ancillaryOptions={ancillaryOptions}
           onChange={onActionChange}
         />
+        {notification}
         <ul>{children}</ul>
       </div>
       <div className="slds-expression__buttons">

--- a/libs/ui/src/lib/expression-group/ExpressionConditionRow.tsx
+++ b/libs/ui/src/lib/expression-group/ExpressionConditionRow.tsx
@@ -252,6 +252,11 @@ export const ExpressionConditionRow: FunctionComponent<ExpressionConditionRowPro
                 label: operatorLabel,
                 labelHelp: operatorHelpText,
                 itemLength: 10,
+                /**
+                 * The query builder body is `overflow: hidden`, so a dropdown this tall gets clipped when there is not
+                 * enough room below the input and it flips upwards - hiding the first operators behind the page header.
+                 */
+                usePortal: true,
               }}
               items={operators}
               selectedItemId={selected.operator}

--- a/libs/ui/src/lib/expression-group/ExpressionContainer.tsx
+++ b/libs/ui/src/lib/expression-group/ExpressionContainer.tsx
@@ -12,13 +12,15 @@ import {
   QueryFilterOperator,
   SalesforceOrgUi,
 } from '@jetstream/types';
-import { FunctionComponent, memo, useCallback, useEffect, useReducer, useState } from 'react';
+import { FunctionComponent, memo, useCallback, useEffect, useMemo, useReducer, useState } from 'react';
 import DropDown from '../form/dropdown/DropDown';
 import Expression from './Expression';
+import { getListOperatorSuggestions, getListOperatorSuggestionValue, ListOperatorSuggestion } from './expression-list-operator-utils';
 import { DraggableRow, RowDropTarget } from './expression-types';
 import { isExpressionConditionType, isExpressionGroupType } from './expression-utils';
 import ExpressionConditionRow from './ExpressionConditionRow';
 import ExpressionGroup from './ExpressionGroup';
+import ExpressionListOperatorSuggestions from './ExpressionListOperatorSuggestions';
 
 const DISPLAY_OPT_ROW = 'expression-ancillary-row';
 const DISPLAY_OPT_WRAP = 'expression-ancillary-wrap';
@@ -46,6 +48,8 @@ export interface ExpressionContainerProps {
   // if declared, these are called any time the resource changes
   getResourceTypeFns?: ExpressionGetResourceTypeFns;
   disableValueForOperators?: QueryFilterOperator[];
+  /** Invoked after the user accepts a suggestion to combine repeated conditions into an In / Not In condition */
+  onConvertToListOperator?: (suggestion: ListOperatorSuggestion) => void;
   onChange: (expression: ExpressionType) => void;
 }
 
@@ -67,7 +71,8 @@ type Action =
       type: 'ROW_MOVED';
       payload: { row: DraggableRow; targetGroupKey?: number };
     }
-  | { type: 'DELETE_ROW'; payload: { row: ExpressionConditionType; group?: ExpressionGroupType } };
+  | { type: 'DELETE_ROW'; payload: { row: ExpressionConditionType; group?: ExpressionGroupType } }
+  | { type: 'CONVERT_ROWS_TO_LIST_OPERATOR'; payload: { suggestion: ListOperatorSuggestion } };
 
 interface State {
   getResourceTypeFns?: ExpressionGetResourceTypeFns;
@@ -284,9 +289,74 @@ function reducer(state: State, action: Action): State {
         showDragHandles: shouldShowDragHandles(expression),
       };
     }
+    case 'CONVERT_ROWS_TO_LIST_OPERATOR': {
+      const { suggestion } = action.payload;
+      const expression = { ...state.expression, rows: [...state.expression.rows] };
+
+      if (suggestion.groupKey == null) {
+        expression.rows = convertRowsToListOperator(expression.rows, suggestion, state.getResourceTypeFns);
+      } else {
+        const groupIdx = expression.rows.findIndex((item) => item.key === suggestion.groupKey);
+        if (groupIdx < 0) {
+          return state;
+        }
+        const group = { ...(expression.rows[groupIdx] as ExpressionGroupType) };
+        group.rows = convertRowsToListOperator(group.rows, suggestion, state.getResourceTypeFns);
+        expression.rows[groupIdx] = group;
+      }
+
+      return {
+        ...state,
+        expression,
+      };
+    }
     default:
       throw new Error('Invalid action');
   }
+}
+
+/**
+ * Replaces every row named by the suggestion with one row using the list operator, keeping the position of
+ * the first matched row. Rows the suggestion does not name (including groups) are left untouched.
+ */
+function convertRowsToListOperator<T extends ExpressionConditionType | ExpressionGroupType>(
+  rows: T[],
+  suggestion: ListOperatorSuggestion,
+  getResourceTypeFns?: ExpressionGetResourceTypeFns,
+): T[] {
+  const [firstRowKey] = suggestion.rowKeys;
+  const rowKeysToReplace = new Set(suggestion.rowKeys);
+  return rows.reduce((newRows: T[], row) => {
+    if (!isExpressionConditionType(row) || !rowKeysToReplace.has(row.key)) {
+      newRows.push(row);
+    } else if (row.key === firstRowKey) {
+      newRows.push(buildListOperatorRow(row, suggestion, getResourceTypeFns) as T);
+    }
+    return newRows;
+  }, []);
+}
+
+function buildListOperatorRow(
+  row: ExpressionConditionType,
+  suggestion: ListOperatorSuggestion,
+  getResourceTypeFns?: ExpressionGetResourceTypeFns,
+): ExpressionConditionType {
+  // the field metadata rules read the value as a set of selections, so the merged values stay a list while the
+  // row metadata is derived - a newline joined value would register as one unrecognized picklist value
+  const selectedForResourceMeta: ExpressionConditionRowSelectedItems = {
+    ...row.selected,
+    operator: suggestion.toOperator,
+    resourceType: suggestion.targetResourceType,
+    value: suggestion.values,
+  };
+  const newRow: ExpressionConditionType = { ...row, resourceType: suggestion.targetResourceType, selected: selectedForResourceMeta };
+  if (getResourceTypeFns) {
+    // recalculates the value input and its options so picklist values not in the field's list are kept
+    updateResourcesOnRow(newRow, selectedForResourceMeta, getResourceTypeFns);
+  }
+  // the value input the row ends up with decides the final shape (e.x. a textarea takes newline separated values)
+  newRow.selected = { ...newRow.selected, value: getListOperatorSuggestionValue(suggestion) };
+  return newRow;
 }
 
 function initExpression(expression?: ExpressionType): ExpressionType {
@@ -384,10 +454,31 @@ export const ExpressionContainer: FunctionComponent<ExpressionContainerProps> = 
     expressionInitValue,
     getResourceTypeFns,
     disableValueForOperators,
+    onConvertToListOperator,
     onChange,
   }) => {
     const [displayOption, setDisplayOption] = useState(DISPLAY_OPT_WRAP);
     const [{ expression, showDragHandles }, dispatch] = useReducer(reducer, expressionInitValue, getInitialState);
+    // dismissals are intentionally scoped to the lifetime of the component - remounting (a new sobject or a
+    // restored query) produces a different set of conditions, which deserves a fresh suggestion
+    const [dismissedSuggestionIds, setDismissedSuggestionIds] = useState<Set<string>>(() => new Set());
+
+    const suggestions = useMemo(
+      () => getListOperatorSuggestions(expression, getResourceTypeFns, operators).filter(({ id }) => !dismissedSuggestionIds.has(id)),
+      [dismissedSuggestionIds, expression, getResourceTypeFns, operators],
+    );
+
+    // mirrors the group number each group is rendered with, so a suggestion can name the group it applies to
+    const groupNumberByGroupKey = useMemo(
+      () =>
+        expression.rows.reduce((groupNumbers: Record<number, number>, row, index) => {
+          if (isExpressionGroupType(row)) {
+            groupNumbers[row.key] = index + 1;
+          }
+          return groupNumbers;
+        }, {}),
+      [expression.rows],
+    );
 
     useEffect(() => {
       dispatch({ type: 'RESOURCE_FILTERS', payload: { getResourceTypeFns } });
@@ -398,6 +489,18 @@ export const ExpressionContainer: FunctionComponent<ExpressionContainerProps> = 
         onChange(expression);
       }
     }, [expression, onChange]);
+
+    const handleConvertToListOperator = useCallback(
+      (suggestion: ListOperatorSuggestion) => {
+        dispatch({ type: 'CONVERT_ROWS_TO_LIST_OPERATOR', payload: { suggestion } });
+        onConvertToListOperator?.(suggestion);
+      },
+      [onConvertToListOperator],
+    );
+
+    const handleDismissSuggestion = useCallback(({ id }: ListOperatorSuggestion) => {
+      setDismissedSuggestionIds((priorIds) => new Set(priorIds).add(id));
+    }, []);
 
     const moveRowToGroup = useCallback((row: DraggableRow, targetGroupKey?: number) => {
       dispatch({ type: 'ROW_MOVED', payload: { row, targetGroupKey } });
@@ -477,6 +580,14 @@ export const ExpressionContainer: FunctionComponent<ExpressionContainerProps> = 
                 onSelected={(id) => setDisplayOption(id)}
               />
             </div>
+          }
+          notification={
+            <ExpressionListOperatorSuggestions
+              suggestions={suggestions}
+              groupNumberByGroupKey={groupNumberByGroupKey}
+              onConvert={handleConvertToListOperator}
+              onDismiss={handleDismissSuggestion}
+            />
           }
           onActionChange={handleExpressionActionChange}
           onAddCondition={handleAddCondition}

--- a/libs/ui/src/lib/expression-group/ExpressionListOperatorSuggestions.tsx
+++ b/libs/ui/src/lib/expression-group/ExpressionListOperatorSuggestions.tsx
@@ -1,0 +1,75 @@
+import classNames from 'classnames';
+import { FunctionComponent } from 'react';
+import Grid from '../grid/Grid';
+import ScopedNotification from '../scoped-notification/ScopedNotification';
+import Icon from '../widgets/Icon';
+import { ListOperatorSuggestion } from './expression-list-operator-utils';
+
+export interface ExpressionListOperatorSuggestionsProps {
+  suggestions: ListOperatorSuggestion[];
+  /** Condition group number by group key, matching the number announced on the group itself */
+  groupNumberByGroupKey: Record<number, number>;
+  onConvert: (suggestion: ListOperatorSuggestion) => void;
+  onDismiss: (suggestion: ListOperatorSuggestion) => void;
+}
+
+/**
+ * Offers to replace repeated conditions on the same field with a single In / Not In condition.
+ * The light theme is deliberate - themed scoped notifications restyle bare neutral buttons.
+ */
+export const ExpressionListOperatorSuggestions: FunctionComponent<ExpressionListOperatorSuggestionsProps> = ({
+  suggestions,
+  groupNumberByGroupKey,
+  onConvert,
+  onDismiss,
+}) => {
+  if (!suggestions.length) {
+    return null;
+  }
+
+  return (
+    <ScopedNotification theme="light" className="slds-m-vertical_x-small">
+      <ul>
+        {suggestions.map((suggestion, index) => {
+          const { id, groupKey, resource, rowKeys, toOperatorLabel } = suggestion;
+          // the same field can be collapsible at the root level and inside a group, so naming the group is
+          // what keeps the two suggestions - and their accessible names - distinguishable
+          const groupNumber = groupKey == null ? undefined : groupNumberByGroupKey[groupKey];
+          const groupSuffix = groupNumber == null ? '' : ` in condition group ${groupNumber}`;
+          const dismissLabel = `Dismiss suggestion for ${resource}${groupSuffix}`;
+          return (
+            <li key={id} className={classNames({ 'slds-m-top_xx-small': index > 0 })}>
+              <Grid verticalAlign="center" align="spread" wrap>
+                <span className="slds-m-right_small">
+                  <strong>{resource}</strong>
+                  {` appears in ${rowKeys.length} conditions${groupSuffix} that can be combined into one.`}
+                </span>
+                <Grid verticalAlign="center">
+                  <button
+                    type="button"
+                    className="slds-button slds-button_neutral"
+                    aria-label={`Use ${toOperatorLabel} operator for ${resource}${groupSuffix}`}
+                    onClick={() => onConvert(suggestion)}
+                  >
+                    {`Use ${toOperatorLabel} operator`}
+                  </button>
+                  <button
+                    type="button"
+                    className="slds-button slds-button_icon slds-button_icon-small slds-m-left_xx-small"
+                    title={dismissLabel}
+                    onClick={() => onDismiss(suggestion)}
+                  >
+                    <Icon type="utility" icon="close" omitContainer className="slds-button__icon" />
+                    <span className="slds-assistive-text">{dismissLabel}</span>
+                  </button>
+                </Grid>
+              </Grid>
+            </li>
+          );
+        })}
+      </ul>
+    </ScopedNotification>
+  );
+};
+
+export default ExpressionListOperatorSuggestions;

--- a/libs/ui/src/lib/expression-group/__tests__/ExpressionContainer.spec.tsx
+++ b/libs/ui/src/lib/expression-group/__tests__/ExpressionContainer.spec.tsx
@@ -1,0 +1,122 @@
+import {
+  ExpressionConditionType,
+  ExpressionGetResourceTypeFns,
+  ExpressionType,
+  ListItem,
+  QueryFilterOperator,
+  SalesforceOrgUi,
+} from '@jetstream/types';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { ExpressionContainer } from '../ExpressionContainer';
+
+const ORG = {} as SalesforceOrgUi;
+
+const RESOURCES: ListItem[] = [{ id: 'Name', label: 'Name', value: 'Name', meta: { name: 'Name', type: 'string' } }];
+
+const OPERATORS: ListItem[] = [
+  { id: 'eq', label: 'Equals', value: 'eq' },
+  { id: 'in', label: 'In', value: 'in' },
+];
+
+// Stands in for the query builder's field metadata rules: a list operator swaps the single line input for a textarea
+const RESOURCE_TYPE_FNS: ExpressionGetResourceTypeFns = {
+  getType: ({ operator }) => (operator === 'in' || operator === 'notIn' ? 'TEXTAREA' : 'TEXT'),
+  getSelectItems: () => [],
+};
+
+function createRow(key: number, value: string, operator: QueryFilterOperator = 'eq'): ExpressionConditionType {
+  return {
+    key,
+    resourceType: 'TEXT',
+    selected: { resource: 'Name', resourceGroup: null, function: null, operator, value },
+  };
+}
+
+function renderExpression(expressionInitValue: ExpressionType) {
+  const onChange = vi.fn();
+  render(
+    <ExpressionContainer
+      org={ORG}
+      actionLabel="Filter When"
+      resources={RESOURCES}
+      operators={OPERATORS}
+      expressionInitValue={expressionInitValue}
+      getResourceTypeFns={RESOURCE_TYPE_FNS}
+      onChange={onChange}
+    />,
+  );
+  return {
+    onChange,
+    /** Throws (so `waitFor` retries) until the container has pushed an expression out */
+    getLatestExpression: (): ExpressionType => {
+      const expression = onChange.mock.calls.at(-1)?.[0] as ExpressionType | undefined;
+      if (!expression) {
+        throw new Error('onChange has not been called yet');
+      }
+      return expression;
+    },
+  };
+}
+
+describe('ExpressionContainer list operator suggestions', () => {
+  it('offers to combine repeated conditions and replaces them with a single list operator row', async () => {
+    const { getLatestExpression } = renderExpression({
+      action: 'OR',
+      rows: [createRow(0, 'Acme'), createRow(1, 'Initech')],
+    });
+
+    expect(screen.getByText(/appears in 2 conditions/)).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Use In operator for Name' }));
+
+    await waitFor(() => expect(getLatestExpression().rows).toHaveLength(1));
+
+    const [row] = getLatestExpression().rows as ExpressionConditionType[];
+    expect(row.key).toBe(0);
+    // the row keeps the multi value input; `selected.resourceType` is only populated for fields that offer a Type dropdown
+    expect(row.resourceType).toBe('TEXTAREA');
+    expect(row.selected).toMatchObject({ resource: 'Name', operator: 'in', value: 'Acme\nInitech' });
+    expect(screen.queryByText(/appears in 2 conditions/)).toBeNull();
+  });
+
+  it('hides a dismissed suggestion without changing the conditions', async () => {
+    const { onChange, getLatestExpression } = renderExpression({
+      action: 'OR',
+      rows: [createRow(0, 'Acme'), createRow(1, 'Initech')],
+    });
+
+    // let the rows settle so a later onChange can only come from the dismissal
+    await waitFor(() => expect(onChange).toHaveBeenCalled());
+    const callCountBeforeDismiss = onChange.mock.calls.length;
+
+    fireEvent.click(screen.getByRole('button', { name: 'Dismiss suggestion for Name' }));
+
+    expect(screen.queryByText(/appears in 2 conditions/)).toBeNull();
+    expect(onChange.mock.calls.length).toBe(callCountBeforeDismiss);
+    expect(getLatestExpression().rows).toHaveLength(2);
+  });
+
+  it('names the group so a root level suggestion and a group suggestion for the same field stay distinct', () => {
+    renderExpression({
+      action: 'OR',
+      rows: [
+        createRow(0, 'Acme'),
+        createRow(1, 'Initech'),
+        { key: 2, action: 'OR', rows: [createRow(3, 'Hooli'), createRow(4, 'Soylent')] },
+      ],
+    });
+
+    // the group is the third row, matching the "Condition Group 3" label the group itself announces
+    expect(screen.getByRole('button', { name: 'Use In operator for Name' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Use In operator for Name in condition group 3' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Dismiss suggestion for Name' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Dismiss suggestion for Name in condition group 3' })).toBeTruthy();
+  });
+
+  it('does not offer a suggestion when the conditions are joined by AND', () => {
+    renderExpression({ action: 'AND', rows: [createRow(0, 'Acme'), createRow(1, 'Initech')] });
+
+    expect(screen.queryByText(/can be combined/)).toBeNull();
+  });
+});

--- a/libs/ui/src/lib/expression-group/__tests__/expression-list-operator-utils.spec.ts
+++ b/libs/ui/src/lib/expression-group/__tests__/expression-list-operator-utils.spec.ts
@@ -1,0 +1,336 @@
+import {
+  ExpressionConditionRowSelectedItems,
+  ExpressionConditionType,
+  ExpressionGetResourceTypeFns,
+  ExpressionGroupType,
+  ExpressionRowValueType,
+  ExpressionType,
+  ListItem,
+  QueryFilterOperator,
+} from '@jetstream/types';
+import { describe, expect, it } from 'vitest';
+import { getListOperatorSuggestions, getListOperatorSuggestionValue } from '../expression-list-operator-utils';
+
+const OPERATORS: ListItem[] = [
+  { id: 'eq', label: 'Equals', value: 'eq' },
+  { id: 'ne', label: 'Does Not Equal', value: 'ne' },
+  { id: 'in', label: 'In', value: 'in' },
+  { id: 'notIn', label: 'Not In', value: 'notIn' },
+];
+
+type TestFieldType = 'string' | 'int' | 'boolean' | 'picklist' | 'multipicklist' | 'reference' | 'date' | 'datetime';
+
+const LIST_OPERATORS = new Set<QueryFilterOperator>(['in', 'notIn', 'includes', 'excludes']);
+
+function toListItems(values: ExpressionRowValueType[]): ListItem<ExpressionRowValueType>[] {
+  return values.map((value) => ({ id: value, label: value, value }));
+}
+
+/**
+ * Mirrors the rules that `getResourceTypeFnsFromFields` derives from field metadata, so suggestions are
+ * exercised against the same value input decisions the query builder makes at runtime.
+ */
+function createResourceTypeFns(fieldTypeByResource: Record<string, TestFieldType>): ExpressionGetResourceTypeFns {
+  function getFieldType({ resource }: ExpressionConditionRowSelectedItems): TestFieldType | undefined {
+    return fieldTypeByResource[resource || ''];
+  }
+  return {
+    getTypes: (selected) => {
+      const fieldType = getFieldType(selected);
+      const isListOperator = LIST_OPERATORS.has(selected.operator as QueryFilterOperator);
+      switch (fieldType) {
+        case 'picklist':
+        case 'multipicklist':
+          return toListItems(isListOperator ? ['SELECT-MULTI', 'TEXTAREA'] : ['SELECT', 'TEXT']);
+        case 'date':
+          return toListItems(isListOperator ? ['DATE', 'SELECT-MULTI', 'TEXT'] : ['DATE', 'SELECT', 'TEXT']);
+        case 'datetime':
+          return toListItems(isListOperator ? ['DATETIME', 'SELECT-MULTI', 'TEXT'] : ['DATETIME', 'SELECT', 'TEXT']);
+        default:
+          return undefined;
+      }
+    },
+    getType: (selected) => {
+      const fieldType = getFieldType(selected);
+      if (!fieldType) {
+        return undefined;
+      }
+      if (selected.resourceType) {
+        return selected.resourceType;
+      }
+      const isListOperator = LIST_OPERATORS.has(selected.operator as QueryFilterOperator);
+      switch (fieldType) {
+        case 'date':
+          return 'DATE';
+        case 'datetime':
+        case 'boolean':
+        case 'picklist':
+        case 'multipicklist':
+          return isListOperator ? 'SELECT-MULTI' : 'SELECT';
+        case 'reference':
+          return isListOperator ? 'TEXTAREA' : 'LOOKUP';
+        default:
+          return isListOperator ? 'TEXTAREA' : 'TEXT';
+      }
+    },
+    getSelectItems: () => [],
+  };
+}
+
+function createRow(
+  key: number,
+  resource: string,
+  operator: QueryFilterOperator,
+  value: string | string[],
+  resourceType: ExpressionRowValueType,
+  selectedOverrides: Partial<ExpressionConditionRowSelectedItems> = {},
+): ExpressionConditionType {
+  return {
+    key,
+    resourceType,
+    selected: { resource, resourceGroup: null, function: null, operator, value, ...selectedOverrides },
+  };
+}
+
+function createGroup(key: number, action: 'AND' | 'OR', rows: ExpressionConditionType[]): ExpressionGroupType {
+  return { key, action, rows };
+}
+
+function getSuggestions(expression: ExpressionType, fieldTypeByResource: Record<string, TestFieldType>) {
+  return getListOperatorSuggestions(expression, createResourceTypeFns(fieldTypeByResource), OPERATORS);
+}
+
+describe('getListOperatorSuggestions', () => {
+  it('suggests In for repeated Equals conditions on a picklist joined by OR', () => {
+    const suggestions = getSuggestions(
+      {
+        action: 'OR',
+        rows: [
+          createRow(0, 'StageName', 'eq', 'Prospecting', 'SELECT'),
+          createRow(1, 'StageName', 'eq', 'Qualification', 'SELECT'),
+          createRow(2, 'StageName', 'eq', 'Closed Won', 'SELECT'),
+        ],
+      },
+      { StageName: 'picklist' },
+    );
+
+    expect(suggestions).toHaveLength(1);
+    expect(suggestions[0]).toMatchObject({
+      resource: 'StageName',
+      fromOperator: 'eq',
+      toOperator: 'in',
+      toOperatorLabel: 'In',
+      rowKeys: [0, 1, 2],
+      targetResourceType: 'SELECT-MULTI',
+      values: ['Prospecting', 'Qualification', 'Closed Won'],
+    });
+    expect(suggestions[0].groupKey).toBeUndefined();
+    expect(getListOperatorSuggestionValue(suggestions[0])).toEqual(['Prospecting', 'Qualification', 'Closed Won']);
+  });
+
+  it('suggests Not In for repeated Does Not Equal conditions on a text field joined by AND', () => {
+    const suggestions = getSuggestions(
+      {
+        action: 'AND',
+        rows: [createRow(0, 'Name', 'ne', 'Acme', 'TEXT'), createRow(1, 'Name', 'ne', 'Initech', 'TEXT')],
+      },
+      { Name: 'string' },
+    );
+
+    expect(suggestions).toHaveLength(1);
+    expect(suggestions[0]).toMatchObject({
+      toOperator: 'notIn',
+      toOperatorLabel: 'Not In',
+      targetResourceType: 'TEXTAREA',
+      values: ['Acme', 'Initech'],
+    });
+    expect(getListOperatorSuggestionValue(suggestions[0])).toBe('Acme\nInitech');
+  });
+
+  it('trims and de-dupes merged values while keeping first-occurrence order', () => {
+    const suggestions = getSuggestions(
+      {
+        action: 'OR',
+        rows: [
+          createRow(0, 'Name', 'eq', ' Acme ', 'TEXT'),
+          createRow(1, 'Name', 'eq', 'Initech', 'TEXT'),
+          createRow(2, 'Name', 'eq', 'Acme', 'TEXT'),
+        ],
+      },
+      { Name: 'string' },
+    );
+
+    expect(suggestions[0].values).toEqual(['Acme', 'Initech']);
+    expect(suggestions[0].rowKeys).toEqual([0, 1, 2]);
+  });
+
+  it('does not suggest when the conjunction does not match the operator', () => {
+    const equalsWithAnd = getSuggestions(
+      { action: 'AND', rows: [createRow(0, 'Name', 'eq', 'Acme', 'TEXT'), createRow(1, 'Name', 'eq', 'Initech', 'TEXT')] },
+      { Name: 'string' },
+    );
+    const notEqualsWithOr = getSuggestions(
+      { action: 'OR', rows: [createRow(0, 'Name', 'ne', 'Acme', 'TEXT'), createRow(1, 'Name', 'ne', 'Initech', 'TEXT')] },
+      { Name: 'string' },
+    );
+
+    expect(equalsWithAnd).toEqual([]);
+    expect(notEqualsWithOr).toEqual([]);
+  });
+
+  it('does not suggest for a single condition, mixed fields, or mixed operators', () => {
+    const fields: Record<string, TestFieldType> = { Name: 'string', Type: 'string' };
+
+    expect(getSuggestions({ action: 'OR', rows: [createRow(0, 'Name', 'eq', 'Acme', 'TEXT')] }, fields)).toEqual([]);
+    expect(
+      getSuggestions(
+        { action: 'OR', rows: [createRow(0, 'Name', 'eq', 'Acme', 'TEXT'), createRow(1, 'Type', 'eq', 'Acme', 'TEXT')] },
+        fields,
+      ),
+    ).toEqual([]);
+    expect(
+      getSuggestions(
+        { action: 'OR', rows: [createRow(0, 'Name', 'eq', 'Acme', 'TEXT'), createRow(1, 'Name', 'ne', 'Initech', 'TEXT')] },
+        fields,
+      ),
+    ).toEqual([]);
+  });
+
+  it('ignores conditions without a value', () => {
+    const suggestions = getSuggestions(
+      {
+        action: 'OR',
+        rows: [createRow(0, 'Name', 'eq', 'Acme', 'TEXT'), createRow(1, 'Name', 'eq', '', 'TEXT'), createRow(2, 'Name', 'eq', [], 'TEXT')],
+      },
+      { Name: 'string' },
+    );
+
+    expect(suggestions).toEqual([]);
+  });
+
+  it('ignores conditions that use a field function, which the having clause relies on', () => {
+    const suggestions = getSuggestions(
+      {
+        action: 'OR',
+        rows: [
+          createRow(0, 'Amount', 'eq', '1', 'TEXT', { function: 'COUNT' }),
+          createRow(1, 'Amount', 'eq', '2', 'TEXT', { function: 'COUNT' }),
+        ],
+      },
+      { Amount: 'int' },
+    );
+
+    expect(suggestions).toEqual([]);
+  });
+
+  it('does not merge rows that use different value inputs for the same field', () => {
+    const suggestions = getSuggestions(
+      {
+        action: 'OR',
+        rows: [createRow(0, 'StageName', 'eq', 'Prospecting', 'SELECT'), createRow(1, 'StageName', 'eq', 'Custom', 'TEXT')],
+      },
+      { StageName: 'picklist' },
+    );
+
+    expect(suggestions).toEqual([]);
+  });
+
+  it('suggests for date fields using relative values but not for the date picker', () => {
+    const relativeValues = getSuggestions(
+      {
+        action: 'OR',
+        rows: [createRow(0, 'CloseDate', 'eq', 'LAST_WEEK', 'SELECT'), createRow(1, 'CloseDate', 'eq', 'TODAY', 'SELECT')],
+      },
+      { CloseDate: 'date' },
+    );
+    const datePicker = getSuggestions(
+      {
+        action: 'OR',
+        rows: [createRow(0, 'CloseDate', 'eq', '2026-01-01', 'DATE'), createRow(1, 'CloseDate', 'eq', '2026-02-01', 'DATE')],
+      },
+      { CloseDate: 'date' },
+    );
+
+    expect(relativeValues).toHaveLength(1);
+    expect(relativeValues[0]).toMatchObject({ targetResourceType: 'SELECT-MULTI', values: ['LAST_WEEK', 'TODAY'] });
+    expect(datePicker).toEqual([]);
+  });
+
+  it('does not suggest for a date field using manual text, which has no multi value input', () => {
+    const suggestions = getSuggestions(
+      {
+        action: 'OR',
+        rows: [createRow(0, 'CloseDate', 'eq', 'yesterday', 'TEXT'), createRow(1, 'CloseDate', 'eq', 'tomorrow', 'TEXT')],
+      },
+      { CloseDate: 'date' },
+    );
+
+    expect(suggestions).toEqual([]);
+  });
+
+  it('converts a reference field lookup into the multi value textarea', () => {
+    const suggestions = getSuggestions(
+      {
+        action: 'OR',
+        rows: [createRow(0, 'AccountId', 'eq', '001000000000001', 'LOOKUP'), createRow(1, 'AccountId', 'eq', '001000000000002', 'LOOKUP')],
+      },
+      { AccountId: 'reference' },
+    );
+
+    expect(suggestions[0]).toMatchObject({ targetResourceType: 'TEXTAREA', values: ['001000000000001', '001000000000002'] });
+  });
+
+  it('evaluates group rows against the group action rather than the expression action', () => {
+    const suggestions = getSuggestions(
+      {
+        action: 'AND',
+        rows: [
+          createRow(0, 'Name', 'eq', 'Acme', 'TEXT'),
+          createGroup(1, 'OR', [createRow(2, 'Type', 'eq', 'Customer', 'TEXT'), createRow(3, 'Type', 'eq', 'Partner', 'TEXT')]),
+        ],
+      },
+      { Name: 'string', Type: 'string' },
+    );
+
+    expect(suggestions).toHaveLength(1);
+    expect(suggestions[0]).toMatchObject({ groupKey: 1, resource: 'Type', rowKeys: [2, 3] });
+  });
+
+  it('keeps the suggestion id stable when the matched rows change', () => {
+    const twoRows = getSuggestions(
+      { action: 'OR', rows: [createRow(0, 'Name', 'eq', 'Acme', 'TEXT'), createRow(1, 'Name', 'eq', 'Initech', 'TEXT')] },
+      { Name: 'string' },
+    );
+    const threeRows = getSuggestions(
+      {
+        action: 'OR',
+        rows: [
+          createRow(0, 'Name', 'eq', 'Acme Updated', 'TEXT'),
+          createRow(1, 'Name', 'eq', 'Initech', 'TEXT'),
+          createRow(5, 'Name', 'eq', 'Umbrella', 'TEXT'),
+        ],
+      },
+      { Name: 'string' },
+    );
+
+    expect(twoRows[0].id).toEqual(threeRows[0].id);
+  });
+
+  it('returns nothing when resource type functions are not provided', () => {
+    const expression: ExpressionType = {
+      action: 'OR',
+      rows: [createRow(0, 'Name', 'eq', 'Acme', 'TEXT'), createRow(1, 'Name', 'eq', 'Initech', 'TEXT')],
+    };
+
+    expect(getListOperatorSuggestions(expression, undefined, OPERATORS)).toEqual([]);
+  });
+
+  it('returns nothing when the consumer does not offer the list operators', () => {
+    const expression: ExpressionType = {
+      action: 'OR',
+      rows: [createRow(0, 'Name', 'eq', 'Acme', 'TEXT'), createRow(1, 'Name', 'eq', 'Initech', 'TEXT')],
+    };
+
+    expect(getListOperatorSuggestions(expression, createResourceTypeFns({ Name: 'string' }), [OPERATORS[0]])).toEqual([]);
+  });
+});

--- a/libs/ui/src/lib/expression-group/expression-list-operator-utils.ts
+++ b/libs/ui/src/lib/expression-group/expression-list-operator-utils.ts
@@ -1,0 +1,209 @@
+import {
+  AndOr,
+  ExpressionConditionRowSelectedItems,
+  ExpressionConditionType,
+  ExpressionGetResourceTypeFns,
+  ExpressionRowValueType,
+  ExpressionType,
+  ListItem,
+  Maybe,
+  QueryFilterOperator,
+} from '@jetstream/types';
+import { isExpressionConditionType, isExpressionGroupType } from './expression-utils';
+
+/**
+ * Repeated conditions on one field only collapse into a list operator when the conjunction agrees:
+ * `A = 1 OR A = 2` is `A IN (1, 2)` and `A != 1 AND A != 2` is `A NOT IN (1, 2)`.
+ * The other two combinations (`A = 1 AND A = 2`, `A != 1 OR A != 2`) are degenerate and never collapsed.
+ */
+const COLLAPSIBLE_OPERATOR_BY_ACTION: Record<AndOr, { from: QueryFilterOperator; to: QueryFilterOperator }> = {
+  OR: { from: 'eq', to: 'in' },
+  AND: { from: 'ne', to: 'notIn' },
+};
+
+/**
+ * Single value inputs mapped to the multi value input that replaces them under a list operator.
+ * The date and datetime pickers are intentionally absent - they have no multi value equivalent,
+ * so rows using them are never offered for conversion.
+ */
+const MULTI_VALUE_TYPE_BY_SINGLE_VALUE_TYPE: Partial<Record<ExpressionRowValueType, ExpressionRowValueType>> = {
+  SELECT: 'SELECT-MULTI',
+  TEXT: 'TEXTAREA',
+  LOOKUP: 'TEXTAREA',
+};
+
+export interface ListOperatorSuggestion {
+  /**
+   * Identifies the suggestion by what it targets rather than by the rows it currently matches, so that
+   * editing a value or adding another condition does not resurrect a suggestion the user dismissed.
+   */
+  id: string;
+  groupKey?: number;
+  resource: string;
+  fromOperator: QueryFilterOperator;
+  toOperator: QueryFilterOperator;
+  toOperatorLabel: string;
+  rowKeys: number[];
+  targetResourceType: ExpressionRowValueType;
+  /** merged values from every matched row - trimmed, de-duped, in first-occurrence order */
+  values: string[];
+}
+
+/** The merged values in the shape the target value input expects */
+export function getListOperatorSuggestionValue({ targetResourceType, values }: ListOperatorSuggestion): string | string[] {
+  return targetResourceType === 'SELECT-MULTI' ? values : values.join('\n');
+}
+
+/**
+ * Find sets of conditions that repeat the same field with the same operator and could be replaced by a
+ * single `In` / `Not In` condition. Root level rows are evaluated against the expression action and each
+ * group's rows against that group's action - both are uniform conjunctions, so collapsing a subset of
+ * rows is always equivalent to the original.
+ */
+export function getListOperatorSuggestions(
+  expression: ExpressionType,
+  getResourceTypeFns: Maybe<ExpressionGetResourceTypeFns>,
+  operators: ListItem[],
+): ListOperatorSuggestion[] {
+  // Without the resource type functions there is no way to know which value input a list operator would
+  // render for the field, so no conversion can be proven safe.
+  if (!getResourceTypeFns) {
+    return [];
+  }
+
+  const rootRows = expression.rows.filter(isExpressionConditionType);
+  const suggestions = getSuggestionsForRows(rootRows, expression.action, getResourceTypeFns, operators, {});
+
+  expression.rows.forEach((row) => {
+    if (isExpressionGroupType(row)) {
+      suggestions.push(...getSuggestionsForRows(row.rows, row.action, getResourceTypeFns, operators, { groupKey: row.key }));
+    }
+  });
+
+  return suggestions;
+}
+
+function getSuggestionsForRows(
+  rows: ExpressionConditionType[],
+  action: AndOr,
+  getResourceTypeFns: ExpressionGetResourceTypeFns,
+  operators: ListItem[],
+  { groupKey }: { groupKey?: number },
+): ListOperatorSuggestion[] {
+  const { from: fromOperator, to: toOperator } = COLLAPSIBLE_OPERATOR_BY_ACTION[action];
+  const toOperatorLabel = operators.find(({ value }) => value === toOperator)?.label;
+  // the list operators are not guaranteed to be offered by every consumer of the expression builder
+  if (!toOperatorLabel) {
+    return [];
+  }
+
+  const rowsByResource = new Map<string, ExpressionConditionType[]>();
+  rows
+    .filter((row) => isCollapsibleRow(row, fromOperator))
+    .forEach((row) => {
+      const resourceKey = getResourceKey(row.selected);
+      const matchedRows = rowsByResource.get(resourceKey);
+      if (matchedRows) {
+        matchedRows.push(row);
+      } else {
+        rowsByResource.set(resourceKey, [row]);
+      }
+    });
+
+  const suggestions: ListOperatorSuggestion[] = [];
+  rowsByResource.forEach((matchedRows) => {
+    if (matchedRows.length < 2) {
+      return;
+    }
+    const [firstRow] = matchedRows;
+    const sourceResourceType = getRowResourceType(firstRow);
+    const targetResourceType = MULTI_VALUE_TYPE_BY_SINGLE_VALUE_TYPE[sourceResourceType];
+    // every row must use the same input, otherwise the merged values cannot all be represented
+    if (!targetResourceType || matchedRows.some((row) => getRowResourceType(row) !== sourceResourceType)) {
+      return;
+    }
+    const values = mergeRowValues(matchedRows);
+    if (!isTargetResourceTypeAvailable(firstRow.selected, toOperator, targetResourceType, values, getResourceTypeFns)) {
+      return;
+    }
+    suggestions.push({
+      id: `${groupKey ?? 'root'}|${getResourceKey(firstRow.selected)}|${toOperator}`,
+      groupKey,
+      resource: firstRow.selected.resource || '',
+      fromOperator,
+      toOperator,
+      toOperatorLabel,
+      rowKeys: matchedRows.map(({ key }) => key),
+      targetResourceType,
+      values,
+    });
+  });
+
+  return suggestions;
+}
+
+function getResourceKey({ resourceGroup, resource }: ExpressionConditionRowSelectedItems): string {
+  return `${resourceGroup || ''}|${resource}`;
+}
+
+/** The row's resourceType drives which value input is rendered, and defaults to TEXT the same way the row does */
+function getRowResourceType(row: ExpressionConditionType): ExpressionRowValueType {
+  return row.resourceType || 'TEXT';
+}
+
+function isCollapsibleRow(row: ExpressionConditionType, fromOperator: QueryFilterOperator): boolean {
+  const { resource, operator, function: fieldFunction, value } = row.selected;
+  return (
+    !!resource &&
+    operator === fromOperator &&
+    // aggregate and date functions (the having clause) change how the value is serialized, so they are left alone
+    !fieldFunction &&
+    (Array.isArray(value) ? value.length > 0 : !!value)
+  );
+}
+
+function mergeRowValues(rows: ExpressionConditionType[]): string[] {
+  const values: string[] = [];
+  const seenValues = new Set<string>();
+  rows.forEach(({ selected }) => {
+    // single value inputs never contain newlines, but splitting also handles a pasted list
+    const rowValues = Array.isArray(selected.value) ? selected.value : `${selected.value ?? ''}`.split('\n');
+    rowValues.forEach((rowValue) => {
+      const value = rowValue.trim();
+      if (value && !seenValues.has(value)) {
+        seenValues.add(value);
+        values.push(value);
+      }
+    });
+  });
+  return values;
+}
+
+/**
+ * A list operator can offer a different set of value inputs than the current operator does - a date field
+ * offers a multi-select of relative values but has no multi value date picker, for example. Ask the
+ * resource type functions what the list operator would render rather than duplicating field metadata rules.
+ */
+function isTargetResourceTypeAvailable(
+  selected: ExpressionConditionRowSelectedItems,
+  toOperator: QueryFilterOperator,
+  targetResourceType: ExpressionRowValueType,
+  values: string[],
+  getResourceTypeFns: ExpressionGetResourceTypeFns,
+): boolean {
+  const selectedWithListOperator: ExpressionConditionRowSelectedItems = {
+    ...selected,
+    operator: toOperator,
+    resourceType: undefined,
+    value: values,
+  };
+  try {
+    const availableTypes = getResourceTypeFns.getTypes?.(selectedWithListOperator);
+    if (availableTypes?.length) {
+      return availableTypes.some(({ value }) => value === targetResourceType);
+    }
+    return getResourceTypeFns.getType(selectedWithListOperator) === targetResourceType;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
The query builder now detects 2+ conditions on the same field that can be collapsed — OR + Equals into In, AND + Does Not Equal into Not In — and offers a one-click conversion in a dismissible inline hint above the filter rows. Rows using a date picker or a field function are skipped, since neither survives the rewrite unchanged.

Closes #1987