### PR TITLE
fix(desktop): fail builds on incomplete app.asar and fix download links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [10.15.1](https://github.com/jetstreamapp/jetstream/compare/v10.15.0...v10.15.1) (2026-08-24)
+
+### Bug Fixes
+
+- **desktop:** fail builds on incomplete app.asar and fix download links ([1f35d90](https://github.com/jetstreamapp/jetstream/commit/1f35d903817dcfab3209bab45163508f72bd7326))
+
 ## [10.15.0](https://github.com/jetstreamapp/jetstream/compare/v10.14.1...v10.15.0) (2026-08-23)
 
 ### Features

--- a/apps/api/src/app/controllers/desktop-assets.controller.ts
+++ b/apps/api/src/app/controllers/desktop-assets.controller.ts
@@ -55,8 +55,6 @@ export const routeDefinition = {
 
 const getDownloadLink = createRoute(routeDefinition.getDownloadLink.validators, async ({ params }, _req, res) => {
   try {
-    const { arch, platform } = params;
-
     // Get latest version info from your S3 bucket
     const latestVersion = await getLatestDesktopVersion(params);
 
@@ -65,8 +63,9 @@ const getDownloadLink = createRoute(routeDefinition.getDownloadLink.validators, 
       return;
     }
 
-    // Generate direct download URL using friendly subdomain
-    const downloadUrl = `https://releases.getjetstream.app/jetstream/${platform}/${arch}/${latestVersion.filename}`;
+    // Use the service-provided link — artifacts only exist at jetstream/releases/<filename>
+    // in the bucket; the old "friendly" jetstream/<platform>/<arch>/ path never had objects.
+    const downloadUrl = latestVersion.link;
 
     // Return download information
     res.json({

--- a/apps/api/src/app/services/desktop-asset.service.ts
+++ b/apps/api/src/app/services/desktop-asset.service.ts
@@ -34,7 +34,10 @@ export const PlatformArchSchema = z.union([
 export type PlatformArch = z.infer<typeof PlatformArchSchema>;
 
 function getDownloadUrl(filename: string) {
-  return `https://releases.getjetstream.app/${ASSET_FOLDER}/${filename}`;
+  // release-updates.getjetstream.app is the R2 custom domain the auto-updater uses (see
+  // electron-builder.config.js publish config) and is the one known-working domain for the
+  // desktop-updates bucket. releases.getjetstream.app was never wired up and served 404s.
+  return `https://release-updates.getjetstream.app/${ASSET_FOLDER}/${filename}`;
 }
 
 async function getAndParseVersionFile(s3Client: S3Client, key: string) {

--- a/apps/api/src/app/utils/security-headers.ts
+++ b/apps/api/src/app/utils/security-headers.ts
@@ -59,6 +59,7 @@ export function buildCspDirectives(extraFrameAncestors: string[] = []): CspDirec
       'https://hooks.stripe.com',
       'https://js.stripe.com',
       'https://maps.googleapis.com',
+      'https://release-updates.getjetstream.app',
       'https://releases.getjetstream.app',
       'https://*.js.stripe.com',
       // Scope WebSocket connections to the app's own origin instead of a blanket `wss:`.

--- a/apps/api/src/app/utils/security-headers.ts
+++ b/apps/api/src/app/utils/security-headers.ts
@@ -60,7 +60,6 @@ export function buildCspDirectives(extraFrameAncestors: string[] = []): CspDirec
       'https://js.stripe.com',
       'https://maps.googleapis.com',
       'https://release-updates.getjetstream.app',
-      'https://releases.getjetstream.app',
       'https://*.js.stripe.com',
       // Scope WebSocket connections to the app's own origin instead of a blanket `wss:`.
       // In development the socket server runs on localhost over an arbitrary port.

--- a/apps/docs/release-notes/2026-08-24-v10.15.1.mdx
+++ b/apps/docs/release-notes/2026-08-24-v10.15.1.mdx
@@ -1,0 +1,30 @@
+---
+slug: v10.15.1
+title: 10.15.1 - Desktop startup crash fix
+date: '2026-08-24'
+tags: [web, desktop]
+versions:
+  web: 10.15.1
+  desktop: 4.12.1
+summary: Fixes the desktop app crash on startup in desktop version 4.12.0. If you installed 4.12.0, reinstall the app from the download page.
+highlights:
+  - title: Desktop startup crash fix
+    description: Desktop version 4.12.0 crashed on startup because of a packaging issue; reinstall the app to get the fixed version.
+    docLink: /desktop-app
+    platforms: [desktop]
+  - title: Fixed desktop download links
+    description: Download links for the desktop app now point to the correct location.
+    platforms: [web]
+---
+
+{/* truncate */}
+
+## What's new
+
+### Desktop startup crash fix
+
+Desktop version 4.12.0 crashed immediately on startup because a packaging issue left a required module out of the installed app. Version 4.12.1 fixes this, and the build process now verifies the packaged app is complete before a release can ship. Because 4.12.0 cannot start, it cannot update itself: if you installed it, download the latest installer from the [download page](https://getjetstream.app/desktop-app/) and reinstall.
+
+### Other fixes
+
+- Desktop app download links pointed to a location that no longer worked; they now download the correct installer for your platform.

--- a/apps/docs/static/release-notes.json
+++ b/apps/docs/static/release-notes.json
@@ -1,10 +1,31 @@
 [
   {
-    "slug": "v10.14.2",
-    "title": "10.14.2 - Record limit for Update Records, map one column to multiple fields",
+    "slug": "v10.15.1",
+    "title": "10.15.1 - Desktop startup crash fix",
+    "date": "2026-08-24",
+    "tags": ["web", "desktop"],
+    "versions": { "web": "10.15.1", "desktop": "4.12.1" },
+    "summary": "Fixes the desktop app crash on startup in desktop version 4.12.0. If you installed 4.12.0, reinstall the app from the download page.",
+    "highlights": [
+      {
+        "title": "Desktop startup crash fix",
+        "description": "Desktop version 4.12.0 crashed on startup because of a packaging issue; reinstall the app to get the fixed version.",
+        "platforms": ["desktop"],
+        "docLink": "/desktop-app"
+      },
+      {
+        "title": "Fixed desktop download links",
+        "description": "Download links for the desktop app now point to the correct location.",
+        "platforms": ["web"]
+      }
+    ]
+  },
+  {
+    "slug": "v10.15.0",
+    "title": "10.15.0 - Record limit for Update Records, map one column to multiple fields",
     "date": "2026-08-23",
     "tags": ["web"],
-    "versions": { "web": "10.14.2" },
+    "versions": { "web": "10.15.0" },
     "summary": "Update Records can limit how many records are updated at a time, and Load Records can map one file column to multiple Salesforce fields.",
     "highlights": [
       {

--- a/apps/jetstream-desktop/package.json
+++ b/apps/jetstream-desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "jetstream",
   "description": "The ultimate Salesforce administrator companion.",
-  "version": "4.11.1",
+  "version": "4.12.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/jetstreamapp/jetstream"

--- a/apps/jetstream-desktop/package.json
+++ b/apps/jetstream-desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "jetstream",
   "description": "The ultimate Salesforce administrator companion.",
-  "version": "4.12.0",
+  "version": "4.12.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/jetstreamapp/jetstream"

--- a/apps/jetstream-desktop/src/config/environment.ts
+++ b/apps/jetstream-desktop/src/config/environment.ts
@@ -1,6 +1,5 @@
 import { getDefaultAppState } from '@jetstream/shared/utils';
 import type { Maybe } from '@jetstream/types';
-import chalk from 'chalk';
 import { app } from 'electron';
 import { z } from 'zod';
 
@@ -75,8 +74,8 @@ const parseResults = envSchema.safeParse({
 });
 
 if (!parseResults.success) {
-  console.error(`❌ ${chalk.red('Error parsing environment variables:')}
-${chalk.yellow(JSON.stringify(z.treeifyError(parseResults.error), null, 2))}
+  console.error(`❌ Error parsing environment variables:
+${JSON.stringify(z.treeifyError(parseResults.error), null, 2)}
 `);
   process.exit(1);
 }

--- a/electron-builder.config.js
+++ b/electron-builder.config.js
@@ -93,7 +93,7 @@ async function verifyAsarDependencyClosure(context) {
   const asar = resolveElectronAsar();
 
   const resourcesDir =
-    context.electronPlatformName === 'darwin'
+    context.electronPlatformName === 'darwin' || context.electronPlatformName === 'mas'
       ? path.join(context.appOutDir, `${context.packager.appInfo.productFilename}.app`, 'Contents', 'Resources')
       : path.join(context.appOutDir, 'resources');
   const asarPath = path.join(resourcesDir, 'app.asar');
@@ -159,7 +159,7 @@ async function verifyAsarDependencyClosure(context) {
 
     const packageJson = readPackagedJson(`${packageDir}/package.json`);
     if (!packageJson) {
-      continue;
+      throw new Error(`afterPack dependency verification: could not read ${packageDir}/package.json from app.asar`);
     }
     const optionalDeps = packageJson.optionalDependencies ?? {};
     for (const childName of Object.keys({ ...packageJson.dependencies, ...optionalDeps })) {

--- a/electron-builder.config.js
+++ b/electron-builder.config.js
@@ -1,4 +1,6 @@
 require('dotenv/config');
+const { createRequire } = require('node:module');
+const fs = require('node:fs');
 const path = require('node:path');
 
 /** @typedef {import('electron-builder').Configuration} Configuration */
@@ -66,8 +68,118 @@ if (ENV.IS_CODESIGNING_ENABLED && process.platform === 'win32') {
   };
 }
 
+/**
+ * `@electron/asar` is not a direct dependency of the build dir — resolve it through
+ * electron-builder -> app-builder-lib, which always ships a compatible version.
+ */
+function resolveElectronAsar() {
+  const requireFromElectronBuilder = createRequire(require.resolve('electron-builder/package.json'));
+  const requireFromAppBuilderLib = createRequire(requireFromElectronBuilder.resolve('app-builder-lib/package.json'));
+  return requireFromAppBuilderLib('@electron/asar');
+}
+
+/**
+ * Fail the build if the packaged app.asar is missing any module in the production dependency
+ * closure. electron-builder's pnpm collector (<= 26.15.x) can silently drop a transitive
+ * dependency when pnpm's `list --json` output only expands it beneath a deduped subtree — it
+ * logs warn-level "cannot find path for dependency" / "unresolved duplicate dependency
+ * references" lines and keeps going. Desktop 4.12.0 shipped without `supports-color` (required
+ * by chalk@4) that way and crashed on startup on every install. This hook turns that class of
+ * silent packaging corruption into a hard build failure.
+ *
+ * @param {import('electron-builder').AfterPackContext} context
+ */
+async function verifyAsarDependencyClosure(context) {
+  const asar = resolveElectronAsar();
+
+  const resourcesDir =
+    context.electronPlatformName === 'darwin'
+      ? path.join(context.appOutDir, `${context.packager.appInfo.productFilename}.app`, 'Contents', 'Resources')
+      : path.join(context.appOutDir, 'resources');
+  const asarPath = path.join(resourcesDir, 'app.asar');
+  if (!fs.existsSync(asarPath)) {
+    throw new Error(`afterPack dependency verification: app.asar not found at ${asarPath}`);
+  }
+
+  // Normalize the archive listing to posix-style paths without a leading slash.
+  const packagedFiles = new Set(asar.listPackage(asarPath).map((entry) => entry.split(path.sep).join('/').replace(/^\//, '')));
+
+  const readPackagedJson = (relativePath) => {
+    try {
+      return JSON.parse(asar.extractFile(asarPath, relativePath).toString('utf-8'));
+    } catch {
+      // Files excluded from the archive via asarUnpack live next to it on disk.
+      const unpackedPath = path.join(resourcesDir, 'app.asar.unpacked', relativePath);
+      if (fs.existsSync(unpackedPath)) {
+        return JSON.parse(fs.readFileSync(unpackedPath, 'utf-8'));
+      }
+      return null;
+    }
+  };
+
+  // Resolve a dependency the way Node does: nearest nested node_modules first, then walk up.
+  const resolvePackagedDependency = (dependentDir, depName) => {
+    let currentDir = dependentDir;
+    while (true) {
+      const candidate = currentDir === '' ? `node_modules/${depName}` : `${currentDir}/node_modules/${depName}`;
+      if (packagedFiles.has(`${candidate}/package.json`)) {
+        return candidate;
+      }
+      if (currentDir === '') {
+        return null;
+      }
+      const parent = currentDir.split('/').slice(0, -1).join('/');
+      currentDir = parent === currentDir ? '' : parent;
+    }
+  };
+
+  const rootPackageJson = readPackagedJson('package.json');
+  if (!rootPackageJson) {
+    throw new Error('afterPack dependency verification: could not read package.json from app.asar');
+  }
+
+  const missing = [];
+  const visited = new Set();
+  const queue = Object.keys(rootPackageJson.dependencies ?? {}).map((depName) => ({ depName, dependentDir: '', optional: false }));
+
+  while (queue.length > 0) {
+    const { depName, dependentDir, optional } = queue.shift();
+    const packageDir = resolvePackagedDependency(dependentDir, depName);
+    if (packageDir == null) {
+      // Optional dependencies (e.g. platform-specific binaries) are legitimately absent.
+      if (!optional) {
+        missing.push(`${depName} (required by ${dependentDir || 'the app'})`);
+      }
+      continue;
+    }
+    if (visited.has(packageDir)) {
+      continue;
+    }
+    visited.add(packageDir);
+
+    const packageJson = readPackagedJson(`${packageDir}/package.json`);
+    if (!packageJson) {
+      continue;
+    }
+    const optionalDeps = packageJson.optionalDependencies ?? {};
+    for (const childName of Object.keys({ ...packageJson.dependencies, ...optionalDeps })) {
+      queue.push({ depName: childName, dependentDir: packageDir, optional: childName in optionalDeps });
+    }
+  }
+
+  if (missing.length > 0) {
+    throw new Error(
+      `app.asar is missing ${missing.length} production dependenc${missing.length === 1 ? 'y' : 'ies'}: ${missing.join(', ')}. ` +
+        `electron-builder's node-module collector dropped them (look for "cannot find path for dependency" warnings above). ` +
+        `The packaged app would crash at runtime with "Cannot find module".`,
+    );
+  }
+  console.log(`afterPack dependency verification passed: ${visited.size} packaged modules, dependency closure complete`);
+}
+
 /** @type {Configuration} */
 const config = {
+  afterPack: verifyAsarDependencyClosure,
   appId: 'app.getjetstream',
   productName: 'Jetstream',
   copyright: `Copyright © ${new Date().getFullYear()} Jetstream Solutions`,

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "url": "https://github.com/jetstreamapp/jetstream"
   },
   "author": "Jetstream Solutions, LLC",
-  "version": "10.15.0",
+  "version": "10.15.1",
   "license": "SEE LICENSE IN LICENSE.md",
   "engines": {
     "node": ">=24 <25",

--- a/scripts/build-electron.mjs
+++ b/scripts/build-electron.mjs
@@ -99,7 +99,7 @@ const packageManagerAddProdDeps = () => {
   const { devDependencies, dependencies } = JSON.parse(readFileSync(ROOT_PACKAGE_JSON_PATH, 'utf-8'));
   const allDependencies = { ...devDependencies, ...dependencies };
 
-  return ['electron-updater'].map((dep) => {
+  const prodDeps = ['electron-updater'].map((dep) => {
     const matchingDependency = Object.entries(allDependencies).find(([packageName]) => packageName === dep);
     if (!matchingDependency) {
       // For packages not in root, use latest
@@ -109,6 +109,8 @@ const packageManagerAddProdDeps = () => {
     const [packageName, packageVersion] = matchingDependency;
     return `${packageName}@${packageVersion}`;
   });
+
+  return prodDeps;
 };
 
 function prepareTargetPackageJson() {


### PR DESCRIPTION
Desktop 4.12.0 shipped an app.asar missing supports-color and crashed on
startup on every install: electron-builder's pnpm collector silently drops
a package when pnpm's list output only expands it beneath a deduped
subtree, logging a warning and packaging anyway. A new afterPack hook now
walks the packaged production dependency closure and fails the build if
any module is missing. chalk, the sole consumer of supports-color, is
removed from the desktop app entirely.

Download links also pointed at releases.getjetstream.app (never wired to
R2) and a jetstream/<platform>/<arch>/ path that has no objects; they now
use the update-feed domain and the real jetstream/releases/ artifact path.
