### PR TITLE
fix(permission-analysis): stop export failing when a selection is in …

### DIFF
--- a/libs/features/analysis-shared/src/permission-export/__tests__/run-permission-export.spec.ts
+++ b/libs/features/analysis-shared/src/permission-export/__tests__/run-permission-export.spec.ts
@@ -139,7 +139,8 @@ describe('runPermissionExport', () => {
     const mutingRows: Record<string, unknown>[] = [];
 
     // The order of queries matches the algorithm: permission sets, then (per parent chunk) object,
-    // field, tabs, assignments, components, then (per group chunk) group + muting.
+    // field, tabs, assignments, components, then (per group chunk) group + component-by-group muting
+    // discovery. No muting members here, so no MutingPermissionSet query is issued.
     mockedQuery
       .mockResolvedValueOnce(done(permissionSetRows))
       .mockResolvedValueOnce(done(objectPermissionRows))
@@ -148,7 +149,7 @@ describe('runPermissionExport', () => {
       .mockResolvedValueOnce(done(assignmentRows))
       .mockResolvedValueOnce(done(componentRows))
       .mockResolvedValueOnce(done(groupRows))
-      .mockResolvedValueOnce(done(mutingRows));
+      .mockResolvedValueOnce(done(componentRows));
 
     const onProgress = vi.fn();
 
@@ -189,6 +190,85 @@ describe('runPermissionExport', () => {
     const lastProgressCall = onProgress.mock.calls.at(-1)?.[0];
     expect(lastProgressCall?.label).toBe('Complete');
     expect(lastProgressCall?.percent).toBe(100);
+
+    // No group member had the muting key prefix, so the MutingPermissionSet query is skipped entirely.
+    expect(mockedQuery).toHaveBeenCalledTimes(8);
+    expect(mockedQuery.mock.calls.some(([, soql]) => (soql as string).includes('FROM MutingPermissionSet'))).toBe(false);
+  });
+
+  it('discovers muting permission sets via group components and stamps the group id onto each row', async () => {
+    const mutingPermissionSetId = '0QM000000000001';
+    const permissionSetRows = [{ Id: PERM_SET_ID, Name: 'CustomPermSet', IsOwnedByProfile: false }];
+    const memberComponentRows = [{ Id: '0PC000000000001', PermissionSetGroupId: GROUP_ID, PermissionSetId: PERM_SET_ID }];
+    const groupComponentRows = [
+      ...memberComponentRows,
+      { Id: '0PC000000000002', PermissionSetGroupId: GROUP_ID, PermissionSetId: mutingPermissionSetId },
+    ];
+    const mutingRows = [{ Id: mutingPermissionSetId, DeveloperName: 'Muting_A', MasterLabel: 'Muting A' }];
+
+    mockedQuery
+      .mockResolvedValueOnce(done(permissionSetRows))
+      .mockResolvedValueOnce(done([])) // object permissions
+      .mockResolvedValueOnce(done([])) // field permissions
+      .mockResolvedValueOnce(done([])) // tab settings
+      .mockResolvedValueOnce(done([])) // assignments
+      .mockResolvedValueOnce(done(memberComponentRows))
+      .mockResolvedValueOnce(done([{ Id: GROUP_ID, DeveloperName: 'GroupA', MasterLabel: 'Group A' }]))
+      .mockResolvedValueOnce(done(groupComponentRows))
+      .mockResolvedValueOnce(done(mutingRows));
+
+    const result = await runPermissionExport(ORG, [], [PERM_SET_ID]);
+
+    expect(result.truncated).toBe(false);
+    expect(result.full.counts.mutingPermissionSets).toBe(1);
+    expect(result.full.mutingPermissionSets).toEqual([
+      { Id: mutingPermissionSetId, DeveloperName: 'Muting_A', MasterLabel: 'Muting A', PermissionSetGroupId: GROUP_ID },
+    ]);
+    // Only member components for the selected permission sets are retained in the export payload.
+    expect(result.full.permissionSetGroupComponents).toEqual(memberComponentRows);
+
+    const mutingSoql = mockedQuery.mock.calls.at(-1)?.[1] as string;
+    expect(mutingSoql).toContain('FROM MutingPermissionSet');
+    expect(mutingSoql).toContain(`Id IN ('${mutingPermissionSetId}')`);
+    expect(mutingSoql).not.toContain('PermissionSetGroupId');
+  });
+
+  it('still discovers muting permission sets when the component budget is exhausted by the member pass', async () => {
+    const mutingPermissionSetId = '0QM000000000001';
+    // One more member component row than the 50k retained-row budget, so the member pass exhausts it.
+    const memberComponentRows = Array.from({ length: 50_001 }, (_, i) => ({
+      Id: `0PC${String(i).padStart(12, '0')}`,
+      PermissionSetGroupId: GROUP_ID,
+      PermissionSetId: PERM_SET_ID,
+    }));
+    const groupComponentRows = [
+      { Id: '0PC000000000001', PermissionSetGroupId: GROUP_ID, PermissionSetId: PERM_SET_ID },
+      { Id: '0PC000000000002', PermissionSetGroupId: GROUP_ID, PermissionSetId: mutingPermissionSetId },
+    ];
+    const mutingRows = [{ Id: mutingPermissionSetId, DeveloperName: 'Muting_A', MasterLabel: 'Muting A' }];
+
+    mockedQuery
+      .mockResolvedValueOnce(done([{ Id: PERM_SET_ID, Name: 'CustomPermSet', IsOwnedByProfile: false }]))
+      .mockResolvedValueOnce(done([])) // object permissions
+      .mockResolvedValueOnce(done([])) // field permissions
+      .mockResolvedValueOnce(done([])) // tab settings
+      .mockResolvedValueOnce(done([])) // assignments
+      .mockResolvedValueOnce(done(memberComponentRows))
+      .mockResolvedValueOnce(done([{ Id: GROUP_ID, DeveloperName: 'GroupA', MasterLabel: 'Group A' }]))
+      .mockResolvedValueOnce(done(groupComponentRows))
+      .mockResolvedValueOnce(done(mutingRows));
+
+    const result = await runPermissionExport(ORG, [], [PERM_SET_ID]);
+
+    // Component truncation is reported, but discovery runs on its own transient budget so the muting
+    // permission set is still found and mutingPermissionSets is NOT marked truncated.
+    expect(result.truncated).toBe(true);
+    expect(result.full.summary).toContain('PermissionSetGroupComponent');
+    expect(result.full.summary).not.toContain('MutingPermissionSet');
+    expect(result.full.counts.permissionSetGroupComponents).toBe(50_000);
+    expect(result.full.mutingPermissionSets).toEqual([
+      { Id: mutingPermissionSetId, DeveloperName: 'Muting_A', MasterLabel: 'Muting A', PermissionSetGroupId: GROUP_ID },
+    ]);
   });
 
   it('throws when isCanceled returns true before queries run', async () => {

--- a/libs/features/analysis-shared/src/permission-export/__tests__/soql-templates.spec.ts
+++ b/libs/features/analysis-shared/src/permission-export/__tests__/soql-templates.spec.ts
@@ -1,11 +1,12 @@
 import { describe, expect, it } from 'vitest';
 import {
   buildFieldPermissionsByParentSoql,
-  buildMutingPermissionSetsByGroupSoql,
+  buildMutingPermissionSetsByIdSoql,
   buildObjectPermissionsByParentSoql,
   buildPermissionSetAssignmentsByPermissionSetSoql,
   buildPermissionSetByIdSoql,
   buildPermissionSetGroupByIdSoql,
+  buildPermissionSetGroupComponentsByGroupSoql,
   buildPermissionSetGroupComponentsByPermissionSetSoql,
   buildTabSettingsByParentSoql,
 } from '../soql-templates';
@@ -62,9 +63,16 @@ describe('soql-templates permission export', () => {
     expect(soql).toContain("Id IN ('g1')");
   });
 
-  it('buildMutingPermissionSetsByGroupSoql composes muting permission set query', () => {
-    const soql = buildMutingPermissionSetsByGroupSoql(['g1']);
-    expect(soql).toContain('FROM MutingPermissionSet');
+  it('buildPermissionSetGroupComponentsByGroupSoql composes component-by-group query', () => {
+    const soql = buildPermissionSetGroupComponentsByGroupSoql(['g1']);
+    expect(soql).toContain('FROM PermissionSetGroupComponent');
     expect(soql).toContain("PermissionSetGroupId IN ('g1')");
+  });
+
+  it('buildMutingPermissionSetsByIdSoql filters MutingPermissionSet by Id (it has no group column)', () => {
+    const soql = buildMutingPermissionSetsByIdSoql(['0QM000000000001']);
+    expect(soql).toContain('FROM MutingPermissionSet');
+    expect(soql).toContain("Id IN ('0QM000000000001')");
+    expect(soql).not.toContain('PermissionSetGroupId');
   });
 });

--- a/libs/features/analysis-shared/src/permission-export/run-permission-export.ts
+++ b/libs/features/analysis-shared/src/permission-export/run-permission-export.ts
@@ -6,11 +6,12 @@ import type { PermissionExportFullResult, SalesforceOrgUi } from '@jetstream/typ
 import { buildIssueCodeSummary, buildPermissionExportFindings } from './build-permission-export-findings';
 import {
   buildFieldPermissionsByParentSoql,
-  buildMutingPermissionSetsByGroupSoql,
+  buildMutingPermissionSetsByIdSoql,
   buildObjectPermissionsByParentSoql,
   buildPermissionSetAssignmentsByPermissionSetSoql,
   buildPermissionSetByIdSoql,
   buildPermissionSetGroupByIdSoql,
+  buildPermissionSetGroupComponentsByGroupSoql,
   buildPermissionSetGroupComponentsByPermissionSetSoql,
   buildTabSettingsByParentSoql,
   OPTIONAL_PERMISSION_SET_METADATA_FIELDS,
@@ -18,6 +19,8 @@ import {
 
 const PARENT_ID_CHUNK_SIZE = 200;
 const GROUP_ID_CHUNK_SIZE = 200;
+/** Salesforce key prefix for MutingPermissionSet ids — how muting members are told apart from regular ones. */
+const MUTING_PERMISSION_SET_ID_PREFIX = '0QM';
 /** Keeps `SobjectType IN (...)` clauses within typical SOQL length limits when many objects are selected. */
 const OBJECT_SOBJECT_TYPE_IN_CHUNK_SIZE = 80;
 
@@ -168,7 +171,8 @@ async function getKnownObjectApiNames(org: SalesforceOrgUi): Promise<Set<string>
  * Mirrors the original server `runPermissionExportSoql` algorithm: PermissionSet first, then per
  * parent-id chunk of 200 we fetch ObjectPermissions/FieldPermissions (optionally re-chunked by
  * sobject type), Tab settings, Assignments, and Group components. Group ids harvested from the
- * components query then drive PermissionSetGroup + MutingPermissionSet queries.
+ * components query then drive PermissionSetGroup queries plus a second components pass that discovers
+ * each group's muting permission sets (MutingPermissionSet itself has no group column to filter on).
  */
 export async function runPermissionExport(
   org: SalesforceOrgUi,
@@ -401,18 +405,55 @@ export async function runPermissionExport(
 
     throwIfCanceled(options?.isCanceled);
     emitProgress(`Loading muting permission sets${groupChunkLabel}`);
+    // MutingPermissionSet cannot be queried by group — it has no PermissionSetGroupId column in any API.
+    // The only link is a PermissionSetGroupComponent row whose PermissionSetId holds the muting set's id,
+    // so discover muting members from the groups' full component lists, then load the muting rows by id
+    // and stamp the group id back on so downstream joins (mutingGroupIds in findings) keep working.
     if (budgets.mutingPermissionSets.remaining > 0) {
-      const mutingResult = await queryWithRecordBudget<Record<string, unknown>>(
+      const groupIdsByMutingPermissionSetId = new Map<string, string>();
+      const discoveryBudget = { remaining: CATEGORY_BUDGETS.permissionSetGroupComponents };
+      const discoveryResult = await queryWithRecordBudget<Record<string, unknown>>(
         org,
-        buildMutingPermissionSetsByGroupSoql(groupIdChunk),
+        buildPermissionSetGroupComponentsByGroupSoql(groupIdChunk),
         false,
-        budgets.mutingPermissionSets,
+        discoveryBudget,
         (page) => {
-          mutingPermissionSets.push(...page);
+          for (const row of page) {
+            const memberId = row.PermissionSetId;
+            const groupId = row.PermissionSetGroupId;
+            if (
+              typeof memberId === 'string' &&
+              memberId.startsWith(MUTING_PERMISSION_SET_ID_PREFIX) &&
+              typeof groupId === 'string' &&
+              groupId.length > 0
+            ) {
+              groupIdsByMutingPermissionSetId.set(memberId, groupId);
+            }
+          }
         },
       );
-      if (mutingResult.truncated) {
+      if (discoveryResult.truncated) {
+        // Incomplete component discovery means an unknown set of muting members, not lost component rows.
         truncatedCategories.add('mutingPermissionSets');
+      }
+
+      const mutingPermissionSetIds = [...groupIdsByMutingPermissionSetId.keys()];
+      if (mutingPermissionSetIds.length > 0) {
+        const mutingResult = await queryWithRecordBudget<Record<string, unknown>>(
+          org,
+          buildMutingPermissionSetsByIdSoql(mutingPermissionSetIds),
+          false,
+          budgets.mutingPermissionSets,
+          (page) => {
+            for (const row of page) {
+              const groupId = typeof row.Id === 'string' ? groupIdsByMutingPermissionSetId.get(row.Id) : undefined;
+              mutingPermissionSets.push(groupId ? { ...row, PermissionSetGroupId: groupId } : row);
+            }
+          },
+        );
+        if (mutingResult.truncated) {
+          truncatedCategories.add('mutingPermissionSets');
+        }
       }
     } else {
       truncatedCategories.add('mutingPermissionSets');

--- a/libs/features/analysis-shared/src/permission-export/soql-templates.ts
+++ b/libs/features/analysis-shared/src/permission-export/soql-templates.ts
@@ -189,15 +189,36 @@ export function buildPermissionSetGroupByIdSoql(groupIds: string[]): string {
   });
 }
 
-export function buildMutingPermissionSetsByGroupSoql(groupIds: string[]): string {
+/**
+ * All components of the given groups (not just the selected permission sets). This is how muting
+ * permission sets are discovered: `MutingPermissionSet` has no group column in any API, the only
+ * link is a `PermissionSetGroupComponent` row whose `PermissionSetId` holds the muting set's id
+ * (key prefix `0QM`).
+ */
+export function buildPermissionSetGroupComponentsByGroupSoql(groupIds: string[]): string {
   return composeQuery({
-    fields: [getField('Id'), getField('PermissionSetGroupId'), getField('DeveloperName'), getField('MasterLabel')],
-    sObject: 'MutingPermissionSet',
+    fields: [getField('Id'), getField('PermissionSetGroupId'), getField('PermissionSetId')],
+    sObject: 'PermissionSetGroupComponent',
     where: {
       left: {
         field: 'PermissionSetGroupId',
         operator: 'IN',
         value: groupIds,
+        literalType: 'STRING',
+      },
+    },
+  });
+}
+
+export function buildMutingPermissionSetsByIdSoql(mutingPermissionSetIds: string[]): string {
+  return composeQuery({
+    fields: [getField('Id'), getField('DeveloperName'), getField('MasterLabel')],
+    sObject: 'MutingPermissionSet',
+    where: {
+      left: {
+        field: 'Id',
+        operator: 'IN',
+        value: mutingPermissionSetIds,
         literalType: 'STRING',
       },
     },


### PR DESCRIPTION
…a permission set group

MutingPermissionSet has no PermissionSetGroupId column in any Salesforce API, so the muting query threw INVALID_FIELD whenever a selected permission set belonged to a permission set group. Muting sets are now discovered from the groups' PermissionSetGroupComponent rows (member ids with the 0QM key prefix) and loaded by id, with the group id stamped back onto each row so the findings join is unchanged.