### PR TITLE
chore: post agent PR/issue comments as the GitHub App bot

### DIFF
--- a/.claude/skills/gh-bot-comment/SKILL.md
+++ b/.claude/skills/gh-bot-comment/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: gh-bot-comment
+description: Post GitHub PR/issue comments, reviews, and review replies as the Jetstream bot account instead of the user's personal account. Use whenever asked to comment on a PR, leave a code review on a PR, reply to review threads, or comment on an issue via gh/the GitHub API.
+---
+
+# Posting to GitHub as the bot account
+
+Any **write** to PR or issue conversations (comments, reviews, review replies) must be
+posted as the app's bot account, not the user's personal account. A GitHub App
+installation token does this automatically - anything posted with it shows up as
+`<app-slug>[bot]`.
+
+Mint the token and run the command in one step:
+
+```bash
+pnpm gh:bot run gh pr comment 1234 --body-file /path/to/comment.md
+pnpm gh:bot run gh issue comment 1234 --body "..."
+pnpm gh:bot run gh api repos/jetstreamapp/jetstream/pulls/1234/reviews -f event=COMMENT -f body='...'
+```
+
+`pnpm gh:bot run <cmd...>` executes the command with `GH_TOKEN` and `GITHUB_TOKEN` set to a
+fresh installation token (cached ~50 minutes in `tmp/gh-app-token/`). This also sidesteps any
+stale `GH_TOKEN` in the user's shell environment.
+
+If a command needs the raw token instead, use `GH_TOKEN=$(pnpm --silent gh:bot token)` - the
+`--silent` flag matters, or pnpm's banner ends up inside the token.
+
+## When NOT to use it
+
+- **The user explicitly asks to post as themselves** ("as me", "from my account") - use plain
+  `gh`. The bot is only the default, not a requirement.
+- **Reads** (`gh pr view`, `gh pr diff`, `gh api` GETs) - use plain `gh`; no bot identity needed.
+- **git push / PR creation from the user's own branches** - those should stay attributed to the
+  user unless they say otherwise.
+
+## Notes
+
+- The token is scoped to `pull_requests: write` + `issues: write` on this repository only; it
+  cannot push code or cut releases.
+- `gh pr comment` posts an issue comment; for line-anchored review comments or a batched review,
+  use `gh api .../pulls/{n}/reviews` with a `comments` array payload.
+- If the script errors, surface its message to the user rather than falling back to posting as
+  the personal account - a permissions error means the GitHub App needs "Pull requests: Read and
+  write" / "Issues: Read and write" granted in its settings.
+- Sanity check identity with `pnpm gh:bot whoami`.

--- a/.env.example
+++ b/.env.example
@@ -191,3 +191,10 @@ SF_LOCAL_CLIENT_SECRET=''
 SF_LOCAL_PRIVATE_KEY_BASE64=''
 # SF_LOCAL_PRIVATE_KEY_PATH='tmp/salesforce-jwt/jetstream-local.key'
 # SF_LOCAL_API_VERSION='v67.0'
+
+# Optional - GitHub App used by `pnpm gh:bot` (scripts/gh-app-token.mjs) so PR comments and reviews
+GH_BOT_CLIENT_ID=''
+# Path to the app's private key .pem (keep it outside the repo), or set GH_BOT_PRIVATE_KEY_BASE64
+GH_BOT_PRIVATE_KEY_PATH=''
+# GH_BOT_PRIVATE_KEY_BASE64=''
+# GH_BOT_REPO='jetstreamapp/jetstream'

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "scripts:replace-deps": "node ./scripts/replace-package-deps.mjs",
     "scripts:generate-env": "node ./scripts/generate.env.mjs",
     "sf:api": "node ./scripts/sf-api.mjs",
+    "gh:bot": "node ./scripts/gh-app-token.mjs",
     "scripts:copy-monaco-assets:desktop": "node scripts/copy-monaco-assets.mjs --target desktop",
     "scripts:copy-monaco-assets:web-extension": "node scripts/copy-monaco-assets.mjs --target web-extension",
     "release": "node scripts/release.mjs",

--- a/scripts/gh-app-token.mjs
+++ b/scripts/gh-app-token.mjs
@@ -1,0 +1,224 @@
+#!/usr/bin/env node
+
+/**
+ * Mint a GitHub App installation token so CLI tooling (and AI agents) can post PR comments and
+ * reviews as the App's bot account instead of a personal account. Uses the same GitHub App that
+ * the release workflow uses (.github/workflows/release.yml).
+ *
+ * Setup (one time):
+ *   1. In the GitHub App settings (https://github.com/organizations/jetstreamapp/settings/apps),
+ *      make sure the App has "Pull requests: Read and write" and "Issues: Read and write"
+ *      repository permissions, then generate/download a private key (.pem).
+ *   2. Store the .pem outside the repo (e.g. ~/.config/jetstream/gh-app.pem) with mode 0600.
+ *   3. Fill in the GH_BOT_* variables in `.env` (see `--help`).
+ *
+ * Usage:
+ *   pnpm gh:bot token                                  # print an installation token
+ *   pnpm gh:bot whoami                                 # print the bot login the token acts as
+ *   pnpm gh:bot run gh pr comment 123 --body "..."     # run a command with GH_TOKEN set to the app token
+ */
+
+import { spawnSync } from 'node:child_process';
+import { createSign } from 'node:crypto';
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import dotenv from 'dotenv';
+
+const ROOT_DIR = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const TOKEN_CACHE_FILE = join(ROOT_DIR, 'tmp', 'gh-app-token', '.token-cache.json');
+/** Installation tokens live for 1 hour - refresh with headroom so a token never dies mid-command. */
+const TOKEN_CACHE_TTL_MS = 1000 * 60 * 50;
+/** Only ask for what commenting/reviewing needs - the token cannot push code or cut releases. */
+const REQUESTED_PERMISSIONS = { pull_requests: 'write', issues: 'write' };
+
+dotenv.config({ path: join(ROOT_DIR, '.env'), quiet: true });
+
+const HELP = `
+Mint a GitHub App installation token to act as the App's bot account.
+
+Usage:
+  pnpm gh:bot token             Print an installation token (also the default command)
+  pnpm gh:bot whoami            Print the bot login and the permissions the token carries
+  pnpm gh:bot run <cmd...>      Run <cmd> with GH_TOKEN/GITHUB_TOKEN set to the app token
+  pnpm gh:bot clear-cache       Delete the cached token
+
+Environment variables (in .env):
+  GH_BOT_CLIENT_ID              GitHub App client ID (same app as the release workflow)
+  GH_BOT_PRIVATE_KEY_PATH       Path to the app's private key .pem file, or
+  GH_BOT_PRIVATE_KEY_BASE64     Base64 encoded private key PEM
+  GH_BOT_REPO                   Optional owner/repo override (defaults to the git origin remote)
+`;
+
+function fail(message) {
+  console.error(`Error: ${message}`);
+  process.exit(1);
+}
+
+function getPrivateKey() {
+  const { GH_BOT_PRIVATE_KEY_BASE64, GH_BOT_PRIVATE_KEY_PATH } = process.env;
+  if (GH_BOT_PRIVATE_KEY_BASE64) {
+    return Buffer.from(GH_BOT_PRIVATE_KEY_BASE64, 'base64').toString('utf8');
+  }
+  if (GH_BOT_PRIVATE_KEY_PATH) {
+    const keyPath = resolve(ROOT_DIR, GH_BOT_PRIVATE_KEY_PATH.replace(/^~(?=\/)/, process.env.HOME ?? '~'));
+    if (!existsSync(keyPath)) {
+      fail(`GH_BOT_PRIVATE_KEY_PATH points to a missing file: ${keyPath}`);
+    }
+    return readFileSync(keyPath, 'utf8');
+  }
+  fail('Set GH_BOT_PRIVATE_KEY_PATH or GH_BOT_PRIVATE_KEY_BASE64 in .env (run with --help for setup).');
+}
+
+function getRepo() {
+  if (process.env.GH_BOT_REPO) {
+    return process.env.GH_BOT_REPO;
+  }
+  const remote = spawnSync('git', ['remote', 'get-url', 'origin'], { cwd: ROOT_DIR, encoding: 'utf8' });
+  const match = remote.stdout?.trim().match(/github\.com[:/]([^/]+\/[^/]+?)(?:\.git)?$/);
+  if (!match) {
+    fail('Could not determine owner/repo from the git origin remote - set GH_BOT_REPO in .env.');
+  }
+  return match[1];
+}
+
+function base64Url(input) {
+  return Buffer.from(input).toString('base64url');
+}
+
+function buildAppJwt(clientId, privateKey) {
+  const nowSeconds = Math.floor(Date.now() / 1000);
+  const header = base64Url(JSON.stringify({ alg: 'RS256', typ: 'JWT' }));
+  // iat is backdated to tolerate clock drift; GitHub caps exp at 10 minutes out.
+  const payload = base64Url(JSON.stringify({ iat: nowSeconds - 60, exp: nowSeconds + 9 * 60, iss: clientId }));
+  const signature = createSign('RSA-SHA256').update(`${header}.${payload}`).sign(privateKey, 'base64url');
+  return `${header}.${payload}.${signature}`;
+}
+
+async function githubApi(path, { method = 'GET', token, body } = {}) {
+  const options = {
+    method,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: 'application/vnd.github+json',
+      'X-GitHub-Api-Version': '2022-11-28',
+    },
+  };
+  if (body) {
+    options.headers['Content-Type'] = 'application/json';
+    options.body = JSON.stringify(body);
+  }
+  const response = await fetch(`https://api.github.com${path}`, options);
+  const responseBody = await response.json().catch(() => ({}));
+  return { response, responseBody };
+}
+
+function readTokenCache(repo) {
+  try {
+    const cache = JSON.parse(readFileSync(TOKEN_CACHE_FILE, 'utf8'));
+    if (cache.repo === repo && cache.createdAt + TOKEN_CACHE_TTL_MS > Date.now()) {
+      return cache;
+    }
+  } catch {
+    // Missing or unparseable cache just means we authenticate again.
+  }
+  return null;
+}
+
+function writeTokenCache(cache) {
+  mkdirSync(dirname(TOKEN_CACHE_FILE), { recursive: true });
+  writeFileSync(TOKEN_CACHE_FILE, JSON.stringify(cache), { mode: 0o600 });
+}
+
+async function getInstallationToken() {
+  const repo = getRepo();
+  const cached = readTokenCache(repo);
+  if (cached) {
+    return cached;
+  }
+
+  const clientId = process.env.GH_BOT_CLIENT_ID;
+  if (!clientId) {
+    fail('Set GH_BOT_CLIENT_ID in .env (run with --help for setup).');
+  }
+  const appJwt = buildAppJwt(clientId, getPrivateKey());
+
+  const installation = await githubApi(`/repos/${repo}/installation`, { token: appJwt });
+  if (!installation.response.ok) {
+    fail(
+      `Could not find an installation of the app on ${repo} (HTTP ${installation.response.status}: ${installation.responseBody.message}). ` +
+        'Check GH_BOT_CLIENT_ID and that the app is installed on the repository.',
+    );
+  }
+
+  const tokenResult = await githubApi(`/app/installations/${installation.responseBody.id}/access_tokens`, {
+    method: 'POST',
+    token: appJwt,
+    body: { repositories: [repo.split('/')[1]], permissions: REQUESTED_PERMISSIONS },
+  });
+  if (!tokenResult.response.ok) {
+    fail(
+      `Could not create an installation token (HTTP ${tokenResult.response.status}: ${tokenResult.responseBody.message}). ` +
+        'If this is a permissions error, grant the app "Pull requests: Read and write" and "Issues: Read and write" ' +
+        'in its settings, then accept the updated permissions on the installation.',
+    );
+  }
+
+  const appSlug = installation.responseBody.app_slug;
+  const cache = {
+    repo,
+    token: tokenResult.responseBody.token,
+    botLogin: `${appSlug}[bot]`,
+    permissions: tokenResult.responseBody.permissions,
+    createdAt: Date.now(),
+  };
+  writeTokenCache(cache);
+  return cache;
+}
+
+async function main() {
+  const [command = 'token', ...args] = process.argv.slice(2);
+
+  if (command === '--help' || command === '-h' || command === 'help') {
+    console.log(HELP);
+    return;
+  }
+
+  if (command === 'clear-cache') {
+    rmSync(TOKEN_CACHE_FILE, { force: true });
+    console.log('Token cache cleared.');
+    return;
+  }
+
+  const { token, botLogin, permissions } = await getInstallationToken();
+
+  switch (command) {
+    case 'token': {
+      console.log(token);
+      return;
+    }
+    case 'whoami': {
+      console.log(`Acting as: ${botLogin}`);
+      console.log(`Token permissions: ${JSON.stringify(permissions)}`);
+      return;
+    }
+    case 'run': {
+      // pnpm strips the first `--`, but tolerate an explicit one: `pnpm gh:bot run -- gh ...`
+      const commandArgs = args[0] === '--' ? args.slice(1) : args;
+      if (commandArgs.length === 0) {
+        fail('No command provided. Usage: pnpm gh:bot run gh pr comment 123 --body "..."');
+      }
+      const result = spawnSync(commandArgs[0], commandArgs.slice(1), {
+        stdio: 'inherit',
+        env: { ...process.env, GH_TOKEN: token, GITHUB_TOKEN: token },
+      });
+      process.exit(result.status ?? 1);
+      return;
+    }
+    default: {
+      fail(`Unknown command "${command}". Run with --help for usage.`);
+    }
+  }
+}
+
+main().catch((error) => fail(error.message));


### PR DESCRIPTION
AI-agent code reviews were attributed to a personal account. `pnpm gh:bot` mints an installation token from the same app the release workflow uses, down-scoped to pull_requests/issues write so it cannot push or release, and a project skill makes agents default to it for conversation writes.