### PR TITLE
fix: crashes on large load retries, date cells, and OPFS captures

### DIFF
--- a/libs/features/load-records/src/components/load-results/LoadRecordsBatchApiResults.tsx
+++ b/libs/features/load-records/src/components/load-results/LoadRecordsBatchApiResults.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/react';
 import { logger } from '@jetstream/shared/client-logger';
 import { ANALYTICS_KEYS } from '@jetstream/shared/constants';
 import { convertDateToLocale, formatNumber, tracker, useBrowserNotifications } from '@jetstream/shared/ui-utils';
-import { flattenRecord, getErrorMessage, getSuccessOrFailureChar, pluralizeFromNumber } from '@jetstream/shared/utils';
+import { flattenRecord, getErrorMessage, getSuccessOrFailureChar, pluralizeFromNumber, pushAll } from '@jetstream/shared/utils';
 import {
   ApiMode,
   DownloadModalData,
@@ -279,7 +279,7 @@ export const LoadRecordsBatchApiResults = ({
           }
           // Mutate the ref array (O(n) total) instead of reallocating the full accumulated array
           // on every batch via concat (O(n^2) total) — matters for large loads.
-          processedRecordsRef.current.push(...batchRecords);
+          pushAll(processedRecordsRef.current, batchRecords);
           setProcessedRecords((previousProcessedRecords) => previousProcessedRecords.concat(batchRecords));
           // Stream this batch's results to Data History (fire-and-forget; same row shape as download)
           const fields = getFieldHeaderFromMapping(fieldMapping);

--- a/libs/features/load-records/src/components/load-results/__tests__/load-results-utils.spec.ts
+++ b/libs/features/load-records/src/components/load-results/__tests__/load-results-utils.spec.ts
@@ -337,6 +337,36 @@ describe('collectFailedRecordsForRetry', () => {
     expect(fetchBatchResults).not.toHaveBeenCalled();
   });
 
+  it('handles hundreds of thousands of unresolved records without overflowing the call stack', async () => {
+    // Regression test: `failedRecords.push(...records)` blew the max call stack when a large batch
+    // never completed, since every one of its records is spread as an argument
+    const largeRecordCount = 200_000;
+    const largeRecords = [
+      { Id: '001A', Name: 'Completed-A' },
+      { Id: '001B', Name: 'Completed-B' },
+      ...Array.from({ length: largeRecordCount }, (_, i) => ({ Id: `002${i}`, Name: `Unresolved-${i}` })),
+    ];
+    const largePreparedData = { data: largeRecords, errors: [] } as unknown as PrepareDataResponse;
+    const largeSummary = {
+      batchSummary: [
+        { id: 'batch-1', batchNumber: 0, startIndex: 0, recordCount: 2 },
+        { id: 'batch-2', batchNumber: 1, startIndex: 2, recordCount: largeRecordCount },
+      ],
+    } as LoadDataBulkApiStatusPayload;
+    const fetchBatchResults = vi.fn(async () => [success('001A'), failure('001B')]);
+    const failed = await collectFailedRecordsForRetry({
+      numFailure: largeRecordCount + 1,
+      jobInfo: jobWith(['Completed', 'Failed']),
+      batchSummary: largeSummary,
+      preparedData: largePreparedData,
+      loadType: 'UPDATE',
+      fetchBatchResults,
+    });
+    expect(failed).toHaveLength(largeRecordCount + 1);
+    expect(failed[0]).toBe(largeRecords[1]);
+    expect(failed[1]).toBe(largeRecords[2]);
+  });
+
   it('on a delete, pairs results with the Id-bearing records and counts the omitted ones as failed', async () => {
     const deleteRecords = [{ Id: '001A' }, { Name: 'no-id' }, { Id: '001B' }];
     const deletePreparedData = { data: deleteRecords, errors: [] } as unknown as PrepareDataResponse;

--- a/libs/features/load-records/src/components/load-results/load-results-utils.ts
+++ b/libs/features/load-records/src/components/load-results/load-results-utils.ts
@@ -1,6 +1,6 @@
 import { logger } from '@jetstream/shared/client-logger';
 import { bulkApiGetRecords, bulkApiGetRecordsFromAllBatches } from '@jetstream/shared/data';
-import { BULK_RESULTS_BASE_HEADER, decodeHtmlEntity, flattenRecord, splitArrayToMaxSize } from '@jetstream/shared/utils';
+import { BULK_RESULTS_BASE_HEADER, decodeHtmlEntity, flattenRecord, pushAll, splitArrayToMaxSize } from '@jetstream/shared/utils';
 import {
   BulkJobBatchInfo,
   BulkJobResultRecord,
@@ -267,7 +267,10 @@ export async function collectFailedRecordsForRetry({
     // For delete batches where SFDC omitted records missing an Id, include them as failures here
     // since they'll never have a result row.
     if (recordsForResults.length !== recordsForBatch.length) {
-      failedRecords.push(...recordsForBatch.filter((record) => !record?.Id));
+      pushAll(
+        failedRecords,
+        recordsForBatch.filter((record) => !record?.Id),
+      );
     }
     recordsForBatch.forEach((record) => resolvedRecords.add(record));
   });
@@ -275,6 +278,10 @@ export async function collectFailedRecordsForRetry({
   // Include all records from any batch we couldn't resolve (fetch failed, unmapped batch id,
   // state !== Completed, etc.). These are conservatively considered failed and retryable. Batches
   // are contiguous slices of the prepared data, so this walks the unresolved batches in order.
-  failedRecords.push(...preparedData.data.filter((record) => !resolvedRecords.has(record)));
+  // pushAll rather than `push(...spread)` - hundreds of thousands of records can be unresolved.
+  pushAll(
+    failedRecords,
+    preparedData.data.filter((record) => !resolvedRecords.has(record)),
+  );
   return failedRecords;
 }

--- a/libs/features/manage-permissions/src/usePermissionRecords.tsx
+++ b/libs/features/manage-permissions/src/usePermissionRecords.tsx
@@ -259,6 +259,13 @@ async function queryChunks<TItem, TRecord>(
  */
 const INVALID_FIELD_REGEX = /INVALID_FIELD|No such column/i;
 
+/**
+ * Users without View Setup access cannot query the Tooling `CustomField` object. Depending on which
+ * path returned it, that surfaces as the error-code form (INVALID_TYPE) or the message form
+ * ("sObject type 'CustomField' is not supported"), so both must be matched.
+ */
+const CUSTOM_FIELD_NOT_SUPPORTED_REGEX = /INVALID_TYPE|sObject type 'CustomField' is not supported/i;
+
 const MAX_TRACKED_ERROR_LENGTH = 500;
 
 /**
@@ -366,9 +373,14 @@ async function queryFieldAuditMetadata(
     }, {});
     return { auditByFieldDefinitionId, loadFailed: false };
   } catch (ex) {
+    const errorMessage = getErrorMessage(ex);
     // Nothing else fails when this does, so this is the only chance to report it
-    logger.warn('[usePermissionRecords][FIELD AUDIT][ERROR]', getErrorMessage(ex));
-    tracker.error('[usePermissionRecords][FIELD AUDIT][ERROR]', ex, { errorDetail: getTrackableErrorDetail(ex) });
+    logger.warn('[usePermissionRecords][FIELD AUDIT][ERROR]', errorMessage);
+    // Missing View Setup access is the expected degradation this catch exists for, not an application
+    // error worth reporting
+    if (!CUSTOM_FIELD_NOT_SUPPORTED_REGEX.test(errorMessage)) {
+      tracker.error('[usePermissionRecords][FIELD AUDIT][ERROR]', ex, { errorDetail: getTrackableErrorDetail(ex) });
+    }
     return { auditByFieldDefinitionId: {}, loadFailed: true };
   }
 }

--- a/libs/shared/ui-data-history/src/lib/file-store/history-storage.worker.ts
+++ b/libs/shared/ui-data-history/src/lib/file-store/history-storage.worker.ts
@@ -245,9 +245,33 @@ async function handleRequest(request: HistoryWorkerRequest): Promise<unknown> {
   }
 }
 
+/**
+ * Ops that resolve their file/directory through `getRootDir()`. When the underlying directory tree is
+ * swept and recreated out from under a cached handle (e.g. another tab's cleanup), Chromium throws
+ * InvalidStateError ("An operation that depends on state cached in an interface object was made but
+ * the state had changed since it was read from disk") — re-resolving from a fresh root succeeds, so
+ * these ops retry once. Stream write/close/abort operate on an already-open exclusive access handle,
+ * which a fresh root cannot repair, so they are excluded.
+ */
+const ROOT_RESOLVED_OPS = new Set<HistoryWorkerRequest['op']>([
+  'init',
+  'write-file',
+  'open-stream',
+  'read-file',
+  'delete-dir',
+  'list-entry-dirs',
+]);
+
 workerScope.onmessage = (event: MessageEvent<HistoryWorkerRequest>) => {
   const request = event.data;
   handleRequest(request)
+    .catch((ex: unknown) => {
+      if ((ex as { name?: string } | null)?.name === 'InvalidStateError' && ROOT_RESOLVED_OPS.has(request.op)) {
+        rootDirPromise = null;
+        return handleRequest(request);
+      }
+      throw ex;
+    })
     .then((result) => {
       workerScope.postMessage({ id: request.id, success: true, result });
     })

--- a/libs/shared/utils/src/lib/utils.ts
+++ b/libs/shared/utils/src/lib/utils.ts
@@ -263,6 +263,19 @@ export function createConcurrencyLimiter(maxConcurrent: number): ConcurrencyLimi
   };
 }
 
+/**
+ * Append every item to `target` without spreading. `target.push(...items)` passes each item as a call
+ * argument, so it overflows the call stack once `items` reaches the engine's argument limit (~125k in
+ * V8). Whether a given call site is safe depends on runtime data volume, so prefer this for any input
+ * that is not strictly bounded.
+ */
+export function pushAll<T>(target: T[], items: readonly T[]): T[] {
+  for (const item of items) {
+    target.push(item);
+  }
+  return target;
+}
+
 export function splitArrayToMaxSize<T = unknown>(items: T[], maxSize: number): T[][] {
   if (!maxSize || maxSize < 1) {
     throw new Error('maxSize must be greater than 0');

--- a/libs/ui/src/lib/data-table/grid/renderers/CellRenderers.tsx
+++ b/libs/ui/src/lib/data-table/grid/renderers/CellRenderers.tsx
@@ -374,7 +374,9 @@ export function withCellValidation<TRow extends RowWithKey>(
 ): (props: DataTableCellProps<TRow>) => ReactNode {
   return function CellWithValidation(props: DataTableCellProps<TRow>): ReactNode {
     const { row, column } = props;
-    const baseContent = baseRender ? baseRender(props) : <div className="slds-truncate">{(row as any)?.[column.key]}</div>;
+    // GenericRenderer handles non-primitive values (Date instances from spreadsheet parsing, objects) that
+    // would crash React if rendered directly as children
+    const baseContent = baseRender ? baseRender(props) : <GenericRenderer {...(props as DataTableCellProps<RowWithKey>)} />;
     const error = (row as any)?._fieldErrors?.[column.key] as string | undefined;
     const warning = error ? undefined : ((row as any)?._fieldWarnings?.[column.key] as string | undefined);
     const message = error || warning;


### PR DESCRIPTION
Fixes from Better Stack production error triage:

- Collecting failed records for retry spread every unresolved record as a push() argument, overflowing the call stack on 100k+ record loads.
- The multi-object load preview rendered raw cell values as JSX children, so an XLSX date cell (a Date object) crashed the page.
- Chromium invalidates the storage worker's cached OPFS directory handle when another tab recreates the tree; root-resolved ops now retry once with a fresh handle instead of failing the capture.
- Field audit's "CustomField is not supported" (user lacks View Setup) is expected degradation, no longer reported as an application error.