### PR TITLE
feat(load): replace steps sidebar with slim header progress indicator

### DIFF
--- a/libs/features/load-records/src/LoadRecords.tsx
+++ b/libs/features/load-records/src/LoadRecords.tsx
@@ -10,7 +10,6 @@ import {
   fireToast,
   getModifierKey,
   Grid,
-  GridCol,
   Icon,
   KeyboardShortcut,
   Page,
@@ -386,6 +385,12 @@ export const LoadRecords = () => {
     trackEvent(ANALYTICS_KEYS.load_GoBackToPrevStep, { step: currentStepIdx });
   }
 
+  // Only completed steps are clickable in the progress indicator, so this is always backwards navigation
+  function handleJumpToStep(stepIdx: number) {
+    setCurrentStepIdx(stepIdx);
+    trackEvent(ANALYTICS_KEYS.load_GoBackToPrevStep, { step: currentStepIdx, targetStep: stepIdx });
+  }
+
   function changeStep(changeBy: number) {
     setCurrentStepIdx((priorStepIdx) => Math.min(Math.max(priorStepIdx + changeBy, 0), steps.length - 1));
     if (currentStepIdx === 0 && selectedSObject?.name) {
@@ -498,98 +503,92 @@ export const LoadRecords = () => {
               <ViewDataHistoryLink />
             </Grid>
           </div>
+          <LoadRecordsProgress currentStepIdx={currentStepIdx} steps={steps} disabled={loading} onStepChange={handleJumpToStep} />
         </PageHeaderRow>
       </PageHeader>
       <AutoFullHeightContainer className="slds-p-horizontal_x-small slds-scrollable_none" bufferIfNotRendered={HEIGHT_BUFFER}>
-        <Grid gutters>
-          <GridCol>
-            {currentStep.name === 'sobjectAndFile' && (
-              <LoadRecordsSelectObjectAndFile
-                hasGoogleDriveAccess={hasGoogleDriveAccess}
-                googleShowUpgradeToPro={googleShowUpgradeToPro}
-                googleApiConfig={googleApiConfig}
+        {currentStep.name === 'sobjectAndFile' && (
+          <LoadRecordsSelectObjectAndFile
+            hasGoogleDriveAccess={hasGoogleDriveAccess}
+            googleShowUpgradeToPro={googleShowUpgradeToPro}
+            googleApiConfig={googleApiConfig}
+            selectedOrg={selectedOrg}
+            sobjects={sobjects}
+            selectedSObject={selectedSObject}
+            isCustomMetadataObject={!!isCustomMetadataObject}
+            loadType={loadType}
+            externalIdFields={externalIdFields}
+            loadingFields={loadingFields}
+            externalId={externalId}
+            inputFilename={inputFilename}
+            inputFileType={inputFilenameType}
+            inputGoogleFile={inputGoogleFile}
+            allowBinaryAttachment={!!allowBinaryAttachment}
+            binaryAttachmentBodyField={binaryAttachmentBodyField}
+            inputZipFilename={inputZipFilename}
+            onSobjects={setSobjects}
+            onSelectedSobject={setSelectedSObject}
+            onFileChange={handleFileChange}
+            onZipFileChange={handleZipFileChange}
+            onLoadTypeChange={setLoadType}
+            onExternalIdChange={setExternalId}
+          >
+            <LoadRecordsDataPreview
+              selectedOrg={selectedOrg}
+              selectedSObject={selectedSObject}
+              loadType={loadType}
+              data={inputFileData}
+              header={inputFileHeader}
+            />
+          </LoadRecordsSelectObjectAndFile>
+        )}
+        {currentStep.name === 'fieldMapping' && selectedSObject && inputFileHeader && inputFileData && (
+          <span>
+            <LoadRecordsFieldMapping
+              org={selectedOrg}
+              sobject={selectedSObject?.name}
+              isCustomMetadataObject={!!isCustomMetadataObject}
+              fields={mappableFields}
+              inputHeader={inputFileHeader}
+              fieldMapping={fieldMapping}
+              fileData={inputFileData}
+              loadType={loadType}
+              externalId={externalId}
+              binaryAttachmentBodyField={binaryAttachmentBodyField}
+              onFieldMappingChange={setFieldMapping}
+              onRefreshFields={handleFieldRefresh}
+            />
+          </span>
+        )}
+        {currentStep.name === 'loadRecords' && selectedSObject && inputFileData && (
+          <span>
+            {!isCustomMetadataObject ? (
+              <PerformLoad
                 selectedOrg={selectedOrg}
-                sobjects={sobjects}
-                selectedSObject={selectedSObject}
-                isCustomMetadataObject={!!isCustomMetadataObject}
+                orgType={orgType}
+                selectedSObject={selectedSObject.name}
+                inputFileHeader={inputFileHeader}
                 loadType={loadType}
-                externalIdFields={externalIdFields}
-                loadingFields={loadingFields}
+                fieldMapping={fieldMapping}
+                inputFileData={inputFileData}
+                inputZipFileData={inputZipFileData}
                 externalId={externalId}
-                inputFilename={inputFilename}
-                inputFileType={inputFilenameType}
-                inputGoogleFile={inputGoogleFile}
-                allowBinaryAttachment={!!allowBinaryAttachment}
-                binaryAttachmentBodyField={binaryAttachmentBodyField}
-                inputZipFilename={inputZipFilename}
-                onSobjects={setSobjects}
-                onSelectedSobject={setSelectedSObject}
-                onFileChange={handleFileChange}
-                onZipFileChange={handleZipFileChange}
-                onLoadTypeChange={setLoadType}
-                onExternalIdChange={setExternalId}
-              >
-                <LoadRecordsDataPreview
-                  selectedOrg={selectedOrg}
-                  selectedSObject={selectedSObject}
-                  loadType={loadType}
-                  data={inputFileData}
-                  header={inputFileHeader}
-                />
-              </LoadRecordsSelectObjectAndFile>
+                onIsLoading={handleIsLoading}
+              />
+            ) : (
+              <PerformLoadCustomMetadata
+                selectedOrg={selectedOrg}
+                orgType={orgType}
+                selectedSObject={selectedSObject.name}
+                inputFileHeader={inputFileHeader}
+                fields={mappableFields}
+                fieldMapping={fieldMapping}
+                inputFileData={inputFileData}
+                onIsLoading={handleIsLoading}
+              />
             )}
-            {currentStep.name === 'fieldMapping' && selectedSObject && inputFileHeader && inputFileData && (
-              <span>
-                <LoadRecordsFieldMapping
-                  org={selectedOrg}
-                  sobject={selectedSObject?.name}
-                  isCustomMetadataObject={!!isCustomMetadataObject}
-                  fields={mappableFields}
-                  inputHeader={inputFileHeader}
-                  fieldMapping={fieldMapping}
-                  fileData={inputFileData}
-                  loadType={loadType}
-                  externalId={externalId}
-                  binaryAttachmentBodyField={binaryAttachmentBodyField}
-                  onFieldMappingChange={setFieldMapping}
-                  onRefreshFields={handleFieldRefresh}
-                />
-              </span>
-            )}
-            {currentStep.name === 'loadRecords' && selectedSObject && inputFileData && (
-              <span>
-                {!isCustomMetadataObject ? (
-                  <PerformLoad
-                    selectedOrg={selectedOrg}
-                    orgType={orgType}
-                    selectedSObject={selectedSObject.name}
-                    inputFileHeader={inputFileHeader}
-                    loadType={loadType}
-                    fieldMapping={fieldMapping}
-                    inputFileData={inputFileData}
-                    inputZipFileData={inputZipFileData}
-                    externalId={externalId}
-                    onIsLoading={handleIsLoading}
-                  />
-                ) : (
-                  <PerformLoadCustomMetadata
-                    selectedOrg={selectedOrg}
-                    orgType={orgType}
-                    selectedSObject={selectedSObject.name}
-                    inputFileHeader={inputFileHeader}
-                    fields={mappableFields}
-                    fieldMapping={fieldMapping}
-                    inputFileData={inputFileData}
-                    onIsLoading={handleIsLoading}
-                  />
-                )}
-              </span>
-            )}
-          </GridCol>
-          <GridCol size={2}>
-            <LoadRecordsProgress currentStepIdx={currentStepIdx} steps={steps} />
-          </GridCol>
-        </Grid>
+          </span>
+        )}
       </AutoFullHeightContainer>
     </Page>
   );

--- a/libs/features/load-records/src/components/LoadRecordsProgress.tsx
+++ b/libs/features/load-records/src/components/LoadRecordsProgress.tsx
@@ -1,26 +1,51 @@
+import { css } from '@emotion/react';
 import { Step } from '@jetstream/types';
-import { ProgressStepIndicator, ProgressStepIndicatorListItem } from '@jetstream/ui';
+import { Grid, ProgressStepIndicator, ProgressStepIndicatorListItem } from '@jetstream/ui';
 import { FunctionComponent } from 'react';
 
 export interface LoadRecordsProgressProps {
   currentStepIdx: number;
   steps: Step[];
+  // Prevents navigating back to completed steps (e.g. while a load is in progress)
+  disabled?: boolean;
+  onStepChange: (stepIdx: number) => void;
 }
 
-export const LoadRecordsProgress: FunctionComponent<LoadRecordsProgressProps> = ({ currentStepIdx, steps }) => {
+/**
+ * Compact step progress designed to sit in the page header - shows the current step label
+ * with a horizontal dot indicator. Completed steps can be clicked to navigate back.
+ */
+export const LoadRecordsProgress: FunctionComponent<LoadRecordsProgressProps> = ({ currentStepIdx, steps, disabled, onStepChange }) => {
   return (
-    <ProgressStepIndicator currentStep={currentStepIdx} isVertical>
-      {steps.map((step, i) => (
-        <ProgressStepIndicatorListItem
-          key={step.name}
-          step={i}
-          stepText={step.label}
-          isVertical
-          isActive={currentStepIdx === i}
-          isComplete={currentStepIdx > i}
-        />
-      ))}
-    </ProgressStepIndicator>
+    <Grid testId="load-records-progress" verticalAlign="center">
+      <span className="slds-text-title slds-m-right_small">
+        Step {currentStepIdx + 1} of {steps.length}: {steps[currentStepIdx].label}
+      </span>
+      <ProgressStepIndicator
+        currentStep={currentStepIdx}
+        className="slds-progress_shade"
+        css={css`
+          width: 7rem;
+          max-width: 7rem;
+          flex: 0 0 auto;
+          /* Blend the completed marker's ring into the grey page header (slds-progress_shade misses this case) */
+          .slds-progress__item.slds-is-completed .slds-progress__marker_icon {
+            border-color: var(--slds-g-color-neutral-base-95, #f3f3f3);
+          }
+        `}
+      >
+        {steps.map((step, i) => (
+          <ProgressStepIndicatorListItem
+            key={step.name}
+            step={i}
+            stepText={step.label}
+            isActive={currentStepIdx === i}
+            isComplete={currentStepIdx > i}
+            onChangeStep={i < currentStepIdx && !disabled ? onStepChange : undefined}
+          />
+        ))}
+      </ProgressStepIndicator>
+    </Grid>
   );
 };
 

--- a/libs/features/load-records/src/steps/PerformLoad.tsx
+++ b/libs/features/load-records/src/steps/PerformLoad.tsx
@@ -471,7 +471,7 @@ export const LoadRecordsPerformLoad: FunctionComponent<LoadRecordsPerformLoadPro
   ]);
 
   return (
-    <div style={{ overflow: 'hidden', maxWidth: '80vw' }}>
+    <div>
       <ConfirmPageChange actionInProgress={loadInProgress} />
       <LoadRecordsDuplicateWarning
         className="slds-m-vertical_x-small"

--- a/libs/ui/src/lib/progress-indicator/ProgressStepIndicatorListItem.tsx
+++ b/libs/ui/src/lib/progress-indicator/ProgressStepIndicatorListItem.tsx
@@ -8,8 +8,9 @@ export interface ProgressStepIndicatorListItemProps {
   isVertical?: boolean;
   isActive?: boolean;
   isComplete?: boolean;
-  disabled?: boolean; // does not apply to vertical
-  onChangeStep?: (step: number) => void; // does not apply to vertical
+  // Horizontal only - when omitted, the marker renders as a non-interactive span.
+  // (a disabled button is not an option, `.slds-button:disabled` makes the marker circle transparent)
+  onChangeStep?: (step: number) => void;
 }
 
 export const ProgressStepIndicatorListItem = ({
@@ -18,7 +19,6 @@ export const ProgressStepIndicatorListItem = ({
   isVertical,
   isActive,
   isComplete,
-  disabled,
   onChangeStep,
 }: ProgressStepIndicatorListItemProps) => {
   const stepTitleVertical = `Step ${step + 1}`;
@@ -50,18 +50,23 @@ export const ProgressStepIndicatorListItem = ({
           <div className="slds-progress__item_content slds-grid slds-grid_align-spread">{stepText || stepTitleVertical}</div>
         </Fragment>
       )}
-      {!isVertical && (
+      {!isVertical && onChangeStep && (
         <button
           className={classNames('slds-button slds-progress__marker', {
             'slds-button_icon slds-progress__marker_icon': isComplete,
           })}
           title={stepText || stepTitle}
-          disabled={disabled}
-          onClick={() => onChangeStep && onChangeStep(step)}
+          onClick={() => onChangeStep(step)}
         >
           {isComplete && <Icon type="utility" icon="success" className="slds-button__icon" omitContainer />}
           <span className="slds-assistive-text">{stepText || stepTitle}</span>
         </button>
+      )}
+      {!isVertical && !onChangeStep && (
+        <span className={classNames('slds-progress__marker', { 'slds-progress__marker_icon': isComplete })} title={stepText || stepTitle}>
+          {isComplete && <Icon type="utility" icon="success" className="slds-button__icon" omitContainer />}
+          <span className="slds-assistive-text">{stepText || stepTitle}</span>
+        </span>
       )}
     </li>
   );

--- a/libs/ui/src/lib/progress-indicator/__tests__/ProgressStepIndicator.spec.tsx
+++ b/libs/ui/src/lib/progress-indicator/__tests__/ProgressStepIndicator.spec.tsx
@@ -61,9 +61,15 @@ describe('ProgressStepIndicator', () => {
 });
 
 describe('ProgressStepIndicatorListItem', () => {
-  test('renders step button in horizontal mode', () => {
-    render(<ProgressStepIndicatorListItem step={0} />);
+  test('renders step button in horizontal mode when onChangeStep is provided', () => {
+    render(<ProgressStepIndicatorListItem step={0} onChangeStep={vi.fn()} />);
     expect(screen.getByRole('button')).toBeTruthy();
+  });
+
+  test('renders non-interactive marker in horizontal mode without onChangeStep', () => {
+    render(<ProgressStepIndicatorListItem step={0} stepText="Start" />);
+    expect(screen.queryByRole('button')).toBeNull();
+    expect(screen.getByTitle('Start')).toBeTruthy();
   });
 
   test('active item gets slds-is-active class', () => {
@@ -84,15 +90,8 @@ describe('ProgressStepIndicatorListItem', () => {
     expect(onChangeStep).toHaveBeenCalledWith(2);
   });
 
-  test('disabled button cannot be clicked', () => {
-    const onChangeStep = vi.fn();
-    render(<ProgressStepIndicatorListItem step={0} disabled onChangeStep={onChangeStep} />);
-    const button = screen.getByRole('button') as HTMLButtonElement;
-    expect(button.disabled).toBe(true);
-  });
-
   test('renders custom stepText as button title', () => {
-    render(<ProgressStepIndicatorListItem step={0} stepText="Start" />);
+    render(<ProgressStepIndicatorListItem step={0} stepText="Start" onChangeStep={vi.fn()} />);
     const button = screen.getByRole('button');
     expect(button.getAttribute('title')).toBe('Start');
   });


### PR DESCRIPTION
The vertical step list reserved a sixth of the page width and competed with the page content. The header meta row now shows "Step X of Y" with progress dots; completed dots navigate back, mirroring the Go Back button.

Horizontal markers without a click handler render as spans rather than disabled buttons, since .slds-button:disabled makes the marker circle transparent.