### PR TITLE
feat(orgs): use the shared org combobox for data history and canvas org pickers

### DIFF
--- a/libs/features/data-history/src/lib/DataHistoryFilters.tsx
+++ b/libs/features/data-history/src/lib/DataHistoryFilters.tsx
@@ -1,5 +1,6 @@
 import { SalesforceOrgUi } from '@jetstream/types';
-import { DatePicker, Grid, Picklist } from '@jetstream/ui';
+import { DatePicker, Grid } from '@jetstream/ui';
+import { OrgsCombobox } from '@jetstream/ui-core';
 import { DataHistoryListFilter } from '@jetstream/ui/db';
 import { endOfDay, startOfDay } from 'date-fns';
 import { FunctionComponent, useMemo } from 'react';
@@ -13,27 +14,19 @@ export interface DataHistoryFiltersProps {
   onChange: (value: DataHistoryFilterValue) => void;
 }
 
-const ALL_ORGS_ID = '__ALL__';
-
 export const DataHistoryFilters: FunctionComponent<DataHistoryFiltersProps> = ({ orgs, value, onChange }) => {
-  const orgItems = useMemo(
-    () => [
-      { id: ALL_ORGS_ID, label: 'All orgs', value: ALL_ORGS_ID },
-      ...orgs.map(({ uniqueId, label }) => ({ id: uniqueId, label, value: uniqueId })),
-    ],
-    [orgs],
-  );
+  const selectedOrg = useMemo(() => orgs.find(({ uniqueId }) => uniqueId === value.org) ?? null, [orgs, value.org]);
 
   return (
     <Grid verticalAlign="end" wrap className="slds-m-bottom_x-small slds-gutters_xx-small">
       <div className="slds-col slds-m-right_x-small">
-        <Picklist
+        <OrgsCombobox
           label="Org"
-          containerClassName="slds-size_small"
-          items={orgItems}
-          selectedItemIds={[value.org ?? ALL_ORGS_ID]}
-          allowDeselection={false}
-          onChange={([selected]) => onChange({ ...value, org: selected?.id === ALL_ORGS_ID ? undefined : selected?.id })}
+          hideLabel={false}
+          orgs={orgs}
+          selectedOrg={selectedOrg}
+          onSelected={(org) => onChange({ ...value, org: org.uniqueId })}
+          onSelectedAllOrgs={() => onChange({ ...value, org: undefined })}
         />
       </div>
       <div className="slds-col slds-m-right_x-small">

--- a/libs/shared/ui-core/src/orgs/OrgsCombobox.tsx
+++ b/libs/shared/ui-core/src/orgs/OrgsCombobox.tsx
@@ -3,9 +3,10 @@ import { getOrgType } from '@jetstream/shared/ui-utils';
 import { multiWordObjectFilter } from '@jetstream/shared/utils';
 import { ListItem, ListItemGroup, Maybe, SalesforceOrgUi } from '@jetstream/types';
 import { Badge, ComboboxWithGroupedItems } from '@jetstream/ui';
+import classNames from 'classnames';
 import groupBy from 'lodash/groupBy';
 import sortBy from 'lodash/sortBy';
-import { FunctionComponent, useEffect, useState } from 'react';
+import { FunctionComponent, ReactNode, useMemo } from 'react';
 import { calculateOrgExpiration } from './useOrgExpiration';
 
 /**
@@ -17,13 +18,24 @@ const ORG_SEARCH_FIELDS: Array<keyof SalesforceOrgUi> = ['label', 'username', 'o
 
 const orgFilterFn = (filter: string) => {
   const matchesOrg = multiWordObjectFilter<SalesforceOrgUi>(ORG_SEARCH_FIELDS, filter);
-  return (item: ListItem<string, SalesforceOrgUi>) => !!item.meta && matchesOrg(item.meta);
+  const matchesItemLabel = multiWordObjectFilter<ListItem<string, SalesforceOrgUi>>(['label'], filter);
+  // Items without an org attached (the "All Orgs" choice) can only match on their label
+  return (item: ListItem<string, SalesforceOrgUi>) => (item.meta ? matchesOrg(item.meta) : matchesItemLabel(item));
+};
+
+const ALL_ORGS_ITEM_ID = '__ALL_ORGS__';
+
+/** Rendered as a headerless group so the choice sits above the per-org groups */
+const ALL_ORGS_GROUP: ListItemGroup<string, SalesforceOrgUi> = {
+  id: ALL_ORGS_ITEM_ID,
+  label: '',
+  items: [{ id: ALL_ORGS_ITEM_ID, label: 'All Orgs', value: ALL_ORGS_ITEM_ID }],
 };
 
 function getSelectedItemLabel(item: ListItem<string, SalesforceOrgUi>) {
   const org = item.meta;
   if (!org) {
-    return '';
+    return item.label;
   }
   let subtext = '';
   if (org.label !== org.username) {
@@ -35,7 +47,7 @@ function getSelectedItemLabel(item: ListItem<string, SalesforceOrgUi>) {
 function getSelectedItemTitle(item: ListItem<string, SalesforceOrgUi>) {
   const org = item.meta;
   if (!org) {
-    return '';
+    return item.label;
   }
   let subtext = '';
   if (org.label !== org.username) {
@@ -117,10 +129,17 @@ export interface OrgsComboboxProps {
   label?: string;
   hideLabel?: boolean;
   placeholder?: string;
+  helpText?: ReactNode | string;
+  containerClassName?: string;
   isRequired?: boolean;
   disabled?: boolean;
   minWidth?: number;
   onSelected: (org: SalesforceOrgUi) => void;
+  /**
+   * When provided, an "All Orgs" choice is shown above the org list and this is called when it is
+   * chosen (instead of onSelected). The choice shows as selected whenever selectedOrg is empty.
+   */
+  onSelectedAllOrgs?: () => void;
 }
 
 export const OrgsCombobox: FunctionComponent<OrgsComboboxProps> = ({
@@ -129,20 +148,23 @@ export const OrgsCombobox: FunctionComponent<OrgsComboboxProps> = ({
   label = 'Orgs',
   hideLabel = true,
   placeholder = 'Select an Org',
+  helpText,
+  containerClassName,
   isRequired,
   disabled,
   minWidth = 300,
   onSelected,
+  onSelectedAllOrgs,
 }) => {
-  const [groupedOrgs, setGroupedOrgs] = useState<ListItemGroup<string, SalesforceOrgUi>[]>(() => groupOrgs(orgs));
-
-  useEffect(() => {
-    setGroupedOrgs(groupOrgs(orgs));
-  }, [orgs]);
+  const includeAllOrgs = !!onSelectedAllOrgs;
+  const groupedOrgs = useMemo<ListItemGroup<string, SalesforceOrgUi>[]>(
+    () => (includeAllOrgs ? [ALL_ORGS_GROUP, ...groupOrgs(orgs)] : groupOrgs(orgs)),
+    [orgs, includeAllOrgs],
+  );
 
   return (
     <div
-      className="slds-col"
+      className={classNames('slds-col', containerClassName)}
       css={css`
         ${minWidth ? `min-width: ${minWidth}px;` : undefined}
       `}
@@ -154,6 +176,7 @@ export const OrgsCombobox: FunctionComponent<OrgsComboboxProps> = ({
           label,
           hideLabel,
           placeholder,
+          helpText,
           itemLength: 7,
           hasError: orgHasError(selectedOrg),
           disabled,
@@ -170,8 +193,14 @@ export const OrgsCombobox: FunctionComponent<OrgsComboboxProps> = ({
         })}
         groups={groupedOrgs}
         filterFn={orgFilterFn}
-        onSelected={(item) => onSelected(item.meta)}
-        selectedItemId={selectedOrg?.uniqueId}
+        onSelected={(item) => {
+          if (item.meta) {
+            onSelected(item.meta);
+          } else {
+            onSelectedAllOrgs?.();
+          }
+        }}
+        selectedItemId={selectedOrg?.uniqueId ?? (includeAllOrgs ? ALL_ORGS_ITEM_ID : undefined)}
         selectedItemLabelFn={getSelectedItemLabel}
         selectedItemTitleFn={getSelectedItemTitle}
       />

--- a/libs/shared/ui-core/src/orgs/__tests__/OrgsCombobox.spec.tsx
+++ b/libs/shared/ui-core/src/orgs/__tests__/OrgsCombobox.spec.tsx
@@ -114,4 +114,41 @@ describe('OrgsCombobox', () => {
       expect(within(listbox).getByText('There are no items for selection')).toBeTruthy();
     });
   });
+
+  describe('all orgs option', () => {
+    function renderWithAllOrgs(selectedOrg: SalesforceOrgUi | null = null) {
+      const onSelected = vi.fn();
+      const onSelectedAllOrgs = vi.fn();
+      const result = render(
+        <OrgsCombobox orgs={orgs} selectedOrg={selectedOrg} onSelected={onSelected} onSelectedAllOrgs={onSelectedAllOrgs} />,
+      );
+      const input = result.container.querySelector('input') as HTMLInputElement;
+      return { ...result, input, onSelected, onSelectedAllOrgs };
+    }
+
+    it('is not shown unless opted in', () => {
+      const { listbox } = renderOpen();
+      expect(within(listbox).queryByText('All Orgs')).toBeNull();
+    });
+
+    it('is shown above the org list and reflects an empty selection', () => {
+      const { input, container } = renderWithAllOrgs(null);
+      expect(input.value).toBe('All Orgs');
+
+      fireEvent.click(input);
+      const listbox = container.querySelector('[role="listbox"]') as HTMLElement;
+      const options = within(listbox).getAllByRole('option');
+      expect(options[0].textContent).toContain('All Orgs');
+      expect(options[0].getAttribute('aria-selected')).toBe('true');
+    });
+
+    it('calls onSelectedAllOrgs instead of onSelected when chosen', () => {
+      const { input, container, onSelected, onSelectedAllOrgs } = renderWithAllOrgs(production);
+      fireEvent.click(input);
+      const listbox = container.querySelector('[role="listbox"]') as HTMLElement;
+      fireEvent.click(within(listbox).getByText('All Orgs'));
+      expect(onSelectedAllOrgs).toHaveBeenCalledTimes(1);
+      expect(onSelected).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/libs/shared/ui-core/src/settings/SalesforceCanvasOrgs.tsx
+++ b/libs/shared/ui-core/src/settings/SalesforceCanvasOrgs.tsx
@@ -11,27 +11,16 @@ import { getErrorMessage } from '@jetstream/shared/utils';
 import {
   CreateSalesforceCanvasOrgRequest,
   CreateSalesforceCanvasOrgRequestSchema,
-  ListItem,
   SALESFORCE_CANVAS_ORG_LIMIT,
   SalesforceCanvasOrg,
+  SalesforceOrgUi,
 } from '@jetstream/types';
-import {
-  Card,
-  ConfirmationModalPromise,
-  fireToast,
-  Grid,
-  GridCol,
-  Icon,
-  Input,
-  Modal,
-  Picklist,
-  ScopedNotification,
-  Spinner,
-} from '@jetstream/ui';
+import { Card, ConfirmationModalPromise, fireToast, Grid, GridCol, Icon, Input, Modal, ScopedNotification, Spinner } from '@jetstream/ui';
 import { fromAppState } from '@jetstream/ui/app-state';
 import { useAtomValue } from 'jotai';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
+import { OrgsCombobox } from '../orgs/OrgsCombobox';
 
 /**
  * Best-effort parse of the "My Domain" base from a connected org's instance URL, so we can prefill the
@@ -219,22 +208,10 @@ function AddCanvasOrgModal({
     }
   }
 
-  const connectedOrgItems = useMemo<ListItem[]>(
-    () =>
-      connectedOrgs.map((org) => ({
-        id: org.uniqueId,
-        label: org.label,
-        secondaryLabel: org.orgIsSandbox ? 'Sandbox' : 'Production',
-        value: org.uniqueId,
-      })),
-    [connectedOrgs],
-  );
+  const [prefillOrg, setPrefillOrg] = useState<SalesforceOrgUi | null>(null);
 
-  function handlePrefillFromOrg(selectedItems: ListItem[]) {
-    const selectedOrg = connectedOrgs.find((org) => org.uniqueId === selectedItems[0]?.id);
-    if (!selectedOrg) {
-      return;
-    }
+  function handlePrefillFromOrg(selectedOrg: SalesforceOrgUi) {
+    setPrefillOrg(selectedOrg);
     setValue('organizationId', selectedOrg.organizationId, { shouldValidate: true, shouldDirty: true });
     setValue('myDomainBase', parseMyDomainBaseFromInstanceUrl(selectedOrg.instanceUrl), { shouldValidate: true, shouldDirty: true });
     setValue('orgName', selectedOrg.orgName || selectedOrg.label, { shouldValidate: true, shouldDirty: true });
@@ -261,16 +238,17 @@ function AddCanvasOrgModal({
             {saveError}
           </ScopedNotification>
         )}
-        {connectedOrgItems.length > 0 && (
+        {connectedOrgs.length > 0 && (
           <>
-            <Picklist
-              className="slds-m-bottom_x-small"
+            <OrgsCombobox
+              containerClassName="slds-m-bottom_x-small"
               label="Prefill from a connected org"
+              hideLabel={false}
               placeholder="Select a connected org"
               helpText="Optional: fills in the fields below from an org you've already connected. You can still edit them."
-              items={connectedOrgItems}
-              allowDeselection
-              onChange={handlePrefillFromOrg}
+              orgs={connectedOrgs}
+              selectedOrg={prefillOrg}
+              onSelected={handlePrefillFromOrg}
             />
             <p className="slds-m-bottom_small slds-text-color_weak slds-text-body_small">Or enter the details manually.</p>
           </>

--- a/libs/ui/src/lib/form/combobox/ComboboxListItemGroup.tsx
+++ b/libs/ui/src/lib/form/combobox/ComboboxListItemGroup.tsx
@@ -9,7 +9,7 @@ export interface ComboboxListItemGroupProps {
 export const ComboboxListItemGroup = forwardRef<HTMLUListElement, ComboboxListItemGroupProps>(({ label, children }, ref) => {
   return (
     <ul ref={ref} className="slds-listbox slds-listbox_vertical" role="group" aria-label={label}>
-      <ComboboxListItemHeading label={label} />
+      {label && <ComboboxListItemHeading label={label} />}
       {children}
     </ul>
   );


### PR DESCRIPTION
The two remaining ad-hoc org Picklists missed the new dropdown style (org-type badge, full usernames, wider panel). OrgsCombobox now supports an opt-in "All Orgs" choice, which was the reason the data history filter couldn't use it. The canvas prefill picker drops allowDeselection, which was already a no-op - deselecting never cleared the form fields.