### PR TITLE
fix(deploy): disable package download until a package is selected or entered

### DIFF
--- a/libs/features/deploy/src/download-metadata-package/DownloadMetadataPackageConfigModal.tsx
+++ b/libs/features/deploy/src/download-metadata-package/DownloadMetadataPackageConfigModal.tsx
@@ -46,26 +46,18 @@ export const DownloadMetadataPackageConfigModal: FunctionComponent<DownloadMetad
     setPackageNames(selectedItems.map((item) => item.value));
   }
 
-  function handleDownloadFromPackageNames() {
-    // combine selected packages with manually entered packages
-    onDownloadFromPackageNames(
-      destinationOrg,
-      Array.from(
-        new Set(
-          packageNames
-            .concat(packageNamesStr.replace(SPLIT_LINE_COMMA, ',').split(','))
-            .map((item) => item.trim())
-            .filter((item) => !!item),
-        ),
-      ),
-    );
-  }
+  // combine selected packages with manually entered packages
+  const combinedPackageNames = Array.from(
+    new Set(
+      packageNames
+        .concat(packageNamesStr.replace(SPLIT_LINE_COMMA, ',').split(','))
+        .map((item) => item.trim())
+        .filter((item) => !!item),
+    ),
+  );
 
-  function isPackageNameDownloadButtonEnabled() {
-    if (packageNames.length || setPackageNamesStr.length) {
-      return false;
-    }
-    return true;
+  function handleDownloadFromPackageNames() {
+    onDownloadFromPackageNames(destinationOrg, combinedPackageNames);
   }
 
   return (
@@ -171,7 +163,7 @@ export const DownloadMetadataPackageConfigModal: FunctionComponent<DownloadMetad
             <button
               className="slds-button slds-button_brand slds-m-top_medium"
               onClick={handleDownloadFromPackageNames}
-              disabled={isPackageNameDownloadButtonEnabled()}
+              disabled={combinedPackageNames.length === 0}
             >
               Download
             </button>


### PR DESCRIPTION
The disabled check read `setPackageNamesStr.length` — the state setter, whose length is always 1 — instead of the textarea value, so the button was always enabled and an empty list hit the server's packageNames validation. The button now keys off the combined, trimmed package list, which also covers whitespace- or comma-only textarea input.