### PR TITLE
fix: address review follow-ups from grouped-row and package-download PRs

### DIFF
--- a/libs/features/deploy/src/download-metadata-package/DownloadMetadataPackageConfigModal.tsx
+++ b/libs/features/deploy/src/download-metadata-package/DownloadMetadataPackageConfigModal.tsx
@@ -67,7 +67,7 @@ export const DownloadMetadataPackageConfigModal: FunctionComponent<DownloadMetad
       onClose={onClose}
       tagline={
         <div className="slds-align_absolute-center">
-          Your metadata will be downloaded from from <OrgLabelBadge org={destinationOrg} />
+          Your metadata will be downloaded from <OrgLabelBadge org={destinationOrg} />
         </div>
       }
     >

--- a/libs/shared/ui-core/src/record/ViewChildRecords.tsx
+++ b/libs/shared/ui-core/src/record/ViewChildRecords.tsx
@@ -163,7 +163,7 @@ export const ViewChildRecords: FunctionComponent<ViewChildRecordsProps> = ({
         name: 'Last Modified',
       },
       {
-        ...setColumnFromType('CreatedByName', 'date'),
+        ...setColumnFromType('CreatedByName', 'text'),
         key: 'CreatedByName',
         name: 'Created By',
       },
@@ -300,7 +300,7 @@ export const ViewChildRecords: FunctionComponent<ViewChildRecordsProps> = ({
         setExpandedGroupIds(new Set(_rows.map((row) => row._groupByLabel)));
 
         onChildrenData && onChildrenData(parentRecordId, record);
-        trackEvent(ANALYTICS_KEYS.record_modal_view_children, { subqueryCount: subqueries.length, childRecordCount: _rows });
+        trackEvent(ANALYTICS_KEYS.record_modal_view_children, { subqueryCount: subqueries.length, childRecordCount: _rows.length });
       } catch (ex) {
         logger.warn('Error loading records', ex);
         setHasFetchErrors((existing) => [...existing, getErrorMessage(ex)]);


### PR DESCRIPTION
Fixes three pre-existing issues flagged during review of #2019 and #2023 (all outside those diffs):

- `ViewChildRecords.tsx` — the `record_modal_view_children` analytics event sent the entire child-record array (including each row's full `_record` payload) as `childRecordCount` instead of `_rows.length`
- `ViewChildRecords.tsx` — the "Created By" column was typed as `'date'` instead of `'text'`, giving a person-name column date cell rendering and a date quick-filter that could never match
- `DownloadMetadataPackageConfigModal.tsx` — doubled word in the modal tagline ("downloaded from from")

Refs #2019
Refs #2023