### PR TITLE
fix: address code review findings in the Apex Test Runner

### DIFF
--- a/apps/jetstream-web-extension/vite.plugins.mts
+++ b/apps/jetstream-web-extension/vite.plugins.mts
@@ -69,6 +69,7 @@ const PLACEHOLDER_PAGES = [
   'formula-evaluator',
   'record-type-manager',
   'apex',
+  'apex-tests',
   'debug-logs',
   'object-export',
   'salesforce-api',

--- a/libs/features/apex-test-runner/src/__tests__/apex-test-runner-composite-requests.spec.ts
+++ b/libs/features/apex-test-runner/src/__tests__/apex-test-runner-composite-requests.spec.ts
@@ -1,0 +1,122 @@
+import type { SalesforceOrgUi } from '@jetstream/types';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { abortTestRun, updateTestSuiteMembership } from '../apex-test-runner-data.utils';
+
+const { makeToolingRequestsMock, queryMock } = vi.hoisted(() => ({
+  makeToolingRequestsMock: vi.fn(),
+  queryMock: vi.fn(),
+}));
+
+vi.mock('@jetstream/shared/ui-utils', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@jetstream/shared/ui-utils')>()),
+  makeToolingRequests: makeToolingRequestsMock,
+}));
+
+vi.mock('@jetstream/shared/data', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@jetstream/shared/data')>()),
+  query: queryMock,
+}));
+
+const org = { uniqueId: 'org-composite-spec' } as SalesforceOrgUi;
+const API_VERSION = 'v64.0';
+
+function compositeItem(httpStatusCode: number, referenceId: string, body: unknown = null) {
+  return { httpStatusCode, referenceId, body, httpHeaders: {} };
+}
+
+beforeEach(() => {
+  makeToolingRequestsMock.mockReset();
+  queryMock.mockReset();
+});
+
+describe('updateTestSuiteMembership', () => {
+  it('resolves when every subrequest succeeds and requests an atomic (allOrNone) save', async () => {
+    makeToolingRequestsMock.mockResolvedValue({
+      compositeResponse: [compositeItem(201, 'add_0', { id: '01p000000000001', success: true }), compositeItem(204, 'remove_0')],
+    });
+
+    await updateTestSuiteMembership(org, API_VERSION, '05F000000000001', {
+      addClassIds: ['01p000000000001'],
+      removeMembershipIds: ['05G000000000001'],
+    });
+
+    expect(makeToolingRequestsMock).toHaveBeenCalledTimes(1);
+    const [, compositeRequests, apiVersion, allOrNone] = makeToolingRequestsMock.mock.calls[0];
+    expect(compositeRequests).toHaveLength(2);
+    expect(apiVersion).toBe(API_VERSION);
+    expect(allOrNone).toBe(true);
+  });
+
+  it('skips the API call entirely when there are no membership changes', async () => {
+    await updateTestSuiteMembership(org, API_VERSION, '05F000000000001', { addClassIds: [], removeMembershipIds: [] });
+    expect(makeToolingRequestsMock).not.toHaveBeenCalled();
+  });
+
+  it('throws the Salesforce error when a subrequest fails, ignoring rollback noise from sibling items', async () => {
+    // Composite requests return per-item statuses inside an overall 200 response
+    makeToolingRequestsMock.mockResolvedValue({
+      compositeResponse: [
+        compositeItem(400, 'add_0', [{ errorCode: 'MALFORMED_ID', message: 'malformed id 01pXXX' }]),
+        compositeItem(400, 'remove_0', [
+          {
+            errorCode: 'PROCESSING_HALTED',
+            message: 'The transaction was rolled back since another operation in the same transaction failed.',
+          },
+        ]),
+      ],
+    });
+
+    await expect(
+      updateTestSuiteMembership(org, API_VERSION, '05F000000000001', {
+        addClassIds: ['01pXXX'],
+        removeMembershipIds: ['05G000000000001'],
+      }),
+    ).rejects.toThrow('malformed id 01pXXX');
+  });
+
+  it('throws a fallback message when a failed subrequest has no error body', async () => {
+    makeToolingRequestsMock.mockResolvedValue({ compositeResponse: [compositeItem(500, 'add_0')] });
+
+    await expect(
+      updateTestSuiteMembership(org, API_VERSION, '05F000000000001', { addClassIds: ['01p000000000001'], removeMembershipIds: [] }),
+    ).rejects.toThrow('Unable to save the test suite changes');
+  });
+});
+
+describe('abortTestRun', () => {
+  function mockQueueItems(statuses: string[]) {
+    queryMock.mockResolvedValue({
+      queryResults: {
+        records: statuses.map((status, i) => ({ Id: `70900000000000${i}`, Status: status })),
+      },
+    });
+  }
+
+  it('returns the aborted item count when every PATCH succeeds', async () => {
+    mockQueueItems(['Queued', 'Processing', 'Completed']);
+    makeToolingRequestsMock.mockResolvedValue({
+      compositeResponse: [compositeItem(204, 'abort_0'), compositeItem(204, 'abort_1')],
+    });
+
+    await expect(abortTestRun(org, API_VERSION, '707000000000001')).resolves.toBe(2);
+  });
+
+  it('returns 0 without any composite call when no queue items are in progress', async () => {
+    mockQueueItems(['Completed', 'Failed']);
+
+    await expect(abortTestRun(org, API_VERSION, '707000000000001')).resolves.toBe(0);
+    expect(makeToolingRequestsMock).not.toHaveBeenCalled();
+  });
+
+  it('throws when any PATCH fails so the UI does not report a successful abort', async () => {
+    mockQueueItems(['Queued', 'Processing']);
+    makeToolingRequestsMock.mockResolvedValue({
+      compositeResponse: [
+        compositeItem(204, 'abort_0'),
+        compositeItem(409, 'abort_1', [{ errorCode: 'ENTITY_IS_LOCKED', message: 'record is locked' }]),
+      ],
+    });
+
+    await expect(abortTestRun(org, API_VERSION, '707000000000001')).rejects.toThrow('record is locked');
+  });
+});

--- a/libs/features/apex-test-runner/src/__tests__/use-apex-test-runs-list-polling.spec.ts
+++ b/libs/features/apex-test-runner/src/__tests__/use-apex-test-runs-list-polling.spec.ts
@@ -1,0 +1,82 @@
+import type { SalesforceOrgUi } from '@jetstream/types';
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useApexTestRunsList } from '../useApexTestRunsList';
+
+const { fetchTestRunsMock } = vi.hoisted(() => ({ fetchTestRunsMock: vi.fn() }));
+
+vi.mock('../apex-test-runner-data.utils', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../apex-test-runner-data.utils')>()),
+  fetchTestRuns: fetchTestRunsMock,
+}));
+
+const org = { uniqueId: 'org-poll-spec' } as SalesforceOrgUi;
+
+// Mirrors the constants in useApexTestRunsList
+const IDLE_POLL_INTERVAL = 30000;
+const MAX_POLL_ERRORS = 25;
+
+async function advanceOnePollCycle() {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(IDLE_POLL_INTERVAL);
+  });
+}
+
+describe('useApexTestRunsList polling error cutoff', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    fetchTestRunsMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('stops polling after MAX_POLL_ERRORS consecutive failures', async () => {
+    fetchTestRunsMock.mockRejectedValue(new Error('org unreachable'));
+
+    const { result } = renderHook(() => useApexTestRunsList(org));
+    // Let the initial mount fetch settle (error #1)
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(fetchTestRunsMock).toHaveBeenCalledTimes(1);
+
+    // Errors #2 through #MAX_POLL_ERRORS via the poll interval
+    for (let i = 0; i < MAX_POLL_ERRORS - 1; i++) {
+      await advanceOnePollCycle();
+    }
+    expect(fetchTestRunsMock).toHaveBeenCalledTimes(MAX_POLL_ERRORS);
+    expect(result.current.errorMessage).toBe('org unreachable');
+
+    // Once the cutoff engages, further intervals must not fire any more requests
+    for (let i = 0; i < 5; i++) {
+      await advanceOnePollCycle();
+    }
+    expect(fetchTestRunsMock).toHaveBeenCalledTimes(MAX_POLL_ERRORS);
+  });
+
+  it('resumes polling after a successful manual refresh resets the error count', async () => {
+    fetchTestRunsMock.mockRejectedValue(new Error('org unreachable'));
+
+    const { result } = renderHook(() => useApexTestRunsList(org));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    for (let i = 0; i < MAX_POLL_ERRORS - 1; i++) {
+      await advanceOnePollCycle();
+    }
+    expect(fetchTestRunsMock).toHaveBeenCalledTimes(MAX_POLL_ERRORS);
+
+    // A manual refresh that succeeds should clear the error state and restart polling
+    fetchTestRunsMock.mockResolvedValue([]);
+    await act(async () => {
+      await result.current.fetchRuns();
+    });
+    expect(result.current.errorMessage).toBeNull();
+    const callsAfterManualRefresh = fetchTestRunsMock.mock.calls.length;
+
+    await advanceOnePollCycle();
+    expect(fetchTestRunsMock.mock.calls.length).toBeGreaterThan(callsAfterManualRefresh);
+  });
+});

--- a/libs/features/apex-test-runner/src/apex-test-runner-data.utils.ts
+++ b/libs/features/apex-test-runner/src/apex-test-runner-data.utils.ts
@@ -433,7 +433,9 @@ export async function updateTestSuiteMembership(
   if (compositeRequests.length === 0) {
     return;
   }
-  // allOrNone so a rejected change rolls back the rest and a retry can re-apply the same diff cleanly
+  // allOrNone so a rejected change rolls back its batch (requests are chunked into sets of 25) and a
+  // retry can re-apply the diff cleanly — the caller refreshes memberships so a partially-applied
+  // multi-batch save is recomputed against real org state
   const response = await makeToolingRequests(org, compositeRequests, apiVersion, true);
   throwIfCompositeItemsFailed(response, 'Unable to save the test suite changes. Please try again.');
 }

--- a/libs/features/apex-test-runner/src/apex-test-runner-data.utils.ts
+++ b/libs/features/apex-test-runner/src/apex-test-runner-data.utils.ts
@@ -333,19 +333,20 @@ export async function fetchOrgWideCoverage(org: SalesforceOrgUi): Promise<number
   return records[0]?.PercentCovered ?? null;
 }
 
-export async function fetchApexClassManifest(org: SalesforceOrgUi) {
-  return (await queryAll<ApexClassRecord>(org, getApexClassManifestQuery(), true)).queryResults.records;
+export async function fetchApexClassManifest(org: SalesforceOrgUi, signal?: AbortSignal) {
+  return (await queryAll<ApexClassRecord>(org, getApexClassManifestQuery(), true, false, undefined, signal)).queryResults.records;
 }
 
 export async function fetchSymbolTables(
   org: SalesforceOrgUi,
   classIds: string[],
   onProgress?: (fetchedCount: number, totalCount: number) => void,
+  signal?: AbortSignal,
 ): Promise<ApexClassRecord[]> {
   const results: ApexClassRecord[] = [];
   const chunks = splitArrayToMaxSize(classIds, SYMBOL_TABLE_CHUNK_SIZE);
   for (const chunk of chunks) {
-    const records = (await query<ApexClassRecord>(org, getApexClassSymbolTableQuery(chunk), true)).queryResults.records;
+    const records = (await query<ApexClassRecord>(org, getApexClassSymbolTableQuery(chunk), true, false, signal)).queryResults.records;
     results.push(...records);
     onProgress?.(results.length, classIds.length);
   }

--- a/libs/features/apex-test-runner/src/apex-test-runner-data.utils.ts
+++ b/libs/features/apex-test-runner/src/apex-test-runner-data.utils.ts
@@ -11,6 +11,7 @@ import type {
   ApexTestRunResultRecord,
   ApexTestSuiteRecord,
   ApexTriggerRecord,
+  CompositeResponse,
   RunTestsAsyncOptions,
   RunTestsAsyncPayload,
   SalesforceOrgUi,
@@ -389,6 +390,24 @@ export async function deleteTestSuite(org: SalesforceOrgUi, suiteId: string) {
 }
 
 /**
+ * Composite subrequests report failures per-item inside an overall 200 response, so a failed
+ * item must be surfaced manually or the operation silently reports success to the user.
+ */
+function throwIfCompositeItemsFailed(response: CompositeResponse<unknown>, fallbackMessage: string) {
+  const failedItems = response.compositeResponse.filter(({ httpStatusCode }) => httpStatusCode > 299);
+  if (failedItems.length === 0) {
+    return;
+  }
+  const errorMessages = failedItems
+    .flatMap(({ body }) => (Array.isArray(body) ? (body as { errorCode?: string; message?: string }[]) : []))
+    // With allOrNone, every sibling subrequest fails with a rollback notice that would drown out the real error
+    .filter(({ errorCode }) => errorCode !== 'PROCESSING_HALTED')
+    .map(({ message }) => message)
+    .filter(Boolean);
+  throw new Error(Array.from(new Set(errorMessages)).join(' ') || fallbackMessage);
+}
+
+/**
  * Apply suite membership changes as a diff — new classes are added, removed memberships are deleted.
  */
 export async function updateTestSuiteMembership(
@@ -413,7 +432,9 @@ export async function updateTestSuiteMembership(
   if (compositeRequests.length === 0) {
     return;
   }
-  await makeToolingRequests(org, compositeRequests, apiVersion);
+  // allOrNone so a rejected change rolls back the rest and a retry can re-apply the same diff cleanly
+  const response = await makeToolingRequests(org, compositeRequests, apiVersion, true);
+  throwIfCompositeItemsFailed(response, 'Unable to save the test suite changes. Please try again.');
 }
 
 /**
@@ -426,7 +447,8 @@ export async function abortTestRun(org: SalesforceOrgUi, apiVersion: string, par
   if (itemsToAbort.length === 0) {
     return 0;
   }
-  await makeToolingRequests(
+  // Not allOrNone — abort as many queue items as possible, then report any that failed
+  const response = await makeToolingRequests(
     org,
     itemsToAbort.map((item, i) => ({
       method: 'PATCH' as const,
@@ -436,5 +458,6 @@ export async function abortTestRun(org: SalesforceOrgUi, apiVersion: string, par
     })),
     apiVersion,
   );
+  throwIfCompositeItemsFailed(response, 'Some tests could not be aborted.');
   return itemsToAbort.length;
 }

--- a/libs/features/apex-test-runner/src/selection/TestSuiteManagerModal.tsx
+++ b/libs/features/apex-test-runner/src/selection/TestSuiteManagerModal.tsx
@@ -14,7 +14,7 @@ import {
   Spinner,
 } from '@jetstream/ui';
 import { useAmplitude } from '@jetstream/ui-core';
-import { FunctionComponent, useEffect, useMemo, useState } from 'react';
+import { FunctionComponent, useEffect, useMemo, useRef, useState } from 'react';
 import { validateTestSuiteName } from '../apex-test-runner-data.utils';
 import type { TestClassListItem } from '../apex-test-runner-types';
 import type { useApexTestSuites } from '../useApexTestSuites';
@@ -55,12 +55,19 @@ export const TestSuiteManagerModal: FunctionComponent<TestSuiteManagerModalProps
     }
   }, [selectedSuiteId, suites]);
 
-  // Re-initialize the editor whenever a different suite is chosen or fresh data arrives
+  // Re-initialize the editor whenever a different suite is chosen. Membership checkboxes are only
+  // initialized when the suite id changes so unrelated refreshes (e.g. a rename, or the reload after
+  // a failed save) don't silently discard unsaved checkbox edits.
+  const initializedMembershipSuiteId = useRef<string | null>(null);
   useEffect(() => {
     if (selectedSuite) {
       setRenameValue(selectedSuite.TestSuiteName);
-      setMemberClassIds(new Set((membershipsBySuiteId.get(selectedSuite.Id) ?? []).map(({ ApexClassId }) => ApexClassId)));
+      if (initializedMembershipSuiteId.current !== selectedSuite.Id) {
+        initializedMembershipSuiteId.current = selectedSuite.Id;
+        setMemberClassIds(new Set((membershipsBySuiteId.get(selectedSuite.Id) ?? []).map(({ ApexClassId }) => ApexClassId)));
+      }
     } else {
+      initializedMembershipSuiteId.current = null;
       setRenameValue('');
       setMemberClassIds(new Set());
     }

--- a/libs/features/apex-test-runner/src/useApexTestClasses.ts
+++ b/libs/features/apex-test-runner/src/useApexTestClasses.ts
@@ -39,6 +39,8 @@ async function writeCache(org: SalesforceOrgUi, cache: ApexClassCache) {
 export function useApexTestClasses(org: SalesforceOrgUi) {
   const isMounted = useRef(true);
   const currentFetchToken = useRef(0);
+  /** Cancels in-flight scanning (up to ~100 sequential queries on large orgs) on unmount or when a newer load supersedes it */
+  const abortControllerRef = useRef<AbortController | null>(null);
   const [loading, setLoading] = useState(true);
   const [progressText, setProgressText] = useState<string | null>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
@@ -50,6 +52,7 @@ export function useApexTestClasses(org: SalesforceOrgUi) {
     isMounted.current = true;
     return () => {
       isMounted.current = false;
+      abortControllerRef.current?.abort();
     };
   }, []);
 
@@ -57,10 +60,13 @@ export function useApexTestClasses(org: SalesforceOrgUi) {
     async ({ skipCache }: { skipCache?: boolean } = {}) => {
       const fetchToken = new Date().getTime();
       currentFetchToken.current = fetchToken;
+      abortControllerRef.current?.abort();
+      const abortController = new AbortController();
+      abortControllerRef.current = abortController;
       try {
         setLoading(true);
         setErrorMessage(null);
-        const manifest = await fetchApexClassManifest(org);
+        const manifest = await fetchApexClassManifest(org, abortController.signal);
         const manifestById = new Map(manifest.map((record) => [record.Id, record]));
         const cache = skipCache ? {} : await readCache(org);
 
@@ -69,11 +75,16 @@ export function useApexTestClasses(org: SalesforceOrgUi) {
           .map(({ Id }) => Id);
 
         if (missingIds.length) {
-          const symbolTableRecords = await fetchSymbolTables(org, missingIds, (fetchedCount, totalCount) => {
-            if (isMounted.current && fetchToken === currentFetchToken.current) {
-              setProgressText(`Analyzing classes ${fetchedCount.toLocaleString()} of ${totalCount.toLocaleString()}…`);
-            }
-          });
+          const symbolTableRecords = await fetchSymbolTables(
+            org,
+            missingIds,
+            (fetchedCount, totalCount) => {
+              if (isMounted.current && fetchToken === currentFetchToken.current) {
+                setProgressText(`Analyzing classes ${fetchedCount.toLocaleString()} of ${totalCount.toLocaleString()}…`);
+              }
+            },
+            abortController.signal,
+          );
           for (const record of symbolTableRecords) {
             const manifestRecord = manifestById.get(record.Id);
             if (manifestRecord) {
@@ -89,8 +100,12 @@ export function useApexTestClasses(org: SalesforceOrgUi) {
             prunedCache[classId] = entry;
           }
         }
-        await writeCache(org, prunedCache);
 
+        // A superseded load must not write its (older) view of the org over the newer load's cache
+        if (!isMounted.current || fetchToken !== currentFetchToken.current) {
+          return;
+        }
+        await writeCache(org, prunedCache);
         if (!isMounted.current || fetchToken !== currentFetchToken.current) {
           return;
         }

--- a/libs/features/apex-test-runner/src/useApexTestRunsList.ts
+++ b/libs/features/apex-test-runner/src/useApexTestRunsList.ts
@@ -76,12 +76,11 @@ export function useApexTestRunsList(org: SalesforceOrgUi) {
           logger.info('[APEX TESTS][RUNS] ignoring results, currentFetchToken is not valid');
         }
       } catch (ex) {
-        if (isMounted.current) {
+        // Only count failures from the latest request so a slow, superseded fetch cannot skew the cutoff
+        if (isMounted.current && fetchToken === currentFetchToken.current) {
           setNumPollErrors((priorCount) => priorCount + 1);
-          if (fetchToken === currentFetchToken.current) {
-            setErrorMessage(getErrorMessage(ex));
-            setLoading(false);
-          }
+          setErrorMessage(getErrorMessage(ex));
+          setLoading(false);
         }
       }
     },

--- a/libs/features/apex-test-runner/src/useApexTestRunsList.ts
+++ b/libs/features/apex-test-runner/src/useApexTestRunsList.ts
@@ -36,7 +36,11 @@ export function useApexTestRunsList(org: SalesforceOrgUi) {
   const isMounted = useRef(true);
   /** If multiple requests overlap, ignore results from any request that is no longer the latest */
   const currentFetchToken = useRef<number>(0);
-  const numPollErrors = useRef<number>(0);
+  /**
+   * Must be state, not a ref — a failed poll may not otherwise re-render (the error message is
+   * often unchanged between failures), and the cutoff below only engages on re-render.
+   */
+  const [numPollErrors, setNumPollErrors] = useState(0);
   const [isPaused, setIsPaused] = useState(false);
   const [loading, setLoading] = useState(true);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
@@ -58,7 +62,7 @@ export function useApexTestRunsList(org: SalesforceOrgUi) {
         setErrorMessage(null);
         const records = await fetchTestRuns(org);
         if (isMounted.current && fetchToken === currentFetchToken.current) {
-          numPollErrors.current = 0;
+          setNumPollErrors(0);
           if (clearPrevious) {
             setRuns(records);
           } else {
@@ -73,7 +77,7 @@ export function useApexTestRunsList(org: SalesforceOrgUi) {
         }
       } catch (ex) {
         if (isMounted.current) {
-          numPollErrors.current++;
+          setNumPollErrors((priorCount) => priorCount + 1);
           if (fetchToken === currentFetchToken.current) {
             setErrorMessage(getErrorMessage(ex));
             setLoading(false);
@@ -118,7 +122,8 @@ export function useApexTestRunsList(org: SalesforceOrgUi) {
   }, []);
 
   const hasRunsInProgress = runs.some(isTestRunInProgress);
-  const intervalDelay = numPollErrors.current >= MAX_POLL_ERRORS ? null : hasRunsInProgress ? ACTIVE_POLL_INTERVAL : IDLE_POLL_INTERVAL;
+  // Stop polling entirely after sustained failures (dead org/session) — a successful manual refresh resets the count
+  const intervalDelay = numPollErrors >= MAX_POLL_ERRORS ? null : hasRunsInProgress ? ACTIVE_POLL_INTERVAL : IDLE_POLL_INTERVAL;
 
   useInterval(handlePoll, intervalDelay);
 
@@ -128,8 +133,8 @@ export function useApexTestRunsList(org: SalesforceOrgUi) {
   }, [org]);
 
   useEffect(() => {
+    setNumPollErrors(0);
     fetchRuns();
-    numPollErrors.current = 0;
   }, [fetchRuns]);
 
   return { runs, loading, errorMessage, lastChecked, isPaused, togglePause, fetchRuns, addOptimisticRun, hasRunsInProgress };

--- a/libs/features/apex-test-runner/src/useApexTestSuites.ts
+++ b/libs/features/apex-test-runner/src/useApexTestSuites.ts
@@ -93,8 +93,12 @@ export function useApexTestSuites(org: SalesforceOrgUi, apiVersion: string) {
       const currentClassIds = new Set(currentMemberships.map(({ ApexClassId }) => ApexClassId));
       const addClassIds = Array.from(classIds).filter((classId) => !currentClassIds.has(classId));
       const removeMembershipIds = currentMemberships.filter(({ ApexClassId }) => !classIds.has(ApexClassId)).map(({ Id }) => Id);
-      await updateTestSuiteMembership(org, apiVersion, suiteId, { addClassIds, removeMembershipIds });
-      await loadSuites();
+      try {
+        await updateTestSuiteMembership(org, apiVersion, suiteId, { addClassIds, removeMembershipIds });
+      } finally {
+        // Refresh even on failure so a partially-applied diff is recomputed against real org state on retry
+        await loadSuites();
+      }
     },
     [org, apiVersion, membershipsBySuiteId, loadSuites],
   );


### PR DESCRIPTION
## Summary

Fixes the findings from the pre-release code review of the Apex Test Runner (#2005), split into one commit per fix for the changelog:

- **Silent composite failures** — Tooling composite subrequests report failures per-item inside an overall 200 response, so a rejected suite membership save or run abort reported success while the user's changes silently vanished. Both now check per-item statuses and throw the Salesforce error. Membership saves are `allOrNone` and the suite list reloads even on failure so retries recompute the diff against real org state.
- **Lost unsaved suite edits** — renaming a suite (or any suite-list refresh) re-initialized the membership checkboxes from server data, discarding unsaved edits; checkboxes now only re-initialize when a different suite is selected.
- **Runs-list poller never stopped** — the `MAX_POLL_ERRORS` cutoff read a ref during render, but fast-failing polls batch their error-state updates into a net no-op so React never re-rendered and polling continued forever against a dead org/session. The counter is now state (regression test included, which reproduced 30 calls where 25 was the cap).
- **Uncancellable class scan** — org switch or unmount mid-scan left up to ~100 sequential SymbolTable queries running; the scan now threads an AbortSignal and stale loads no longer overwrite the newer load's cache.
- **Extension deep links 404** — `apex-tests` was missing from the web extension's emitted placeholder pages, so open-in-new-tab/bookmarked links hit ERR_FILE_NOT_FOUND.

## Testing

- 32 unit tests pass, including 9 new ones (composite failure surfacing, polling cutoff + resume)
- `features-apex-test-runner:typecheck` clean, oxlint clean (only pre-existing a11y warnings in untouched files)

Refs #2005