### PR TITLE
build(desktop): raise smoke-test renderer timeout for Rosetta x64 builds

### DIFF
--- a/apps/jetstream-desktop/src/config/smoke-test.ts
+++ b/apps/jetstream-desktop/src/config/smoke-test.ts
@@ -1,7 +1,13 @@
 import { app, BrowserWindow } from 'electron';
 import logger from 'electron-log';
 
-const SMOKE_TEST_TIMEOUT_MS = 30_000;
+// Generous because the x64 build is smoke-tested under Rosetta 2 on GitHub's arm64 macOS
+// runners, where V8's JIT output must be translated at runtime — loading the full renderer
+// bundle can take minutes instead of seconds (the 30s original failed the 4.14.0 release with
+// the renderer still grinding). Genuinely broken builds still fail fast through the error
+// events below; only a silent hang waits out this timer. Must stay comfortably under the 300s
+// launch timeout in electron-builder.config.js, which starts earlier (at process spawn).
+const SMOKE_TEST_TIMEOUT_MS = 180_000;
 
 /**
  * Startup smoke test for the packaged build, driven by the afterPack hook in
@@ -18,16 +24,27 @@ const SMOKE_TEST_TIMEOUT_MS = 30_000;
  */
 export function initializeSmokeTest(browserWindow: BrowserWindow) {
   let finished = false;
+  const startedAt = Date.now();
+
+  const log = (message: string) => {
+    const line = `[SMOKE TEST] ${message} (+${((Date.now() - startedAt) / 1000).toFixed(1)}s)`;
+    console.log(line);
+    logger.info(line);
+  };
 
   const finish = (exitCode: number, message: string) => {
     if (finished) {
       return;
     }
     finished = true;
-    console.log(`[SMOKE TEST] ${message}`);
-    logger.info(`[SMOKE TEST] ${message}`);
+    log(message);
     app.exit(exitCode);
   };
+
+  // Progress markers so a timeout in CI shows how far the renderer got (distinguishes a
+  // slow-but-progressing load under Rosetta from a genuine hang).
+  browserWindow.webContents.on('did-start-loading', () => log('renderer started loading'));
+  browserWindow.webContents.on('dom-ready', () => log('renderer DOM ready'));
 
   // Electron's default uncaughtException behavior shows a dialog and keeps the process alive,
   // which would hang CI until the outer timeout instead of failing fast.

--- a/electron-builder.config.js
+++ b/electron-builder.config.js
@@ -184,9 +184,11 @@ async function verifyAsarDependencyClosure(context) {
 
 // Generous because the x64 slice runs under Rosetta 2 on GitHub's arm64 macOS runners, where
 // first-launch binary translation of the Electron framework alone can take well over a minute
-// (the 4.13.0 release run needed ~80s just to reach "App starting..."). Real post-boot hangs are
-// caught by the app's own 30s renderer timer (smoke-test.ts); this only guards a failure to boot.
-const SMOKE_TEST_LAUNCH_TIMEOUT_MS = 300_000;
+// (the 4.13.0 release run needed ~80s just to reach "App starting..."). The app's own renderer
+// timer (smoke-test.ts, 180s) starts later — at window creation — and catches post-boot hangs
+// with a specific message; this outer timer is the backstop for a failure to boot at all. Keep
+// it comfortably larger than boot time + the in-app timer so the inner one always fires first.
+const SMOKE_TEST_LAUNCH_TIMEOUT_MS = 420_000;
 
 /**
  * Launch the freshly packaged app binary with `--smoke-test` and require it to boot to a fully


### PR DESCRIPTION
The desktop-v4.14.0 macOS publish failed the packaged smoke test with the renderer still loading: the x64 slice runs under Rosetta 2 on the arm64 runner, which translates V8's JIT output at runtime, so the 30s renderer timer was far too tight. Now 180s, with the outer launch timeout at 420s so the informative in-app failure always fires before the SIGKILL backstop, and load-progress logging to tell a slow load from a hang next time.