### PR TITLE
chore: migrate playwright to inferred

### DIFF
--- a/apps/jetstream-desktop-e2e/project.json
+++ b/apps/jetstream-desktop-e2e/project.json
@@ -3,15 +3,11 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "apps/jetstream-desktop-e2e/src",
   "projectType": "application",
-  "implicitDependencies": ["jetstream-desktop", "jetstream-desktop-client"],
   "tags": ["scope:e2e"],
+  "implicitDependencies": ["jetstream-desktop", "jetstream-desktop-client"],
   "targets": {
     "e2e": {
-      "executor": "@nx/playwright:playwright",
       "outputs": ["{workspaceRoot}/dist/.playwright/apps/jetstream-desktop-e2e"],
-      "options": {
-        "config": "apps/jetstream-desktop-e2e/playwright.config.ts"
-      },
       "dependsOn": [
         {
           "projects": ["jetstream-desktop"],
@@ -23,16 +19,16 @@
     "e2e-ci": {
       "executor": "nx:run-commands",
       "outputs": ["{projectRoot}/playwright-report", "{projectRoot}/playwright-summary.json"],
-      "options": {
-        "command": "pnpm start-server-and-test --expect 200 'pnpm start:e2e' http://localhost:3333 'pnpm start:desktop:client' http://localhost:4201 'xvfb-run --auto-servernum --server-args=\"-screen 0 1920x1080x24 -nolisten tcp\" -- pnpm nx run jetstream-desktop-e2e:e2e'"
-      },
       "dependsOn": [
         {
           "projects": ["jetstream-desktop"],
           "target": "build",
           "params": "ignore"
         }
-      ]
+      ],
+      "options": {
+        "command": "pnpm start-server-and-test --expect 200 'pnpm start:e2e' http://localhost:3333 'pnpm start:desktop:client' http://localhost:4201 'xvfb-run --auto-servernum --server-args=\"-screen 0 1920x1080x24 -nolisten tcp\" -- pnpm nx run jetstream-desktop-e2e:e2e'"
+      }
     }
   }
 }

--- a/apps/jetstream-e2e/project.json
+++ b/apps/jetstream-e2e/project.json
@@ -3,29 +3,25 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "apps/jetstream-e2e/src",
   "projectType": "application",
-  "implicitDependencies": ["jetstream"],
   "tags": ["scope:e2e"],
+  "implicitDependencies": ["jetstream"],
   "targets": {
     "e2e": {
-      "executor": "@nx/playwright:playwright",
-      "outputs": ["{workspaceRoot}/dist/.playwright/apps/jetstream-e2e"],
-      "options": {
-        "config": "apps/jetstream-e2e/playwright.config.ts"
-      }
+      "outputs": ["{workspaceRoot}/dist/.playwright/apps/jetstream-e2e"]
     },
     "e2e-ci": {
       "executor": "nx:run-commands",
       "outputs": ["{projectRoot}/playwright-report"],
-      "options": {
-        "command": "pnpm start-server-and-test --expect 200 'pnpm start:e2e' http://localhost:3333 'pnpm playwright:test'"
-      },
       "dependsOn": [
         {
           "target": "build",
           "params": "ignore",
           "dependencies": true
         }
-      ]
+      ],
+      "options": {
+        "command": "pnpm start-server-and-test --expect 200 'pnpm start:e2e' http://localhost:3333 'pnpm playwright:test'"
+      }
     }
   }
 }

--- a/apps/jetstream-web-extension-e2e/project.json
+++ b/apps/jetstream-web-extension-e2e/project.json
@@ -3,15 +3,11 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "projectType": "application",
   "sourceRoot": "apps/jetstream-web-extension-e2e/src",
-  "implicitDependencies": ["jetstream-web-extension"],
   "tags": ["scope:e2e"],
+  "implicitDependencies": ["jetstream-web-extension"],
   "targets": {
     "e2e": {
-      "executor": "@nx/playwright:playwright",
-      "outputs": ["{workspaceRoot}/dist/.playwright/apps/jetstream-web-extension-e2e"],
-      "options": {
-        "config": "apps/jetstream-web-extension-e2e/playwright.config.ts"
-      }
+      "outputs": ["{workspaceRoot}/dist/.playwright/apps/jetstream-web-extension-e2e"]
     }
   }
 }

--- a/nx.json
+++ b/nx.json
@@ -130,6 +130,13 @@
         "testTargetName": "test",
         "testMode": "watch"
       }
+    },
+    {
+      "plugin": "@nx/playwright/plugin",
+      "options": {
+        "targetName": "e2e",
+        "ciTargetName": "e2e-ci"
+      }
     }
   ],
   "defaultBase": "main",


### PR DESCRIPTION
>The `@nx/playwright:playwright` executor is deprecated and will be removed in Nx v24. Run `nx g @nx/playwright:convert-to-inferred` to migrate to the `@nx/playwright/plugin` inferred targets. See https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.