### PR TITLE
chore: upgrade electron to v44 (drops macOS 12 support)

### DIFF
--- a/apps/jetstream-desktop/src/browser/browser.ts
+++ b/apps/jetstream-desktop/src/browser/browser.ts
@@ -132,7 +132,9 @@ export class Browser {
         menuItems.push({
           label: 'Copy Selection',
           click: () => {
-            clipboard.writeText(properties.selectionText);
+            // Electron 44 made the clipboard API promise-based. Nothing waits on the copy, so a
+            // failure is logged rather than left to surface as an unhandled rejection.
+            void clipboard.writeText(properties.selectionText).catch((error) => log.warn('Failed to copy selection to clipboard:', error));
           },
         });
       }

--- a/package.json
+++ b/package.json
@@ -212,7 +212,7 @@
     "chrome-types": "^0.1.442",
     "contentful": "^11.12.9",
     "cross-env": "^10.1.0",
-    "electron": "^43.4.0",
+    "electron": "^44.1.1",
     "electron-builder": "^26.15.3",
     "electron-updater": "^6.8.9",
     "esbuild": "^0.28.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -389,7 +389,7 @@ importers:
         version: 17.4.2
       electron-app-universal-protocol-client:
         specifier: ^2.1.1
-        version: 2.1.1(electron@43.4.0(supports-color@7.2.0))
+        version: 2.1.1(electron@44.1.1(supports-color@7.2.0))
       electron-log:
         specifier: ^5.4.4
         version: 5.4.4
@@ -779,8 +779,8 @@ importers:
         specifier: ^10.1.0
         version: 10.1.0
       electron:
-        specifier: ^43.4.0
-        version: 43.4.0(supports-color@7.2.0)
+        specifier: ^44.1.1
+        version: 44.1.1(supports-color@7.2.0)
       electron-builder:
         specifier: ^26.15.3
         version: 26.15.3(electron-builder-squirrel-windows@26.15.3)(supports-color@7.2.0)
@@ -9584,8 +9584,8 @@ packages:
     resolution: {integrity: sha512-bO3y10YikuUwUuDUQRM4KfwNkKhnpVO7IPdbsrejwN9/AABJzzTQ4GeHwyzNSrVO+tEH3/Np255a3sVZpZDjvg==}
     engines: {node: '>=8.0.0'}
 
-  electron@43.4.0:
-    resolution: {integrity: sha512-3qxGF0CeQbiox5oWV1JlbWGQ1VerbmDhTFqW4sJ8h7uqTHniFYPObXJcDna0DMh32et0fFyKzz0YY8lJv3t5jg==}
+  electron@44.1.1:
+    resolution: {integrity: sha512-N2WCq2sbOkqQgvXJYx2lS6UiO8bF+Yr67trDnS6JKa2WxTCRQsAjGl57SUtdW9h6r5PlduBFjIhxhgd3dzv1hg==}
     engines: {node: '>= 22.12.0'}
     hasBin: true
 
@@ -27946,9 +27946,9 @@ snapshots:
 
   ejs@5.0.1: {}
 
-  electron-app-universal-protocol-client@2.1.1(electron@43.4.0(supports-color@7.2.0)):
+  electron-app-universal-protocol-client@2.1.1(electron@44.1.1(supports-color@7.2.0)):
     dependencies:
-      electron: 43.4.0(supports-color@7.2.0)
+      electron: 44.1.1(supports-color@7.2.0)
       typed-emitter: 2.1.0
 
   electron-builder-squirrel-windows@26.15.3(dmg-builder@26.15.3)(supports-color@7.2.0):
@@ -28019,7 +28019,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  electron@43.4.0(supports-color@7.2.0):
+  electron@44.1.1(supports-color@7.2.0):
     dependencies:
       '@electron-internal/extract-zip': 1.0.5
       '@electron/get': 5.1.0(supports-color@7.2.0)


### PR DESCRIPTION
Electron 43.4.0 → 44.1.1. Split out from #2046 because it carries a user-facing support decision.

Chromium 150 → 152, Node 24.17 → 24.19, V8 15.0 → 15.2.

* [ ] WAIT FOR #2048 to merge in and be live for a while so we can see if there would be negative impact to drop `macOS 12 Monterey`

## ⚠️ This drops macOS 12 Monterey

Electron 44 requires macOS 13+. Packaged builds from this branch declare `LSMinimumSystemVersion 13.0` (verified on both the x64 and arm64 slices), so macOS will refuse to launch the app on Monterey.

Worth deciding before merging: `electron-updater` doesn't gate downloads on OS version, so a Monterey user on 4.14.0 would download an update they then can't launch. Desktop users skew toward locked-down and VDI environments where OS upgrades aren't self-service. If install telemetry shows a meaningful Monterey population, we may want a staged rollout or an update gate first.

Not blocking otherwise — I have no visibility into those numbers, so flagging rather than deciding.

## Code changes

Electron 44 rearchitects the clipboard module toward the W3C shape: main-process methods return Promises, the module is no longer exposed to renderers, and narrow helpers (`readBookmark`/`writeHTML`/`readImage`) are gone.

Exactly one site is affected — the context menu's **Copy Selection** handler in [browser.ts](apps/jetstream-desktop/src/browser/browser.ts). `clipboard.writeText` is now `Promise<void>`, so the handler logs a failed write instead of leaving an unhandled rejection. Nothing waits on the copy, so it stays fire-and-forget.

The renderer never imported the clipboard module (it uses `copy-to-clipboard` and `navigator.clipboard`), so the renderer removal doesn't apply.

## Everything else audited and clear

- **`net.request` Sec-Fetch validation** — `net.fetch` is called in `protocol.service.ts` and `api.service.ts`, always with a freshly constructed URL and never forwarding a `Sec-Fetch-Dest` header, so the new frame-type rejection doesn't apply.
- **Dropped ia32 / armv7l binaries** — never built. `electron-builder.config.js` produces macOS dmg/zip for x64 + arm64 and Windows nsis/portable for x64 only.
- **Login item settings** (`openAsHidden`, `wasOpenedAsHidden`, `restoreState` removed on macOS) — not used.
- **`select-client-certificate` may now pass a null `webContents`** — not handled anywhere.
- **ANGLE now statically linked** — no custom ANGLE usage.

## Verification

Full packaged macOS build (`electron-builder build --mac`, both slices), which exercises the real release path:

```
afterPack dependency verification passed: 61 packaged modules, dependency closure complete
packaged smoke test: launching .../Jetstream.app/Contents/MacOS/Jetstream
  electron: 44.1.1, chrome: 152.0.7977.65, node: 24.19.0, v8: 15.2.124.18-electron.0
[SMOKE TEST] renderer DOM ready (+9.0s)
[SMOKE TEST] PASSED - main process booted and renderer finished loading (+12.9s)
packaged smoke test: passed
```

That covers the failure mode from 4.12.0 — the asar dependency closure is complete and the app boots from `app.asar` rather than the workspace `node_modules`. Typecheck of `jetstream-desktop`, `jetstream-desktop-client` and `jetstream-desktop-e2e` is clean, as are `oxlint` and `oxfmt --check`.

Still needs a **Windows packaged build** and hands-on testing of the Copy Selection menu item, neither of which I can do here.

## Note on version

Pinned to 44.1.1 rather than 44.2.0 — 44.2.0 is still inside the `minimumReleaseAge` window (published Sept 4, eligible Sept 7).
