### PR TITLE
build: fix and improve release not tag versions

### DIFF
--- a/.claude/commands/release-notes.md
+++ b/.claude/commands/release-notes.md
@@ -31,7 +31,8 @@ Map the command argument:
   not-yet-tagged release.
 - **`--version X.Y.Z`** → pass through unchanged (upcoming release, explicit version).
 
-The script prints the resolved mode, target version, release date, and every merged PR in
+The script prints the resolved mode, target version, release date, the desktop and extension
+releases cut in the range (plus the current desktop/extension versions), and every merged PR in
 the release's commit range (title, labels, touched areas, body) plus direct commits. This is
 your source material — base the note on it, not on guesses. If it warns that a note already
 exists for the version, update that existing file instead of creating a new one.
@@ -58,11 +59,11 @@ from Step 1.
 slug: v<version> # e.g. v10.4.0
 title: <version> - <short description> # e.g. "10.4.0 - Faster data tables and SSO fixes"
 date: '<YYYY-MM-DD>'
-tags: [web] # subset of: web, desktop, extension, all (>= 1)
-versions: # only the platforms actually releasing
+tags: [web, desktop, extension] # every platform whose users receive the changes, see "Tags / versions mapping"
+versions: # for each tagged platform, the release that carries the changes
   web: <version>
-  # desktop: <version>                 # include only if desktop is releasing
-  # extension: <version>               # include only if the extension is releasing
+  desktop: <version> # omit only when desktop is not tagged
+  extension: <version> # omit only when the extension is not tagged
 summary: <one or two sentences for the in-app popover>
 highlights: # 2-6 items, most important first
   - title: <short, user-facing headline>
@@ -77,17 +78,54 @@ must be non-empty; `summary` is required.
 
 ### Tags / versions mapping
 
-Infer platforms from each PR's "touched" areas in the digest:
+`tags` decides who sees the note. The in-app What's New popover
+(`libs/release-notes/src/lib/release-notes-utils.ts`) shows a note only on platforms listed in its
+`tags`, and hides any highlight whose `platforms` field excludes the viewer's platform. A note tagged
+only `web` is never shown to desktop or extension users, even when they received the feature. So
+`tags` must list every platform whose users receive the changes, not just the platform whose release
+you happen to be writing about.
 
-- `apps/jetstream/`, `apps/api/`, or shared `libs/**` → **web**
-- `apps/jetstream-desktop` / `apps/jetstream-desktop-client` → **desktop**
-- `apps/jetstream-web-extension` → **extension**
-- Use `all` only when a change genuinely ships to every platform.
+Jetstream is one codebase: the web app, the desktop app and the browser extension all mount the same
+feature libraries, and the desktop and extension releases are normally cut minutes after the web
+release from the same commit. Decide per change, then take the union:
 
-Put the platform(s) the release ships to in `tags`, and list each releasing platform's version
-in `versions`. If you are unsure which platforms a given highlight applies to, set its
-`platforms: [...]` field. **Default to `web`** unless the digest clearly shows desktop/extension
-changes.
+- **Shared feature or shared UI change** → **web, desktop, extension**. This is anything under
+  `libs/features/**`, `libs/shared/**`, `libs/ui/**`, or any app page (Query, Load Records, Update
+  Records, Automation Control, Manage Permissions, Permission Analysis, Deploy Metadata, Create Fields,
+  Formula Evaluator, Record Type Manager, Anonymous Apex, Apex Tests, Debug Logs, Platform Events,
+  Salesforce API, Export Object Metadata, Data History, field usage analysis) plus cross-cutting UI
+  (data tables, editors, header and navigation, org dropdown, keyboard shortcuts, record modals, file
+  exports). The desktop app mounts every page. The extension mounts every page except Create Records
+  and Org Groups; when unsure, check the `<Route>` list in
+  `apps/jetstream-web-extension/src/pages/app/App.tsx`.
+- **Web-only surface** (`apps/jetstream/` or `apps/api/` only) → **web**: login, signup, MFA,
+  passkeys, profile, billing and subscriptions, team management, SSO, the web "add org" OAuth flow,
+  PWA, Salesforce Canvas, the landing and docs sites, server-only behaviour.
+- **Desktop-only** (`apps/jetstream-desktop*`) → **desktop**: auto-update, installers, menus,
+  desktop settings, local org storage. Add **web** as well when the surface is the website's
+  download page.
+- **Extension-only** (`apps/jetstream-web-extension`) → **extension**: popup, Salesforce page
+  injection, extension permissions and manifest, extension login.
+
+Never use `all`; list the platforms explicitly. The context script prints each PR's touched areas,
+labelling shared libraries by their reach, and lists the desktop and extension releases cut in the
+range, so the digest alone is usually enough to decide.
+
+When the union spans more than one platform, set `platforms: [...]` on every highlight that does not
+reach all of them (a billing fix in an otherwise shared release gets `platforms: [web]`), so the
+popover does not show desktop users a web-only bullet. Highlights that reach every tagged platform
+need no `platforms` field.
+
+`versions` lists, for each tagged platform, the release that carries the changes:
+
+- **Already-cut release:** use the `desktop-v*` / `web-ext-v*` tags the context script lists for the
+  range (they are cut minutes after the web tag).
+- **Upcoming release:** the next desktop/extension version, i.e. a bump of the current
+  `apps/jetstream-desktop/package.json` and `apps/jetstream-web-extension/src/manifest.json` versions
+  (the context script prints both). Say in the handoff that those platforms must be selected in the
+  `pnpm release` platform picker. If the human decides not to cut a tagged platform, drop it from both
+  `tags` and `versions` before merging, since its users would otherwise see a note for changes they do
+  not have.
 
 ### Voice and style
 
@@ -237,4 +275,5 @@ them to:
    workflow runs on the PR.
 3. For an **already-cut release**, just merge — the note goes live on the docs site (and in
    the in-app popover) once the docs deploy completes. For an **upcoming release**, merge the
-   PR **before** cutting the release (`pnpm release`).
+   PR **before** cutting the release (`pnpm release`), and select every platform listed in
+   `versions` in the release script's platform picker so the note matches what ships.

--- a/apps/docs/release-notes/2025-08-09-v7.1.0.mdx
+++ b/apps/docs/release-notes/2025-08-09-v7.1.0.mdx
@@ -2,23 +2,21 @@
 slug: v7.1.0
 title: 7.1.0 - Diff editor toggle, folder metadata fixes
 date: '2025-08-09'
-tags: [web, extension]
+tags: [web, desktop, extension]
 versions:
   web: 7.1.0
+  desktop: 1.1.0
   extension: 2.0.1
 summary: Compare metadata got an option to hide unchanged lines, folder metadata types are now retrieved correctly, and several datatable and popover bugs are fixed.
 highlights:
   - title: Toggle unchanged lines in the metadata diff editor
     description: When comparing metadata between orgs you can now collapse unchanged lines, which makes larger files much easier to scan.
     docLink: /deploy-metadata
-    platforms: [web, extension]
   - title: Folder metadata types work correctly
     description: Document, Email, Report, and Dashboard folders now appear in the metadata picker and retrieve the correct metadata from Salesforce.
     docLink: /deploy-metadata
-    platforms: [web, extension]
   - title: Datatable tab navigation fix
     description: Fixed an edge case where Tab navigation inside the datatable could skip the action and Id columns in production builds.
-    platforms: [web, extension]
 ---
 
 {/* truncate */}

--- a/apps/docs/release-notes/2025-08-09-v7.2.0.mdx
+++ b/apps/docs/release-notes/2025-08-09-v7.2.0.mdx
@@ -2,16 +2,16 @@
 slug: v7.2.0
 title: 7.2.0 - Copy load results to clipboard
 date: '2025-08-09'
-tags: [web, extension]
+tags: [web, desktop, extension]
 versions:
   web: 7.2.0
+  desktop: 1.1.0
   extension: 2.1.0
 summary: You can now copy load results directly to the clipboard as Excel, CSV, or JSON without downloading a file first.
 highlights:
   - title: Copy load results to clipboard
     description: From the load results modal, copy all or selected rows to the clipboard in spreadsheet, CSV, or JSON format.
     docLink: /load
-    platforms: [web, extension]
 ---
 
 {/* truncate */}

--- a/apps/docs/release-notes/2025-08-14-v7.3.2.mdx
+++ b/apps/docs/release-notes/2025-08-14-v7.3.2.mdx
@@ -2,9 +2,11 @@
 slug: v7.3.2
 title: 7.3.2 - Fix view-results modal for bulk edits from query
 date: '2025-08-14'
-tags: [web]
+tags: [web, desktop, extension]
 versions:
   web: 7.3.2
+  desktop: 1.2.0
+  extension: 2.2.0
 summary: Fixes a bug where viewing bulk results after bulk editing records from query results did nothing.
 highlights:
   - title: View bulk results works again

--- a/apps/docs/release-notes/2025-08-21-v7.3.3.mdx
+++ b/apps/docs/release-notes/2025-08-21-v7.3.3.mdx
@@ -2,9 +2,10 @@
 slug: v7.3.3
 title: 7.3.3 - Connected app guidance and annual pricing fix
 date: '2025-08-21'
-tags: [web]
+tags: [web, desktop]
 versions:
   web: 7.3.3
+  desktop: 1.2.0
 summary: Adds an in-app banner about upcoming Salesforce Connected App changes, updates the related docs, and fixes annual pricing display for existing subscribers.
 highlights:
   - title: Upcoming Salesforce Connected App notice
@@ -12,8 +13,10 @@ highlights:
     docLink: /troubleshooting
   - title: Annual subscription pricing fix
     description: Existing annual subscribers now see the correct price on the billing page.
+    platforms: [web]
   - title: Docs refresh
     description: Overview, security, and troubleshooting docs have been updated with current Connected App install steps.
+    platforms: [web]
 ---
 
 {/* truncate */}

--- a/apps/docs/release-notes/2025-08-23-v7.3.4.mdx
+++ b/apps/docs/release-notes/2025-08-23-v7.3.4.mdx
@@ -2,9 +2,11 @@
 slug: v7.3.4
 title: 7.3.4 - One-click field change in query filters
 date: '2025-08-23'
-tags: [web]
+tags: [web, desktop, extension]
 versions:
   web: 7.3.4
+  desktop: 1.2.0
+  extension: 2.2.0
 summary: Removes the extra clear step when changing the field in a query filter condition.
 highlights:
   - title: Faster field swap in query filters

--- a/apps/docs/release-notes/2025-08-23-v7.3.5.mdx
+++ b/apps/docs/release-notes/2025-08-23-v7.3.5.mdx
@@ -2,9 +2,11 @@
 slug: v7.3.5
 title: 7.3.5 - Diff editor collapses unchanged regions after swap
 date: '2025-08-23'
-tags: [web]
+tags: [web, desktop, extension]
 versions:
   web: 7.3.5
+  desktop: 1.2.0
+  extension: 2.2.0
 summary: Fixes the view/compare metadata diff editor so collapsed unchanged regions stay collapsed after swapping the two sides.
 highlights:
   - title: Diff editor swap fix

--- a/apps/docs/release-notes/2025-08-26-v7.4.0.mdx
+++ b/apps/docs/release-notes/2025-08-26-v7.4.0.mdx
@@ -2,14 +2,13 @@
 slug: v7.4.0
 title: 7.4.0 - Stronger encryption for stored org credentials
 date: '2025-08-26'
-tags: [web, desktop]
+tags: [web]
 versions:
   web: 7.4.0
 summary: Each stored Salesforce org is now encrypted with its own unique key.
 highlights:
   - title: Per-org encryption keys
     description: Each stored Salesforce org now uses its own unique encryption key instead of a single shared key.
-    platforms: [web, desktop]
 ---
 
 {/* truncate */}

--- a/apps/docs/release-notes/2025-08-30-v7.5.0.mdx
+++ b/apps/docs/release-notes/2025-08-30-v7.5.0.mdx
@@ -2,15 +2,16 @@
 slug: v7.5.0
 title: 7.5.0 - Accurate record count preview for queries
 date: '2025-08-30'
-tags: [web]
+tags: [web, desktop, extension]
 versions:
   web: 7.5.0
+  desktop: 1.2.0
+  extension: 2.2.0
 summary: The record count preview shown before running a query no longer fails when the query includes an ORDER BY clause.
 highlights:
   - title: Query record count preview works with ORDER BY
     description: The count preview now strips the incompatible ORDER BY before running, so you get an accurate record total every time.
     docLink: /query/results
-    platforms: [web, desktop, extension]
 ---
 
 {/* truncate */}

--- a/apps/docs/release-notes/2025-09-07-v7.6.3.mdx
+++ b/apps/docs/release-notes/2025-09-07-v7.6.3.mdx
@@ -2,16 +2,16 @@
 slug: v7.6.3
 title: 7.6.3 - Binary file load fixes
 date: '2025-09-07'
-tags: [web]
+tags: [web, desktop, extension]
 versions:
   web: 7.6.3
   desktop: 1.3.1
+  extension: 2.4.0
 summary: Fixes a file picker conflict on the binary attachment loader.
 highlights:
   - title: Binary attachment file picker fix
     description: Clicking the "Zip with attachments" input no longer accidentally triggers the main CSV file input.
     docLink: /load
-    platforms: [web, desktop, extension]
 ---
 
 {/* truncate */}

--- a/apps/docs/release-notes/2025-09-11-v7.7.0.mdx
+++ b/apps/docs/release-notes/2025-09-11-v7.7.0.mdx
@@ -2,24 +2,23 @@
 slug: v7.7.0
 title: 7.7.0 - Field mapping and UI polish
 date: '2025-09-11'
-tags: [web]
+tags: [web, desktop, extension]
 versions:
   web: 7.7.0
+  desktop: 2.0.0
+  extension: 2.4.0
 summary: Cleans up the field mapping dropdown and fixes several small UI issues.
 highlights:
   - title: Cleaner field mapping dropdown
     description: The load records field mapping dropdown now shows the field type as tertiary text, matching the rest of the app.
     docLink: /load
-    platforms: [web, desktop, extension]
   - title: Combobox sizing fix
     description: The combobox no longer miscalculates its size in certain layouts.
-    platforms: [web, desktop, extension]
   - title: Better Salesforce domain detection in the extension
     description: The Chrome extension now detects Salesforce domains more reliably.
-    platforms: [web, extension]
+    platforms: [extension]
   - title: Error popover styling
     description: The error popover nubbin color now matches the popover background.
-    platforms: [web, desktop, extension]
 ---
 
 {/* truncate */}

--- a/apps/docs/release-notes/2025-09-13-v7.7.1.mdx
+++ b/apps/docs/release-notes/2025-09-13-v7.7.1.mdx
@@ -2,14 +2,15 @@
 slug: v7.7.1
 title: 7.7.1 - Salesforce login URL fix
 date: '2025-09-13'
-tags: [web]
+tags: [web, desktop, extension]
 versions:
   web: 7.7.1
+  desktop: 2.0.0
+  extension: 2.4.0
 summary: Fixes invalid URLs generated when logging in to Salesforce from Jetstream links.
 highlights:
   - title: Login with Salesforce URL fix
     description: Links that log you into Salesforce now generate valid URLs, avoiding double-slash and other malformed links.
-    platforms: [web, desktop, extension]
 ---
 
 {/* truncate */}

--- a/apps/docs/release-notes/2025-09-20-v7.8.0.mdx
+++ b/apps/docs/release-notes/2025-09-20-v7.8.0.mdx
@@ -2,22 +2,21 @@
 slug: v7.8.0
 title: 7.8.0 - Better large-file uploads and higher free-plan limit
 date: '2025-09-20'
-tags: [web]
+tags: [web, desktop, extension]
 versions:
   web: 7.8.0
+  desktop: 2.0.0
+  extension: 2.4.0
 summary: Improves binary file uploads so large files upload reliably, and raises the free-plan attachment filesize limit.
 highlights:
   - title: Reliable large attachment uploads
     description: Binary attachment loads now handle large files reliably, so big files upload without timeouts.
     docLink: /load
-    platforms: [web, desktop, extension]
   - title: Higher free-plan attachment limit
     description: The attachment filesize cap on the free plan was raised.
     docLink: /load
-    platforms: [web, desktop, extension]
   - title: Platform events publishing fix
     description: Fixed an issue that could occur when publishing platform events.
-    platforms: [web, desktop, extension]
 ---
 
 {/* truncate */}

--- a/apps/docs/release-notes/2025-09-24-v7.9.0.mdx
+++ b/apps/docs/release-notes/2025-09-24-v7.9.0.mdx
@@ -2,19 +2,19 @@
 slug: v7.9.0
 title: 7.9.0 - View All Fields in Manage Permissions
 date: '2025-09-24'
-tags: [web]
+tags: [web, desktop, extension]
 versions:
   web: 7.9.0
+  desktop: 3.0.0
+  extension: 2.4.0
 summary: Adds support for the new View All Fields object permission in Manage Permissions and fixes a save bug affecting View All Records.
 highlights:
   - title: View All Fields object permission
     description: Grant or revoke the new Salesforce View All Fields permission alongside the other object permissions in Manage Permissions.
     docLink: /permissions
-    platforms: [web, desktop, extension]
   - title: Fix View All Records save value
     description: Saving permissions now persists the value you selected for View All Records and View All.
     docLink: /permissions
-    platforms: [web, desktop, extension]
 ---
 
 {/* truncate */}

--- a/apps/docs/release-notes/2025-09-24-v7.9.1.mdx
+++ b/apps/docs/release-notes/2025-09-24-v7.9.1.mdx
@@ -2,15 +2,16 @@
 slug: v7.9.1
 title: 7.9.1 - Permission manager column fix and desktop download link
 date: '2025-09-24'
-tags: [web]
+tags: [web, desktop, extension]
 versions:
   web: 7.9.1
+  desktop: 3.0.1
+  extension: 2.4.0
 summary: Fixes the View All Records column width in Manage Permissions and corrects the x64 desktop download link.
 highlights:
   - title: View All Records column width
     description: The View All Records column in the permission manager grid now renders with the correct width.
     docLink: /permissions
-    platforms: [web, desktop, extension]
   - title: Correct x64 desktop download link
     description: The desktop download page now points at the right x64 installer asset.
     platforms: [web]

--- a/apps/docs/release-notes/2025-09-27-v7.10.0.mdx
+++ b/apps/docs/release-notes/2025-09-27-v7.10.0.mdx
@@ -2,14 +2,16 @@
 slug: v7.10.0
 title: 7.10.0 - Desktop history sync and binary upload fixes
 date: '2025-09-27'
-tags: [web]
+tags: [web, desktop, extension]
 versions:
   web: 7.10.0
+  desktop: 3.0.2
+  extension: 2.4.0
 summary: Fixes binary uploads on the desktop app and documents the upcoming outbound IP address ranges.
 highlights:
   - title: Desktop history sync fix
     description: Fixed an issue where history sync could fail to connect on the desktop app.
-    platforms: [web, desktop, extension]
+    platforms: [desktop]
   - title: Binary file uploads on desktop
     description: Binary attachment uploads from the desktop app now work correctly.
     docLink: /load
@@ -17,7 +19,6 @@ highlights:
   - title: Outbound IP address ranges
     description: The getting started docs now include a dedicated page describing the upcoming API outbound IP address ranges.
     docLink: /
-    platforms: [web, desktop, extension]
 ---
 
 {/* truncate */}

--- a/apps/docs/release-notes/2025-10-08-v8.0.0.mdx
+++ b/apps/docs/release-notes/2025-10-08-v8.0.0.mdx
@@ -10,8 +10,10 @@ summary: Introduces the new Jetstream Team plan with a team dashboard, member ma
 highlights:
   - title: Team plan and team dashboard
     description: Invite teammates, manage members and roles, configure login rules, and review session and authentication activity from a single dashboard.
+    platforms: [web]
   - title: Unified billing experience
     description: Reworked billing page with clearer plan cards, monthly/annual toggle, and team naming during upgrade.
+    platforms: [web]
   - title: Desktop update fixes
     description: Fixed Windows auto-update failures seen on the previous release.
     platforms: [desktop]

--- a/apps/docs/release-notes/2025-10-14-v8.2.0.mdx
+++ b/apps/docs/release-notes/2025-10-14-v8.2.0.mdx
@@ -2,9 +2,10 @@
 slug: v8.2.0
 title: 8.2.0 - Bug bash fixes across load, deploy, and automation control
 date: '2025-10-14'
-tags: [web, extension]
+tags: [web, desktop, extension]
 versions:
   web: 8.2.0
+  desktop: 3.1.0
   extension: 2.4.0
 summary: Collection of fixes from a bug bash, including deploy-metadata token refresh, a safer default for rollbackOnError in production, and a fix for Automation Control select-all on filtered rows.
 highlights:

--- a/apps/docs/release-notes/2025-10-21-v8.3.0.mdx
+++ b/apps/docs/release-notes/2025-10-21-v8.3.0.mdx
@@ -2,10 +2,11 @@
 slug: v8.3.0
 title: 8.3.0 - Better related-object loading and assorted bug fixes
 date: '2025-10-21'
-tags: [web, desktop]
+tags: [web, desktop, extension]
 versions:
   web: 8.3.0
   desktop: 3.1.0
+  extension: 2.5.0
 summary: Load Records now shows every related object on polymorphic lookups and fetches related-field metadata on demand. Also fixes Firefox drag in the query builder and a create-organization regression.
 highlights:
   - title: All related objects on polymorphic lookups
@@ -17,8 +18,10 @@ highlights:
   - title: Firefox query builder drag
     description: Condition rows in the query builder can be dragged on Firefox again.
     docLink: /query/results
+    platforms: [web, extension]
   - title: Create organization from selected org
     description: Creating a new organization no longer fails when another organization is selected.
+    platforms: [web, desktop]
 ---
 
 {/* truncate */}

--- a/apps/docs/release-notes/2025-10-28-v8.4.0.mdx
+++ b/apps/docs/release-notes/2025-10-28-v8.4.0.mdx
@@ -2,10 +2,11 @@
 slug: v8.4.0
 title: 8.4.0 - View Record checkbox fix, smoother desktop auto-update
 date: '2025-10-28'
-tags: [web, desktop]
+tags: [web, desktop, extension]
 versions:
   web: 8.4.0
   desktop: 3.3.0
+  extension: 2.5.0
 summary: Fixes checkboxes rendering blank in View Record, improves the desktop auto-update UX, and lets you pick filename formats for zip attachment exports.
 highlights:
   - title: Checkbox fields render correctly in View Record

--- a/apps/docs/release-notes/2025-11-13-v8.7.0.mdx
+++ b/apps/docs/release-notes/2025-11-13-v8.7.0.mdx
@@ -2,9 +2,11 @@
 slug: v8.7.0
 title: 8.7.0 - Table filter fixes and connected-app onboarding help
 date: '2025-11-13'
-tags: [web]
+tags: [web, desktop, extension]
 versions:
   web: 8.7.0
+  desktop: 3.5.0
+  extension: 2.6.0
 summary: Table filters now stay in sync when data reloads, password reset accepts plus-sign emails, and orgs missing the Jetstream connected app get clearer install guidance.
 highlights:
   - title: Table filters follow data updates
@@ -14,10 +16,13 @@ highlights:
     description: Filters on numeric fields now behave correctly and no longer drop values on refresh.
   - title: Password reset with plus-sign emails
     description: Emails containing a "+" no longer get mangled into a space during password reset.
+    platforms: [web]
   - title: Connected app install guidance
     description: Help links point users to the page where they would install the Jetstream connected app if it is missing, plus a sandbox sync callout.
+    platforms: [web, desktop]
   - title: Cookie banner padding fix
     description: The consent banner no longer throws off in-app alignment while still looking right on the landing page.
+    platforms: [web]
 ---
 
 {/* truncate */}

--- a/apps/docs/release-notes/2025-11-15-v8.8.0.mdx
+++ b/apps/docs/release-notes/2025-11-15-v8.8.0.mdx
@@ -2,19 +2,25 @@
 slug: v8.8.0
 title: 8.8.0 - Org expiration, Organization Groups, bulk org delete
 date: '2025-11-15'
-tags: [web]
+tags: [web, desktop, extension]
 versions:
   web: 8.8.0
+  desktop: 3.5.0
+  extension: 2.6.0
 summary: Unused Salesforce orgs now expire with advance email notice, the Organization page handles refresh/reconnect cleanly, and you can delete orgs in bulk.
 highlights:
   - title: Org expiration with email notice
     description: Salesforce orgs unused for 90 days are flagged for expiration, with email notifications summarizing expiring and expired orgs.
+    platforms: [web]
   - title: Easier reconnect for expired orgs
     description: The Organization page surfaces expiring and expired orgs, and reconnect pre-fills your existing connection details.
+    platforms: [web]
   - title: Bulk delete Salesforce orgs
     description: Select and delete multiple connected orgs at once from the Organizations page.
+    platforms: [web, desktop]
   - title: Rename to "Organization Group"
     description: What used to be called "Jetstream Organization" is now "Organization Group" everywhere in the app, to avoid confusion with a Salesforce organization.
+    platforms: [web, desktop]
   - title: Download format is remembered
     description: Your last-used download format (CSV, Excel, JSON, etc.) is remembered per-user as the new default.
 ---

--- a/apps/docs/release-notes/2025-12-14-v8.14.0.mdx
+++ b/apps/docs/release-notes/2025-12-14-v8.14.0.mdx
@@ -2,18 +2,18 @@
 slug: v8.14.0
 title: 8.14.0 - Record lookup in query filters
 date: '2025-12-14'
-tags: [web, desktop]
+tags: [web, desktop, extension]
 versions:
   web: 8.14.0
+  desktop: 3.8.2
+  extension: 2.10.0
 summary: Query filter values now support a record lookup so you can search for the record you want to filter on instead of hunting for an ID.
 highlights:
   - title: Record lookup in query filters
     description: When building a query filter on a reference field, search for the related record and have the ID inserted into your SOQL.
     docLink: /query/results
-    platforms: [web, desktop, extension]
   - title: Lookup clear button fix
     description: The clear button now works correctly when the lookup editor is in manual text entry mode.
-    platforms: [web, desktop, extension]
 ---
 
 {/* truncate */}

--- a/apps/docs/release-notes/2026-02-03-v8.20.0.mdx
+++ b/apps/docs/release-notes/2026-02-03-v8.20.0.mdx
@@ -2,22 +2,21 @@
 slug: v8.20.0
 title: 8.20.0 - Permission export improvements
 date: '2026-02-03'
-tags: [web]
+tags: [web, desktop, extension]
 versions:
   web: 8.20.0
+  desktop: 3.14.0
+  extension: 2.15.0
 summary: Permission manager exports are more reliable, show real errors on failure, and now offer CSV as a fallback format.
 highlights:
   - title: More reliable permission exports
     description: Reduced export failures when downloading large permission sets.
     docLink: /permissions
-    platforms: [web]
   - title: CSV fallback for permission exports
     description: Added CSV as an export option so you can fall back when XLSX generation fails on very large exports.
     docLink: /permissions
-    platforms: [web]
   - title: Real error messages on export failure
     description: Export failures now surface an error to the user instead of silently doing nothing.
-    platforms: [web]
 ---
 
 {/* truncate */}

--- a/apps/docs/release-notes/2026-02-09-v8.22.0.mdx
+++ b/apps/docs/release-notes/2026-02-09-v8.22.0.mdx
@@ -2,14 +2,14 @@
 slug: v8.22.0
 title: 8.22.0 - Auto-select org on group change
 date: '2026-02-09'
-tags: [web]
+tags: [web, desktop]
 versions:
   web: 8.22.0
+  desktop: 3.15.0
 summary: Switching org groups now auto-selects the most recently used org in that group, or the first org if none have been used.
 highlights:
   - title: Auto-select org when changing groups
     description: Changing the active org group now picks the most recently used org from that group, or the first org in the list.
-    platforms: [web]
 ---
 
 {/* truncate */}

--- a/apps/docs/release-notes/2026-02-12-v8.23.0.mdx
+++ b/apps/docs/release-notes/2026-02-12-v8.23.0.mdx
@@ -2,9 +2,11 @@
 slug: v8.23.0
 title: 8.23.0 - Friendlier record creation and keyboard fixes
 date: '2026-02-12'
-tags: [web]
+tags: [web, desktop, extension]
 versions:
   web: 8.23.0
+  desktop: 3.15.0
+  extension: 2.16.0
 summary: Owner and audit fields are now optional when creating records, with an option to save even when the form reports errors. Keyboard navigation in lookup pickers is fixed.
 highlights:
   - title: Audit fields treated as optional on create

--- a/apps/docs/release-notes/2026-02-17-v8.24.0.mdx
+++ b/apps/docs/release-notes/2026-02-17-v8.24.0.mdx
@@ -2,9 +2,11 @@
 slug: v8.24.0
 title: 8.24.0 - Metadata audit signals and Google folder memory
 date: '2026-02-17'
-tags: [web]
+tags: [web, desktop, extension]
 versions:
   web: 8.24.0
+  desktop: 3.15.0
+  extension: 2.16.0
 summary: Custom metadata records now show a last-modified date, invalid metadata timestamps are flagged with a warning, and Jetstream remembers your recent Google Drive folder.
 highlights:
   - title: Last modified on custom metadata records
@@ -14,6 +16,7 @@ highlights:
     description: When Salesforce returns an invalid audit timestamp, a warning icon now tells you the correct data is not available instead of showing a misleading date.
   - title: Remembered Google folder selection
     description: When exporting or uploading to Google Drive, your recent folder choice is remembered so repeat uploads take fewer clicks.
+    platforms: [web]
   - title: Automation Control works in namespaced orgs
     description: Orgs that have their own namespace can now manage components inside their managed package from Automation Control.
 ---

--- a/apps/docs/release-notes/2026-03-08-v9.1.0.mdx
+++ b/apps/docs/release-notes/2026-03-08-v9.1.0.mdx
@@ -2,23 +2,21 @@
 slug: v9.1.0
 title: 9.1.0 - Paste sanitization and bulk-update errors
 date: '2026-03-08'
-tags: [web, extension]
+tags: [web, desktop, extension]
 versions:
   web: 9.1.0
+  desktop: 3.16.0
   extension: 2.17.0
 summary: Editors now strip invisible characters from pasted text, and bulk update failures surface the real server error instead of a generic message.
 highlights:
   - title: Sanitize pasted text in editors
     description: Invisible characters from copied content are removed on paste so Salesforce won't reject the value.
-    platforms: [web, extension]
   - title: Real error messages on bulk update failures
     description: When updating records without a file, the actual server error is shown instead of a generic one.
     docLink: /load
-    platforms: [web, extension]
   - title: Editor line-number reset
     description: Anonymous Apex and the metadata compare modal no longer jump to an odd scroll position when the editor re-renders.
     docLink: /developer/anonymous-apex
-    platforms: [web, extension]
   - title: Error handling in bulk API loads
     description: Errors during bulk API loads are now shown instead of the job silently stopping.
     platforms: [web]

--- a/apps/docs/release-notes/2026-03-31-v9.4.1.mdx
+++ b/apps/docs/release-notes/2026-03-31-v9.4.1.mdx
@@ -2,10 +2,11 @@
 slug: v9.4.1
 title: 9.4.1 - Desktop org list and Salesforce API fixes
 date: '2026-03-31'
-tags: [web, desktop]
+tags: [web, desktop, extension]
 versions:
   web: 9.4.1
-  desktop: 3.18.1
+  desktop: 3.18.2
+  extension: 2.21.0
 summary: Fix for orgs and org groups not appearing on first launch of the desktop app, plus cleaner handling of empty-body requests in the Salesforce API tool.
 highlights:
   - title: Orgs visible on desktop first launch
@@ -13,7 +14,6 @@ highlights:
     platforms: [desktop]
   - title: Salesforce API request with empty body
     description: Sending a Salesforce API request with an empty body no longer crashes the request editor.
-    platforms: [web, desktop]
 ---
 
 {/* truncate */}

--- a/apps/docs/release-notes/2026-04-01-v9.5.0.mdx
+++ b/apps/docs/release-notes/2026-04-01-v9.5.0.mdx
@@ -2,15 +2,15 @@
 slug: v9.5.0
 title: 9.5.0 - Better Salesforce formula evaluation, desktop persistence fixes
 date: '2026-04-01'
-tags: [web, desktop]
+tags: [web, desktop, extension]
 versions:
   web: 9.5.0
   desktop: 3.18.2
+  extension: 2.21.0
 summary: Formula evaluation now covers far more of the Salesforce formula language with fewer bugs, plus desktop persistence fixes for VDI environments.
 highlights:
   - title: Better formula evaluation
     description: Formula evaluation now supports far more of the Salesforce formula language with fewer bugs.
-    platforms: [web, desktop, extension]
   - title: Desktop persistence reliability
     description: Fewer unexpected logouts and no more wiped org lists on Windows VDI setups.
     platforms: [desktop]

--- a/apps/docs/release-notes/2026-04-02-v9.6.0.mdx
+++ b/apps/docs/release-notes/2026-04-02-v9.6.0.mdx
@@ -2,14 +2,13 @@
 slug: v9.6.0
 title: 9.6.0 - Safer user profile handling
 date: '2026-04-02'
-tags: [web, desktop]
+tags: [web]
 versions:
   web: 9.6.0
 summary: Jetstream now falls back gracefully instead of showing a confusing error when your user profile fails to load.
 highlights:
   - title: Safer profile fetch
     description: If loading your user profile fails, Jetstream now falls back to a default instead of surfacing a confusing error.
-    platforms: [web, desktop, extension]
 ---
 
 {/* truncate */}

--- a/apps/docs/release-notes/2026-04-02-v9.7.0.mdx
+++ b/apps/docs/release-notes/2026-04-02-v9.7.0.mdx
@@ -9,7 +9,6 @@ summary: Refreshed Terms of Service with a new last-updated date and added guida
 highlights:
   - title: Updated Terms of Service
     description: New last-updated date and a compliance reporting section describing how to report security, ethics, or compliance concerns.
-    platforms: [web, desktop, extension]
 ---
 
 {/* truncate */}

--- a/apps/docs/release-notes/2026-04-03-v9.8.0.mdx
+++ b/apps/docs/release-notes/2026-04-03-v9.8.0.mdx
@@ -2,9 +2,11 @@
 slug: v9.8.0
 title: 9.8.0 - IdP-initiated OIDC login, resilient SOQL formatting
 date: '2026-04-03'
-tags: [web]
+tags: [web, desktop, extension]
 versions:
   web: 9.8.0
+  desktop: 3.19.0
+  extension: 2.21.0
 summary: Log in to Jetstream directly from your identity provider's dashboard, plus the query editor no longer crashes on partially typed SOQL.
 highlights:
   - title: IdP-initiated OIDC login
@@ -13,7 +15,6 @@ highlights:
   - title: SOQL formatter crash fix
     description: Invalid or in-progress SOQL no longer crashes the query editor while you are still typing.
     docLink: /query/results
-    platforms: [web, desktop, extension]
 ---
 
 {/* truncate */}

--- a/apps/docs/release-notes/2026-04-08-v9.10.0.mdx
+++ b/apps/docs/release-notes/2026-04-08-v9.10.0.mdx
@@ -2,9 +2,11 @@
 slug: v9.10.0
 title: 9.10.0 - Import existing fields, more copy-to-clipboard tables
 date: '2026-04-08'
-tags: [web]
+tags: [web, desktop, extension]
 versions:
   web: 9.10.0
+  desktop: 3.19.0
+  extension: 2.21.0
 summary: Preload definitions of existing Salesforce fields into Create Fields, and copy data from more tables with a right-click context menu.
 highlights:
   - title: Import existing fields into Create Fields

--- a/apps/docs/release-notes/2026-04-14-v9.12.0.mdx
+++ b/apps/docs/release-notes/2026-04-14-v9.12.0.mdx
@@ -2,9 +2,11 @@
 slug: v9.12.0
 title: 9.12.0 - Bulk API error handling improvements
 date: '2026-04-14'
-tags: [web]
+tags: [web, desktop, extension]
 versions:
   web: 9.12.0
+  desktop: 3.20.0
+  extension: 2.22.0
 summary: Bulk API loads now detect fatal errors and retry transient failures instead of plowing ahead, with clearer progress reporting.
 highlights:
   - title: Smarter Bulk API error handling

--- a/apps/docs/release-notes/2026-04-14-v9.12.1.mdx
+++ b/apps/docs/release-notes/2026-04-14-v9.12.1.mdx
@@ -2,9 +2,11 @@
 slug: v9.12.1
 title: 9.12.1 - Retry failed rows on a data load
 date: '2026-04-14'
-tags: [web]
+tags: [web, desktop, extension]
 versions:
   web: 9.12.1
+  desktop: 3.20.0
+  extension: 2.22.0
 summary: Retry just the failed rows from a data load without re-running the whole job.
 highlights:
   - title: Retry failed rows from the load-failures modal

--- a/apps/docs/release-notes/2026-04-19-v9.13.0.mdx
+++ b/apps/docs/release-notes/2026-04-19-v9.13.0.mdx
@@ -2,9 +2,11 @@
 slug: v9.13.0
 title: 9.13.0 - Clickable Name links in query results, auth hardening
 date: '2026-04-19'
-tags: [web]
+tags: [web, desktop, extension]
 versions:
   web: 9.13.0
+  desktop: 3.20.0
+  extension: 2.22.0
 summary: Name fields in query results now open the same record-lookup popover as Id links, plus several authentication and session hardening changes.
 highlights:
   - title: Clickable Name columns in query results
@@ -12,12 +14,16 @@ highlights:
     docLink: /query/results
   - title: Salesforce refresh token rotation
     description: Jetstream now stores rotated refresh tokens when Salesforce issues them during a refresh.
+    platforms: [web, desktop]
   - title: Verification attempt limits
     description: OTP, email verification, and password reset tokens now expire after a set number of invalid attempts, with rate limits on internal password reset endpoints.
+    platforms: [web]
   - title: Revoke other sessions on password change
     description: Setting a new password or removing a password from the profile page now logs out all other active sessions.
+    platforms: [web]
   - title: Require auth before serving the app
     description: Unauthenticated requests to app pages are redirected to login up front instead of briefly loading the app first.
+    platforms: [web]
 ---
 
 {/* truncate */}

--- a/apps/docs/release-notes/2026-04-23-v9.15.2.mdx
+++ b/apps/docs/release-notes/2026-04-23-v9.15.2.mdx
@@ -2,17 +2,21 @@
 slug: v9.15.2
 title: 9.15.2 - Smoother SSO sign-in
 date: '2026-04-23'
-tags: [web]
+tags: [web, desktop, extension]
 summary: A round of single sign-on improvements — fewer double logins, fewer race conditions, and clearer messaging when an account can't be matched.
 versions:
   web: 9.15.2
+  desktop: 3.20.1
+  extension: 2.22.1
 highlights:
   - title: Fewer double logins and auth race conditions
     description: Signing in through SSO is smoother across the desktop app and browser extension, with the extra login prompt and timing-related hiccups ironed out.
     docLink: /team-management/sso/overview
+    platforms: [desktop, extension]
   - title: Clearer SSO account-matching errors
     description: When SSO can't confidently match you to a single account, Jetstream now explains what happened instead of failing silently.
     docLink: /team-management/sso/overview
+    platforms: [web]
 ---
 
 {/* truncate */}

--- a/apps/docs/release-notes/2026-05-22-v9.18.0.mdx
+++ b/apps/docs/release-notes/2026-05-22-v9.18.0.mdx
@@ -2,10 +2,11 @@
 slug: v9.18.0
 title: 9.18.0 - Refresh records in place and jump from the extension into Query
 date: '2026-05-22'
-tags: [web, extension]
+tags: [web, desktop, extension]
 versions:
   web: 9.18.0
-  extension: 2.24.1
+  desktop: 3.23.0
+  extension: 2.25.0
 summary: Refresh a record without closing the modal, deep-link from the browser extension straight into a query, and get more visibility into org-level actions through expanded audit logs.
 highlights:
   - title: Refresh a record without leaving the modal
@@ -14,8 +15,10 @@ highlights:
   - title: Jump from the extension into Query
     description: Opening Jetstream from the browser extension can pre-fill the object and add a filter for the record you came from.
     docLink: /query
+    platforms: [extension]
   - title: More org action audit logs
     description: Adding, deleting, and refreshing Salesforce org connections are now recorded for better team accountability.
+    platforms: [web]
 ---
 
 {/* truncate */}

--- a/apps/docs/release-notes/2026-06-10-v10.0.0.mdx
+++ b/apps/docs/release-notes/2026-06-10-v10.0.0.mdx
@@ -2,9 +2,11 @@
 slug: v10.0.0
 title: 10.0.0 - A fresh look with SLDS 2 and dark mode
 date: '2026-06-10'
-tags: [web]
+tags: [web, desktop, extension]
 versions:
   web: 10.0.0
+  desktop: 4.0.0
+  extension: 3.0.0
 summary: Jetstream gets a refreshed look built on Salesforce's SLDS 2 "Cosmos" design system — and, by popular demand, a dark mode.
 highlights:
   - title: Refreshed SLDS 2 "Cosmos" look

--- a/apps/docs/release-notes/2026-06-14-v10.1.2.mdx
+++ b/apps/docs/release-notes/2026-06-14-v10.1.2.mdx
@@ -5,7 +5,7 @@ date: '2026-06-14'
 tags: [web, desktop]
 versions:
   web: 10.1.2
-  desktop: 4.1.1
+  desktop: 4.1.2
 summary: Behind-the-scenes maintenance and security updates. No changes to how the app works.
 highlights:
   - title: Maintenance and security updates

--- a/apps/docs/release-notes/2026-06-18-v10.1.3.mdx
+++ b/apps/docs/release-notes/2026-06-18-v10.1.3.mdx
@@ -2,10 +2,9 @@
 slug: v10.1.3
 title: 10.1.3 - Salesforce permissions documentation
 date: '2026-06-18'
-tags: [web, desktop]
+tags: [web]
 versions:
   web: 10.1.3
-  desktop: 4.1.2
 summary: New documentation detailing the Salesforce permissions Jetstream needs, to help admins grant the right access.
 highlights:
   - title: Salesforce permissions and data-access docs

--- a/apps/docs/release-notes/2026-06-20-v10.2.0.mdx
+++ b/apps/docs/release-notes/2026-06-20-v10.2.0.mdx
@@ -2,9 +2,11 @@
 slug: v10.2.0
 title: 10.2.0 - Better keyboard navigation and smoother drag-and-drop
 date: '2026-06-20'
-tags: [web]
+tags: [web, desktop, extension]
 versions:
   web: 10.2.0
+  desktop: 4.2.0
+  extension: 3.2.0
 summary: Keyboard navigation around popovers and the app gets a lot less frustrating, drag-and-drop for org groups and filters feels smoother, and the browser extension stops churning through tokens.
 highlights:
   - title: Better keyboard navigation
@@ -14,6 +16,7 @@ highlights:
     docLink: /query
   - title: Fewer extension token refreshes
     description: The browser extension no longer churns through access tokens, refreshing far less often than it used to.
+    platforms: [extension]
 ---
 
 {/* truncate */}

--- a/apps/docs/release-notes/2026-06-21-v10.3.0.mdx
+++ b/apps/docs/release-notes/2026-06-21-v10.3.0.mdx
@@ -2,10 +2,11 @@
 slug: v10.3.0
 title: 10.3.0 - Rebuilt data tables with cell selection, copy, and export
 date: '2026-06-21'
-tags: [web, extension]
+tags: [web, desktop, extension]
 versions:
   web: 10.3.0
-  extension: 3.2.0
+  desktop: 4.2.0
+  extension: 3.3.0
 summary: Jetstream's data tables are rebuilt on a new foundation — select and copy ranges of cells, copy columns and export tables from a richer right-click menu, and export just the cells you selected. Subqueries gain filter/order/limit support, the permission manager shows per-object selection counts, and new keyboard shortcuts speed up multi-step pages.
 highlights:
   - title: Select and copy ranges of cells

--- a/apps/docs/release-notes/2026-06-21-v10.3.1.mdx
+++ b/apps/docs/release-notes/2026-06-21-v10.3.1.mdx
@@ -2,10 +2,11 @@
 slug: v10.3.1
 title: 10.3.1 - Data table polish
 date: '2026-06-21'
-tags: [web, extension]
+tags: [web, desktop, extension]
 versions:
   web: 10.3.1
-  extension: 3.3.0
+  desktop: 4.2.0
+  extension: 3.3.1
 summary: A couple of small but welcome usability fixes for the rebuilt data tables.
 highlights:
   - title: Steadier tooltips and column resizing

--- a/apps/docs/release-notes/2026-06-22-v10.3.2.mdx
+++ b/apps/docs/release-notes/2026-06-22-v10.3.2.mdx
@@ -2,10 +2,11 @@
 slug: v10.3.2
 title: 10.3.2 - Faster data tables and steadier sign-in
 date: '2026-06-22'
-tags: [web, extension]
+tags: [web, desktop, extension]
 versions:
   web: 10.3.2
-  extension: 3.3.1
+  desktop: 4.2.0
+  extension: 3.3.2
 summary: Data tables load and filter faster, and desktop and browser-extension sessions stay signed in more reliably.
 highlights:
   - title: Faster data tables
@@ -13,6 +14,7 @@ highlights:
     docLink: /query/results
   - title: More reliable sign-in
     description: Improved token verification keeps the desktop app and browser extension signed in more reliably.
+    platforms: [desktop, extension]
 ---
 
 {/* truncate */}

--- a/apps/docs/release-notes/2026-06-22-v10.3.5.mdx
+++ b/apps/docs/release-notes/2026-06-22-v10.3.5.mdx
@@ -2,9 +2,11 @@
 slug: v10.3.5
 title: 10.3.5 - Data table crash fix
 date: '2026-06-22'
-tags: [web]
+tags: [web, desktop, extension]
 versions:
   web: 10.3.5
+  desktop: 4.2.0
+  extension: 3.3.2
 summary: Fixes a crash that could affect query results and other data tables, with further single sign-on reliability improvements.
 highlights:
   - title: Fixed a data table crash

--- a/apps/docs/release-notes/2026-06-30-v10.4.0.mdx
+++ b/apps/docs/release-notes/2026-06-30-v10.4.0.mdx
@@ -2,10 +2,11 @@
 slug: v10.4.0
 title: 10.4.0 - Preview bulk updates and view field metadata
 date: '2026-06-30'
-tags: [web, extension]
+tags: [web, desktop, extension]
 versions:
   web: 10.4.0
-  extension: 3.3.2
+  desktop: 4.2.0
+  extension: 3.4.0
 summary: Preview exactly what a bulk update will change before you apply it, and view field metadata right from the query results grid.
 highlights:
   - title: Preview bulk updates before saving

--- a/apps/docs/release-notes/2026-07-15-v10.5.0.mdx
+++ b/apps/docs/release-notes/2026-07-15-v10.5.0.mdx
@@ -2,10 +2,11 @@
 slug: v10.5.0
 title: 10.5.0 - Copy, paste, and undo in editable tables
 date: '2026-07-15'
-tags: [web, extension]
+tags: [web, desktop, extension]
 versions:
   web: 10.5.0
-  extension: 3.4.0
+  desktop: 4.2.0
+  extension: 3.5.0
 summary: A big upgrade to table editing — copy and paste ranges of cells, undo your changes, and preview everything before saving — plus row range selection and a batch of reliability fixes.
 highlights:
   - title: Copy, paste, and undo in editable tables
@@ -16,6 +17,7 @@ highlights:
     docLink: /query/results
   - title: Clearer reconnect prompts
     description: Salesforce authentication failures now prompt you to reconnect instead of showing a confusing error.
+    platforms: [web]
   - title: Steadier dates and large orgs
     description: Invalid dates show their raw value instead of erroring, and querying objects in very large orgs no longer hits a Salesforce limit.
 ---

--- a/apps/docs/release-notes/2026-07-17-v10.6.0.mdx
+++ b/apps/docs/release-notes/2026-07-17-v10.6.0.mdx
@@ -2,9 +2,11 @@
 slug: v10.6.0
 title: 10.6.0 - SOQL comments and sturdier bulk updates
 date: '2026-07-17'
-tags: [web]
+tags: [web, desktop, extension]
 versions:
   web: 10.6.0
+  desktop: 4.3.0
+  extension: 3.6.0
 summary: Write comments in your SOQL queries, get more resilient bulk record updates, and benefit from single sign-on configuration improvements.
 highlights:
   - title: Comments in SOQL queries
@@ -16,6 +18,7 @@ highlights:
   - title: Single sign-on improvements
     description: Improved OIDC configuration handling and discovery for single sign-on.
     docLink: /team-management/sso/overview
+    platforms: [web]
 ---
 
 {/* truncate */}

--- a/apps/docs/release-notes/2026-07-19-v10.6.1.mdx
+++ b/apps/docs/release-notes/2026-07-19-v10.6.1.mdx
@@ -4,7 +4,7 @@ title: 10.6.1 - Windows update fix and security hardening
 date: '2026-07-19'
 tags: [desktop, extension]
 versions:
-  desktop: 4.3.0
+  desktop: 4.3.1
   extension: 3.6.0
 summary: Fixes broken auto-updates for the Windows desktop app and adds security hardening to the desktop app and browser extension.
 highlights:
@@ -13,7 +13,6 @@ highlights:
     platforms: [desktop]
   - title: Security hardening on desktop and extension
     description: Safer handling of external links and downloads in the desktop app, and stricter message handling in the browser extension.
-    platforms: [desktop, extension]
 ---
 
 {/* truncate */}

--- a/apps/docs/release-notes/2026-07-22-v10.7.0.mdx
+++ b/apps/docs/release-notes/2026-07-22-v10.7.0.mdx
@@ -2,9 +2,11 @@
 slug: v10.7.0
 title: 10.7.0 - Manage system permissions
 date: '2026-07-22'
-tags: [web]
+tags: [web, desktop, extension]
 versions:
   web: 10.7.0
+  desktop: 4.4.0
+  extension: 3.7.0
 summary: Manage Permissions now covers system permissions — review and edit them across profiles and permission sets side by side, with required permissions handled automatically.
 highlights:
   - title: Edit system permissions in Manage Permissions
@@ -12,6 +14,7 @@ highlights:
     docLink: /permissions
   - title: Release notes
     description: Jetstream now publishes release notes on the docs site, so you can keep up with new features and fixes.
+    platforms: [web]
 ---
 
 {/* truncate */}

--- a/apps/docs/release-notes/2026-07-27-v10.7.2.mdx
+++ b/apps/docs/release-notes/2026-07-27-v10.7.2.mdx
@@ -2,9 +2,11 @@
 slug: v10.7.2
 title: 10.7.2 - Very long queries no longer fail
 date: '2026-07-27'
-tags: [web]
+tags: [web, desktop, extension]
 versions:
   web: 10.7.2
+  desktop: 4.4.1
+  extension: 3.7.1
 summary: Queries with a large number of fields no longer fail with a request-too-large error from Salesforce, and results now come back in a single round trip.
 highlights:
   - title: Very long queries no longer fail

--- a/apps/docs/release-notes/2026-08-05-v10.10.0.mdx
+++ b/apps/docs/release-notes/2026-08-05-v10.10.0.mdx
@@ -2,16 +2,17 @@
 slug: v10.10.0
 title: 10.10.0 - Change your email address, SOQL autocomplete
 date: '2026-08-05'
-tags: [web, desktop]
+tags: [web, desktop, extension]
 versions:
   web: 10.10.0
   desktop: 4.7.0
+  extension: 3.10.0
 summary: Change the email address on your account without filing a support ticket, get autocomplete while writing SOQL, and see org connection expiration dates that match what Salesforce actually enforces.
 highlights:
   - title: Change your email address from your profile
     description: Update the email address on your Jetstream account yourself, confirmed from the new mailbox, instead of filing a support ticket.
-    platforms: [web]
     docLink: /user-profile-and-settings/user-profile
+    platforms: [web]
   - title: Autocomplete while writing SOQL
     description: The SOQL editor suggests objects, fields, relationships, picklist values, and keywords from the org you have selected.
     docLink: /query
@@ -20,8 +21,8 @@ highlights:
     platforms: [web]
   - title: Orgs are saved per account on the desktop app
     description: Each Jetstream account signed in on the same computer keeps its own set of connected orgs.
-    platforms: [desktop]
     docLink: /desktop-app
+    platforms: [desktop]
 ---
 
 {/* truncate */}

--- a/apps/docs/release-notes/2026-08-10-v10.11.0.mdx
+++ b/apps/docs/release-notes/2026-08-10-v10.11.0.mdx
@@ -2,9 +2,11 @@
 slug: v10.11.0
 title: 10.11.0 - Faster tables, right-click copy everywhere, multi-range selection
 date: '2026-08-10'
-tags: [web]
+tags: [web, desktop, extension]
 versions:
   web: 10.11.0
+  desktop: 4.8.0
+  extension: 3.11.0
 summary: Data tables across the app get a big upgrade — faster rendering, a right-click copy menu on every table, and spreadsheet-style multi-range cell selection — plus a permission manager that recovers on its own when your org's permissions change.
 highlights:
   - title: Copy from any table with a right-click

--- a/apps/docs/release-notes/2026-08-21-v10.14.1.mdx
+++ b/apps/docs/release-notes/2026-08-21-v10.14.1.mdx
@@ -2,9 +2,11 @@
 slug: v10.14.1
 title: 10.14.1 - Manage Permissions object list fix
 date: '2026-08-21'
-tags: [web]
+tags: [web, desktop, extension]
 versions:
   web: 10.14.1
+  desktop: 4.11.1
+  extension: 3.14.1
 summary: Manage Permissions now shows objects that only support field-level security, such as Price Book Entry and Task, which were missing from the object list.
 highlights:
   - title: Manage Permissions object list fix

--- a/apps/docs/release-notes/2026-08-23-v10.15.0.mdx
+++ b/apps/docs/release-notes/2026-08-23-v10.15.0.mdx
@@ -2,9 +2,11 @@
 slug: v10.15.0
 title: 10.15.0 - Record limit for Update Records, map one column to multiple fields
 date: '2026-08-23'
-tags: [web]
+tags: [web, desktop, extension]
 versions:
   web: 10.15.0
+  desktop: 4.12.0
+  extension: 3.15.0
 summary: Update Records can limit how many records are updated at a time, and Load Records can map one file column to multiple Salesforce fields.
 highlights:
   - title: Record limit in Update Records

--- a/apps/docs/release-notes/2026-08-25-v10.15.2.mdx
+++ b/apps/docs/release-notes/2026-08-25-v10.15.2.mdx
@@ -2,9 +2,11 @@
 slug: v10.15.2
 title: 10.15.2 - Permission Analysis fix for permission set groups
 date: '2026-08-25'
-tags: [web]
+tags: [web, desktop, extension]
 versions:
   web: 10.15.2
+  desktop: 4.12.2
+  extension: 3.15.1
 summary: Fixes a Permission Analysis error when a selected permission set belongs to a permission set group.
 highlights:
   - title: Permission Analysis fix for permission set groups

--- a/apps/docs/release-notes/2026-08-27-v10.16.0.mdx
+++ b/apps/docs/release-notes/2026-08-27-v10.16.0.mdx
@@ -2,15 +2,18 @@
 slug: v10.16.0
 title: 10.16.0 - Org dropdown improvements and large load retry fix
 date: '2026-08-27'
-tags: [web]
+tags: [web, desktop, extension]
 versions:
   web: 10.16.0
+  desktop: 4.13.0
+  extension: 3.16.0
 summary: The org dropdown shows full usernames and labels each org with its type. Also fixes a crash when retrying failed records on very large data loads.
 highlights:
   - title: Full usernames and org types in the org dropdown
     description: The org dropdown shows full usernames without truncation and labels each org with its type, so sandboxes stand out.
   - title: Paste any Salesforce URL to add a custom domain
     description: The custom domain field on the add-org form accepts a full pasted Salesforce URL, including sandbox URLs, and extracts the domain for you.
+    platforms: [web, desktop]
   - title: Fix for load retries with 100,000+ records
     description: Retrying failed records on very large data loads no longer crashes the page.
     docLink: /load

--- a/apps/docs/release-notes/2026-09-01-v10.17.0.mdx
+++ b/apps/docs/release-notes/2026-09-01-v10.17.0.mdx
@@ -2,9 +2,11 @@
 slug: v10.17.0
 title: 10.17.0 - Apex Test Runner
 date: '2026-09-01'
-tags: [web]
+tags: [web, desktop, extension]
 versions:
   web: 10.17.0
+  desktop: 4.14.0
+  extension: 3.17.0
 summary: Adds the Apex Test Runner. Run Apex tests, monitor test runs in real time, and view code coverage with per-line highlighting.
 highlights:
   - title: Apex Test Runner

--- a/apps/docs/release-notes/2026-09-07-v10.18.0.mdx
+++ b/apps/docs/release-notes/2026-09-07-v10.18.0.mdx
@@ -1,0 +1,61 @@
+---
+slug: v10.18.0
+title: 10.18.0 - Desktop update controls and portable Windows build
+date: '2026-09-07'
+tags: [web, desktop]
+versions:
+  web: 10.18.0
+  desktop: 4.15.0
+summary: The desktop app now lets you turn off automatic updates, and IT teams can manage updates for an entire organization. A portable Windows build is now available on the download page.
+highlights:
+  - title: Turn off automatic updates in the desktop app
+    description: A new Automatically Download Updates setting stops background checks and downloads, while Check for Updates in the File menu still works on demand.
+    docLink: /desktop-app-updates
+    platforms: [desktop]
+  - title: Managed update policy for organizations
+    description: IT teams can disable or pin automatic updates for every install with a registry key, macOS configuration profile, environment variable, command-line flag, or policy file.
+    docLink: /desktop-app-updates
+    platforms: [desktop]
+  - title: Administrator prompts on all-users Windows installs
+    description: Updates on all-users installs no longer try to install silently when the app closes, which showed a User Account Control prompt that standard users could not complete.
+    docLink: /desktop-app-updates
+    platforms: [desktop]
+  - title: Portable Windows build on the download page
+    description: A Windows build that runs without installing and never asks for an administrator is now offered on the download page.
+    docLink: /desktop-app-updates
+    platforms: [web, desktop]
+---
+
+{/* truncate */}
+
+## What's new
+
+### Turn off automatic updates in the desktop app
+
+Settings has a new **Automatically Download Updates** toggle. When it is off, Jetstream stops checking for and downloading new versions in the background, and the update icon in the header shows that updates are turned off. You can still get a new version at any time from **Check for Updates** in the File menu (the Jetstream menu on a Mac) or from the header icon.
+
+### Managed update policy for organizations
+
+If you deploy Jetstream with an MDM or software-distribution tool, you can now own the update schedule. Jetstream reads these sources in order and uses the first one that is set:
+
+- The `--disable-auto-update` command-line flag
+- The `JETSTREAM_DISABLE_AUTO_UPDATE` environment variable
+- A `DisableAutoUpdate` value under `HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Jetstream` (Windows)
+- A configuration profile for the `app.getjetstream` preference domain (macOS)
+- A machine-wide `policy.json` file
+
+When updates are disabled by any of these, the in-app toggle becomes read-only, the **Check for Updates** menu item is replaced with **Updates Managed by Your Organization**, and deploying new versions is up to your distribution tool. Setting the value to `0` instead pins automatic updates on so users cannot turn them off.
+
+### Administrator prompts on all-users Windows installs
+
+When Jetstream is installed for all users of a Windows computer, installing an update means writing outside your own user profile, so Windows asks for administrator approval. Previously the update tried to install silently when the app closed, which showed an unexplained User Account Control prompt on every quit, and a user without administrator rights could never complete it. Jetstream now never installs these updates in the background. The update still downloads, and the header notification explains that an administrator is needed and only starts the install when you click **Install Update**.
+
+### Portable Windows build on the download page
+
+The download page now offers **Windows (Portable)**, a build that runs without installing and never asks for an administrator. It does not update itself: download a new copy to move to a newer version. The in-app update controls say so when you are running the portable build.
+
+### Other fixes
+
+- Windows updates now download only the parts of the installer that changed. Updating to this version still downloads the full installer, and later updates will be smaller.
+- Clicking **Restart Now** in the header update notification on a per-user Windows install now installs the update silently instead of opening the installer wizard.
+- The Windows installer license screen now shows formatted text instead of raw markdown symbols.

--- a/apps/docs/static/release-notes.json
+++ b/apps/docs/static/release-notes.json
@@ -1,10 +1,44 @@
 [
   {
+    "slug": "v10.18.0",
+    "title": "10.18.0 - Desktop update controls and portable Windows build",
+    "date": "2026-09-07",
+    "tags": ["web", "desktop"],
+    "versions": { "web": "10.18.0", "desktop": "4.15.0" },
+    "summary": "The desktop app now lets you turn off automatic updates, and IT teams can manage updates for an entire organization. A portable Windows build is now available on the download page.",
+    "highlights": [
+      {
+        "title": "Turn off automatic updates in the desktop app",
+        "description": "A new Automatically Download Updates setting stops background checks and downloads, while Check for Updates in the File menu still works on demand.",
+        "platforms": ["desktop"],
+        "docLink": "/desktop-app-updates"
+      },
+      {
+        "title": "Managed update policy for organizations",
+        "description": "IT teams can disable or pin automatic updates for every install with a registry key, macOS configuration profile, environment variable, command-line flag, or policy file.",
+        "platforms": ["desktop"],
+        "docLink": "/desktop-app-updates"
+      },
+      {
+        "title": "Administrator prompts on all-users Windows installs",
+        "description": "Updates on all-users installs no longer try to install silently when the app closes, which showed a User Account Control prompt that standard users could not complete.",
+        "platforms": ["desktop"],
+        "docLink": "/desktop-app-updates"
+      },
+      {
+        "title": "Portable Windows build on the download page",
+        "description": "A Windows build that runs without installing and never asks for an administrator is now offered on the download page.",
+        "platforms": ["web", "desktop"],
+        "docLink": "/desktop-app-updates"
+      }
+    ]
+  },
+  {
     "slug": "v10.17.0",
     "title": "10.17.0 - Apex Test Runner",
     "date": "2026-09-01",
-    "tags": ["web"],
-    "versions": { "web": "10.17.0" },
+    "tags": ["web", "desktop", "extension"],
+    "versions": { "web": "10.17.0", "desktop": "4.14.0", "extension": "3.17.0" },
     "summary": "Adds the Apex Test Runner. Run Apex tests, monitor test runs in real time, and view code coverage with per-line highlighting.",
     "highlights": [
       {
@@ -31,8 +65,8 @@
     "slug": "v10.16.0",
     "title": "10.16.0 - Org dropdown improvements and large load retry fix",
     "date": "2026-08-27",
-    "tags": ["web"],
-    "versions": { "web": "10.16.0" },
+    "tags": ["web", "desktop", "extension"],
+    "versions": { "web": "10.16.0", "desktop": "4.13.0", "extension": "3.16.0" },
     "summary": "The org dropdown shows full usernames and labels each org with its type. Also fixes a crash when retrying failed records on very large data loads.",
     "highlights": [
       {
@@ -41,7 +75,8 @@
       },
       {
         "title": "Paste any Salesforce URL to add a custom domain",
-        "description": "The custom domain field on the add-org form accepts a full pasted Salesforce URL, including sandbox URLs, and extracts the domain for you."
+        "description": "The custom domain field on the add-org form accepts a full pasted Salesforce URL, including sandbox URLs, and extracts the domain for you.",
+        "platforms": ["web", "desktop"]
       },
       {
         "title": "Fix for load retries with 100,000+ records",
@@ -54,8 +89,8 @@
     "slug": "v10.15.2",
     "title": "10.15.2 - Permission Analysis fix for permission set groups",
     "date": "2026-08-25",
-    "tags": ["web"],
-    "versions": { "web": "10.15.2" },
+    "tags": ["web", "desktop", "extension"],
+    "versions": { "web": "10.15.2", "desktop": "4.12.2", "extension": "3.15.1" },
     "summary": "Fixes a Permission Analysis error when a selected permission set belongs to a permission set group.",
     "highlights": [
       {
@@ -90,8 +125,8 @@
     "slug": "v10.15.0",
     "title": "10.15.0 - Record limit for Update Records, map one column to multiple fields",
     "date": "2026-08-23",
-    "tags": ["web"],
-    "versions": { "web": "10.15.0" },
+    "tags": ["web", "desktop", "extension"],
+    "versions": { "web": "10.15.0", "desktop": "4.12.0", "extension": "3.15.0" },
     "summary": "Update Records can limit how many records are updated at a time, and Load Records can map one file column to multiple Salesforce fields.",
     "highlights": [
       {
@@ -125,8 +160,8 @@
     "slug": "v10.14.1",
     "title": "10.14.1 - Manage Permissions object list fix",
     "date": "2026-08-21",
-    "tags": ["web"],
-    "versions": { "web": "10.14.1" },
+    "tags": ["web", "desktop", "extension"],
+    "versions": { "web": "10.14.1", "desktop": "4.11.1", "extension": "3.14.1" },
     "summary": "Manage Permissions now shows objects that only support field-level security, such as Price Book Entry and Task, which were missing from the object list.",
     "highlights": [
       {
@@ -239,8 +274,8 @@
     "slug": "v10.11.0",
     "title": "10.11.0 - Faster tables, right-click copy everywhere, multi-range selection",
     "date": "2026-08-10",
-    "tags": ["web"],
-    "versions": { "web": "10.11.0" },
+    "tags": ["web", "desktop", "extension"],
+    "versions": { "web": "10.11.0", "desktop": "4.8.0", "extension": "3.11.0" },
     "summary": "Data tables across the app get a big upgrade — faster rendering, a right-click copy menu on every table, and spreadsheet-style multi-range cell selection — plus a permission manager that recovers on its own when your org's permissions change.",
     "highlights": [
       {
@@ -286,8 +321,8 @@
     "slug": "v10.10.0",
     "title": "10.10.0 - Change your email address, SOQL autocomplete",
     "date": "2026-08-05",
-    "tags": ["web", "desktop"],
-    "versions": { "web": "10.10.0", "desktop": "4.7.0" },
+    "tags": ["web", "desktop", "extension"],
+    "versions": { "web": "10.10.0", "desktop": "4.7.0", "extension": "3.10.0" },
     "summary": "Change the email address on your account without filing a support ticket, get autocomplete while writing SOQL, and see org connection expiration dates that match what Salesforce actually enforces.",
     "highlights": [
       {
@@ -388,8 +423,8 @@
     "slug": "v10.7.2",
     "title": "10.7.2 - Very long queries no longer fail",
     "date": "2026-07-27",
-    "tags": ["web"],
-    "versions": { "web": "10.7.2" },
+    "tags": ["web", "desktop", "extension"],
+    "versions": { "web": "10.7.2", "desktop": "4.4.1", "extension": "3.7.1" },
     "summary": "Queries with a large number of fields no longer fail with a request-too-large error from Salesforce, and results now come back in a single round trip.",
     "highlights": [
       {
@@ -429,8 +464,8 @@
     "slug": "v10.7.0",
     "title": "10.7.0 - Manage system permissions",
     "date": "2026-07-22",
-    "tags": ["web"],
-    "versions": { "web": "10.7.0" },
+    "tags": ["web", "desktop", "extension"],
+    "versions": { "web": "10.7.0", "desktop": "4.4.0", "extension": "3.7.0" },
     "summary": "Manage Permissions now covers system permissions — review and edit them across profiles and permission sets side by side, with required permissions handled automatically.",
     "highlights": [
       {
@@ -440,7 +475,8 @@
       },
       {
         "title": "Release notes",
-        "description": "Jetstream now publishes release notes on the docs site, so you can keep up with new features and fixes."
+        "description": "Jetstream now publishes release notes on the docs site, so you can keep up with new features and fixes.",
+        "platforms": ["web"]
       }
     ]
   },
@@ -449,7 +485,7 @@
     "title": "10.6.1 - Windows update fix and security hardening",
     "date": "2026-07-19",
     "tags": ["desktop", "extension"],
-    "versions": { "desktop": "4.3.0", "extension": "3.6.0" },
+    "versions": { "desktop": "4.3.1", "extension": "3.6.0" },
     "summary": "Fixes broken auto-updates for the Windows desktop app and adds security hardening to the desktop app and browser extension.",
     "highlights": [
       {
@@ -459,8 +495,7 @@
       },
       {
         "title": "Security hardening on desktop and extension",
-        "description": "Safer handling of external links and downloads in the desktop app, and stricter message handling in the browser extension.",
-        "platforms": ["desktop", "extension"]
+        "description": "Safer handling of external links and downloads in the desktop app, and stricter message handling in the browser extension."
       }
     ]
   },
@@ -468,8 +503,8 @@
     "slug": "v10.6.0",
     "title": "10.6.0 - SOQL comments and sturdier bulk updates",
     "date": "2026-07-17",
-    "tags": ["web"],
-    "versions": { "web": "10.6.0" },
+    "tags": ["web", "desktop", "extension"],
+    "versions": { "web": "10.6.0", "desktop": "4.3.0", "extension": "3.6.0" },
     "summary": "Write comments in your SOQL queries, get more resilient bulk record updates, and benefit from single sign-on configuration improvements.",
     "highlights": [
       {
@@ -485,6 +520,7 @@
       {
         "title": "Single sign-on improvements",
         "description": "Improved OIDC configuration handling and discovery for single sign-on.",
+        "platforms": ["web"],
         "docLink": "/team-management/sso/overview"
       }
     ]
@@ -512,8 +548,8 @@
     "slug": "v10.5.0",
     "title": "10.5.0 - Copy, paste, and undo in editable tables",
     "date": "2026-07-15",
-    "tags": ["web", "extension"],
-    "versions": { "web": "10.5.0", "extension": "3.4.0" },
+    "tags": ["web", "desktop", "extension"],
+    "versions": { "web": "10.5.0", "desktop": "4.2.0", "extension": "3.5.0" },
     "summary": "A big upgrade to table editing — copy and paste ranges of cells, undo your changes, and preview everything before saving — plus row range selection and a batch of reliability fixes.",
     "highlights": [
       {
@@ -528,7 +564,8 @@
       },
       {
         "title": "Clearer reconnect prompts",
-        "description": "Salesforce authentication failures now prompt you to reconnect instead of showing a confusing error."
+        "description": "Salesforce authentication failures now prompt you to reconnect instead of showing a confusing error.",
+        "platforms": ["web"]
       },
       {
         "title": "Steadier dates and large orgs",
@@ -540,8 +577,8 @@
     "slug": "v10.4.0",
     "title": "10.4.0 - Preview bulk updates and view field metadata",
     "date": "2026-06-30",
-    "tags": ["web", "extension"],
-    "versions": { "web": "10.4.0", "extension": "3.3.2" },
+    "tags": ["web", "desktop", "extension"],
+    "versions": { "web": "10.4.0", "desktop": "4.2.0", "extension": "3.4.0" },
     "summary": "Preview exactly what a bulk update will change before you apply it, and view field metadata right from the query results grid.",
     "highlights": [
       {
@@ -565,8 +602,8 @@
     "slug": "v10.3.5",
     "title": "10.3.5 - Data table crash fix",
     "date": "2026-06-22",
-    "tags": ["web"],
-    "versions": { "web": "10.3.5" },
+    "tags": ["web", "desktop", "extension"],
+    "versions": { "web": "10.3.5", "desktop": "4.2.0", "extension": "3.3.2" },
     "summary": "Fixes a crash that could affect query results and other data tables, with further single sign-on reliability improvements.",
     "highlights": [
       {
@@ -610,8 +647,8 @@
     "slug": "v10.3.2",
     "title": "10.3.2 - Faster data tables and steadier sign-in",
     "date": "2026-06-22",
-    "tags": ["web", "extension"],
-    "versions": { "web": "10.3.2", "extension": "3.3.1" },
+    "tags": ["web", "desktop", "extension"],
+    "versions": { "web": "10.3.2", "desktop": "4.2.0", "extension": "3.3.2" },
     "summary": "Data tables load and filter faster, and desktop and browser-extension sessions stay signed in more reliably.",
     "highlights": [
       {
@@ -621,7 +658,8 @@
       },
       {
         "title": "More reliable sign-in",
-        "description": "Improved token verification keeps the desktop app and browser extension signed in more reliably."
+        "description": "Improved token verification keeps the desktop app and browser extension signed in more reliably.",
+        "platforms": ["desktop", "extension"]
       }
     ]
   },
@@ -629,8 +667,8 @@
     "slug": "v10.3.1",
     "title": "10.3.1 - Data table polish",
     "date": "2026-06-21",
-    "tags": ["web", "extension"],
-    "versions": { "web": "10.3.1", "extension": "3.3.0" },
+    "tags": ["web", "desktop", "extension"],
+    "versions": { "web": "10.3.1", "desktop": "4.2.0", "extension": "3.3.1" },
     "summary": "A couple of small but welcome usability fixes for the rebuilt data tables.",
     "highlights": [
       {
@@ -644,8 +682,8 @@
     "slug": "v10.3.0",
     "title": "10.3.0 - Rebuilt data tables with cell selection, copy, and export",
     "date": "2026-06-21",
-    "tags": ["web", "extension"],
-    "versions": { "web": "10.3.0", "extension": "3.2.0" },
+    "tags": ["web", "desktop", "extension"],
+    "versions": { "web": "10.3.0", "desktop": "4.2.0", "extension": "3.3.0" },
     "summary": "Jetstream's data tables are rebuilt on a new foundation — select and copy ranges of cells, copy columns and export tables from a richer right-click menu, and export just the cells you selected. Subqueries gain filter/order/limit support, the permission manager shows per-object selection counts, and new keyboard shortcuts speed up multi-step pages.",
     "highlights": [
       {
@@ -683,8 +721,8 @@
     "slug": "v10.2.0",
     "title": "10.2.0 - Better keyboard navigation and smoother drag-and-drop",
     "date": "2026-06-20",
-    "tags": ["web"],
-    "versions": { "web": "10.2.0" },
+    "tags": ["web", "desktop", "extension"],
+    "versions": { "web": "10.2.0", "desktop": "4.2.0", "extension": "3.2.0" },
     "summary": "Keyboard navigation around popovers and the app gets a lot less frustrating, drag-and-drop for org groups and filters feels smoother, and the browser extension stops churning through tokens.",
     "highlights": [
       {
@@ -698,7 +736,8 @@
       },
       {
         "title": "Fewer extension token refreshes",
-        "description": "The browser extension no longer churns through access tokens, refreshing far less often than it used to."
+        "description": "The browser extension no longer churns through access tokens, refreshing far less often than it used to.",
+        "platforms": ["extension"]
       }
     ]
   },
@@ -706,8 +745,8 @@
     "slug": "v10.1.3",
     "title": "10.1.3 - Salesforce permissions documentation",
     "date": "2026-06-18",
-    "tags": ["web", "desktop"],
-    "versions": { "web": "10.1.3", "desktop": "4.1.2" },
+    "tags": ["web"],
+    "versions": { "web": "10.1.3" },
     "summary": "New documentation detailing the Salesforce permissions Jetstream needs, to help admins grant the right access.",
     "highlights": [
       {
@@ -722,7 +761,7 @@
     "title": "10.1.2 - Maintenance and security updates",
     "date": "2026-06-14",
     "tags": ["web", "desktop"],
-    "versions": { "web": "10.1.2", "desktop": "4.1.1" },
+    "versions": { "web": "10.1.2", "desktop": "4.1.2" },
     "summary": "Behind-the-scenes maintenance and security updates. No changes to how the app works.",
     "highlights": [
       { "title": "Maintenance and security updates", "description": "Routine behind-the-scenes updates. No changes to how the app works." }
@@ -797,8 +836,8 @@
     "slug": "v10.0.0",
     "title": "10.0.0 - A fresh look with SLDS 2 and dark mode",
     "date": "2026-06-10",
-    "tags": ["web"],
-    "versions": { "web": "10.0.0" },
+    "tags": ["web", "desktop", "extension"],
+    "versions": { "web": "10.0.0", "desktop": "4.0.0", "extension": "3.0.0" },
     "summary": "Jetstream gets a refreshed look built on Salesforce's SLDS 2 \"Cosmos\" design system — and, by popular demand, a dark mode.",
     "highlights": [
       {
@@ -884,8 +923,8 @@
     "slug": "v9.18.0",
     "title": "9.18.0 - Refresh records in place and jump from the extension into Query",
     "date": "2026-05-22",
-    "tags": ["web", "extension"],
-    "versions": { "web": "9.18.0", "extension": "2.24.1" },
+    "tags": ["web", "desktop", "extension"],
+    "versions": { "web": "9.18.0", "desktop": "3.23.0", "extension": "2.25.0" },
     "summary": "Refresh a record without closing the modal, deep-link from the browser extension straight into a query, and get more visibility into org-level actions through expanded audit logs.",
     "highlights": [
       {
@@ -896,11 +935,13 @@
       {
         "title": "Jump from the extension into Query",
         "description": "Opening Jetstream from the browser extension can pre-fill the object and add a filter for the record you came from.",
+        "platforms": ["extension"],
         "docLink": "/query"
       },
       {
         "title": "More org action audit logs",
-        "description": "Adding, deleting, and refreshing Salesforce org connections are now recorded for better team accountability."
+        "description": "Adding, deleting, and refreshing Salesforce org connections are now recorded for better team accountability.",
+        "platforms": ["web"]
       }
     ]
   },
@@ -977,18 +1018,20 @@
     "slug": "v9.15.2",
     "title": "9.15.2 - Smoother SSO sign-in",
     "date": "2026-04-23",
-    "tags": ["web"],
-    "versions": { "web": "9.15.2" },
+    "tags": ["web", "desktop", "extension"],
+    "versions": { "web": "9.15.2", "desktop": "3.20.1", "extension": "2.22.1" },
     "summary": "A round of single sign-on improvements — fewer double logins, fewer race conditions, and clearer messaging when an account can't be matched.",
     "highlights": [
       {
         "title": "Fewer double logins and auth race conditions",
         "description": "Signing in through SSO is smoother across the desktop app and browser extension, with the extra login prompt and timing-related hiccups ironed out.",
+        "platforms": ["desktop", "extension"],
         "docLink": "/team-management/sso/overview"
       },
       {
         "title": "Clearer SSO account-matching errors",
         "description": "When SSO can't confidently match you to a single account, Jetstream now explains what happened instead of failing silently.",
+        "platforms": ["web"],
         "docLink": "/team-management/sso/overview"
       }
     ]
@@ -1051,8 +1094,8 @@
     "slug": "v9.13.0",
     "title": "9.13.0 - Clickable Name links in query results, auth hardening",
     "date": "2026-04-19",
-    "tags": ["web"],
-    "versions": { "web": "9.13.0" },
+    "tags": ["web", "desktop", "extension"],
+    "versions": { "web": "9.13.0", "desktop": "3.20.0", "extension": "2.22.0" },
     "summary": "Name fields in query results now open the same record-lookup popover as Id links, plus several authentication and session hardening changes.",
     "highlights": [
       {
@@ -1062,19 +1105,23 @@
       },
       {
         "title": "Salesforce refresh token rotation",
-        "description": "Jetstream now stores rotated refresh tokens when Salesforce issues them during a refresh."
+        "description": "Jetstream now stores rotated refresh tokens when Salesforce issues them during a refresh.",
+        "platforms": ["web", "desktop"]
       },
       {
         "title": "Verification attempt limits",
-        "description": "OTP, email verification, and password reset tokens now expire after a set number of invalid attempts, with rate limits on internal password reset endpoints."
+        "description": "OTP, email verification, and password reset tokens now expire after a set number of invalid attempts, with rate limits on internal password reset endpoints.",
+        "platforms": ["web"]
       },
       {
         "title": "Revoke other sessions on password change",
-        "description": "Setting a new password or removing a password from the profile page now logs out all other active sessions."
+        "description": "Setting a new password or removing a password from the profile page now logs out all other active sessions.",
+        "platforms": ["web"]
       },
       {
         "title": "Require auth before serving the app",
-        "description": "Unauthenticated requests to app pages are redirected to login up front instead of briefly loading the app first."
+        "description": "Unauthenticated requests to app pages are redirected to login up front instead of briefly loading the app first.",
+        "platforms": ["web"]
       }
     ]
   },
@@ -1082,8 +1129,8 @@
     "slug": "v9.12.1",
     "title": "9.12.1 - Retry failed rows on a data load",
     "date": "2026-04-14",
-    "tags": ["web"],
-    "versions": { "web": "9.12.1" },
+    "tags": ["web", "desktop", "extension"],
+    "versions": { "web": "9.12.1", "desktop": "3.20.0", "extension": "2.22.0" },
     "summary": "Retry just the failed rows from a data load without re-running the whole job.",
     "highlights": [
       {
@@ -1097,8 +1144,8 @@
     "slug": "v9.12.0",
     "title": "9.12.0 - Bulk API error handling improvements",
     "date": "2026-04-14",
-    "tags": ["web"],
-    "versions": { "web": "9.12.0" },
+    "tags": ["web", "desktop", "extension"],
+    "versions": { "web": "9.12.0", "desktop": "3.20.0", "extension": "2.22.0" },
     "summary": "Bulk API loads now detect fatal errors and retry transient failures instead of plowing ahead, with clearer progress reporting.",
     "highlights": [
       {
@@ -1132,8 +1179,8 @@
     "slug": "v9.10.0",
     "title": "9.10.0 - Import existing fields, more copy-to-clipboard tables",
     "date": "2026-04-08",
-    "tags": ["web"],
-    "versions": { "web": "9.10.0" },
+    "tags": ["web", "desktop", "extension"],
+    "versions": { "web": "9.10.0", "desktop": "3.19.0", "extension": "2.21.0" },
     "summary": "Preload definitions of existing Salesforce fields into Create Fields, and copy data from more tables with a right-click context menu.",
     "highlights": [
       {
@@ -1212,8 +1259,8 @@
     "slug": "v9.8.0",
     "title": "9.8.0 - IdP-initiated OIDC login, resilient SOQL formatting",
     "date": "2026-04-03",
-    "tags": ["web"],
-    "versions": { "web": "9.8.0" },
+    "tags": ["web", "desktop", "extension"],
+    "versions": { "web": "9.8.0", "desktop": "3.19.0", "extension": "2.21.0" },
     "summary": "Log in to Jetstream directly from your identity provider's dashboard, plus the query editor no longer crashes on partially typed SOQL.",
     "highlights": [
       {
@@ -1224,7 +1271,6 @@
       {
         "title": "SOQL formatter crash fix",
         "description": "Invalid or in-progress SOQL no longer crashes the query editor while you are still typing.",
-        "platforms": ["web", "desktop", "extension"],
         "docLink": "/query/results"
       }
     ]
@@ -1239,8 +1285,7 @@
     "highlights": [
       {
         "title": "Updated Terms of Service",
-        "description": "New last-updated date and a compliance reporting section describing how to report security, ethics, or compliance concerns.",
-        "platforms": ["web", "desktop", "extension"]
+        "description": "New last-updated date and a compliance reporting section describing how to report security, ethics, or compliance concerns."
       }
     ]
   },
@@ -1248,14 +1293,13 @@
     "slug": "v9.6.0",
     "title": "9.6.0 - Safer user profile handling",
     "date": "2026-04-02",
-    "tags": ["web", "desktop"],
+    "tags": ["web"],
     "versions": { "web": "9.6.0" },
     "summary": "Jetstream now falls back gracefully instead of showing a confusing error when your user profile fails to load.",
     "highlights": [
       {
         "title": "Safer profile fetch",
-        "description": "If loading your user profile fails, Jetstream now falls back to a default instead of surfacing a confusing error.",
-        "platforms": ["web", "desktop", "extension"]
+        "description": "If loading your user profile fails, Jetstream now falls back to a default instead of surfacing a confusing error."
       }
     ]
   },
@@ -1263,14 +1307,13 @@
     "slug": "v9.5.0",
     "title": "9.5.0 - Better Salesforce formula evaluation, desktop persistence fixes",
     "date": "2026-04-01",
-    "tags": ["web", "desktop"],
-    "versions": { "web": "9.5.0", "desktop": "3.18.2" },
+    "tags": ["web", "desktop", "extension"],
+    "versions": { "web": "9.5.0", "desktop": "3.18.2", "extension": "2.21.0" },
     "summary": "Formula evaluation now covers far more of the Salesforce formula language with fewer bugs, plus desktop persistence fixes for VDI environments.",
     "highlights": [
       {
         "title": "Better formula evaluation",
-        "description": "Formula evaluation now supports far more of the Salesforce formula language with fewer bugs.",
-        "platforms": ["web", "desktop", "extension"]
+        "description": "Formula evaluation now supports far more of the Salesforce formula language with fewer bugs."
       },
       {
         "title": "Desktop persistence reliability",
@@ -1283,8 +1326,8 @@
     "slug": "v9.4.1",
     "title": "9.4.1 - Desktop org list and Salesforce API fixes",
     "date": "2026-03-31",
-    "tags": ["web", "desktop"],
-    "versions": { "web": "9.4.1", "desktop": "3.18.1" },
+    "tags": ["web", "desktop", "extension"],
+    "versions": { "web": "9.4.1", "desktop": "3.18.2", "extension": "2.21.0" },
     "summary": "Fix for orgs and org groups not appearing on first launch of the desktop app, plus cleaner handling of empty-body requests in the Salesforce API tool.",
     "highlights": [
       {
@@ -1294,8 +1337,7 @@
       },
       {
         "title": "Salesforce API request with empty body",
-        "description": "Sending a Salesforce API request with an empty body no longer crashes the request editor.",
-        "platforms": ["web", "desktop"]
+        "description": "Sending a Salesforce API request with an empty body no longer crashes the request editor."
       }
     ]
   },
@@ -1376,25 +1418,22 @@
     "slug": "v9.1.0",
     "title": "9.1.0 - Paste sanitization and bulk-update errors",
     "date": "2026-03-08",
-    "tags": ["web", "extension"],
-    "versions": { "web": "9.1.0", "extension": "2.17.0" },
+    "tags": ["web", "desktop", "extension"],
+    "versions": { "web": "9.1.0", "desktop": "3.16.0", "extension": "2.17.0" },
     "summary": "Editors now strip invisible characters from pasted text, and bulk update failures surface the real server error instead of a generic message.",
     "highlights": [
       {
         "title": "Sanitize pasted text in editors",
-        "description": "Invisible characters from copied content are removed on paste so Salesforce won't reject the value.",
-        "platforms": ["web", "extension"]
+        "description": "Invisible characters from copied content are removed on paste so Salesforce won't reject the value."
       },
       {
         "title": "Real error messages on bulk update failures",
         "description": "When updating records without a file, the actual server error is shown instead of a generic one.",
-        "platforms": ["web", "extension"],
         "docLink": "/load"
       },
       {
         "title": "Editor line-number reset",
         "description": "Anonymous Apex and the metadata compare modal no longer jump to an odd scroll position when the editor re-renders.",
-        "platforms": ["web", "extension"],
         "docLink": "/developer/anonymous-apex"
       },
       {
@@ -1475,8 +1514,8 @@
     "slug": "v8.24.0",
     "title": "8.24.0 - Metadata audit signals and Google folder memory",
     "date": "2026-02-17",
-    "tags": ["web"],
-    "versions": { "web": "8.24.0" },
+    "tags": ["web", "desktop", "extension"],
+    "versions": { "web": "8.24.0", "desktop": "3.15.0", "extension": "2.16.0" },
     "summary": "Custom metadata records now show a last-modified date, invalid metadata timestamps are flagged with a warning, and Jetstream remembers your recent Google Drive folder.",
     "highlights": [
       {
@@ -1490,7 +1529,8 @@
       },
       {
         "title": "Remembered Google folder selection",
-        "description": "When exporting or uploading to Google Drive, your recent folder choice is remembered so repeat uploads take fewer clicks."
+        "description": "When exporting or uploading to Google Drive, your recent folder choice is remembered so repeat uploads take fewer clicks.",
+        "platforms": ["web"]
       },
       {
         "title": "Automation Control works in namespaced orgs",
@@ -1517,8 +1557,8 @@
     "slug": "v8.23.0",
     "title": "8.23.0 - Friendlier record creation and keyboard fixes",
     "date": "2026-02-12",
-    "tags": ["web"],
-    "versions": { "web": "8.23.0" },
+    "tags": ["web", "desktop", "extension"],
+    "versions": { "web": "8.23.0", "desktop": "3.15.0", "extension": "2.16.0" },
     "summary": "Owner and audit fields are now optional when creating records, with an option to save even when the form reports errors. Keyboard navigation in lookup pickers is fixed.",
     "highlights": [
       {
@@ -1539,14 +1579,13 @@
     "slug": "v8.22.0",
     "title": "8.22.0 - Auto-select org on group change",
     "date": "2026-02-09",
-    "tags": ["web"],
-    "versions": { "web": "8.22.0" },
+    "tags": ["web", "desktop"],
+    "versions": { "web": "8.22.0", "desktop": "3.15.0" },
     "summary": "Switching org groups now auto-selects the most recently used org in that group, or the first org if none have been used.",
     "highlights": [
       {
         "title": "Auto-select org when changing groups",
-        "description": "Changing the active org group now picks the most recently used org from that group, or the first org in the list.",
-        "platforms": ["web"]
+        "description": "Changing the active org group now picks the most recently used org from that group, or the first org in the list."
       }
     ]
   },
@@ -1591,26 +1630,23 @@
     "slug": "v8.20.0",
     "title": "8.20.0 - Permission export improvements",
     "date": "2026-02-03",
-    "tags": ["web"],
-    "versions": { "web": "8.20.0" },
+    "tags": ["web", "desktop", "extension"],
+    "versions": { "web": "8.20.0", "desktop": "3.14.0", "extension": "2.15.0" },
     "summary": "Permission manager exports are more reliable, show real errors on failure, and now offer CSV as a fallback format.",
     "highlights": [
       {
         "title": "More reliable permission exports",
         "description": "Reduced export failures when downloading large permission sets.",
-        "platforms": ["web"],
         "docLink": "/permissions"
       },
       {
         "title": "CSV fallback for permission exports",
         "description": "Added CSV as an export option so you can fall back when XLSX generation fails on very large exports.",
-        "platforms": ["web"],
         "docLink": "/permissions"
       },
       {
         "title": "Real error messages on export failure",
-        "description": "Export failures now surface an error to the user instead of silently doing nothing.",
-        "platforms": ["web"]
+        "description": "Export failures now surface an error to the user instead of silently doing nothing."
       }
     ]
   },
@@ -1831,20 +1867,18 @@
     "slug": "v8.14.0",
     "title": "8.14.0 - Record lookup in query filters",
     "date": "2025-12-14",
-    "tags": ["web", "desktop"],
-    "versions": { "web": "8.14.0" },
+    "tags": ["web", "desktop", "extension"],
+    "versions": { "web": "8.14.0", "desktop": "3.8.2", "extension": "2.10.0" },
     "summary": "Query filter values now support a record lookup so you can search for the record you want to filter on instead of hunting for an ID.",
     "highlights": [
       {
         "title": "Record lookup in query filters",
         "description": "When building a query filter on a reference field, search for the related record and have the ID inserted into your SOQL.",
-        "platforms": ["web", "desktop", "extension"],
         "docLink": "/query/results"
       },
       {
         "title": "Lookup clear button fix",
-        "description": "The clear button now works correctly when the lookup editor is in manual text entry mode.",
-        "platforms": ["web", "desktop", "extension"]
+        "description": "The clear button now works correctly when the lookup editor is in manual text entry mode."
       }
     ]
   },
@@ -2036,25 +2070,29 @@
     "slug": "v8.8.0",
     "title": "8.8.0 - Org expiration, Organization Groups, bulk org delete",
     "date": "2025-11-15",
-    "tags": ["web"],
-    "versions": { "web": "8.8.0" },
+    "tags": ["web", "desktop", "extension"],
+    "versions": { "web": "8.8.0", "desktop": "3.5.0", "extension": "2.6.0" },
     "summary": "Unused Salesforce orgs now expire with advance email notice, the Organization page handles refresh/reconnect cleanly, and you can delete orgs in bulk.",
     "highlights": [
       {
         "title": "Org expiration with email notice",
-        "description": "Salesforce orgs unused for 90 days are flagged for expiration, with email notifications summarizing expiring and expired orgs."
+        "description": "Salesforce orgs unused for 90 days are flagged for expiration, with email notifications summarizing expiring and expired orgs.",
+        "platforms": ["web"]
       },
       {
         "title": "Easier reconnect for expired orgs",
-        "description": "The Organization page surfaces expiring and expired orgs, and reconnect pre-fills your existing connection details."
+        "description": "The Organization page surfaces expiring and expired orgs, and reconnect pre-fills your existing connection details.",
+        "platforms": ["web"]
       },
       {
         "title": "Bulk delete Salesforce orgs",
-        "description": "Select and delete multiple connected orgs at once from the Organizations page."
+        "description": "Select and delete multiple connected orgs at once from the Organizations page.",
+        "platforms": ["web", "desktop"]
       },
       {
         "title": "Rename to \"Organization Group\"",
-        "description": "What used to be called \"Jetstream Organization\" is now \"Organization Group\" everywhere in the app, to avoid confusion with a Salesforce organization."
+        "description": "What used to be called \"Jetstream Organization\" is now \"Organization Group\" everywhere in the app, to avoid confusion with a Salesforce organization.",
+        "platforms": ["web", "desktop"]
       },
       {
         "title": "Download format is remembered",
@@ -2066,8 +2104,8 @@
     "slug": "v8.7.0",
     "title": "8.7.0 - Table filter fixes and connected-app onboarding help",
     "date": "2025-11-13",
-    "tags": ["web"],
-    "versions": { "web": "8.7.0" },
+    "tags": ["web", "desktop", "extension"],
+    "versions": { "web": "8.7.0", "desktop": "3.5.0", "extension": "2.6.0" },
     "summary": "Table filters now stay in sync when data reloads, password reset accepts plus-sign emails, and orgs missing the Jetstream connected app get clearer install guidance.",
     "highlights": [
       {
@@ -2081,15 +2119,18 @@
       },
       {
         "title": "Password reset with plus-sign emails",
-        "description": "Emails containing a \"+\" no longer get mangled into a space during password reset."
+        "description": "Emails containing a \"+\" no longer get mangled into a space during password reset.",
+        "platforms": ["web"]
       },
       {
         "title": "Connected app install guidance",
-        "description": "Help links point users to the page where they would install the Jetstream connected app if it is missing, plus a sandbox sync callout."
+        "description": "Help links point users to the page where they would install the Jetstream connected app if it is missing, plus a sandbox sync callout.",
+        "platforms": ["web", "desktop"]
       },
       {
         "title": "Cookie banner padding fix",
-        "description": "The consent banner no longer throws off in-app alignment while still looking right on the landing page."
+        "description": "The consent banner no longer throws off in-app alignment while still looking right on the landing page.",
+        "platforms": ["web"]
       }
     ]
   },
@@ -2139,8 +2180,8 @@
     "slug": "v8.4.0",
     "title": "8.4.0 - View Record checkbox fix, smoother desktop auto-update",
     "date": "2025-10-28",
-    "tags": ["web", "desktop"],
-    "versions": { "web": "8.4.0", "desktop": "3.3.0" },
+    "tags": ["web", "desktop", "extension"],
+    "versions": { "web": "8.4.0", "desktop": "3.3.0", "extension": "2.5.0" },
     "summary": "Fixes checkboxes rendering blank in View Record, improves the desktop auto-update UX, and lets you pick filename formats for zip attachment exports.",
     "highlights": [
       {
@@ -2172,8 +2213,8 @@
     "slug": "v8.3.0",
     "title": "8.3.0 - Better related-object loading and assorted bug fixes",
     "date": "2025-10-21",
-    "tags": ["web", "desktop"],
-    "versions": { "web": "8.3.0", "desktop": "3.1.0" },
+    "tags": ["web", "desktop", "extension"],
+    "versions": { "web": "8.3.0", "desktop": "3.1.0", "extension": "2.5.0" },
     "summary": "Load Records now shows every related object on polymorphic lookups and fetches related-field metadata on demand. Also fixes Firefox drag in the query builder and a create-organization regression.",
     "highlights": [
       {
@@ -2189,11 +2230,13 @@
       {
         "title": "Firefox query builder drag",
         "description": "Condition rows in the query builder can be dragged on Firefox again.",
+        "platforms": ["web", "extension"],
         "docLink": "/query/results"
       },
       {
         "title": "Create organization from selected org",
-        "description": "Creating a new organization no longer fails when another organization is selected."
+        "description": "Creating a new organization no longer fails when another organization is selected.",
+        "platforms": ["web", "desktop"]
       }
     ]
   },
@@ -2201,8 +2244,8 @@
     "slug": "v8.2.0",
     "title": "8.2.0 - Bug bash fixes across load, deploy, and automation control",
     "date": "2025-10-14",
-    "tags": ["web", "extension"],
-    "versions": { "web": "8.2.0", "extension": "2.4.0" },
+    "tags": ["web", "desktop", "extension"],
+    "versions": { "web": "8.2.0", "desktop": "3.1.0", "extension": "2.4.0" },
     "summary": "Collection of fixes from a bug bash, including deploy-metadata token refresh, a safer default for rollbackOnError in production, and a fix for Automation Control select-all on filtered rows.",
     "highlights": [
       {
@@ -2266,11 +2309,13 @@
     "highlights": [
       {
         "title": "Team plan and team dashboard",
-        "description": "Invite teammates, manage members and roles, configure login rules, and review session and authentication activity from a single dashboard."
+        "description": "Invite teammates, manage members and roles, configure login rules, and review session and authentication activity from a single dashboard.",
+        "platforms": ["web"]
       },
       {
         "title": "Unified billing experience",
-        "description": "Reworked billing page with clearer plan cards, monthly/annual toggle, and team naming during upgrade."
+        "description": "Reworked billing page with clearer plan cards, monthly/annual toggle, and team naming during upgrade.",
+        "platforms": ["web"]
       },
       {
         "title": "Desktop update fixes",
@@ -2283,14 +2328,14 @@
     "slug": "v7.10.0",
     "title": "7.10.0 - Desktop history sync and binary upload fixes",
     "date": "2025-09-27",
-    "tags": ["web"],
-    "versions": { "web": "7.10.0" },
+    "tags": ["web", "desktop", "extension"],
+    "versions": { "web": "7.10.0", "desktop": "3.0.2", "extension": "2.4.0" },
     "summary": "Fixes binary uploads on the desktop app and documents the upcoming outbound IP address ranges.",
     "highlights": [
       {
         "title": "Desktop history sync fix",
         "description": "Fixed an issue where history sync could fail to connect on the desktop app.",
-        "platforms": ["web", "desktop", "extension"]
+        "platforms": ["desktop"]
       },
       {
         "title": "Binary file uploads on desktop",
@@ -2301,7 +2346,6 @@
       {
         "title": "Outbound IP address ranges",
         "description": "The getting started docs now include a dedicated page describing the upcoming API outbound IP address ranges.",
-        "platforms": ["web", "desktop", "extension"],
         "docLink": "/"
       }
     ]
@@ -2310,14 +2354,13 @@
     "slug": "v7.9.1",
     "title": "7.9.1 - Permission manager column fix and desktop download link",
     "date": "2025-09-24",
-    "tags": ["web"],
-    "versions": { "web": "7.9.1" },
+    "tags": ["web", "desktop", "extension"],
+    "versions": { "web": "7.9.1", "desktop": "3.0.1", "extension": "2.4.0" },
     "summary": "Fixes the View All Records column width in Manage Permissions and corrects the x64 desktop download link.",
     "highlights": [
       {
         "title": "View All Records column width",
         "description": "The View All Records column in the permission manager grid now renders with the correct width.",
-        "platforms": ["web", "desktop", "extension"],
         "docLink": "/permissions"
       },
       {
@@ -2331,20 +2374,18 @@
     "slug": "v7.9.0",
     "title": "7.9.0 - View All Fields in Manage Permissions",
     "date": "2025-09-24",
-    "tags": ["web"],
-    "versions": { "web": "7.9.0" },
+    "tags": ["web", "desktop", "extension"],
+    "versions": { "web": "7.9.0", "desktop": "3.0.0", "extension": "2.4.0" },
     "summary": "Adds support for the new View All Fields object permission in Manage Permissions and fixes a save bug affecting View All Records.",
     "highlights": [
       {
         "title": "View All Fields object permission",
         "description": "Grant or revoke the new Salesforce View All Fields permission alongside the other object permissions in Manage Permissions.",
-        "platforms": ["web", "desktop", "extension"],
         "docLink": "/permissions"
       },
       {
         "title": "Fix View All Records save value",
         "description": "Saving permissions now persists the value you selected for View All Records and View All.",
-        "platforms": ["web", "desktop", "extension"],
         "docLink": "/permissions"
       }
     ]
@@ -2353,27 +2394,21 @@
     "slug": "v7.8.0",
     "title": "7.8.0 - Better large-file uploads and higher free-plan limit",
     "date": "2025-09-20",
-    "tags": ["web"],
-    "versions": { "web": "7.8.0" },
+    "tags": ["web", "desktop", "extension"],
+    "versions": { "web": "7.8.0", "desktop": "2.0.0", "extension": "2.4.0" },
     "summary": "Improves binary file uploads so large files upload reliably, and raises the free-plan attachment filesize limit.",
     "highlights": [
       {
         "title": "Reliable large attachment uploads",
         "description": "Binary attachment loads now handle large files reliably, so big files upload without timeouts.",
-        "platforms": ["web", "desktop", "extension"],
         "docLink": "/load"
       },
       {
         "title": "Higher free-plan attachment limit",
         "description": "The attachment filesize cap on the free plan was raised.",
-        "platforms": ["web", "desktop", "extension"],
         "docLink": "/load"
       },
-      {
-        "title": "Platform events publishing fix",
-        "description": "Fixed an issue that could occur when publishing platform events.",
-        "platforms": ["web", "desktop", "extension"]
-      }
+      { "title": "Platform events publishing fix", "description": "Fixed an issue that could occur when publishing platform events." }
     ]
   },
   {
@@ -2395,14 +2430,13 @@
     "slug": "v7.7.1",
     "title": "7.7.1 - Salesforce login URL fix",
     "date": "2025-09-13",
-    "tags": ["web"],
-    "versions": { "web": "7.7.1" },
+    "tags": ["web", "desktop", "extension"],
+    "versions": { "web": "7.7.1", "desktop": "2.0.0", "extension": "2.4.0" },
     "summary": "Fixes invalid URLs generated when logging in to Salesforce from Jetstream links.",
     "highlights": [
       {
         "title": "Login with Salesforce URL fix",
-        "description": "Links that log you into Salesforce now generate valid URLs, avoiding double-slash and other malformed links.",
-        "platforms": ["web", "desktop", "extension"]
+        "description": "Links that log you into Salesforce now generate valid URLs, avoiding double-slash and other malformed links."
       }
     ]
   },
@@ -2410,45 +2444,35 @@
     "slug": "v7.7.0",
     "title": "7.7.0 - Field mapping and UI polish",
     "date": "2025-09-11",
-    "tags": ["web"],
-    "versions": { "web": "7.7.0" },
+    "tags": ["web", "desktop", "extension"],
+    "versions": { "web": "7.7.0", "desktop": "2.0.0", "extension": "2.4.0" },
     "summary": "Cleans up the field mapping dropdown and fixes several small UI issues.",
     "highlights": [
       {
         "title": "Cleaner field mapping dropdown",
         "description": "The load records field mapping dropdown now shows the field type as tertiary text, matching the rest of the app.",
-        "platforms": ["web", "desktop", "extension"],
         "docLink": "/load"
       },
-      {
-        "title": "Combobox sizing fix",
-        "description": "The combobox no longer miscalculates its size in certain layouts.",
-        "platforms": ["web", "desktop", "extension"]
-      },
+      { "title": "Combobox sizing fix", "description": "The combobox no longer miscalculates its size in certain layouts." },
       {
         "title": "Better Salesforce domain detection in the extension",
         "description": "The Chrome extension now detects Salesforce domains more reliably.",
-        "platforms": ["web", "extension"]
+        "platforms": ["extension"]
       },
-      {
-        "title": "Error popover styling",
-        "description": "The error popover nubbin color now matches the popover background.",
-        "platforms": ["web", "desktop", "extension"]
-      }
+      { "title": "Error popover styling", "description": "The error popover nubbin color now matches the popover background." }
     ]
   },
   {
     "slug": "v7.6.3",
     "title": "7.6.3 - Binary file load fixes",
     "date": "2025-09-07",
-    "tags": ["web"],
-    "versions": { "web": "7.6.3", "desktop": "1.3.1" },
+    "tags": ["web", "desktop", "extension"],
+    "versions": { "web": "7.6.3", "desktop": "1.3.1", "extension": "2.4.0" },
     "summary": "Fixes a file picker conflict on the binary attachment loader.",
     "highlights": [
       {
         "title": "Binary attachment file picker fix",
         "description": "Clicking the \"Zip with attachments\" input no longer accidentally triggers the main CSV file input.",
-        "platforms": ["web", "desktop", "extension"],
         "docLink": "/load"
       }
     ]
@@ -2529,14 +2553,13 @@
     "slug": "v7.5.0",
     "title": "7.5.0 - Accurate record count preview for queries",
     "date": "2025-08-30",
-    "tags": ["web"],
-    "versions": { "web": "7.5.0" },
+    "tags": ["web", "desktop", "extension"],
+    "versions": { "web": "7.5.0", "desktop": "1.2.0", "extension": "2.2.0" },
     "summary": "The record count preview shown before running a query no longer fails when the query includes an ORDER BY clause.",
     "highlights": [
       {
         "title": "Query record count preview works with ORDER BY",
         "description": "The count preview now strips the incompatible ORDER BY before running, so you get an accurate record total every time.",
-        "platforms": ["web", "desktop", "extension"],
         "docLink": "/query/results"
       }
     ]
@@ -2545,14 +2568,13 @@
     "slug": "v7.4.0",
     "title": "7.4.0 - Stronger encryption for stored org credentials",
     "date": "2025-08-26",
-    "tags": ["web", "desktop"],
+    "tags": ["web"],
     "versions": { "web": "7.4.0" },
     "summary": "Each stored Salesforce org is now encrypted with its own unique key.",
     "highlights": [
       {
         "title": "Per-org encryption keys",
-        "description": "Each stored Salesforce org now uses its own unique encryption key instead of a single shared key.",
-        "platforms": ["web", "desktop"]
+        "description": "Each stored Salesforce org now uses its own unique encryption key instead of a single shared key."
       }
     ]
   },
@@ -2560,8 +2582,8 @@
     "slug": "v7.3.5",
     "title": "7.3.5 - Diff editor collapses unchanged regions after swap",
     "date": "2025-08-23",
-    "tags": ["web"],
-    "versions": { "web": "7.3.5" },
+    "tags": ["web", "desktop", "extension"],
+    "versions": { "web": "7.3.5", "desktop": "1.2.0", "extension": "2.2.0" },
     "summary": "Fixes the view/compare metadata diff editor so collapsed unchanged regions stay collapsed after swapping the two sides.",
     "highlights": [
       {
@@ -2575,8 +2597,8 @@
     "slug": "v7.3.4",
     "title": "7.3.4 - One-click field change in query filters",
     "date": "2025-08-23",
-    "tags": ["web"],
-    "versions": { "web": "7.3.4" },
+    "tags": ["web", "desktop", "extension"],
+    "versions": { "web": "7.3.4", "desktop": "1.2.0", "extension": "2.2.0" },
     "summary": "Removes the extra clear step when changing the field in a query filter condition.",
     "highlights": [
       {
@@ -2590,8 +2612,8 @@
     "slug": "v7.3.3",
     "title": "7.3.3 - Connected app guidance and annual pricing fix",
     "date": "2025-08-21",
-    "tags": ["web"],
-    "versions": { "web": "7.3.3" },
+    "tags": ["web", "desktop"],
+    "versions": { "web": "7.3.3", "desktop": "1.2.0" },
     "summary": "Adds an in-app banner about upcoming Salesforce Connected App changes, updates the related docs, and fixes annual pricing display for existing subscribers.",
     "highlights": [
       {
@@ -2601,11 +2623,13 @@
       },
       {
         "title": "Annual subscription pricing fix",
-        "description": "Existing annual subscribers now see the correct price on the billing page."
+        "description": "Existing annual subscribers now see the correct price on the billing page.",
+        "platforms": ["web"]
       },
       {
         "title": "Docs refresh",
-        "description": "Overview, security, and troubleshooting docs have been updated with current Connected App install steps."
+        "description": "Overview, security, and troubleshooting docs have been updated with current Connected App install steps.",
+        "platforms": ["web"]
       }
     ]
   },
@@ -2613,8 +2637,8 @@
     "slug": "v7.3.2",
     "title": "7.3.2 - Fix view-results modal for bulk edits from query",
     "date": "2025-08-14",
-    "tags": ["web"],
-    "versions": { "web": "7.3.2" },
+    "tags": ["web", "desktop", "extension"],
+    "versions": { "web": "7.3.2", "desktop": "1.2.0", "extension": "2.2.0" },
     "summary": "Fixes a bug where viewing bulk results after bulk editing records from query results did nothing.",
     "highlights": [
       {
@@ -2665,14 +2689,13 @@
     "slug": "v7.2.0",
     "title": "7.2.0 - Copy load results to clipboard",
     "date": "2025-08-09",
-    "tags": ["web", "extension"],
-    "versions": { "web": "7.2.0", "extension": "2.1.0" },
+    "tags": ["web", "desktop", "extension"],
+    "versions": { "web": "7.2.0", "desktop": "1.1.0", "extension": "2.1.0" },
     "summary": "You can now copy load results directly to the clipboard as Excel, CSV, or JSON without downloading a file first.",
     "highlights": [
       {
         "title": "Copy load results to clipboard",
         "description": "From the load results modal, copy all or selected rows to the clipboard in spreadsheet, CSV, or JSON format.",
-        "platforms": ["web", "extension"],
         "docLink": "/load"
       }
     ]
@@ -2681,26 +2704,23 @@
     "slug": "v7.1.0",
     "title": "7.1.0 - Diff editor toggle, folder metadata fixes",
     "date": "2025-08-09",
-    "tags": ["web", "extension"],
-    "versions": { "web": "7.1.0", "extension": "2.0.1" },
+    "tags": ["web", "desktop", "extension"],
+    "versions": { "web": "7.1.0", "desktop": "1.1.0", "extension": "2.0.1" },
     "summary": "Compare metadata got an option to hide unchanged lines, folder metadata types are now retrieved correctly, and several datatable and popover bugs are fixed.",
     "highlights": [
       {
         "title": "Toggle unchanged lines in the metadata diff editor",
         "description": "When comparing metadata between orgs you can now collapse unchanged lines, which makes larger files much easier to scan.",
-        "platforms": ["web", "extension"],
         "docLink": "/deploy-metadata"
       },
       {
         "title": "Folder metadata types work correctly",
         "description": "Document, Email, Report, and Dashboard folders now appear in the metadata picker and retrieve the correct metadata from Salesforce.",
-        "platforms": ["web", "extension"],
         "docLink": "/deploy-metadata"
       },
       {
         "title": "Datatable tab navigation fix",
-        "description": "Fixed an edge case where Tab navigation inside the datatable could skip the action and Id columns in production builds.",
-        "platforms": ["web", "extension"]
+        "description": "Fixed an edge case where Tab navigation inside the datatable could skip the action and Id columns in production builds."
       }
     ]
   },

--- a/scripts/release-notes-context.mjs
+++ b/scripts/release-notes-context.mjs
@@ -41,6 +41,8 @@ const BODY_TRUNCATE = 1200;
 
 // Map a changed-file path to a coarse platform/area signal so the drafter can
 // infer the release-note `tags` / `versions` without reading raw file lists.
+// Shared client libraries are mounted by the web app, the desktop app and the browser
+// extension alike, so they are labelled with that reach rather than as generic "shared".
 const AREA_RULES = [
   { match: /^apps\/jetstream-web-extension\//, area: 'extension' },
   { match: /^apps\/jetstream-desktop(-client)?\//, area: 'desktop' },
@@ -48,8 +50,23 @@ const AREA_RULES = [
   { match: /^apps\/api\//, area: 'web (server)' },
   { match: /^apps\/landing\//, area: 'landing site' },
   { match: /^apps\/docs\//, area: 'docs' },
+  { match: /^libs\/features\//, area: 'shared feature (web, desktop, extension)' },
+  {
+    match: /^libs\/(ui|icon-factory|monaco-configuration|splitjs|shared\/(ui-[^/]+|data|utils|constants|client-logger))\//,
+    area: 'shared UI (web, desktop, extension)',
+  },
+  { match: /^libs\/desktop-types\//, area: 'desktop' },
+  { match: /^libs\/(api-config|api-types|auth|audit-logs|email|prisma|shared\/node-utils)\//, area: 'web (server)' },
   { match: /^libs\//, area: 'shared lib' },
 ];
+
+// Desktop and extension releases are cut from the same history minutes after the web release,
+// so the platform tags inside the range tell the drafter which versions carry the changes.
+const PLATFORM_TAG_PATTERNS = ['desktop-v*', 'web-ext-v*'];
+const PLATFORM_VERSION_FILES = {
+  desktop: 'apps/jetstream-desktop/package.json',
+  extension: 'apps/jetstream-web-extension/src/manifest.json',
+};
 
 const options = parseArgs(process.argv.slice(2));
 
@@ -106,6 +123,8 @@ if (!(await refExists(head))) {
 const existingNoteFile = await findReleaseNoteFor(targetVersion);
 
 const { headSha, currentBranch, prs, directCommits, totalCommits } = await getMergedPrsSince(baseTag, { head });
+const platformReleases = await listPlatformTagsInRange(baseTag, head);
+const platformVersions = await readPlatformVersions();
 
 // When head is a tag/ref (not the working tree), label the range with it instead of the branch.
 const headLabel = head !== 'HEAD' ? head : currentBranch;
@@ -126,6 +145,8 @@ const context = {
   currentBranch,
   headLabel,
   totalCommits,
+  platformReleases,
+  platformVersions,
   prs: enrichedPrs,
   directCommits,
 };
@@ -134,6 +155,35 @@ if (options.json) {
   printJson(context);
 } else {
   printMarkdown(context);
+}
+
+// ── Platform releases ───────────────────────────────────────────────────────
+
+/** Desktop / extension tags reachable from `head` but not from `baseTag`, oldest first. */
+async function listPlatformTagsInRange(baseTag, head) {
+  const raw = (
+    await $`git tag --list ${PLATFORM_TAG_PATTERNS} --merged ${head} --no-merged ${baseTag} --sort=creatordate --format=${'%(creatordate:short) %(refname:short)'}`
+  ).stdout.trim();
+  if (!raw) {
+    return [];
+  }
+  return raw.split('\n').map((line) => {
+    const [date, tag] = line.split(' ');
+    return { tag, date, platform: tag.startsWith('desktop-v') ? 'desktop' : 'extension' };
+  });
+}
+
+/** Current desktop / extension versions in the working tree (the next release bumps these). */
+async function readPlatformVersions() {
+  const versions = {};
+  for (const [platform, file] of Object.entries(PLATFORM_VERSION_FILES)) {
+    try {
+      versions[platform] = JSON.parse(await readFile(path.join(ROOT, file), 'utf8')).version;
+    } catch {
+      versions[platform] = null;
+    }
+  }
+  return versions;
 }
 
 // ── Enrichment ──────────────────────────────────────────────────────────────
@@ -188,6 +238,19 @@ function printMarkdown(ctx) {
   lines.push(`- base tag: **${ctx.baseTag}** → head: **${ctx.headLabel}** (${ctx.headSha.slice(0, 9)})`);
   lines.push(`- total commits in range: ${ctx.totalCommits}`);
   lines.push(`- compare: https://github.com/${REPO_SLUG}/compare/${ctx.baseTag}...${ctx.headSha}`);
+  if (ctx.platformReleases.length) {
+    lines.push(
+      `- desktop/extension releases cut in this range: ${ctx.platformReleases.map(({ tag, date }) => `${tag} (${date})`).join(', ')}`,
+    );
+  } else {
+    lines.push('- desktop/extension releases cut in this range: none');
+  }
+  lines.push(
+    `- current platform versions in the tree: desktop ${ctx.platformVersions.desktop ?? 'unknown'}, extension ${ctx.platformVersions.extension ?? 'unknown'}`,
+  );
+  lines.push(
+    '- reminder: shared feature / shared UI changes ship to the desktop app and the browser extension too. Tag every platform that receives the changes and list its carrying version (an upcoming release bumps the current platform versions above).',
+  );
   lines.push('');
 
   if (ctx.prs.length === 0) {


### PR DESCRIPTION
Many release note togs often targeted "web" when in reality most features apply to all platforms

Update ai skill to include this and backfill all release note tage