### PR TITLE
build: push release commits and tags atomically

### DIFF
--- a/.release-it-desktop.json
+++ b/.release-it-desktop.json
@@ -18,6 +18,7 @@
     "commitMessage": "chore: release desktop ${version}",
     "tag": true,
     "tagName": "desktop-v${version}",
+    "pushArgs": ["--follow-tags", "--atomic"],
     "requireBranch": ["main", "hotfix/*"]
   },
   "npm": false,

--- a/.release-it-web-ext.json
+++ b/.release-it-web-ext.json
@@ -18,6 +18,7 @@
     "commitMessage": "chore: release web extension ${version}",
     "tag": true,
     "tagName": "web-ext-v${version}",
+    "pushArgs": ["--follow-tags", "--atomic"],
     "requireBranch": ["main", "hotfix/*"]
   },
   "npm": false,

--- a/.release-it.json
+++ b/.release-it.json
@@ -22,6 +22,7 @@
     "commitMessage": "chore: release ${version}",
     "tag": true,
     "tagName": "v${version}",
+    "pushArgs": ["--follow-tags", "--atomic"],
     "requireBranch": ["main", "hotfix/*"]
   },
   "npm": false,


### PR DESCRIPTION
## Why

On 2026-09-06 a desktop-only release run pushed with `git push --follow-tags` while `main` had moved between checkout and push. Git rejected the branch update as non-fast-forward but had already accepted the tag, so `desktop-v4.15.0` briefly existed on the remote, triggered both desktop publish workflows, and was then deleted by release-it's rollback. Both publish runs failed at checkout for a tag that no longer existed (#2043, #2044).

## Change

Adds `--atomic` to release-it's push args in all three release configs. The push is now all-or-nothing: if the branch update is rejected, the tag never reaches the remote and release-it's local rollback is the only cleanup. `--follow-tags` is kept because overriding `pushArgs` replaces release-it's default list.
