### PR TITLE
feat(landing): add the SOC 2 Type II badge and report availability

### DIFF
--- a/apps/jetstream/src/app/components/billing/billing.constants.ts
+++ b/apps/jetstream/src/app/components/billing/billing.constants.ts
@@ -33,7 +33,7 @@ export const teamFeatures = [
   'Role-based access control',
 ];
 
-export const teamFeaturesComingSoon = ['SOC 2 (in progress)', 'Share orgs between team members', 'Audit logs'];
+export const teamFeaturesComingSoon = ['Share orgs between team members', 'Audit logs'];
 
 export const enterpriseFeatures = [
   'Everything in Team',

--- a/apps/landing/components/Footer.tsx
+++ b/apps/landing/components/Footer.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link';
 import { ROUTES } from '../utils/environment';
+import { Soc2Badge } from './Soc2Badge';
 
 const footerNavigation = {
   support: [
@@ -43,6 +44,7 @@ export const Footer = ({ omitLinks = [] }: FooterProps) => (
             />
           </Link>
           <p className="text-gray-500 text-base">Providing tools to help you get your job done faster.</p>
+          <Soc2Badge className="inline-block" imageClassName="h-28 w-auto" />
         </div>
         <div className="mt-12 grid grid-cols-3 gap-8 xl:mt-0 xl:col-span-2">
           <div className="md:grid md:grid-cols-1 md:gap-8">

--- a/apps/landing/components/Soc2Badge.tsx
+++ b/apps/landing/components/Soc2Badge.tsx
@@ -1,0 +1,40 @@
+/**
+ * The source asset has a large transparent margin, so Cloudinary's trim transformation is applied
+ * to keep the shield flush with surrounding content. Dimensions are those of the trimmed image so the
+ * browser reserves the right footprint before the lazy image loads.
+ */
+const SOC2_BADGE = {
+  src: 'https://res.cloudinary.com/getjetstream/image/upload/e_trim/v1788963624/A_LIGN_badge_SOC_2_gu4mu2.png',
+  alt: 'SOC 2 Type II, audited by A-LIGN',
+  width: 938,
+  height: 1200,
+};
+
+/** A-LIGN's logo usage terms require every use of their badge to link to their website. */
+const A_LIGN_URL = 'https://www.a-lign.com';
+
+export interface Soc2BadgeProps {
+  /** Applied to the wrapping link, use for layout (positioning, margins, flex behavior). */
+  className?: string;
+  /** Applied to the image, use for sizing. */
+  imageClassName?: string;
+}
+
+/**
+ * A-LIGN SOC 2 badge, always wrapped in a link to A-LIGN as their logo terms require.
+ * Render this component rather than the image directly so the link is never omitted.
+ */
+export const Soc2Badge = ({ className, imageClassName }: Soc2BadgeProps) => (
+  <a href={A_LIGN_URL} target="_blank" rel="noreferrer" className={className}>
+    <img
+      className={imageClassName}
+      src={SOC2_BADGE.src}
+      alt={SOC2_BADGE.alt}
+      width={SOC2_BADGE.width}
+      height={SOC2_BADGE.height}
+      loading="lazy"
+    />
+  </a>
+);
+
+export default Soc2Badge;

--- a/apps/landing/components/blog-post-renderers.tsx
+++ b/apps/landing/components/blog-post-renderers.tsx
@@ -7,6 +7,13 @@ import { Fragment, ReactNode } from 'react';
 import FigureImgWithViewFullScreen from './FigureImgWithViewFullScreen';
 const NON_URL_CHARACTERS = /[^a-zA-Z0-9-]/g;
 
+/**
+ * Contentful returns protocol-relative asset urls (`//images.ctfassets.net/...`), which resolve to
+ * http when the site itself is served over http (e.g. local development) and get blocked by the
+ * https-only img-src content security policy.
+ */
+const ensureHttpsUrl = (url: string) => (url.startsWith('//') ? `https:${url}` : url);
+
 const getNodeText = (node: ReactNode) => {
   if (['string', 'number'].includes(typeof node)) {
     return node;
@@ -147,7 +154,9 @@ export function renderBlogPostRichText(richText: Document) {
             return <Fragment />;
           }
 
-          return <FigureImgWithViewFullScreen src={url} title={title} description={description} width={width} height={height} />;
+          return (
+            <FigureImgWithViewFullScreen src={ensureHttpsUrl(url)} title={title} description={description} width={width} height={height} />
+          );
         } catch (ex) {
           console.warn('[RENDER ASSET ERROR]', ex.message);
           return <Fragment />;

--- a/apps/landing/components/landing/HeroSection.tsx
+++ b/apps/landing/components/landing/HeroSection.tsx
@@ -7,10 +7,10 @@ export const HeroSection = () => (
       {/* Announcement pill */}
       <div className="flex justify-center">
         <Link
-          href={ROUTES.blogPost('jetstream-sso')}
+          href={ROUTES.blogPost('soc2-type-2')}
           className="inline-flex items-center gap-x-2 rounded-full bg-white/5 px-4 py-1.5 text-sm text-gray-300 ring-1 ring-white/10 transition hover:ring-white/20"
         >
-          Now with <span className="font-semibold text-cyan-400">SSO</span> support
+          Now <span className="font-semibold text-cyan-400">SOC 2 Type II</span> audited
           <span aria-hidden="true">&rarr;</span>
         </Link>
       </div>

--- a/apps/landing/pages/dpa/index.tsx
+++ b/apps/landing/pages/dpa/index.tsx
@@ -9,7 +9,7 @@ export default function Page() {
   return (
     <div className="m-8">
       <div className="flex items-center justify-between gap-4">
-        <LastUpdated className="text-gray-500" day={4} month="August" year={2026} />
+        <LastUpdated className="text-gray-500" day={9} month="September" year={2026} />
         <PrintButton />
       </div>
       <h1>Data Processing Agreement</h1>
@@ -175,6 +175,10 @@ export default function Page() {
         <li>Documentation of security practices and data handling procedures;</li>
         <li>Summary reports of compliance activities and security measures.</li>
       </ol>
+      <p className="mb-2 pl-2">
+        The Processor maintains a SOC 2 Type II report issued by an independent auditor and will make its most recent report available to
+        the Controller upon written request, subject to a non-disclosure agreement.
+      </p>
       <p className="mb-2 pl-2">
         The Controller shall provide at least 30 days' advance written notice for any audit request. Any audit activities shall be conducted
         in a manner that minimizes disruption to the Processor's operations and does not compromise the security, confidentiality, or
@@ -568,7 +572,11 @@ export default function Page() {
 
       <h3>Governance and Compliance</h3>
       <ul className="mb-2 list-disc pl-6">
-        <li>The security program is aligned with the SOC 2 Trust Services Criteria.</li>
+        <li>
+          The security program is aligned with the SOC 2 Trust Services Criteria and has been independently audited. Jetstream maintains a
+          SOC 2 Type II report covering its own controls, available to Controllers on request under a non-disclosure agreement as described
+          in Section 10.
+        </li>
         <li>Security policies are documented, reviewed, and updated at least annually.</li>
         <li>
           A formal risk management process identifies, analyzes, prioritizes, treats, and monitors information security and operational
@@ -582,6 +590,10 @@ export default function Page() {
         by the version in effect at signing, as described in Section 15.
       </p>
       <ul className="mb-2 list-disc pl-6">
+        <li>
+          <strong>September 9, 2026</strong> - Noted the availability of the Processor's SOC 2 Type II report (Section 10; Annex 2,
+          Governance and Compliance).
+        </li>
         <li>
           <strong>August 4, 2026</strong> - Incorporated the EU Standard Contractual Clauses, the UK Addendum, and Swiss FADP adaptations
           (Section 11); added CCPA service provider restrictions (Section 12); shortened Security Incident notification from 72 hours to 48

--- a/apps/landing/pages/pricing/index.tsx
+++ b/apps/landing/pages/pricing/index.tsx
@@ -68,7 +68,7 @@ const tiers = [
       'View & Manage team member session activity',
       'Role-based access control',
     ],
-    comingSoonFeatures: ['SOC 2 compliance (in-progress)', 'Share orgs between team members', 'Audit logs'],
+    comingSoonFeatures: ['Share orgs between team members', 'Audit logs'],
     mostPopular: false,
   },
   {

--- a/apps/landing/pages/privacy/index.tsx
+++ b/apps/landing/pages/privacy/index.tsx
@@ -14,7 +14,7 @@ export default function Page() {
   return (
     <div className="m-8">
       <div className="flex items-center justify-between gap-4">
-        <LastUpdated className="text-gray-500" day={17} month="March" year={2026} />
+        <LastUpdated className="text-gray-500" day={9} month="September" year={2026} />
         <PrintButton />
       </div>
       <h1>Privacy Policy</h1>
@@ -27,6 +27,13 @@ export default function Page() {
         <li>
           We strive to follow industry best practices for all processes, including our development processes, deployment processes, hosting
           processes, and data access processes.
+        </li>
+        <li>
+          Jetstream has completed a SOC 2 Type II audit performed by an independent audit firm. See the{' '}
+          <a className="underline" href="#soc-2">
+            SOC 2 Type II
+          </a>{' '}
+          section below for details and how to request the report.
         </li>
         <li>We never store any of your Salesforce record data.</li>
         <li>We use browser-based caching to avoid having to store any metadata on our server.</li>
@@ -70,6 +77,23 @@ export default function Page() {
           for information about our Data Protection Policy.
         </li>
       </ol>
+      <h2 id="soc-2">SOC 2 TYPE II</h2>
+      <p className="mb-2 pl-2">
+        Jetstream has completed a SOC 2 Type II audit performed by A-LIGN, an independent audit firm. A Type II report evaluates whether
+        security controls are suitably designed and operated effectively over a period of time, rather than at a single point in time.
+      </p>
+      <p className="mb-2 pl-2">
+        The audit covers the Jetstream platform as a whole. Every plan, including the Free plan, runs on the same infrastructure and is
+        protected by the same controls.
+      </p>
+      <p className="mb-2 pl-2">
+        The full report is available under a non-disclosure agreement to paying customers and to organizations evaluating a paid plan. To
+        request a copy, email{' '}
+        <a className="underline" href="mailto:sales@getjetstream.app?subject=SOC 2 Report Request" target="_blank" rel="noreferrer">
+          sales@getjetstream.app
+        </a>
+        .
+      </p>
       <h2>PERSONAL INFORMATION WE COLLECT</h2>
       <p className="mb-2 pl-2">
         When you visit the Site, we may automatically collect certain information about your device, including information about your web


### PR DESCRIPTION
## Summary

- Adds the A-LIGN SOC 2 Type II badge under the footer logo. The badge always links to A-LIGN, which their logo usage terms require, and the link lives inside the shared `Soc2Badge` component so it cannot be omitted.
- Adds a "SOC 2 Type II" section to the Privacy page explaining the audit and how to request the report under NDA, with a summary bullet linking to it.
- Records in the DPA that the report is available to controllers on request (audit rights section and the governance bullet in Annex 2), with a version-history entry.

## Notes

- The Privacy page and DPA "Last updated" dates were bumped. The terms version constant was not, since nothing about data handling changed.
- Report requests route to sales@getjetstream.app.
- `chore/update-pricing` currently carries a copy of this commit; rebasing it onto main after this merges drops the duplicate.