### PR TITLE
docs: release notes v10.18.1

### DIFF
--- a/apps/docs/release-notes/2026-09-12-v10.18.1.mdx
+++ b/apps/docs/release-notes/2026-09-12-v10.18.1.mdx
@@ -1,0 +1,53 @@
+---
+slug: v10.18.1
+title: 10.18.1 - Permission Analysis documentation and SOC 2 Type II report
+date: '2026-09-12'
+tags: [web, desktop, extension]
+versions:
+  web: 10.18.1
+  desktop: 4.15.1
+  extension: 3.18.1
+summary: Permission Analysis is now fully documented, and the app links to those docs from the home card, upgrade screen, results toolbar, and findings modal. The Jetstream SOC 2 Type II report is available on request.
+highlights:
+  - title: Permission Analysis documentation
+    description: The documentation now lists every issue code with its severity, the system permissions treated as high risk, and what the scan is commonly used for.
+    docLink: /permission-analysis
+  - title: Documentation links inside Permission Analysis
+    description: The home card, upgrade screen, results toolbar, and findings modal all link to the documentation.
+    docLink: /permission-analysis
+  - title: SOC 2 Type II report
+    description: Jetstream completed a SOC 2 Type II audit, and the report is available to customers on request under an NDA.
+---
+
+{/* truncate */}
+
+## What's new
+
+### Permission Analysis documentation
+
+The Permission Analysis documentation was rewritten to describe the scan and its results rather than comparing it to Manage Permissions. It now covers:
+
+- All twelve issue codes with their severity, so a code in the findings modal is something you can look up.
+- The sixteen system permissions Jetstream treats as high risk, grouped by tier.
+- Common uses for the scan: quarterly access reviews, audit preparation, offboarding, cleanup after a migration, and tracing why a user can see something.
+- Downloads, which the page never covered. Every result grid exports to Excel, CSV, JSON, or straight to Google Drive.
+
+Manage Permissions now links across to Permission Analysis as well.
+
+### Documentation links inside Permission Analysis
+
+The documentation is now reachable from the places where a question comes up:
+
+- Home cards for paid features keep their Documentation link on plans that do not include them.
+- The upgrade screen describes what each tool does and links to the documentation for the one you opened.
+- The results toolbar has a Documentation link.
+- The findings modal has a "What do these codes mean?" link that opens the issue code table.
+
+### SOC 2 Type II report
+
+Jetstream completed a SOC 2 Type II audit with A-LIGN. The Privacy page explains what the audit covers and how to request the report, which is available to customers under an NDA by writing to sales@getjetstream.app. The data processing addendum records the same commitment.
+
+### Other fixes
+
+- The pricing page and the in-app billing page now list Permission Analysis and Field Usage Analysis under the Professional plan. Upgrading from the paywall previously landed on a page that mentioned neither.
+- The Permission Analysis documentation no longer carries a pre-release warning. The feature is generally available.

--- a/apps/docs/static/release-notes.json
+++ b/apps/docs/static/release-notes.json
@@ -1,5 +1,29 @@
 [
   {
+    "slug": "v10.18.1",
+    "title": "10.18.1 - Permission Analysis documentation and SOC 2 Type II report",
+    "date": "2026-09-12",
+    "tags": ["web", "desktop", "extension"],
+    "versions": { "web": "10.18.1", "desktop": "4.15.1", "extension": "3.18.1" },
+    "summary": "Permission Analysis is now fully documented, and the app links to those docs from the home card, upgrade screen, results toolbar, and findings modal. The Jetstream SOC 2 Type II report is available on request.",
+    "highlights": [
+      {
+        "title": "Permission Analysis documentation",
+        "description": "The documentation now lists every issue code with its severity, the system permissions treated as high risk, and what the scan is commonly used for.",
+        "docLink": "/permission-analysis"
+      },
+      {
+        "title": "Documentation links inside Permission Analysis",
+        "description": "The home card, upgrade screen, results toolbar, and findings modal all link to the documentation.",
+        "docLink": "/permission-analysis"
+      },
+      {
+        "title": "SOC 2 Type II report",
+        "description": "Jetstream completed a SOC 2 Type II audit, and the report is available to customers on request under an NDA."
+      }
+    ]
+  },
+  {
     "slug": "v10.18.0",
     "title": "10.18.0 - Desktop update controls and portable Windows build",
     "date": "2026-09-07",


### PR DESCRIPTION
Release note for the upcoming 10.18.1 release, planned for 2026-09-12.

## What it covers

- **Permission Analysis documentation.** The rewritten docs page: twelve issue codes with severities, sixteen high-risk system permissions by tier, what the scan is used for, and the download formats. All three counts were verified against the page itself rather than the PR description.
- **Documentation links inside Permission Analysis.** Home card while locked, the upgrade screen, the results toolbar, and the "What do these codes mean?" link in the findings modal.
- **SOC 2 Type II report.** Audit with A-LIGN and how to request the report under an NDA.
- **Other fixes.** Permission Analysis and Field Usage Analysis now listed under the Professional plan on the pricing and billing pages, and the pre-release warning dropped from the docs.

Release tooling, CI build and flaky test changes in the range are omitted as not user facing.

## Decisions worth a look

- **Tagged `web`, `desktop` and `extension`,** with `versions` listing desktop 4.15.1 and extension 3.18.1. The documentation links ship from shared libraries and the extension mounts the Permission Analysis route. Select both platforms in the `pnpm release` picker, or drop them from `tags` and `versions` before merging if only web is cut.
- **The SOC 2 highlight has no `platforms` restriction.** The change itself is website only, but the fact applies to every customer. Add `platforms: [web]` if it should stay off the desktop and extension popover.

## Verification

`pnpm release-notes:generate` passes: schema valid, the `/permission-analysis` doc link resolves, and `release-notes.json` is regenerated with 127 notes. The body contains no bare angle brackets or braces. The full Docusaurus build was not run.

Merge before cutting the release so the note matches what ships.