### PR TITLE
fix(permission-manager): allow large permission exports to xlsx

### DIFF
--- a/libs/features/manage-permissions/src/utils/__tests__/permission-manager-field-export.spec.ts
+++ b/libs/features/manage-permissions/src/utils/__tests__/permission-manager-field-export.spec.ts
@@ -1,6 +1,7 @@
 import { PermissionSetWithProfileRecord, PermissionTableFieldCell } from '@jetstream/types';
 import { parse } from 'papaparse';
 import { describe, expect, it } from 'vitest';
+import * as XLSX from 'xlsx';
 import { generateFieldCsv, generateFieldWorksheet } from '../permission-manager-export-utils';
 import { getFieldColumns } from '../permission-manager-table-utils';
 
@@ -15,6 +16,16 @@ const PREFIX_COLUMN_COUNT = 7;
 const TIME_ZONE = Intl.DateTimeFormat().resolvedOptions().timeZone;
 
 const columns = getFieldColumns([PROFILE_ID], [], profilesById, {});
+
+/** Worksheets are built in dense mode, so cells live in `!data` rather than under their A1 address */
+function getCell(worksheet: XLSX.WorkSheet, address: string): XLSX.CellObject {
+  const { r, c } = XLSX.utils.decode_cell(address);
+  const denseRows = worksheet['!data'];
+  if (!denseRows) {
+    throw new Error(`Worksheet is not dense, cannot read ${address}`);
+  }
+  return denseRows[r][c];
+}
 
 function buildRow(overrides: Partial<PermissionTableFieldCell>): PermissionTableFieldCell {
   return {
@@ -84,7 +95,7 @@ describe('generateFieldWorksheet', () => {
     const worksheet = generateFieldWorksheet(columns, [customFieldRow]);
     const [, , csvRow] = parse<string[]>(generateFieldCsv(columns, [customFieldRow])).data;
     // Row 3 (index 2) is the first data row, column D is Created Date
-    const createdDateCell = worksheet['D3'];
+    const createdDateCell = getCell(worksheet, 'D3');
 
     expect(createdDateCell.t).toBe('d');
     expect(createdDateCell.z).toBe('yyyy-mm-dd hh:mm:ss');
@@ -92,16 +103,40 @@ describe('generateFieldWorksheet', () => {
     // rendering depends on the timezone the test runs in
     expect(createdDateCell.w).toBe(csvRow[3]);
     // The user name column beside it stays text
-    expect(worksheet['E3'].t).toBe('s');
-    expect(worksheet['E3'].v).toBe('Austin Turner');
+    expect(getCell(worksheet, 'E3').t).toBe('s');
+    expect(getCell(worksheet, 'E3').v).toBe('Austin Turner');
   });
 
   it('should leave the audit cells empty for a field with no audit data', () => {
     const worksheet = generateFieldWorksheet(columns, [standardFieldRow]);
 
     ['D3', 'E3', 'F3', 'G3'].forEach((cellAddress) => {
-      expect(worksheet[cellAddress].v).toBe('');
+      expect(getCell(worksheet, cellAddress).v).toBe('');
     });
+  });
+
+  it('should build the worksheet in dense mode so a wide export stays under v8 object property limits', () => {
+    const worksheet = generateFieldWorksheet(columns, [customFieldRow]);
+
+    // Sparse worksheets key every cell by its A1 address, which caps an export near 8.4 million cells
+    expect(Array.isArray(worksheet['!data'])).toBe(true);
+    expect('D3' in worksheet).toBe(false);
+  });
+
+  it('should still write a readable xlsx from the dense worksheet', () => {
+    const workbook = XLSX.utils.book_new();
+    XLSX.utils.book_append_sheet(workbook, generateFieldWorksheet(columns, [customFieldRow]), 'Field Permissions');
+    const [, , csvRow] = parse<string[]>(generateFieldCsv(columns, [customFieldRow])).data;
+
+    const reread = XLSX.read(XLSX.write(workbook, { bookType: 'xlsx', type: 'array', bookSST: true }), {
+      type: 'array',
+      cellDates: true,
+    });
+    const sheet = reread.Sheets['Field Permissions'];
+
+    expect(sheet['B3'].v).toBe('Custom__c');
+    expect(sheet['D3'].t).toBe('d');
+    expect(sheet['D3'].w).toBe(csvRow[3]);
   });
 
   it('should shift the profile header merge past the audit columns', () => {

--- a/libs/features/manage-permissions/src/utils/permission-manager-export-utils.ts
+++ b/libs/features/manage-permissions/src/utils/permission-manager-export-utils.ts
@@ -23,6 +23,15 @@ import { FIELD_AUDIT_COLUMNS, getFieldAuditExportHeaders } from './permission-ma
  */
 const AUDIT_DATE_EXCEL_FORMAT = 'yyyy-mm-dd hh:mm:ss';
 
+/**
+ * Every worksheet here is built in dense mode. Without it SheetJS stores each cell as its own property on the
+ * worksheet object, and V8 caps a single object near 8.4 million enumerable properties - a permission export
+ * covering many fields across many profiles and permission sets blows past that and throws
+ * `RangeError: Too many properties to enumerate`. Dense mode holds the cells in a 2D array instead and writes
+ * byte identical output.
+ */
+const WORKSHEET_OPTIONS = { dense: true } as const;
+
 type PermissionExportColumn =
   | ColumnWithFilter<PermissionTableObjectCell, PermissionTableSummaryRow>
   | ColumnWithFilter<PermissionTableFieldCell, PermissionTableSummaryRow>
@@ -185,7 +194,7 @@ function generateObjectWorksheet(columns: PermissionExportColumn[], rows: Permis
     excelRows.push(currRow);
   });
 
-  const worksheet = XLSX.utils.aoa_to_sheet(excelRows);
+  const worksheet = XLSX.utils.aoa_to_sheet(excelRows, WORKSHEET_OPTIONS);
   worksheet['!cols'] = getMaxWidthFromColumnContent(excelRows, new Set([0]));
   worksheet['!merges'] = merges;
   return worksheet;
@@ -231,7 +240,7 @@ export function generateFieldWorksheet(columns: PermissionExportColumn[], rows: 
     excelRows.push(currRow);
   });
 
-  const worksheet = XLSX.utils.aoa_to_sheet(excelRows, { cellDates: true, dateNF: AUDIT_DATE_EXCEL_FORMAT });
+  const worksheet = XLSX.utils.aoa_to_sheet(excelRows, { ...WORKSHEET_OPTIONS, cellDates: true, dateNF: AUDIT_DATE_EXCEL_FORMAT });
   // Column widths are measured from the stringified value, and a Date stringifies to the full js date string,
   // so the date cells are measured against how Excel will actually render them
   worksheet['!cols'] = getMaxWidthFromColumnContent(
@@ -279,7 +288,7 @@ function generateTabVisibilityWorksheet(columns: PermissionExportColumn[], rows:
     excelRows.push(currRow);
   });
 
-  const worksheet = XLSX.utils.aoa_to_sheet(excelRows);
+  const worksheet = XLSX.utils.aoa_to_sheet(excelRows, WORKSHEET_OPTIONS);
   worksheet['!cols'] = getMaxWidthFromColumnContent(excelRows, new Set([0]));
   worksheet['!merges'] = merges;
   return worksheet;
@@ -416,7 +425,7 @@ function generateSystemPermissionWorksheet(columns: PermissionExportColumn[], ro
     excelRows.push(currRow);
   });
 
-  const worksheet = XLSX.utils.aoa_to_sheet(excelRows);
+  const worksheet = XLSX.utils.aoa_to_sheet(excelRows, WORKSHEET_OPTIONS);
   worksheet['!cols'] = getMaxWidthFromColumnContent(excelRows, new Set([0, 1]));
   return worksheet;
 }


### PR DESCRIPTION
## Problem

A user hit `RangeError: Too many properties to enumerate` on 2026-09-11 when exporting from Permission Manager to xlsx. No file was produced.

All four worksheet builders in `permission-manager-export-utils.ts` called `XLSX.utils.aoa_to_sheet` without `dense: true`. In sparse mode SheetJS stores every cell as its own property on a single worksheet object (`ws['A1'] = cell`). V8 caps a single object near 8.4 million enumerable properties, and the field permissions sheet is fields x 2 columns per profile or permission set, so a wide selection blows past it.

The generic `prepareExcelFile` helper already passes `dense: true`, which is why query downloads survive much larger sheets.

## Fix

Build all four worksheets in dense mode. Cells move into a 2D array under `!data` instead of A1 keyed properties. `!cols` and `!merges` are unaffected.

Verified the written bytes are identical between sparse and dense for the same input, including date cells, number formats and merges.

## Tests

- Existing date cell and merge assertions updated to read through a dense cell helper.
- New test asserting the worksheet is dense, so dropping the option fails loudly rather than only at 8.4 million cells.
- New round trip test writing and re-reading the xlsx to confirm the dense worksheet still produces a valid file.

Found during BetterStack error triage.