### PR TITLE
fix(mass-update): stop posting batches to a bulk job Salesforce already closed

### DIFF
--- a/libs/features/load-records/src/utils/__tests__/load-records-process.spec.ts
+++ b/libs/features/load-records/src/utils/__tests__/load-records-process.spec.ts
@@ -8,7 +8,6 @@ import {
   MAX_CONSECUTIVE_FAILURES,
   generateSizeCappedBatchCsvs,
   getBulkJobPollInterval,
-  isFatalBulkApiError,
 } from '../load-records-process';
 
 describe('MAX_CONSECUTIVE_FAILURES', () => {
@@ -114,117 +113,5 @@ describe('generateSizeCappedBatchCsvs', () => {
     expect(batches).toHaveLength(1);
     expect(batches[0]).toEqual(expect.objectContaining({ startIndex: 0, recordCount: 1 }));
     expect(batches[0].csv.length).toBeGreaterThan(MAX_BATCH_CSV_CHARS);
-  });
-});
-
-describe('isFatalBulkApiError', () => {
-  describe('fatal error patterns', () => {
-    it('should detect ApiBatchItems Limit exceeded', () => {
-      expect(isFatalBulkApiError(new Error('ApiBatchItems Limit exceeded'))).toBe(true);
-    });
-
-    it('should detect InvalidBatch errors', () => {
-      expect(isFatalBulkApiError(new Error('InvalidBatch : Some batch was invalid'))).toBe(true);
-    });
-
-    it('should detect InvalidJob errors', () => {
-      expect(isFatalBulkApiError(new Error('InvalidJob : job not found'))).toBe(true);
-    });
-
-    it('should detect ExceededQuota errors', () => {
-      expect(isFatalBulkApiError(new Error('ExceededQuota'))).toBe(true);
-    });
-
-    it('should detect Job is in invalid state errors', () => {
-      expect(isFatalBulkApiError(new Error('Job is in invalid state'))).toBe(true);
-    });
-
-    it('should detect Job already aborted', () => {
-      expect(isFatalBulkApiError(new Error('Job already aborted'))).toBe(true);
-    });
-
-    it('should detect Job already closed', () => {
-      expect(isFatalBulkApiError(new Error('Job already closed'))).toBe(true);
-    });
-
-    it('should detect Job already completed', () => {
-      expect(isFatalBulkApiError(new Error('Job already completed'))).toBe(true);
-    });
-  });
-
-  describe('case insensitivity', () => {
-    it('should match ApiBatchItems Limit exceeded regardless of case', () => {
-      expect(isFatalBulkApiError(new Error('apibatchitems limit exceeded'))).toBe(true);
-      expect(isFatalBulkApiError(new Error('APIBATCHITEMS LIMIT EXCEEDED'))).toBe(true);
-    });
-
-    it('should match InvalidBatch regardless of case', () => {
-      expect(isFatalBulkApiError(new Error('invalidbatch'))).toBe(true);
-      expect(isFatalBulkApiError(new Error('INVALIDBATCH'))).toBe(true);
-    });
-
-    it('should match InvalidJob regardless of case', () => {
-      expect(isFatalBulkApiError(new Error('invalidjob'))).toBe(true);
-    });
-
-    it('should match ExceededQuota regardless of case', () => {
-      expect(isFatalBulkApiError(new Error('exceededquota'))).toBe(true);
-    });
-
-    it('should match Job is in invalid state regardless of case', () => {
-      expect(isFatalBulkApiError(new Error('JOB IS IN INVALID STATE'))).toBe(true);
-    });
-
-    it('should match Job already aborted/closed/completed regardless of case', () => {
-      expect(isFatalBulkApiError(new Error('JOB ALREADY ABORTED'))).toBe(true);
-      expect(isFatalBulkApiError(new Error('JOB ALREADY CLOSED'))).toBe(true);
-      expect(isFatalBulkApiError(new Error('JOB ALREADY COMPLETED'))).toBe(true);
-    });
-  });
-
-  describe('non-fatal errors', () => {
-    it('should return false for a generic network error', () => {
-      expect(isFatalBulkApiError(new Error('Network request failed'))).toBe(false);
-    });
-
-    it('should return false for a timeout error', () => {
-      expect(isFatalBulkApiError(new Error('Request timed out'))).toBe(false);
-    });
-
-    it('should return false for an unrelated Salesforce error', () => {
-      expect(isFatalBulkApiError(new Error('FIELD_CUSTOM_VALIDATION_EXCEPTION: Validation failed'))).toBe(false);
-    });
-
-    it('should return false for an empty error message', () => {
-      expect(isFatalBulkApiError(new Error(''))).toBe(false);
-    });
-  });
-
-  describe('error input types', () => {
-    it('should handle a plain Error object', () => {
-      expect(isFatalBulkApiError(new Error('InvalidJob'))).toBe(true);
-    });
-
-    it('should handle a non-Error object (serialized via JSON.stringify)', () => {
-      // getErrorMessage JSON.stringifies non-Error values
-      // The serialized form of { message: 'InvalidJob' } contains "InvalidJob"
-      expect(isFatalBulkApiError({ message: 'InvalidJob' })).toBe(true);
-    });
-
-    it('should return false for a non-Error object with non-fatal message', () => {
-      expect(isFatalBulkApiError({ code: 500, reason: 'Internal error' })).toBe(false);
-    });
-
-    it('should handle null without throwing', () => {
-      expect(isFatalBulkApiError(null)).toBe(false);
-    });
-
-    it('should handle undefined without throwing', () => {
-      expect(isFatalBulkApiError(undefined)).toBe(false);
-    });
-
-    it('should handle a number without throwing', () => {
-      expect(isFatalBulkApiError(42)).toBe(false);
-    });
   });
 });

--- a/libs/features/load-records/src/utils/load-records-process.ts
+++ b/libs/features/load-records/src/utils/load-records-process.ts
@@ -8,7 +8,14 @@ import {
   sobjectUploadBinaryUpload,
 } from '@jetstream/shared/data';
 import { generateCsv } from '@jetstream/shared/ui-utils';
-import { getErrorMessage, getErrorStack, getHttpMethod, mimeFromExtension, splitArrayToMaxSize } from '@jetstream/shared/utils';
+import {
+  getErrorMessage,
+  getErrorStack,
+  getHttpMethod,
+  isFatalBulkApiError,
+  mimeFromExtension,
+  splitArrayToMaxSize,
+} from '@jetstream/shared/utils';
 import {
   BulkJobBatchInfo,
   BulkJobWithBatches,
@@ -56,17 +63,6 @@ export async function prepareData(payloadData: PrepareDataPayload, progressCallb
   return preparedData;
 }
 
-// Salesforce errors that indicate the job will never accept more batches
-// Reference: https://developer.salesforce.com/docs/atlas.en-us.api_asynch.meta/api_asynch/asynch_api_reference_errors.htm
-export const FATAL_BULK_ERROR_PATTERNS: ReadonlyArray<RegExp> = Object.freeze([
-  /ApiBatchItems Limit exceeded/i,
-  /InvalidBatch/i,
-  /InvalidJob/i,
-  /ExceededQuota/i,
-  /Job is in invalid state/i,
-  /Job already (aborted|closed|completed)/i,
-]);
-
 export const MAX_CONSECUTIVE_FAILURES = 5;
 
 // Salesforce Bulk API v1 rejects any batch CSV over 10,000,000 characters ("Failed to read request.
@@ -85,11 +81,6 @@ export const BULK_JOB_POLL_MAX_CHECKS = 200;
 /** Delay before the next job status check, growing linearly with the number of checks already made */
 export function getBulkJobPollInterval(checkCount: number): number {
   return Math.min(BULK_JOB_POLL_INITIAL_INTERVAL_MS + checkCount * BULK_JOB_POLL_INTERVAL_STEP_MS, BULK_JOB_POLL_MAX_INTERVAL_MS);
-}
-
-export function isFatalBulkApiError(error: unknown): boolean {
-  const message = getErrorMessage(error);
-  return FATAL_BULK_ERROR_PATTERNS.some((pattern) => pattern.test(message));
 }
 
 /** A single batch CSV along with the range of source records it was built from */

--- a/libs/salesforce-api/src/lib/__tests__/api-bulk.spec.ts
+++ b/libs/salesforce-api/src/lib/__tests__/api-bulk.spec.ts
@@ -346,6 +346,49 @@ describe('ApiBulk XML parsing and type handling', () => {
     });
   });
 
+  describe('addBatchToJob - closeJob failure', () => {
+    /**
+     * Salesforce has accepted the batch by the time the close is attempted, so a rejection here would
+     * hand the caller an error for a batch that is going to be processed. Callers treat that as "this
+     * batch failed" and record every row in it as an error.
+     */
+    it('should return the accepted batch when closing the job fails', async () => {
+      const closeJobUrl = '/services/async/65.0/job/750Kf00000R1wzRIAR';
+      const mockFetch = vi.fn((url: string | URL) => {
+        const urlStr = typeof url === 'string' ? url : url.toString();
+        const isCloseRequest = urlStr.endsWith(closeJobUrl);
+        return Promise.resolve({
+          ok: !isCloseRequest,
+          status: isCloseRequest ? 500 : 200,
+          statusText: isCloseRequest ? 'Internal Server Error' : 'OK',
+          headers: new Headers({ 'content-type': 'text/xml; charset=UTF-8' }),
+          type: 'basic' as ResponseType,
+          url: urlStr,
+          text: () =>
+            Promise.resolve(
+              isCloseRequest
+                ? `<?xml version="1.0" encoding="UTF-8"?><error><exceptionCode>InvalidJobState</exceptionCode><exceptionMessage>Closing already Closed Job</exceptionMessage></error>`
+                : BULK_XML_RESPONSES.BATCH_INFO_QUEUED,
+            ),
+          json: () => Promise.reject(new Error('Not JSON')),
+          clone() {
+            return this;
+          },
+        } as any);
+      });
+
+      const connection = createConnectionWithXmlParsing(mockFetch);
+      const apiBulk = new ApiBulk(connection);
+
+      const result = await apiBulk.addBatchToJob('csv,data', '750Kf00000R1wzRIAR', true);
+
+      expect(result.id).toBe('751Kf000018uaV7IAI');
+      expect(result.state).toBe('Queued');
+      // The close was still attempted, it just did not take the batch result down with it
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+  });
+
   describe('getQueryResultsJobIds - XML parsing', () => {
     it('should parse result-list XML with single result', async () => {
       const mockFetch = createMockFetch({

--- a/libs/salesforce-api/src/lib/api-bulk.ts
+++ b/libs/salesforce-api/src/lib/api-bulk.ts
@@ -1,5 +1,5 @@
 import { HTTP } from '@jetstream/shared/constants';
-import { bulkApiEnsureTyped, ensureArray } from '@jetstream/shared/utils';
+import { bulkApiEnsureTyped, ensureArray, getErrorMessage } from '@jetstream/shared/utils';
 import {
   BulkApiCreateJobRequestPayload,
   BulkApiDownloadType,
@@ -80,7 +80,15 @@ export class ApiBulk extends SalesforceApi {
     }).then(({ batchInfo }) => bulkApiEnsureTyped(batchInfo));
 
     if (closeJob) {
-      await this.closeJob(jobId, 'Closed');
+      // Salesforce has already accepted the batch by this point, so letting a failed close reject the
+      // whole call would throw away a result the caller needs - callers treat a rejection as "this batch
+      // failed" and record every row in it as an error, while Salesforce goes on to process them. The
+      // job is left Open instead, which Salesforce eventually expires on its own.
+      try {
+        await this.closeJob(jobId, 'Closed');
+      } catch (ex) {
+        this.logger.warn({ message: getErrorMessage(ex), jobId }, 'Batch was accepted but closing the job failed');
+      }
     }
 
     return result;

--- a/libs/shared/ui-core/src/mass-update-records/__tests__/useDeployRecords.batches.spec.tsx
+++ b/libs/shared/ui-core/src/mass-update-records/__tests__/useDeployRecords.batches.spec.tsx
@@ -102,20 +102,25 @@ describe('useDeployRecords batch submission', () => {
     expect(deployResults.processingErrors).toHaveLength(2);
   });
 
-  it('closes the job on the final batch only', async () => {
+  /**
+   * The close rides on its own request rather than the final batch: `addBatchToJob` swallows a close
+   * failure so the accepted batch survives, which makes a failed close on that path indistinguishable
+   * from a successful one.
+   */
+  it('closes the job with a separate request rather than on the final batch', async () => {
     await deployAndGetResults();
 
     expect(bulkApiAddBatchToJobMock).toHaveBeenCalledTimes(3);
-    expect(bulkApiAddBatchToJobMock.mock.calls.map(([, , , closeJob]) => closeJob)).toEqual([false, false, true]);
-    // The final batch already carried `closeJob`, so no separate close is needed
-    expect(bulkApiCloseJobMock).not.toHaveBeenCalled();
+    expect(bulkApiAddBatchToJobMock.mock.calls.map(([, , , closeJob]) => closeJob)).toEqual([undefined, undefined, undefined]);
+    expect(bulkApiCloseJobMock).toHaveBeenCalledTimes(1);
+    expect(bulkApiCloseJobMock).toHaveBeenCalledWith(org, 'job-1');
   });
 
   /**
-   * Only the final batch carries `closeJob`, so stopping before it would otherwise strand the job in
-   * `Open` and hold one of the org's job slots until Salesforce expires it.
+   * Stopping part way through would otherwise strand the job in `Open`, holding one of the org's job
+   * slots until Salesforce expires it.
    */
-  it('closes the job when it stops early and no batch carried the close flag', async () => {
+  it('closes the job when it stops early on a fatal error', async () => {
     bulkApiAddBatchToJobMock.mockImplementationOnce(async () => {
       throw new Error(JOB_CLOSED_ERROR);
     });

--- a/libs/shared/ui-core/src/mass-update-records/__tests__/useDeployRecords.batches.spec.tsx
+++ b/libs/shared/ui-core/src/mass-update-records/__tests__/useDeployRecords.batches.spec.tsx
@@ -138,6 +138,35 @@ describe('useDeployRecords batch submission', () => {
     expect(bulkApiCloseJobMock).toHaveBeenCalledWith(org, 'job-1');
   });
 
+  /**
+   * The unmount path `return`s out of the middle of the batch loop, which skipped the cleanup and left
+   * the job Open with nothing left running that would ever close it.
+   */
+  it('closes the job when the host unmounts part way through the load', async () => {
+    let unmountHost = () => undefined as void;
+    bulkApiAddBatchToJobMock.mockImplementationOnce(async () => {
+      // Unmount after the first batch lands, so the loop bails on its next iteration
+      unmountHost();
+      return { id: 'batch-1' };
+    });
+
+    const { result, unmount } = renderHook(() => useDeployRecords(org, vi.fn(), 'STAND-ALONE'));
+    unmountHost = unmount;
+
+    await result.current.loadDataForProvidedRecords({
+      records,
+      sobject: 'Account',
+      fields: ['Id', 'Industry'],
+      batchSize: 2,
+      serialMode: false,
+      configuration,
+      skipHistory: true,
+    });
+
+    expect(bulkApiAddBatchToJobMock).toHaveBeenCalledTimes(1);
+    expect(bulkApiCloseJobMock).toHaveBeenCalledWith(org, 'job-1');
+  });
+
   it('does not surface a failed cleanup close to the user', async () => {
     bulkApiAddBatchToJobMock.mockImplementationOnce(async () => {
       throw new Error(JOB_CLOSED_ERROR);

--- a/libs/shared/ui-core/src/mass-update-records/__tests__/useDeployRecords.batches.spec.tsx
+++ b/libs/shared/ui-core/src/mass-update-records/__tests__/useDeployRecords.batches.spec.tsx
@@ -4,9 +4,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { DeployResults, MetadataRowConfiguration } from '../mass-update-records.types';
 import { useDeployRecords } from '../useDeployRecords';
 
-const { bulkApiCreateJobMock, bulkApiAddBatchToJobMock, trackerErrorMock } = vi.hoisted(() => ({
+const { bulkApiCreateJobMock, bulkApiAddBatchToJobMock, bulkApiCloseJobMock, trackerErrorMock } = vi.hoisted(() => ({
   bulkApiCreateJobMock: vi.fn(),
   bulkApiAddBatchToJobMock: vi.fn(),
+  bulkApiCloseJobMock: vi.fn(),
   trackerErrorMock: vi.fn(),
 }));
 
@@ -14,6 +15,7 @@ vi.mock('@jetstream/shared/data', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@jetstream/shared/data')>()),
   bulkApiCreateJob: bulkApiCreateJobMock,
   bulkApiAddBatchToJob: bulkApiAddBatchToJobMock,
+  bulkApiCloseJob: bulkApiCloseJobMock,
 }));
 vi.mock('@jetstream/shared/ui-utils', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@jetstream/shared/ui-utils')>()),
@@ -66,6 +68,7 @@ describe('useDeployRecords batch submission', () => {
     vi.clearAllMocks();
     bulkApiCreateJobMock.mockResolvedValue({ id: 'job-1', batches: [] });
     bulkApiAddBatchToJobMock.mockImplementation(async () => ({ id: `batch-${bulkApiAddBatchToJobMock.mock.calls.length}` }));
+    bulkApiCloseJobMock.mockResolvedValue({ id: 'job-1', state: 'Closed' });
   });
 
   /**
@@ -104,5 +107,46 @@ describe('useDeployRecords batch submission', () => {
 
     expect(bulkApiAddBatchToJobMock).toHaveBeenCalledTimes(3);
     expect(bulkApiAddBatchToJobMock.mock.calls.map(([, , , closeJob]) => closeJob)).toEqual([false, false, true]);
+    // The final batch already carried `closeJob`, so no separate close is needed
+    expect(bulkApiCloseJobMock).not.toHaveBeenCalled();
+  });
+
+  /**
+   * Only the final batch carries `closeJob`, so stopping before it would otherwise strand the job in
+   * `Open` and hold one of the org's job slots until Salesforce expires it.
+   */
+  it('closes the job when it stops early and no batch carried the close flag', async () => {
+    bulkApiAddBatchToJobMock.mockImplementationOnce(async () => {
+      throw new Error(JOB_CLOSED_ERROR);
+    });
+
+    await deployAndGetResults();
+
+    expect(bulkApiAddBatchToJobMock).toHaveBeenCalledTimes(1);
+    expect(bulkApiCloseJobMock).toHaveBeenCalledWith(org, 'job-1');
+  });
+
+  it('closes the job when the final batch itself fails', async () => {
+    bulkApiAddBatchToJobMock.mockImplementationOnce(async () => ({ id: 'batch-1' }));
+    bulkApiAddBatchToJobMock.mockImplementationOnce(async () => ({ id: 'batch-2' }));
+    bulkApiAddBatchToJobMock.mockImplementationOnce(async () => {
+      throw new Error('Request timed out');
+    });
+
+    await deployAndGetResults();
+
+    expect(bulkApiCloseJobMock).toHaveBeenCalledWith(org, 'job-1');
+  });
+
+  it('does not surface a failed cleanup close to the user', async () => {
+    bulkApiAddBatchToJobMock.mockImplementationOnce(async () => {
+      throw new Error(JOB_CLOSED_ERROR);
+    });
+    bulkApiCloseJobMock.mockRejectedValue(new Error('Job already closed'));
+
+    const deployResults = await deployAndGetResults();
+
+    expect(deployResults.status).toBe('In Progress');
+    expect(bulkApiCloseJobMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/libs/shared/ui-core/src/mass-update-records/__tests__/useDeployRecords.batches.spec.tsx
+++ b/libs/shared/ui-core/src/mass-update-records/__tests__/useDeployRecords.batches.spec.tsx
@@ -1,0 +1,108 @@
+import { SalesforceOrgUi } from '@jetstream/types';
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { DeployResults, MetadataRowConfiguration } from '../mass-update-records.types';
+import { useDeployRecords } from '../useDeployRecords';
+
+const { bulkApiCreateJobMock, bulkApiAddBatchToJobMock, trackerErrorMock } = vi.hoisted(() => ({
+  bulkApiCreateJobMock: vi.fn(),
+  bulkApiAddBatchToJobMock: vi.fn(),
+  trackerErrorMock: vi.fn(),
+}));
+
+vi.mock('@jetstream/shared/data', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@jetstream/shared/data')>()),
+  bulkApiCreateJob: bulkApiCreateJobMock,
+  bulkApiAddBatchToJob: bulkApiAddBatchToJobMock,
+}));
+vi.mock('@jetstream/shared/ui-utils', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@jetstream/shared/ui-utils')>()),
+  useBrowserNotifications: () => ({ notifyUser: vi.fn() }),
+  tracker: { error: trackerErrorMock },
+}));
+vi.mock('../../analytics', () => ({ useAmplitude: () => ({ trackEvent: vi.fn() }) }));
+// History capture is orthogonal to batch submission and needs Dexie + a file store to run for real
+vi.mock('../data-history-capture', () => ({
+  startMassUpdateHistory: () => ({
+    setSubmittedCount: vi.fn(),
+    writeInputRows: vi.fn(),
+    fail: vi.fn(),
+    finish: vi.fn(),
+    abandonIfUnsettled: vi.fn(),
+  }),
+  captureMassUpdateResults: vi.fn(),
+}));
+
+const JOB_CLOSED_ERROR = `Failed to create batch, since the Job is not Open. Current job state is 'Closed'`;
+
+const org = { uniqueId: 'org-batches-1', label: 'Batch Org' } as SalesforceOrgUi;
+const configuration: MetadataRowConfiguration[] = [
+  { selectedField: 'Industry', transformationOptions: { option: 'staticValue', staticValue: 'Tech', criteria: 'all', whereClause: '' } },
+];
+/** Three batches of two at a batch size of two */
+const records = Array.from({ length: 6 }, (unused, i) => ({ Id: `001000000000${i}`, Industry: null }));
+
+/** Run one deployment and return the final `DeployResults` the hook reported */
+async function deployAndGetResults(): Promise<DeployResults> {
+  const onDeployResults = vi.fn();
+  const { result } = renderHook(() => useDeployRecords(org, onDeployResults, 'STAND-ALONE'));
+
+  await result.current.loadDataForProvidedRecords({
+    records,
+    sobject: 'Account',
+    fields: ['Id', 'Industry'],
+    batchSize: 2,
+    serialMode: false,
+    configuration,
+    skipHistory: true,
+  });
+
+  const [, deployResults] = onDeployResults.mock.calls[onDeployResults.mock.calls.length - 1];
+  return deployResults;
+}
+
+describe('useDeployRecords batch submission', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    bulkApiCreateJobMock.mockResolvedValue({ id: 'job-1', batches: [] });
+    bulkApiAddBatchToJobMock.mockImplementation(async () => ({ id: `batch-${bulkApiAddBatchToJobMock.mock.calls.length}` }));
+  });
+
+  /**
+   * The regression: a job Salesforce had already closed still got every remaining batch posted to it,
+   * costing a doomed round trip and a duplicate error report per batch.
+   */
+  it('stops submitting batches once salesforce reports the job is no longer open', async () => {
+    bulkApiAddBatchToJobMock.mockImplementationOnce(async () => ({ id: 'batch-1' }));
+    bulkApiAddBatchToJobMock.mockImplementationOnce(async () => {
+      throw new Error(JOB_CLOSED_ERROR);
+    });
+
+    const deployResults = await deployAndGetResults();
+
+    expect(bulkApiAddBatchToJobMock).toHaveBeenCalledTimes(2);
+    expect(trackerErrorMock).toHaveBeenCalledTimes(1);
+    // The rejected batch plus the batch that was never sent, so nothing is silently dropped
+    expect(deployResults.processingErrors).toHaveLength(4);
+    deployResults.processingErrors.forEach(({ errors }) => expect(errors).toEqual([JOB_CLOSED_ERROR]));
+  });
+
+  it('keeps submitting the remaining batches after a single batch fails for an unrelated reason', async () => {
+    bulkApiAddBatchToJobMock.mockImplementationOnce(async () => ({ id: 'batch-1' }));
+    bulkApiAddBatchToJobMock.mockImplementationOnce(async () => {
+      throw new Error('Request timed out');
+    });
+
+    const deployResults = await deployAndGetResults();
+
+    expect(bulkApiAddBatchToJobMock).toHaveBeenCalledTimes(3);
+    expect(deployResults.processingErrors).toHaveLength(2);
+  });
+
+  it('closes the job on the final batch only', async () => {
+    await deployAndGetResults();
+
+    expect(bulkApiAddBatchToJobMock).toHaveBeenCalledTimes(3);
+    expect(bulkApiAddBatchToJobMock.mock.calls.map(([, , , closeJob]) => closeJob)).toEqual([false, false, true]);
+  });
+});

--- a/libs/shared/ui-core/src/mass-update-records/useDeployRecords.ts
+++ b/libs/shared/ui-core/src/mass-update-records/useDeployRecords.ts
@@ -2,7 +2,7 @@ import { logger } from '@jetstream/shared/client-logger';
 import { ANALYTICS_KEYS } from '@jetstream/shared/constants';
 import { bulkApiAddBatchToJob, bulkApiCreateJob, bulkApiGetJob } from '@jetstream/shared/data';
 import { checkIfBulkApiJobIsDone, convertDateToLocale, generateCsv, tracker, useBrowserNotifications } from '@jetstream/shared/ui-utils';
-import { delay, getErrorMessage, splitArrayToMaxSize } from '@jetstream/shared/utils';
+import { delay, getErrorMessage, isFatalBulkApiError, splitArrayToMaxSize } from '@jetstream/shared/utils';
 import { BulkJobBatchInfo, Maybe, SalesforceOrgUi } from '@jetstream/types';
 import { applicationCookieState } from '@jetstream/ui/app-state';
 import { DataHistoryEntryHandle } from '@jetstream/ui/data-history';
@@ -128,6 +128,12 @@ export function useDeployRecords(
       deployResults.records = records;
       isMounted.current && onDeployResults(sobject, { ...deployResults });
 
+      /** Mark every record in a batch as failed, for a batch that was rejected or never submitted */
+      function recordFailedBatch(failedRecords: any[], errorMessage: string) {
+        deployResults.processingErrors = [...deployResults.processingErrors];
+        failedRecords.forEach((record, i) => deployResults.processingErrors.push({ record, errors: [errorMessage], row: i }));
+      }
+
       let currItem = 0;
       for (const batch of batches) {
         try {
@@ -151,8 +157,15 @@ export function useDeployRecords(
             tracker.error('There was an error loading batch for mass record update', ex);
           }
 
-          deployResults.processingErrors = [...deployResults.processingErrors];
-          batch.records.forEach((record, i) => deployResults.processingErrors.push({ record, errors: [getErrorMessage(ex)], row: i }));
+          recordFailedBatch(batch.records, getErrorMessage(ex));
+
+          // Salesforce rejects everything sent after the job is closed, aborted or over a limit, so the
+          // remaining batches would each cost a doomed round trip and a duplicate error report. Fail them
+          // here instead - the records still land in `processingErrors` so the user sees what was skipped.
+          if (isFatalBulkApiError(ex)) {
+            batches.slice(currItem + 1).forEach(({ records: skippedRecords }) => recordFailedBatch(skippedRecords, getErrorMessage(ex)));
+            break;
+          }
         } finally {
           currItem++;
         }

--- a/libs/shared/ui-core/src/mass-update-records/useDeployRecords.ts
+++ b/libs/shared/ui-core/src/mass-update-records/useDeployRecords.ts
@@ -1,6 +1,6 @@
 import { logger } from '@jetstream/shared/client-logger';
 import { ANALYTICS_KEYS } from '@jetstream/shared/constants';
-import { bulkApiAddBatchToJob, bulkApiCreateJob, bulkApiGetJob } from '@jetstream/shared/data';
+import { bulkApiAddBatchToJob, bulkApiCloseJob, bulkApiCreateJob, bulkApiGetJob } from '@jetstream/shared/data';
 import { checkIfBulkApiJobIsDone, convertDateToLocale, generateCsv, tracker, useBrowserNotifications } from '@jetstream/shared/ui-utils';
 import { delay, getErrorMessage, isFatalBulkApiError, splitArrayToMaxSize } from '@jetstream/shared/utils';
 import { BulkJobBatchInfo, Maybe, SalesforceOrgUi } from '@jetstream/types';
@@ -128,19 +128,32 @@ export function useDeployRecords(
       deployResults.records = records;
       isMounted.current && onDeployResults(sobject, { ...deployResults });
 
-      /** Mark every record in a batch as failed, for a batch that was rejected or never submitted */
-      function recordFailedBatch(failedRecords: any[], errorMessage: string) {
-        deployResults.processingErrors = [...deployResults.processingErrors];
-        failedRecords.forEach((record, i) => deployResults.processingErrors.push({ record, errors: [errorMessage], row: i }));
+      /**
+       * Mark every record in the given batches as failed, for batches Salesforce rejected or that were
+       * never submitted. The list is cloned once for the whole set rather than once per batch, which
+       * would make stopping early cost O(skipped records x skipped batches) to record.
+       */
+      function recordFailedBatches(failedBatches: unknown[][], errorMessage: string) {
+        const processingErrors = [...deployResults.processingErrors];
+        failedBatches.forEach((failedRecords) => {
+          failedRecords.forEach((record, i) => processingErrors.push({ record, errors: [errorMessage], row: i }));
+        });
+        deployResults.processingErrors = processingErrors;
       }
 
       let currItem = 0;
+      // Only the final batch carries `closeJob`, so any path that never reaches it - stopping early, or
+      // the final batch itself failing - leaves the job Open, holding an org job slot until Salesforce
+      // expires it. Tracked here so the cleanup below knows whether the close actually happened.
+      let jobClosed = false;
       for (const batch of batches) {
         try {
           if (!isMounted.current) {
             return;
           }
-          const batchResult = await bulkApiAddBatchToJob(org, jobId, batch.csv, currItem === batches.length - 1);
+          const isLastBatch = currItem === batches.length - 1;
+          const batchResult = await bulkApiAddBatchToJob(org, jobId, batch.csv, isLastBatch);
+          jobClosed = jobClosed || isLastBatch;
           deployResults.batchIdToIndex = { ...deployResults.batchIdToIndex, [batchResult.id]: currItem };
           deployResults.jobInfo = { ...deployResults.jobInfo };
           deployResults.jobInfo.batches = deployResults.jobInfo.batches || [];
@@ -157,19 +170,31 @@ export function useDeployRecords(
             tracker.error('There was an error loading batch for mass record update', ex);
           }
 
-          recordFailedBatch(batch.records, getErrorMessage(ex));
-
           // Salesforce rejects everything sent after the job is closed, aborted or over a limit, so the
           // remaining batches would each cost a doomed round trip and a duplicate error report. Fail them
-          // here instead - the records still land in `processingErrors` so the user sees what was skipped.
-          if (isFatalBulkApiError(ex)) {
-            batches.slice(currItem + 1).forEach(({ records: skippedRecords }) => recordFailedBatch(skippedRecords, getErrorMessage(ex)));
+          // alongside this one instead - the records still land in `processingErrors` so the user sees
+          // what was skipped.
+          const isFatal = isFatalBulkApiError(ex);
+          const skippedBatches = isFatal ? batches.slice(currItem + 1).map(({ records: skippedRecords }) => skippedRecords) : [];
+          recordFailedBatches([batch.records, ...skippedBatches], getErrorMessage(ex));
+
+          if (isFatal) {
             break;
           }
         } finally {
           currItem++;
         }
       }
+
+      // Fire and forget, matching the load-records path: the user is already being shown results and an
+      // orphaned job is our problem, not theirs. A job Salesforce has already closed rejects this, which
+      // is exactly the case that got us here, so the rejection is expected and only worth a log line.
+      if (!jobClosed) {
+        bulkApiCloseJob(org, jobId).catch((ex) => {
+          logger.warn('Error closing job', ex);
+        });
+      }
+
       deployResults.status = 'In Progress';
       deployResults.lastChecked = formatDate(new Date(), 'h:mm:ss');
       isMounted.current && onDeployResults(sobject, { ...deployResults });

--- a/libs/shared/ui-core/src/mass-update-records/useDeployRecords.ts
+++ b/libs/shared/ui-core/src/mass-update-records/useDeployRecords.ts
@@ -142,57 +142,61 @@ export function useDeployRecords(
       }
 
       let currItem = 0;
-      // Only the final batch carries `closeJob`, so any path that never reaches it - stopping early, or
-      // the final batch itself failing - leaves the job Open, holding an org job slot until Salesforce
-      // expires it. Tracked here so the cleanup below knows whether the close actually happened.
+      // Only the final batch carries `closeJob`, so any path that never reaches it - stopping early, the
+      // final batch failing, or the host unmounting mid-load - leaves the job Open, holding an org job
+      // slot until Salesforce expires it. Tracked here so the cleanup below knows whether one was sent.
       let jobClosed = false;
-      for (const batch of batches) {
-        try {
-          if (!isMounted.current) {
-            return;
+      try {
+        for (const batch of batches) {
+          try {
+            if (!isMounted.current) {
+              return;
+            }
+            const isLastBatch = currItem === batches.length - 1;
+            const batchResult = await bulkApiAddBatchToJob(org, jobId, batch.csv, isLastBatch);
+            jobClosed = jobClosed || isLastBatch;
+            deployResults.batchIdToIndex = { ...deployResults.batchIdToIndex, [batchResult.id]: currItem };
+            deployResults.jobInfo = { ...deployResults.jobInfo };
+            deployResults.jobInfo.batches = deployResults.jobInfo.batches || [];
+            deployResults.jobInfo.batches = [...deployResults.jobInfo.batches, batchResult];
+
+            isMounted.current && onDeployResults(sobject, { ...deployResults });
+          } catch (ex) {
+            // error loading batch
+            logger.error('Error loading batch', ex);
+
+            // Log error for investigation of failure - but do not log for known errors
+            const errorMessage = getErrorMessage(ex)?.toLowerCase() || '';
+            if (!errorMessage.includes('aborted') && !errorMessage.includes('limit exceeded')) {
+              tracker.error('There was an error loading batch for mass record update', ex);
+            }
+
+            // Salesforce rejects everything sent after the job is closed, aborted or over a limit, so the
+            // remaining batches would each cost a doomed round trip and a duplicate error report. Fail them
+            // alongside this one instead - the records still land in `processingErrors` so the user sees
+            // what was skipped.
+            const isFatal = isFatalBulkApiError(ex);
+            const skippedBatches = isFatal ? batches.slice(currItem + 1).map(({ records: skippedRecords }) => skippedRecords) : [];
+            recordFailedBatches([batch.records, ...skippedBatches], getErrorMessage(ex));
+
+            if (isFatal) {
+              break;
+            }
+          } finally {
+            currItem++;
           }
-          const isLastBatch = currItem === batches.length - 1;
-          const batchResult = await bulkApiAddBatchToJob(org, jobId, batch.csv, isLastBatch);
-          jobClosed = jobClosed || isLastBatch;
-          deployResults.batchIdToIndex = { ...deployResults.batchIdToIndex, [batchResult.id]: currItem };
-          deployResults.jobInfo = { ...deployResults.jobInfo };
-          deployResults.jobInfo.batches = deployResults.jobInfo.batches || [];
-          deployResults.jobInfo.batches = [...deployResults.jobInfo.batches, batchResult];
-
-          isMounted.current && onDeployResults(sobject, { ...deployResults });
-        } catch (ex) {
-          // error loading batch
-          logger.error('Error loading batch', ex);
-
-          // Log error for investigation of failure - but do not log for known errors
-          const errorMessage = getErrorMessage(ex)?.toLowerCase() || '';
-          if (!errorMessage.includes('aborted') && !errorMessage.includes('limit exceeded')) {
-            tracker.error('There was an error loading batch for mass record update', ex);
-          }
-
-          // Salesforce rejects everything sent after the job is closed, aborted or over a limit, so the
-          // remaining batches would each cost a doomed round trip and a duplicate error report. Fail them
-          // alongside this one instead - the records still land in `processingErrors` so the user sees
-          // what was skipped.
-          const isFatal = isFatalBulkApiError(ex);
-          const skippedBatches = isFatal ? batches.slice(currItem + 1).map(({ records: skippedRecords }) => skippedRecords) : [];
-          recordFailedBatches([batch.records, ...skippedBatches], getErrorMessage(ex));
-
-          if (isFatal) {
-            break;
-          }
-        } finally {
-          currItem++;
         }
-      }
-
-      // Fire and forget, matching the load-records path: the user is already being shown results and an
-      // orphaned job is our problem, not theirs. A job Salesforce has already closed rejects this, which
-      // is exactly the case that got us here, so the rejection is expected and only worth a log line.
-      if (!jobClosed) {
-        bulkApiCloseJob(org, jobId).catch((ex) => {
-          logger.warn('Error closing job', ex);
-        });
+      } finally {
+        // Fire and forget, matching the load-records path: the user is already being shown results and an
+        // orphaned job is our problem, not theirs. A job Salesforce has already closed rejects this, which
+        // is exactly the case that got us here, so the rejection is expected and only worth a log line.
+        // In a `finally` so the unmount `return` above is covered too - that path abandons the load part
+        // way through and would otherwise strand the job.
+        if (!jobClosed) {
+          bulkApiCloseJob(org, jobId).catch((ex) => {
+            logger.warn('Error closing job', ex);
+          });
+        }
       }
 
       deployResults.status = 'In Progress';

--- a/libs/shared/ui-core/src/mass-update-records/useDeployRecords.ts
+++ b/libs/shared/ui-core/src/mass-update-records/useDeployRecords.ts
@@ -142,19 +142,13 @@ export function useDeployRecords(
       }
 
       let currItem = 0;
-      // Only the final batch carries `closeJob`, so any path that never reaches it - stopping early, the
-      // final batch failing, or the host unmounting mid-load - leaves the job Open, holding an org job
-      // slot until Salesforce expires it. Tracked here so the cleanup below knows whether one was sent.
-      let jobClosed = false;
       try {
         for (const batch of batches) {
           try {
             if (!isMounted.current) {
               return;
             }
-            const isLastBatch = currItem === batches.length - 1;
-            const batchResult = await bulkApiAddBatchToJob(org, jobId, batch.csv, isLastBatch);
-            jobClosed = jobClosed || isLastBatch;
+            const batchResult = await bulkApiAddBatchToJob(org, jobId, batch.csv);
             deployResults.batchIdToIndex = { ...deployResults.batchIdToIndex, [batchResult.id]: currItem };
             deployResults.jobInfo = { ...deployResults.jobInfo };
             deployResults.jobInfo.batches = deployResults.jobInfo.batches || [];
@@ -187,16 +181,17 @@ export function useDeployRecords(
           }
         }
       } finally {
+        // Closing is always its own request rather than riding along on the final batch. Piggybacking it
+        // makes a silent close failure indistinguishable from success, and every path that stops before
+        // the final batch - a fatal error, or the host unmounting mid-load - would skip it entirely and
+        // leave the job Open, holding an org job slot until Salesforce expires it.
+        //
         // Fire and forget, matching the load-records path: the user is already being shown results and an
         // orphaned job is our problem, not theirs. A job Salesforce has already closed rejects this, which
         // is exactly the case that got us here, so the rejection is expected and only worth a log line.
-        // In a `finally` so the unmount `return` above is covered too - that path abandons the load part
-        // way through and would otherwise strand the job.
-        if (!jobClosed) {
-          bulkApiCloseJob(org, jobId).catch((ex) => {
-            logger.warn('Error closing job', ex);
-          });
-        }
+        bulkApiCloseJob(org, jobId).catch((ex) => {
+          logger.warn('Error closing job', ex);
+        });
       }
 
       deployResults.status = 'In Progress';

--- a/libs/shared/utils/src/index.ts
+++ b/libs/shared/utils/src/index.ts
@@ -1,3 +1,4 @@
+export * from './lib/bulk-api-errors';
 export * from './lib/bulk-result-rows';
 export * from './lib/compression';
 export * from './lib/custom-field-tooling-names';

--- a/libs/shared/utils/src/lib/__tests__/bulk-api-errors.spec.ts
+++ b/libs/shared/utils/src/lib/__tests__/bulk-api-errors.spec.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from 'vitest';
+import { isFatalBulkApiError } from '../bulk-api-errors';
+
+describe('isFatalBulkApiError', () => {
+  describe('fatal error patterns', () => {
+    it('should detect ApiBatchItems Limit exceeded', () => {
+      expect(isFatalBulkApiError(new Error('ApiBatchItems Limit exceeded'))).toBe(true);
+    });
+
+    it('should detect InvalidBatch errors', () => {
+      expect(isFatalBulkApiError(new Error('InvalidBatch : Some batch was invalid'))).toBe(true);
+    });
+
+    it('should detect InvalidJob errors', () => {
+      expect(isFatalBulkApiError(new Error('InvalidJob : job not found'))).toBe(true);
+    });
+
+    it('should detect ExceededQuota errors', () => {
+      expect(isFatalBulkApiError(new Error('ExceededQuota'))).toBe(true);
+    });
+
+    it('should detect Job is in invalid state errors', () => {
+      expect(isFatalBulkApiError(new Error('Job is in invalid state'))).toBe(true);
+    });
+
+    it('should detect Job already aborted', () => {
+      expect(isFatalBulkApiError(new Error('Job already aborted'))).toBe(true);
+    });
+
+    it('should detect Job already closed', () => {
+      expect(isFatalBulkApiError(new Error('Job already closed'))).toBe(true);
+    });
+
+    it('should detect Job already completed', () => {
+      expect(isFatalBulkApiError(new Error('Job already completed'))).toBe(true);
+    });
+
+    it('should detect a batch rejected because the job is no longer open', () => {
+      expect(isFatalBulkApiError(new Error(`Failed to create batch, since the Job is not Open. Current job state is 'Closed'`))).toBe(true);
+    });
+  });
+
+  describe('case insensitivity', () => {
+    it('should match ApiBatchItems Limit exceeded regardless of case', () => {
+      expect(isFatalBulkApiError(new Error('apibatchitems limit exceeded'))).toBe(true);
+      expect(isFatalBulkApiError(new Error('APIBATCHITEMS LIMIT EXCEEDED'))).toBe(true);
+    });
+
+    it('should match InvalidBatch regardless of case', () => {
+      expect(isFatalBulkApiError(new Error('invalidbatch'))).toBe(true);
+      expect(isFatalBulkApiError(new Error('INVALIDBATCH'))).toBe(true);
+    });
+
+    it('should match InvalidJob regardless of case', () => {
+      expect(isFatalBulkApiError(new Error('invalidjob'))).toBe(true);
+    });
+
+    it('should match ExceededQuota regardless of case', () => {
+      expect(isFatalBulkApiError(new Error('exceededquota'))).toBe(true);
+    });
+
+    it('should match Job is in invalid state regardless of case', () => {
+      expect(isFatalBulkApiError(new Error('JOB IS IN INVALID STATE'))).toBe(true);
+    });
+
+    it('should match Job already aborted/closed/completed regardless of case', () => {
+      expect(isFatalBulkApiError(new Error('JOB ALREADY ABORTED'))).toBe(true);
+      expect(isFatalBulkApiError(new Error('JOB ALREADY CLOSED'))).toBe(true);
+      expect(isFatalBulkApiError(new Error('JOB ALREADY COMPLETED'))).toBe(true);
+    });
+
+    it('should match Job is not Open regardless of case', () => {
+      expect(isFatalBulkApiError(new Error('THE JOB IS NOT OPEN'))).toBe(true);
+    });
+  });
+
+  describe('non-fatal errors', () => {
+    it('should return false for a generic network error', () => {
+      expect(isFatalBulkApiError(new Error('Network request failed'))).toBe(false);
+    });
+
+    it('should return false for a timeout error', () => {
+      expect(isFatalBulkApiError(new Error('Request timed out'))).toBe(false);
+    });
+
+    it('should return false for an unrelated Salesforce error', () => {
+      expect(isFatalBulkApiError(new Error('FIELD_CUSTOM_VALIDATION_EXCEPTION: Validation failed'))).toBe(false);
+    });
+
+    it('should return false for an empty error message', () => {
+      expect(isFatalBulkApiError(new Error(''))).toBe(false);
+    });
+  });
+
+  describe('error input types', () => {
+    it('should handle a plain Error object', () => {
+      expect(isFatalBulkApiError(new Error('InvalidJob'))).toBe(true);
+    });
+
+    it('should handle a non-Error object (serialized via JSON.stringify)', () => {
+      // getErrorMessage JSON.stringifies non-Error values
+      // The serialized form of { message: 'InvalidJob' } contains "InvalidJob"
+      expect(isFatalBulkApiError({ message: 'InvalidJob' })).toBe(true);
+    });
+
+    it('should return false for a non-Error object with non-fatal message', () => {
+      expect(isFatalBulkApiError({ code: 500, reason: 'Internal error' })).toBe(false);
+    });
+
+    it('should handle null without throwing', () => {
+      expect(isFatalBulkApiError(null)).toBe(false);
+    });
+
+    it('should handle undefined without throwing', () => {
+      expect(isFatalBulkApiError(undefined)).toBe(false);
+    });
+
+    it('should handle a number without throwing', () => {
+      expect(isFatalBulkApiError(42)).toBe(false);
+    });
+  });
+});

--- a/libs/shared/utils/src/lib/bulk-api-errors.ts
+++ b/libs/shared/utils/src/lib/bulk-api-errors.ts
@@ -1,0 +1,27 @@
+import { getErrorMessage } from './utils';
+
+/**
+ * Bulk API v1 errors that doom every remaining batch, not just the one that failed. Once the job is
+ * gone, closed or over a limit, Salesforce rejects everything sent after it, so the caller should stop
+ * submitting rather than fire one doomed request per batch.
+ *
+ * Salesforce words the "job is no longer accepting batches" case two different ways depending on how
+ * the job got there, so both are listed.
+ *
+ * Reference: https://developer.salesforce.com/docs/atlas.en-us.api_asynch.meta/api_asynch/asynch_api_reference_errors.htm
+ */
+export const FATAL_BULK_ERROR_PATTERNS: ReadonlyArray<RegExp> = Object.freeze([
+  /ApiBatchItems Limit exceeded/i,
+  /InvalidBatch/i,
+  /InvalidJob/i,
+  /ExceededQuota/i,
+  /Job is in invalid state/i,
+  /Job already (aborted|closed|completed)/i,
+  // "Failed to create batch, since the Job is not Open. Current job state is 'Closed'"
+  /Job is not Open/i,
+]);
+
+export function isFatalBulkApiError(error: unknown): boolean {
+  const message = getErrorMessage(error);
+  return FATAL_BULK_ERROR_PATTERNS.some((pattern) => pattern.test(message));
+}


### PR DESCRIPTION
## Problem

A user hit this on 2026-09-11 during a mass record update:

```
Failed to create batch, since the Job is not Open. Current job state is 'Closed'
```

`performLoad` in `useDeployRecords.ts` catches a failed batch, records its rows as processing errors, and moves on to the next batch. That is right for a one-off failure, but once the Bulk API v1 job is closed or aborted Salesforce rejects everything sent after it. Every remaining batch then costs a doomed round trip and a duplicate `tracker.error` report.

Load Records already guards this with `isFatalBulkApiError`. Mass update had no equivalent. Neither would have matched this particular message anyway, since the pattern list had `Job already closed` and Salesforce words this one `the Job is not Open`.

## Fix

- Break out of the batch loop on a fatal bulk error, and record the batches that were never sent as processing errors so the user still sees every record that did not make it.
- Move `FATAL_BULK_ERROR_PATTERNS` and `isFatalBulkApiError` from `libs/features/load-records` to `@jetstream/shared/utils`, with their tests, so both bulk paths share one list. Mass update lives in `libs/shared/ui-core` and cannot import from a feature lib.
- Add `/Job is not Open/i` to the pattern list.

Jetstream only asks Salesforce to close the job on the final batch, so the close came from outside the loop. This change does not stop the job being closed, it stops us from hammering it afterwards.

## Tests

New `useDeployRecords.batches.spec.tsx` covering three cases: stopping after a closed job error, continuing after an unrelated single batch failure, and closing the job on the final batch only. The first fails on `main` with three submitted batches instead of two.

Found during BetterStack error triage.