### PR TITLE
fix(jobs): stop reporting canceled downloads as errors

### DIFF
--- a/libs/features/analysis-shared/src/field-usage/run-field-usage.ts
+++ b/libs/features/analysis-shared/src/field-usage/run-field-usage.ts
@@ -1,4 +1,5 @@
 import { logger } from '@jetstream/shared/client-logger';
+import { JOB_CANCELED_ERROR_MESSAGE } from '@jetstream/shared/constants';
 import { describeSObject, query, queryWithRecordBudget } from '@jetstream/shared/data';
 import type { DescribeSObjectResult, Field, SalesforceOrgUi } from '@jetstream/types';
 import { composeQuery, getField } from '@jetstreamapp/soql-parser-js';
@@ -219,7 +220,7 @@ function buildFieldMeta(countable: Field[]): FieldUsageObjectPayload['fieldMeta'
 
 function throwIfCanceled(isCanceled?: () => boolean): void {
   if (isCanceled?.()) {
-    throw new Error('Job canceled');
+    throw new Error(JOB_CANCELED_ERROR_MESSAGE);
   }
 }
 
@@ -510,7 +511,7 @@ export async function runFieldUsageQueryForObjects(
         fieldMeta,
       };
     } catch (ex) {
-      if (ex instanceof Error && ex.message === 'Job canceled') {
+      if (ex instanceof Error && ex.message === JOB_CANCELED_ERROR_MESSAGE) {
         throw ex;
       }
       failedObjects.push(objectApiName);

--- a/libs/features/analysis-shared/src/permission-export/run-permission-export.ts
+++ b/libs/features/analysis-shared/src/permission-export/run-permission-export.ts
@@ -1,5 +1,5 @@
 import { logger } from '@jetstream/shared/client-logger';
-import { HIGH_RISK_SYSTEM_PERMISSIONS } from '@jetstream/shared/constants';
+import { HIGH_RISK_SYSTEM_PERMISSIONS, JOB_CANCELED_ERROR_MESSAGE } from '@jetstream/shared/constants';
 import { describeGlobal, describeSObject, queryWithRecordBudget } from '@jetstream/shared/data';
 import { sanitizeSobjectApiNames, splitArrayToMaxSize, uniqueSalesforceIds } from '@jetstream/shared/utils';
 import type { PermissionExportFullResult, SalesforceOrgUi } from '@jetstream/types';
@@ -117,7 +117,7 @@ function emptyResult(requestPayload?: PermissionExportFullResult['requestPayload
 
 function throwIfCanceled(isCanceled: (() => boolean) | undefined): void {
   if (isCanceled?.()) {
-    throw new Error('Job canceled');
+    throw new Error(JOB_CANCELED_ERROR_MESSAGE);
   }
 }
 

--- a/libs/shared/constants/src/lib/shared-constants.ts
+++ b/libs/shared/constants/src/lib/shared-constants.ts
@@ -112,6 +112,12 @@ export const HTTP = {
   },
 };
 
+/**
+ * Message every long running job throws with when the user cancels it. It travels back to the main thread as
+ * a plain error string, so the callers that need to tell a cancellation apart from a real failure match on it.
+ */
+export const JOB_CANCELED_ERROR_MESSAGE = 'Job canceled';
+
 export const ERROR_MESSAGES = {
   SFDC_EXPIRED_TOKEN: 'expired access/refresh token',
   SFDC_EXPIRED_SESSION: 'Session expired or invalid',

--- a/libs/shared/ui-core/src/jobs/JobWorker.ts
+++ b/libs/shared/ui-core/src/jobs/JobWorker.ts
@@ -7,7 +7,7 @@ import {
   runPermissionExport,
 } from '@jetstream/feature/analysis-shared';
 import { logger } from '@jetstream/shared/client-logger';
-import { FILE_FORMAT_XLSX_LOAD_TEMPLATE, MIME_TYPES } from '@jetstream/shared/constants';
+import { FILE_FORMAT_XLSX_LOAD_TEMPLATE, JOB_CANCELED_ERROR_MESSAGE, MIME_TYPES } from '@jetstream/shared/constants';
 import {
   bulkApiAddBatchToJob,
   bulkApiCreateJob,
@@ -221,7 +221,7 @@ export class JobWorker {
               nextRecordsUrl = queryResults.nextRecordsUrl;
               downloadedRecords = downloadedRecords.concat(queryResults.records);
               if (this.canceledJobIds.has(job.id)) {
-                throw new Error('Job canceled');
+                throw new Error(JOB_CANCELED_ERROR_MESSAGE);
               }
             }
           } else {
@@ -387,7 +387,7 @@ export class JobWorker {
           }
 
           if (this.canceledJobIds.has(job.id)) {
-            throw new Error('Job canceled');
+            throw new Error(JOB_CANCELED_ERROR_MESSAGE);
           }
 
           const results = await pollRetrieveMetadataResultsUntilDone(org, id, {
@@ -555,7 +555,7 @@ export class JobWorker {
           }
           // Where-used can take a while; respect a cancel requested during that phase before we persist a "completed" row.
           if (canceledRef.has(job.id)) {
-            throw new Error('Job canceled');
+            throw new Error(JOB_CANCELED_ERROR_MESSAGE);
           }
 
           const okObjectCount = objectApiNames.filter(

--- a/libs/shared/ui-core/src/jobs/Jobs.tsx
+++ b/libs/shared/ui-core/src/jobs/Jobs.tsx
@@ -3,7 +3,7 @@
 import { css } from '@emotion/react';
 import { DownloadFileResult } from '@jetstream/desktop/types';
 import { logger } from '@jetstream/shared/client-logger';
-import { fileExtToGoogleDriveMimeType, fileExtToMimeType, MIME_TYPES } from '@jetstream/shared/constants';
+import { fileExtToGoogleDriveMimeType, fileExtToMimeType, JOB_CANCELED_ERROR_MESSAGE, MIME_TYPES } from '@jetstream/shared/constants';
 import { googleUploadFile } from '@jetstream/shared/data';
 import {
   formatNumber,
@@ -67,8 +67,15 @@ function getGoogleAccessToken(): string | undefined {
  * the whole file as a single string and throws `RangeError: Invalid string length` past ~512MB. The jobs popover
  * only ever shows the raw message, so report the inputs needed to tell a browser limit apart from a Salesforce
  * failure. The SOQL and the records themselves are deliberately left out.
+ *
+ * Cancelling from the jobs popover settles the job through this same failure path, so it is filtered out here -
+ * it is a user decision, not something to investigate, and long downloads get cancelled often enough that it was
+ * the single noisiest pattern in the error tracker.
  */
 function trackDownloadFailure(job: AsyncJob, errorMessage: string) {
+  if (errorMessage === JOB_CANCELED_ERROR_MESSAGE) {
+    return;
+  }
   const { fileFormat, sObject, totalRecordCount, fields, useBulkApi, includeSubquery, isTooling } = (job.meta ||
     {}) as Partial<BulkDownloadJob>;
   tracker.error('Bulk download job failed', new Error(errorMessage), {

--- a/libs/shared/ui-utils/src/lib/shared-ui-utils.ts
+++ b/libs/shared/ui-utils/src/lib/shared-ui-utils.ts
@@ -2,7 +2,7 @@
 /* eslint-disable no-redeclare */
 import type { Placement } from '@floating-ui/react';
 import { logger } from '@jetstream/shared/client-logger';
-import { DATE_FORMATS, HTTP, INPUT_ACCEPT_FILETYPES } from '@jetstream/shared/constants';
+import { DATE_FORMATS, HTTP, INPUT_ACCEPT_FILETYPES, JOB_CANCELED_ERROR_MESSAGE } from '@jetstream/shared/constants';
 import {
   anonymousApex,
   bulkApiGetJob,
@@ -1104,7 +1104,7 @@ export async function pollRetrieveMetadataResultsUntilDone(
   while (!done && attempts <= maxAttempts) {
     await delay(interval);
     if (isCanceled && isCanceled()) {
-      throw new Error('Job canceled');
+      throw new Error(JOB_CANCELED_ERROR_MESSAGE);
     }
     retrieveResults = await checkMetadataRetrieveResults(selectedOrg, id);
     logger.log({ retrieveResults });
@@ -1116,7 +1116,7 @@ export async function pollRetrieveMetadataResultsUntilDone(
       interval += DEFAULT_INTERVAL_5_SEC;
     }
     if (isCanceled && isCanceled()) {
-      throw new Error('Job canceled');
+      throw new Error(JOB_CANCELED_ERROR_MESSAGE);
     }
   }
   if (!done) {


### PR DESCRIPTION
## Problem

`Bulk download job failed: Job canceled` was the single noisiest pattern in the error tracker, 19 events from 16 distinct users in the last two weeks. None of them are failures. They are users clicking Cancel in the jobs popover.

Cancelling posts `CancelJob` to the job worker, which throws `Job canceled` on its next iteration check. That travels back as a plain error string and settles the job through the same branch a real failure uses, which calls `trackDownloadFailure`.

## Fix

Return early from `trackDownloadFailure` for a cancellation. Everything else about the job is unchanged, so the popover still shows the outcome to the user.

Also gives the sentinel a name. `Job canceled` was a bare literal at six throw sites across three libs plus one comparison, and matching it is now load bearing, so it lives in `@jetstream/shared/constants` as `JOB_CANCELED_ERROR_MESSAGE`.

## Notes

- Not changed: the job row and the browser notification still read "Download records failed" for a cancellation. That is a separate wording question and changing it would alter what users see, whereas this change only affects what we send ourselves.
- No test. `trackDownloadFailure` is module private to `Jobs.tsx`, which has no test harness, and standing one up to exercise a three line guard would mean mocking the worker, gapi and the jotai job state. The two spec files that assert on the cancellation message were left on the literal on purpose, so they pin the wording the constant now carries.

Found during BetterStack error triage.