### PR TITLE
feat(landing): call out the AppExchange listing and Salesforce Security Review

### DIFF
--- a/apps/docs/docs/getting-started/overview.mdx
+++ b/apps/docs/docs/getting-started/overview.mdx
@@ -15,6 +15,10 @@ Jetstream is the most advanced toolkit for working with and administering Salesf
 
 If you have questions or want to talk with a human, you can reach support by emailing [support@getjetstream.app](mailto:support@getjetstream.app).
 
+Jetstream has passed the Salesforce Security Review and is published on the
+[Salesforce AppExchange](https://appexchange.salesforce.com/appxListingDetail?listingId=1a2b1a6e-013e-40b9-9113-3481282cb415).
+We have also completed a SOC 2 Type II audit. See [Security](./security.mdx) for what those reviews cover and how to request the report.
+
 :::tip
 
 If you haven't created a Jetstream account, you can [sign up here](https://getjetstream.app/auth/signup/).

--- a/apps/docs/docs/getting-started/security.mdx
+++ b/apps/docs/docs/getting-started/security.mdx
@@ -11,8 +11,30 @@ import { JetstreamProLogo } from '@site/src/shared-components/JetstreamProLogo';
 
 Jetstream is designed with security and privacy in mind. We take the protection of your data seriously and implement industry-standard practices to ensure its safety.
 
+## Independent Reviews
+
+Jetstream has been reviewed by Salesforce and by an independent audit firm. If your security team needs documentation to approve Jetstream, start here.
+
+### Salesforce Security Review
+
+Jetstream has passed the [Salesforce Security Review](https://developer.salesforce.com/docs/atlas.en-us.packagingGuide.meta/packagingGuide/security_review_overview.htm)
+and is published on the [Salesforce AppExchange](https://appexchange.salesforce.com/appxListingDetail?listingId=1a2b1a6e-013e-40b9-9113-3481282cb415).
+
+The Security Review is Salesforce's own assessment of a partner application, covering how the application authenticates, what data it accesses,
+and how it protects that data. Only applications that pass it may be listed on the AppExchange.
+
+### SOC 2 Type II
+
+Jetstream has completed a SOC 2 Type II audit performed by A-LIGN, an independent audit firm. A Type II report evaluates whether security
+controls are suitably designed **and** operated effectively over a period of time, rather than at a single point in time. The audit covers the
+Jetstream platform as a whole, so every plan runs on the same infrastructure and is protected by the same controls.
+
+The full report is available under a non-disclosure agreement to paying customers and to organizations evaluating a paid plan. To request a
+copy, email [sales@getjetstream.app](mailto:sales@getjetstream.app?subject=SOC%202%20Report%20Request).
+
 ## Additional Resources
 
+- [Jetstream on the Salesforce AppExchange](https://appexchange.salesforce.com/appxListingDetail?listingId=1a2b1a6e-013e-40b9-9113-3481282cb415)
 - [Data Processing Agreement](https://getjetstream.app/dpa/)
 - [Data Sub-Processors](https://getjetstream.app/subprocessors/)
 - [Security and Privacy](https://getjetstream.app/privacy/)

--- a/apps/landing/components/Footer.tsx
+++ b/apps/landing/components/Footer.tsx
@@ -45,6 +45,14 @@ export const Footer = ({ omitLinks = [] }: FooterProps) => (
           </Link>
           <p className="text-gray-500 text-base">Providing tools to help you get your job done faster.</p>
           <Soc2Badge className="inline-block" imageClassName="h-28 w-auto" />
+          <a
+            href={ROUTES.EXTERNAL.APP_EXCHANGE}
+            className="block text-base text-gray-500 hover:text-gray-900"
+            target="_blank"
+            rel="noreferrer"
+          >
+            Find us on the Salesforce AppExchange &rarr;
+          </a>
         </div>
         <div className="mt-12 grid grid-cols-3 gap-8 xl:mt-0 xl:col-span-2">
           <div className="md:grid md:grid-cols-1 md:gap-8">

--- a/apps/landing/components/landing/LandingPage.tsx
+++ b/apps/landing/components/landing/LandingPage.tsx
@@ -3,6 +3,7 @@ import { FooterCta } from './FooterCta';
 import { HeroSection } from './HeroSection';
 import { PlatformSection } from './PlatformSection';
 import { PricingPreview } from './PricingPreview';
+import { TrustSignals } from './TrustSignals';
 import { ValueProposition } from './ValueProposition';
 
 export const LandingPage = () => (
@@ -23,6 +24,7 @@ export const LandingPage = () => (
 
     <HeroSection />
     <ValueProposition />
+    <TrustSignals />
     <FeatureShowcase />
     <PlatformSection />
     <PricingPreview />

--- a/apps/landing/components/landing/TrustSignals.tsx
+++ b/apps/landing/components/landing/TrustSignals.tsx
@@ -1,0 +1,51 @@
+import Link from 'next/link';
+import { TRUST_SIGNALS } from './landing-page-data';
+
+export const TrustSignals = () => (
+  <section>
+    <div className="mx-auto max-w-4xl px-6 pb-24 sm:pb-32 lg:px-8">
+      {/* Section header */}
+      <div className="text-center">
+        <p className="text-sm font-semibold uppercase tracking-wider text-cyan-400">Verified &amp; Reviewed</p>
+        <h2 className="mt-2 text-3xl font-semibold tracking-tight text-white sm:text-4xl">Vetted by people who aren&apos;t us</h2>
+        <p className="mx-auto mt-6 max-w-2xl text-lg text-gray-400">
+          Jetstream connects to your production org, so we put it through the reviews your security team will ask about.
+        </p>
+      </div>
+
+      {/* Trust cards */}
+      <div className="mt-16 grid grid-cols-1 gap-8 md:grid-cols-2">
+        {TRUST_SIGNALS.map(({ icon: Icon, title, description, cta, href }) => {
+          const isExternal = href.startsWith('http');
+
+          return (
+            <div key={title} className="rounded-2xl bg-white/5 p-8 ring-1 ring-white/10 transition-all duration-200 hover:ring-white/20">
+              <Icon className="h-10 w-10 text-teal-400" />
+              <h3 className="mt-4 text-xl font-semibold text-white">{title}</h3>
+              <p className="mt-2 text-base text-gray-400">{description}</p>
+              {isExternal ? (
+                <a
+                  href={href}
+                  className="mt-6 inline-flex items-center gap-1 text-sm font-semibold text-teal-400 transition hover:text-teal-300"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  {cta} &rarr;
+                </a>
+              ) : (
+                <Link
+                  href={href}
+                  className="mt-6 inline-flex items-center gap-1 text-sm font-semibold text-teal-400 transition hover:text-teal-300"
+                >
+                  {cta} &rarr;
+                </Link>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  </section>
+);
+
+export default TrustSignals;

--- a/apps/landing/components/landing/landing-page-data.ts
+++ b/apps/landing/components/landing/landing-page-data.ts
@@ -2,6 +2,7 @@ import {
   ChatBubbleLeftRightIcon,
   ChatBubbleOvalLeftEllipsisIcon,
   CircleStackIcon,
+  CloudIcon,
   CodeBracketIcon,
   Cog6ToothIcon,
   ComputerDesktopIcon,
@@ -9,6 +10,7 @@ import {
   HeartIcon,
   PuzzlePieceIcon,
   RocketLaunchIcon,
+  ShieldCheckIcon,
 } from '@heroicons/react/24/outline';
 import { ForwardRefExoticComponent, RefAttributes, SVGProps } from 'react';
 import { ENVIRONMENT, ROUTES } from '../../utils/environment';
@@ -24,6 +26,8 @@ export interface TrustSignal {
   icon: HeroIcon;
   title: string;
   description: string;
+  cta: string;
+  href: string;
 }
 
 export interface ValuePillar {
@@ -63,6 +67,25 @@ export interface CommunityLink {
   description: string;
   href: string;
 }
+
+export const TRUST_SIGNALS: TrustSignal[] = [
+  {
+    icon: CloudIcon,
+    title: 'On the Salesforce AppExchange',
+    description:
+      'Jetstream passed the Salesforce Security Review and is published on the AppExchange, the Salesforce marketplace of vetted partner apps.',
+    cta: 'View our listing',
+    href: ROUTES.EXTERNAL.APP_EXCHANGE,
+  },
+  {
+    icon: ShieldCheckIcon,
+    title: 'SOC 2 Type II audited',
+    description:
+      'A-LIGN, an independent audit firm, verified that our security controls are designed well and operate effectively over time. The report is available under NDA.',
+    cta: 'Read about our SOC 2 report',
+    href: `${ROUTES.PRIVACY}#soc-2`,
+  },
+];
 
 export const VALUE_PILLARS: ValuePillar[] = [
   {

--- a/apps/landing/utils/environment.ts
+++ b/apps/landing/utils/environment.ts
@@ -23,6 +23,7 @@ export const ROUTES = {
     DOCS: 'https://docs.getjetstream.app',
     DOCS_PERMISSION_ANALYSIS: 'https://docs.getjetstream.app/permission-analysis',
     DOCS_DATA_ANALYSIS: 'https://docs.getjetstream.app/data-analysis',
+    APP_EXCHANGE: 'https://appexchange.salesforce.com/appxListingDetail?listingId=1a2b1a6e-013e-40b9-9113-3481282cb415',
     STATUS: 'https://status.getjetstream.app',
     SUPPORT_EMAIL: 'mailto:support@getjetstream.app',
     DISCORD: 'https://discord.gg/sfxd',


### PR DESCRIPTION
Jetstream is now published on the AppExchange, which means it has passed the Salesforce Security Review. That is the review a prospect's security team asks about first, so it belongs next to SOC 2 rather than buried in the footer.

## Landing site

- New trust section on the home page, between the value pillars and the feature showcase, carrying both the AppExchange/Security Review and SOC 2 Type II signals. The AppExchange card links to the listing, the SOC 2 card links to the report request instructions on the privacy page.
- Footer link on every landing page, under the existing A-LIGN badge.
- The listing URL is a route constant rather than a literal.

## Docs

- The security page gets an "Independent Reviews" section explaining what the Salesforce Security Review and the SOC 2 Type II audit each cover, and how to request the report. The listing is also added to that page's resource list.
- The overview page gets a short mention that points at the security page.

## Notes

- **The privacy page was deliberately left alone.** It carries a warning that changes need legal and leadership approval, and a material edit requires bumping `CURRENT_TOS_VERSION`. Adding the Security Review there is a reasonable follow-up but is a separate decision.
- **No official AppExchange badge image is used.** Salesforce publishes an "Available on AppExchange" badge through their brand center. This uses a text and icon treatment instead of inventing an asset URL. If we download the badge it can drop into the trust card the same way the A-LIGN badge does.
- **Pre-existing stale copy nearby, not touched here:** the docs security page still says we don't offer SSO via SAML or OIDC, which contradicts the pricing page.

## Verification

- `nx run landing:build` and the Docusaurus build both pass, including the admonition lint and internal link resolution.
- Rendered the home page and footer locally against the built export.