### PR TITLE
chore(email): await the email_activity insert so cron sends are recorded

### DIFF
--- a/libs/api-config/src/lib/__tests__/email.config.spec.ts
+++ b/libs/api-config/src/lib/__tests__/email.config.spec.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const prismaMock = vi.hoisted(() => ({
+  emailActivity: { create: vi.fn() },
+}));
+
+const loggerMock = vi.hoisted(() => ({ warn: vi.fn(), error: vi.fn(), info: vi.fn() }));
+
+const mailgunCreateMessage = vi.hoisted(() => vi.fn());
+
+// Mutable so the "client not configured" case can re-import the module with the key unset —
+// the Mailgun client is built once at module load.
+const envMock = vi.hoisted(() => ({
+  MAILGUN_API_KEY: 'test-key' as string | undefined,
+  JETSTREAM_EMAIL_DOMAIN: 'mail.example.com',
+  JETSTREAM_EMAIL_FROM_NAME: 'Jetstream <noreply@example.com>',
+  JETSTREAM_EMAIL_REPLY_TO: 'support@example.com',
+}));
+
+vi.mock('mailgun.js', () => ({
+  default: class MailgunMock {
+    client() {
+      return { messages: { create: mailgunCreateMessage } };
+    }
+  },
+}));
+vi.mock('../api-db-config', () => ({ prisma: prismaMock }));
+vi.mock('../api-logger', () => ({ logger: loggerMock }));
+vi.mock('../env-config', () => ({ ENV: envMock }));
+
+const emailArgs = { to: 'user@example.com', subject: 'Test Subject', html: '<p>body</p>', text: 'body' };
+
+/** Resolves only after a macrotask, so a caller that fails to await is observably out of order. */
+function createSlowInsert(order: string[]) {
+  return vi.fn().mockImplementation(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    order.push('insert-complete');
+    return { id: 1 };
+  });
+}
+
+describe('sendEmail', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    envMock.MAILGUN_API_KEY = 'test-key';
+    mailgunCreateMessage.mockResolvedValue({ status: 200, id: '<message-id>' });
+  });
+
+  it('records the send in email_activity', async () => {
+    const { sendEmail } = await import('../email.config');
+    prismaMock.emailActivity.create.mockResolvedValue({ id: 1 });
+
+    await sendEmail(emailArgs);
+
+    expect(prismaMock.emailActivity.create).toHaveBeenCalledWith({
+      data: { email: 'user@example.com', subject: 'Test Subject', status: '200', providerId: '<message-id>' },
+      select: { id: true },
+    });
+  });
+
+  // Regression: the insert used to be fire-and-forget, so every cron task's `process.exit(0)` killed it
+  // before Postgres committed and no automated mail was ever recorded.
+  it('does not resolve until the email_activity insert has committed', async () => {
+    const order: string[] = [];
+    const { sendEmail } = await import('../email.config');
+    prismaMock.emailActivity.create.mockImplementation(createSlowInsert(order));
+
+    await sendEmail(emailArgs);
+    order.push('send-resolved');
+
+    expect(order).toEqual(['insert-complete', 'send-resolved']);
+  });
+
+  it('does not resolve until the insert has committed when the mail client is not configured', async () => {
+    const order: string[] = [];
+    envMock.MAILGUN_API_KEY = undefined;
+    vi.resetModules();
+    const { sendEmail } = await import('../email.config');
+    prismaMock.emailActivity.create.mockImplementation(createSlowInsert(order));
+
+    await sendEmail(emailArgs);
+    order.push('send-resolved');
+
+    expect(order).toEqual(['insert-complete', 'send-resolved']);
+    expect(prismaMock.emailActivity.create).toHaveBeenCalledWith({
+      data: { email: 'user@example.com', subject: 'Test Subject', status: 'unsent' },
+      select: { id: true },
+    });
+    expect(mailgunCreateMessage).not.toHaveBeenCalled();
+    vi.resetModules();
+  });
+
+  it('still resolves when logging the activity fails so delivery is never broken by it', async () => {
+    const { sendEmail } = await import('../email.config');
+    prismaMock.emailActivity.create.mockRejectedValue(new Error('db unavailable'));
+
+    await expect(sendEmail(emailArgs)).resolves.toBeUndefined();
+    expect(loggerMock.error).toHaveBeenCalledWith({ message: 'db unavailable' }, '[EMAIL][ERROR] Error logging email activity');
+  });
+});

--- a/libs/api-config/src/lib/email.config.ts
+++ b/libs/api-config/src/lib/email.config.ts
@@ -43,12 +43,7 @@ export async function sendEmail({
 }) {
   if (!mailgun) {
     logger.warn('[EMAIL][ERROR] Mail client not configured, skipping sending email');
-    prisma.emailActivity
-      .create({
-        data: { email: to, subject, status: `unsent` },
-        select: { id: true },
-      })
-      .catch((err) => logger.error({ message: err?.message }, '[EMAIL][ERROR] Error logging email activity'));
+    await logEmailActivity({ email: to, subject, status: `unsent` });
     return;
   }
 
@@ -63,10 +58,22 @@ export async function sendEmail({
     ...rest,
   });
 
-  prisma.emailActivity
-    .create({
-      data: { email: to, subject, status: `${results.status}` || null, providerId: results.id },
-      select: { id: true },
-    })
+  await logEmailActivity({ email: to, subject, status: `${results.status}` || null, providerId: results.id });
+}
+
+/**
+ * Records the send in `email_activity`.
+ *
+ * Awaited rather than fire-and-forget: every cron task calls `process.exit` as soon as its work
+ * resolves, which drops an in-flight insert and leaves no local record that the mail went out. The
+ * Cloudflare WAF spike detector additionally reads this table to enforce its alert cooldown, so a
+ * lost row makes it re-alert on the same window.
+ *
+ * Failures are logged and swallowed so that logging can never break delivery of an email that Mailgun
+ * has already accepted.
+ */
+async function logEmailActivity(data: { email: string; subject: string; status: string | null; providerId?: string }) {
+  await prisma.emailActivity
+    .create({ data, select: { id: true } })
     .catch((err) => logger.error({ message: err?.message }, '[EMAIL][ERROR] Error logging email activity'));
 }


### PR DESCRIPTION
## Problem

`sendEmail` fired the `email_activity` insert without awaiting it:

```js
prisma.emailActivity
  .create({ ... })
  .catch((err) => logger.error(...));
```

So `sendEmail` resolved as soon as **Mailgun** responded, not when Postgres committed. Every cron entry point calls `process.exit(0)` the moment its work resolves, which destroys the in-flight insert. This is deterministic, not a flaky race — the insert needs a network round-trip and always loses.

### What was actually lost

Only crons where the email send is the **last** awaited operation before the process exits:

| Cron | Send site |
|---|---|
| Cloudflare spike detector | `cloudflare-spike-detector.utils.ts:288` |
| Cloudflare daily digest | `cloudflare-daily-digest.utils.ts:85` |
| Stats summary | `stats-summary.utils.ts:159` |
| Org expiration **test-mode summary** | `salesforce-org-expiration.utils.ts:476` |

`salesforce-org-expiration` and `sso-certificate-expiration` survive for their customer-facing mail only because they `await` unrelated DB writes *after* the send, which gives the queued insert time to land. That is incidental, not guaranteed — this fixes the source so it doesn't depend on trailing work.

### It also explains the WAF alert storm

`alerts@` received 7 "WAF spike detected" emails in 90 minutes on 2026-09-12. The detector's 120-minute cooldown works by looking for a prior `email_activity` row whose subject contains `WAF spike detected` (`cloudflare-spike-detector.utils.ts:227`). That row never existed, so the cooldown never engaged and it re-alerted on the same hour window up to four times:

| Alert times (UTC) | Window evaluated |
|---|---|
| 19:16, 19:32, 19:45 | 18:00–19:00 |
| 20:01, 20:16, 20:32, 20:46 | 19:00–20:00 |

(The underlying traffic was a non-event — commodity vulnerability scanning over Tor, 100% blocked at the edge by a default-deny rule on `webhooks.getjetstream.app`. The alerting was the only defect. That cron is now disabled in Render.)

## Fix

Both inserts are awaited, via a small `logEmailActivity` helper so the "why awaited" explanation lives in one place. The `.catch()` is retained — a logging failure still cannot break delivery of an email Mailgun has already accepted, and the only cost is one round-trip of latency per send.

Worth noting this hazard was discovered and worked around **locally** once before, for audit logs in `sso-certificate-expiration.utils.ts:183-184`:

> `// Awaited (rather than the fire-and-forget createTeamAuditLog) because the cron calls`
> `// process.exit as soon as this resolves, which would drop an in-flight insert.`

`sendEmail` never got the same treatment.

## Tests

New `libs/api-config/src/lib/__tests__/email.config.spec.ts` (4 tests). The two ordering tests encode the actual invariant — the insert completes *before* `sendEmail` resolves — and were confirmed to fail against the old fire-and-forget code:

```
× does not resolve until the email_activity insert has committed
× does not resolve until the insert has committed when the mail client is not configured
  AssertionError: expected [ 'send-resolved' ] to deeply equal [ 'insert-complete', 'send-resolved' ]
```

Also green: `cron-tasks` `cloudflare-spike-detector.spec.ts` + `cloudflare.utils.spec.ts` (18 tests), `api-config:typecheck`, oxlint, oxfmt.

## Notes

- Typed `chore` deliberately — infra-only, no user-visible behaviour change, so it stays out of the changelog.
- **Compliance touch-point:** `monitoring-policy.md` names email logs as supporting "verifying communications sent to users" with 180-day retention. `email_activity` was incomplete for the cron paths above. Mailgun retained the sends, so this was a gap in the local system of record rather than total blindness.
- Not changed here: `sendCloudflareSecurityAlertEmail` (`libs/email/src/lib/email.tsx:315-327`) wraps its whole body in a `try/catch` that only logs, so a send failure is invisible to the caller. `sendOrgExpirationWarningEmail` directly below it has a comment explaining why it deliberately propagates instead. Happy to make the Cloudflare one consistent, but it's a separate decision and the cron is disabled.